### PR TITLE
Remove legacy hook path

### DIFF
--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -1,21 +1,16 @@
 package cmd
 
 import (
-	"time"
-
 	"github.com/spf13/cobra"
 
-	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
-	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/state"
 )
 
 var preToolCmd = &cobra.Command{
 	Use:   "pre-tool",
-	Short: "Gate file writes to inject security policy context",
+	Short: "Observe pre-tool events for local endpoint telemetry",
 	Long: `PreToolUse hook - triggered before a Write tool execution in Cursor.
-On the first Write of a prompt cycle, denies the operation to inject cached
-security policies into the agent's context. Subsequent writes are allowed.`,
+Records local telemetry for the tool request and allows the runtime to continue.`,
 	Run: runPreTool,
 }
 
@@ -27,8 +22,6 @@ func init() {
 var allowResponse = map[string]interface{}{"permission": "allow"}
 
 func runPreTool(cmd *cobra.Command, args []string) {
-	start := time.Now()
-
 	input, err := readStdinJSON()
 	if err != nil {
 		outputJSON(allowResponse)
@@ -43,72 +36,9 @@ func runPreTool(cmd *cobra.Command, args []string) {
 		logger = logging.NewLoggerForPlatform("pre-tool", platformFlag)
 	}
 
-	// Short-circuit: SbD disabled → no-op
-	if !config.IsSecureByDesignEnabled(platformFlag) {
-		logger.Debug("Secure by design is disabled, allowing")
-		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "Secure by Design disabled")
-		outputJSON(allowResponse)
-		return
-	}
-
-	if sessionID == "" {
-		logger.Debug("No session ID, allowing")
-		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "No session ID")
-		outputJSON(allowResponse)
-		return
-	}
-
-	// Read generation_id from input to validate against stored state
-	inputGenerationID, _ := input["generation_id"].(string)
-
-	// Check SbD state for this conversation
-	st := state.NewSessionState(sessionID, platformFlag)
-	policies, storedGenerationID, injected := st.GetSbdState()
-
-	// No policies cached → no-op
-	if policies == "" {
-		logger.Debug("No policies cached, allowing")
-		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "No cached policies")
-		outputJSON(allowResponse)
-		return
-	}
-
-	// Generation mismatch → stale state, allow through
-	if inputGenerationID != "" && storedGenerationID != "" && inputGenerationID != storedGenerationID {
-		logger.Debug("Generation ID mismatch, allowing Write (stale state)",
-			"input_generation_id", inputGenerationID,
-			"stored_generation_id", storedGenerationID)
-		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "Generation ID mismatch")
-		outputJSON(allowResponse)
-		return
-	}
-
-	// Already injected for this generation → allow
-	if injected {
-		logger.Debug("Policy already injected, allowing Write",
-			"generation_id", storedGenerationID)
-		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "Policy already injected")
-		outputJSON(allowResponse)
-		return
-	}
-
-	// First Write of this generation: deny once to inject policy context
-	st.MarkSbdInjected()
-
-	message := policies + "You must comply with these policies. Retry your file write with policy-compliant code, or inform the user if the requested change would violate a policy."
-
-	elapsed := time.Since(start)
-	logger.Info("Policy gate: denying Write for context injection",
-		"generation_id", storedGenerationID,
-		"policy_length", len(policies),
-		"duration_ms", elapsed.Milliseconds())
-	emitPreToolDecision(logger, input, sessionID, "approval.denied", "deny", "Policy context injection")
-
-	outputJSON(map[string]interface{}{
-		"permission":    "deny",
-		"user_message":  message,
-		"agent_message": message,
-	})
+	logger.Debug("Pre-tool observed, allowing")
+	emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "Pre-tool observed")
+	outputJSON(allowResponse)
 }
 
 func emitPreToolDecision(logger *logging.Logger, input map[string]interface{}, sessionID, action, decision, reason string) {

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -13,63 +12,17 @@ import (
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/state"
 )
 
-func TestRunPreToolSecureByDesignGateBranches(t *testing.T) {
+func TestRunPreToolAllowsAndEmitsTelemetry(t *testing.T) {
 	tests := []struct {
-		name       string
-		enableSBD  bool
-		sessionID  string
-		inputGen   string
-		storedGen  string
-		policies   string
-		injected   bool
-		wantPerm   string
-		wantInject bool
+		name      string
+		sessionID string
 	}{
 		{
-			name:      "disabled allows",
-			sessionID: "conv-disabled",
-			policies:  "policy\n",
-			wantPerm:  "allow",
+			name: "missing session allows",
 		},
 		{
-			name:      "missing session allows",
-			enableSBD: true,
-			wantPerm:  "allow",
-		},
-		{
-			name:      "no policies allows",
-			enableSBD: true,
-			sessionID: "conv-no-policies",
-			wantPerm:  "allow",
-		},
-		{
-			name:      "generation mismatch allows",
-			enableSBD: true,
-			sessionID: "conv-stale",
-			inputGen:  "gen-2",
-			storedGen: "gen-1",
-			policies:  "policy\n",
-			wantPerm:  "allow",
-		},
-		{
-			name:      "already injected allows",
-			enableSBD: true,
-			sessionID: "conv-injected",
-			inputGen:  "gen-1",
-			storedGen: "gen-1",
-			policies:  "policy\n",
-			injected:  true,
-			wantPerm:  "allow",
-		},
-		{
-			name:       "first write denies and marks injected",
-			enableSBD:  true,
-			sessionID:  "conv-deny",
-			inputGen:   "gen-1",
-			storedGen:  "gen-1",
-			policies:   "policy\n",
-			wantPerm:   "deny",
-			wantInject: true,
+			name:      "session allows",
+			sessionID: "conv-observe",
 		},
 	}
 
@@ -77,58 +30,27 @@ func TestRunPreToolSecureByDesignGateBranches(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			setupHookConfigDirs(t)
 			platformFlag = "cursor"
-			if tt.enableSBD {
-				writePlatformConfig(t, "cursor", `{"secure_by_design":true}`)
-			}
-			if tt.sessionID != "" && tt.policies != "" {
-				st := state.NewSessionState(tt.sessionID, "cursor")
-				st.SetSbdPolicies(tt.policies, tt.storedGen)
-				if tt.injected {
-					st.MarkSbdInjected()
-				}
-			}
 
 			input := map[string]interface{}{}
 			if tt.sessionID != "" {
 				input["conversation_id"] = tt.sessionID
 			}
-			if tt.inputGen != "" {
-				input["generation_id"] = tt.inputGen
-			}
 			out := runHookWithInput(t, runPreTool, input)
 
-			if out["permission"] != tt.wantPerm {
-				t.Fatalf("permission = %v, want %s; output=%#v", out["permission"], tt.wantPerm, out)
-			}
-			if tt.wantPerm == "deny" {
-				message, _ := out["agent_message"].(string)
-				if !strings.Contains(message, tt.policies) || !strings.Contains(message, "Retry your file write") {
-					t.Fatalf("deny message missing policy context: %#v", out)
-				}
-			}
-			if tt.sessionID != "" {
-				_, _, injected := state.NewSessionState(tt.sessionID, "cursor").GetSbdState()
-				if injected != (tt.injected || tt.wantInject) {
-					t.Fatalf("injected = %v, want %v", injected, tt.injected || tt.wantInject)
-				}
+			if out["permission"] != "allow" {
+				t.Fatalf("permission = %v, want allow; output=%#v", out["permission"], out)
 			}
 		})
 	}
 }
 
-func TestRunPromptSubmitClearsSbdPoliciesAndUsesCursorResponse(t *testing.T) {
+func TestRunPromptSubmitUsesCursorResponse(t *testing.T) {
 	setupHookConfigDirs(t)
 	platformFlag = "cursor"
-	st := state.NewSessionState("conv-clear", "cursor")
-	st.SetSbdPolicies("policy", "gen-1")
 
-	out := runHookWithInput(t, runPromptSubmit, map[string]interface{}{"conversation_id": "conv-clear"})
+	out := runHookWithInput(t, runPromptSubmit, map[string]interface{}{"conversation_id": "conv-submit"})
 	if out["continue"] != true {
 		t.Fatalf("cursor prompt response = %#v, want continue=true", out)
-	}
-	policies, generationID, injected := st.GetSbdState()
-	if policies != "" || generationID != "" || injected {
-		t.Fatalf("SbD state was not cleared: policies=%q generation=%q injected=%v", policies, generationID, injected)
 	}
 }
 
@@ -190,17 +112,6 @@ func setupHookConfigDirs(t *testing.T) {
 		hookconfig.FactoryDir = origFactoryDir
 		platformFlag = origPlatform
 	})
-}
-
-func writePlatformConfig(t *testing.T, platform, body string) {
-	t.Helper()
-	path := filepath.Join(hookconfig.GetStateDir(platform), "config.json")
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		t.Fatalf("mkdir platform config dir: %v", err)
-	}
-	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
-		t.Fatalf("write platform config: %v", err)
-	}
 }
 
 func runHookWithInput(t *testing.T, run func(cmd *cobra.Command, args []string), input map[string]interface{}) map[string]interface{} {

--- a/cli/beacon-hooks/cmd/prompt_submit.go
+++ b/cli/beacon-hooks/cmd/prompt_submit.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
-	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/state"
 )
 
 var promptSubmitCmd = &cobra.Command{
 	Use:   "prompt-submit",
 	Short: "Handle prompt submission for local endpoint telemetry",
 	Long: `UserPromptSubmit hook - triggered when the user submits a prompt.
-The public Beacon build does not fetch hosted policies or inject remote context.`,
+Records local prompt submission telemetry.`,
 	Run: runPromptSubmit,
 }
 
@@ -40,14 +39,7 @@ func runPromptSubmit(cmd *cobra.Command, args []string) {
 		logger = logging.NewLoggerForPlatform("prompt-submit", platformFlag)
 	}
 
-	if sessionID != "" {
-		state.NewSessionState(sessionID, platformFlag).ClearSbdPolicies()
-	}
-	if config.IsSecureByDesignEnabled(platformFlag) {
-		logger.Warn("Secure by Design policy injection is unavailable in the local-only Beacon build")
-	} else {
-		logger.Debug("Prompt submit observed")
-	}
+	logger.Debug("Prompt submit observed")
 	fields := sessionFields(sessionID, input)
 	if config.ContentRetentionMode() != config.ContentRetentionMetadata {
 		if prompt := getFirstStr(input, "prompt", "user_prompt", "text"); prompt != "" {

--- a/cli/beacon-hooks/internal/config/config.go
+++ b/cli/beacon-hooks/internal/config/config.go
@@ -133,22 +133,6 @@ func EnsureStateDir(platform string) error {
 	return os.MkdirAll(GetStateDir(platform), 0755)
 }
 
-// IsSecureByDesignEnabled checks if Secure by Design is enabled for the given platform.
-// Reads from platform-specific config at ~/.beacon/{platform}/config.json.
-func IsSecureByDesignEnabled(platform string) bool {
-	platformPath := filepath.Join(GetStateDir(platform), "config.json")
-	data, err := os.ReadFile(platformPath)
-	if err != nil {
-		return false
-	}
-	var cfg map[string]interface{}
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return false
-	}
-	enabled, ok := cfg["secure_by_design"].(bool)
-	return ok && enabled
-}
-
 func ContentRetentionMode() ContentRetention {
 	endpointPath := filepath.Join(BeaconDir, "endpoint", "config.json")
 	data, err := os.ReadFile(endpointPath)

--- a/cli/beacon-hooks/internal/config/config_test.go
+++ b/cli/beacon-hooks/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -103,96 +102,5 @@ func TestCursorDirPath(t *testing.T) {
 	}
 	if filepath.Base(filepath.Dir(CursorDir)) != ".beacon" {
 		t.Errorf("CursorDir parent should be '.beacon', got %q", filepath.Dir(CursorDir))
-	}
-}
-
-func TestIsSecureByDesignEnabled_PlatformSpecific(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	origCursorDir := CursorDir
-	origBeaconDir := BeaconDir
-	CursorDir = filepath.Join(tmpDir, "cursor")
-	BeaconDir = tmpDir
-	defer func() {
-		CursorDir = origCursorDir
-		BeaconDir = origBeaconDir
-	}()
-
-	os.MkdirAll(filepath.Join(tmpDir, "cursor"), 0755)
-
-	// No config file → false
-	if IsSecureByDesignEnabled("cursor") {
-		t.Error("should be false when no config exists")
-	}
-
-	// Platform config enabled
-	os.WriteFile(filepath.Join(tmpDir, "cursor", "config.json"), []byte(`{"secure_by_design": true}`), 0644)
-	if !IsSecureByDesignEnabled("cursor") {
-		t.Error("should be true when platform config has secure_by_design: true")
-	}
-
-	// Platform-specific false overrides global true
-	os.WriteFile(filepath.Join(tmpDir, "cursor", "config.json"), []byte(`{"secure_by_design": false}`), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(`{"secure_by_design": true}`), 0644)
-	if IsSecureByDesignEnabled("cursor") {
-		t.Error("platform-specific false should take precedence over global true")
-	}
-}
-
-func TestIsSecureByDesignEnabled_GlobalIgnored(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	origClaudeDir := ClaudeDir
-	origBeaconDir := BeaconDir
-	ClaudeDir = filepath.Join(tmpDir, "claude")
-	BeaconDir = tmpDir
-	defer func() {
-		ClaudeDir = origClaudeDir
-		BeaconDir = origBeaconDir
-	}()
-
-	// No platform config, global has SbD enabled → should NOT fall back (global deprecated)
-	os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(`{"secure_by_design": true}`), 0644)
-	if IsSecureByDesignEnabled("claude") {
-		t.Error("should ignore global config, only platform-specific config matters")
-	}
-}
-
-func TestIsSecureByDesignEnabled_NoConfigFiles(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	origClaudeDir := ClaudeDir
-	origBeaconDir := BeaconDir
-	ClaudeDir = filepath.Join(tmpDir, "claude")
-	BeaconDir = tmpDir
-	defer func() {
-		ClaudeDir = origClaudeDir
-		BeaconDir = origBeaconDir
-	}()
-
-	// No config files at all → false
-	if IsSecureByDesignEnabled("claude") {
-		t.Error("should be false when no config files exist")
-	}
-}
-
-func TestIsSecureByDesignEnabled_InvalidJSON(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	origCursorDir := CursorDir
-	origBeaconDir := BeaconDir
-	CursorDir = filepath.Join(tmpDir, "cursor")
-	BeaconDir = tmpDir
-	defer func() {
-		CursorDir = origCursorDir
-		BeaconDir = origBeaconDir
-	}()
-
-	os.MkdirAll(filepath.Join(tmpDir, "cursor"), 0755)
-
-	// Invalid JSON in platform config → false (no fallback)
-	os.WriteFile(filepath.Join(tmpDir, "cursor", "config.json"), []byte(`not json`), 0644)
-	if IsSecureByDesignEnabled("cursor") {
-		t.Error("should be false when platform config has invalid JSON")
 	}
 }

--- a/cli/beacon-hooks/internal/state/state.go
+++ b/cli/beacon-hooks/internal/state/state.go
@@ -29,11 +29,6 @@ type SessionData struct {
 	RepromptCount int          `json:"reprompt_count"`
 	Model         string       `json:"model,omitempty"`
 	CreatedAt     string       `json:"created_at,omitempty"`
-
-	// Secure-by-Design fields (used by Cursor's pre-tool gate)
-	SbdPolicies     string `json:"sbd_policies,omitempty"`
-	SbdGenerationID string `json:"sbd_generation_id,omitempty"`
-	SbdInjected     bool   `json:"sbd_injected,omitempty"`
 }
 
 // SessionState manages session state
@@ -189,59 +184,6 @@ func (s *SessionState) ResetRepromptCount() {
 	state := s.loadStateFile()
 	s.ensureSession(state)
 	state[s.sessionID].RepromptCount = 0
-	s.saveStateFile(state)
-}
-
-// SetSbdPolicies stores local policy context and resets the injection flag for a new generation.
-func (s *SessionState) SetSbdPolicies(policies, generationID string) {
-	stateMutex.Lock()
-	defer stateMutex.Unlock()
-
-	state := s.loadStateFile()
-	s.ensureSession(state)
-	state[s.sessionID].SbdPolicies = policies
-	state[s.sessionID].SbdGenerationID = generationID
-	state[s.sessionID].SbdInjected = false
-	s.saveStateFile(state)
-}
-
-// GetSbdState returns the current Secure-by-Design state for this session.
-func (s *SessionState) GetSbdState() (policies, generationID string, injected bool) {
-	stateMutex.Lock()
-	defer stateMutex.Unlock()
-
-	state := s.loadStateFile()
-	if sessionData, ok := state[s.sessionID]; ok {
-		return sessionData.SbdPolicies, sessionData.SbdGenerationID, sessionData.SbdInjected
-	}
-	return "", "", false
-}
-
-// ClearSbdPolicies removes cached SbD policies for this session.
-// Called on Cursor early-return paths in prompt-submit to prevent stale policies
-// from being injected in later generations.
-func (s *SessionState) ClearSbdPolicies() {
-	stateMutex.Lock()
-	defer stateMutex.Unlock()
-
-	state := s.loadStateFile()
-	if sessionData, ok := state[s.sessionID]; ok {
-		sessionData.SbdPolicies = ""
-		sessionData.SbdGenerationID = ""
-		sessionData.SbdInjected = false
-		s.saveStateFile(state)
-	}
-}
-
-// MarkSbdInjected sets the injection flag to true, indicating policies have been
-// delivered to the agent for the current generation.
-func (s *SessionState) MarkSbdInjected() {
-	stateMutex.Lock()
-	defer stateMutex.Unlock()
-
-	state := s.loadStateFile()
-	s.ensureSession(state)
-	state[s.sessionID].SbdInjected = true
 	s.saveStateFile(state)
 }
 

--- a/cli/beacon-hooks/internal/state/state_test.go
+++ b/cli/beacon-hooks/internal/state/state_test.go
@@ -21,231 +21,60 @@ func setupTestStateDir(t *testing.T) (tmpDir string, cleanup func()) {
 	}
 }
 
-func TestSetSbdPolicies(t *testing.T) {
+func TestSessionModelPersistsToDisk(t *testing.T) {
 	_, cleanup := setupTestStateDir(t)
 	defer cleanup()
 
-	st := NewSessionState("test-session", "cursor")
-	st.SetSbdPolicies("policy content", "gen-1")
-
-	policies, generationID, injected := st.GetSbdState()
-	if policies != "policy content" {
-		t.Errorf("policies = %q, want %q", policies, "policy content")
-	}
-	if generationID != "gen-1" {
-		t.Errorf("generationID = %q, want %q", generationID, "gen-1")
-	}
-	if injected {
-		t.Error("injected should be false after SetSbdPolicies")
-	}
-}
-
-func TestSetSbdPolicies_ResetsInjectedFlag(t *testing.T) {
-	_, cleanup := setupTestStateDir(t)
-	defer cleanup()
-
-	st := NewSessionState("test-session", "cursor")
-
-	// Set policies and mark as injected
-	st.SetSbdPolicies("policy v1", "gen-1")
-	st.MarkSbdInjected()
-
-	_, _, injected := st.GetSbdState()
-	if !injected {
-		t.Fatal("injected should be true after MarkSbdInjected")
-	}
-
-	// New generation resets the injected flag
-	st.SetSbdPolicies("policy v2", "gen-2")
-
-	policies, generationID, injected := st.GetSbdState()
-	if policies != "policy v2" {
-		t.Errorf("policies = %q, want %q", policies, "policy v2")
-	}
-	if generationID != "gen-2" {
-		t.Errorf("generationID = %q, want %q", generationID, "gen-2")
-	}
-	if injected {
-		t.Error("injected should be reset to false on new generation")
-	}
-}
-
-func TestMarkSbdInjected(t *testing.T) {
-	_, cleanup := setupTestStateDir(t)
-	defer cleanup()
-
-	st := NewSessionState("test-session", "cursor")
-	st.SetSbdPolicies("policy content", "gen-1")
-
-	st.MarkSbdInjected()
-
-	_, _, injected := st.GetSbdState()
-	if !injected {
-		t.Error("injected should be true after MarkSbdInjected")
-	}
-}
-
-func TestGetSbdState_NoSession(t *testing.T) {
-	_, cleanup := setupTestStateDir(t)
-	defer cleanup()
-
-	st := NewSessionState("nonexistent-session", "cursor")
-
-	policies, generationID, injected := st.GetSbdState()
-	if policies != "" {
-		t.Errorf("policies = %q, want empty", policies)
-	}
-	if generationID != "" {
-		t.Errorf("generationID = %q, want empty", generationID)
-	}
-	if injected {
-		t.Error("injected should be false for nonexistent session")
-	}
-}
-
-func TestSbdState_PersistsToDisk(t *testing.T) {
-	_, cleanup := setupTestStateDir(t)
-	defer cleanup()
-
-	// Write with one SessionState instance
 	st1 := NewSessionState("test-session", "cursor")
-	st1.SetSbdPolicies("persisted policy", "gen-1")
+	st1.SetModel("gpt-5.5")
 
-	// Read with a fresh instance
 	st2 := NewSessionState("test-session", "cursor")
-	policies, generationID, injected := st2.GetSbdState()
-	if policies != "persisted policy" {
-		t.Errorf("policies = %q, want %q", policies, "persisted policy")
-	}
-	if generationID != "gen-1" {
-		t.Errorf("generationID = %q, want %q", generationID, "gen-1")
-	}
-	if injected {
-		t.Error("injected should be false")
+	if got := st2.GetModel(); got != "gpt-5.5" {
+		t.Errorf("model = %q, want %q", got, "gpt-5.5")
 	}
 }
 
-func TestSbdState_IsolatedBySessions(t *testing.T) {
+func TestSessionStateIsolatedBySession(t *testing.T) {
 	_, cleanup := setupTestStateDir(t)
 	defer cleanup()
 
 	st1 := NewSessionState("session-a", "cursor")
 	st2 := NewSessionState("session-b", "cursor")
 
-	st1.SetSbdPolicies("policy-a", "gen-a")
-	st2.SetSbdPolicies("policy-b", "gen-b")
+	st1.SetModel("model-a")
+	st2.SetModel("model-b")
 
-	policies1, gen1, _ := st1.GetSbdState()
-	policies2, gen2, _ := st2.GetSbdState()
-
-	if policies1 != "policy-a" || gen1 != "gen-a" {
-		t.Errorf("session-a: policies=%q gen=%q, want policy-a/gen-a", policies1, gen1)
+	if got := st1.GetModel(); got != "model-a" {
+		t.Errorf("session-a model = %q, want model-a", got)
 	}
-	if policies2 != "policy-b" || gen2 != "gen-b" {
-		t.Errorf("session-b: policies=%q gen=%q, want policy-b/gen-b", policies2, gen2)
+	if got := st2.GetModel(); got != "model-b" {
+		t.Errorf("session-b model = %q, want model-b", got)
 	}
 }
 
-func TestSbdState_DoesNotAffectOtherFields(t *testing.T) {
+func TestEvaluationsPersistToDisk(t *testing.T) {
 	_, cleanup := setupTestStateDir(t)
 	defer cleanup()
 
-	st := NewSessionState("test-session", "cursor")
+	st1 := NewSessionState("test-session", "cursor")
+	st1.AddEvaluation("eval-1", "/path/to/file.go")
 
-	// Set non-SbD fields first
-	st.SetModel("gpt-4")
-	st.AddEvaluation("eval-1", "/path/to/file.go")
-
-	// Set SbD fields
-	st.SetSbdPolicies("policy", "gen-1")
-
-	// Verify non-SbD fields are preserved
-	model := st.GetModel()
-	if model != "gpt-4" {
-		t.Errorf("model = %q, want %q", model, "gpt-4")
-	}
-	evals := st.GetPendingEvaluations()
+	st2 := NewSessionState("test-session", "cursor")
+	evals := st2.GetPendingEvaluations()
 	if len(evals) != 1 || evals[0].EvaluationID != "eval-1" {
-		t.Errorf("evaluations not preserved after SetSbdPolicies")
+		t.Fatalf("evaluations = %#v, want eval-1", evals)
+	}
+	if evals[0].FilePath != "/path/to/file.go" {
+		t.Errorf("file path = %q, want /path/to/file.go", evals[0].FilePath)
 	}
 }
 
-func TestClearSbdPolicies(t *testing.T) {
-	_, cleanup := setupTestStateDir(t)
-	defer cleanup()
-
-	st := NewSessionState("test-session", "cursor")
-	st.SetSbdPolicies("policy content", "gen-1")
-	st.MarkSbdInjected()
-
-	// Verify state is set
-	policies, _, injected := st.GetSbdState()
-	if policies == "" || !injected {
-		t.Fatal("precondition failed: state should be set")
-	}
-
-	// Clear
-	st.ClearSbdPolicies()
-
-	policies, generationID, injected := st.GetSbdState()
-	if policies != "" {
-		t.Errorf("policies = %q, want empty after clear", policies)
-	}
-	if generationID != "" {
-		t.Errorf("generationID = %q, want empty after clear", generationID)
-	}
-	if injected {
-		t.Error("injected should be false after clear")
-	}
-}
-
-func TestClearSbdPolicies_NoSession(t *testing.T) {
-	_, cleanup := setupTestStateDir(t)
-	defer cleanup()
-
-	// Should not panic on nonexistent session
-	st := NewSessionState("nonexistent", "cursor")
-	st.ClearSbdPolicies()
-
-	policies, _, _ := st.GetSbdState()
-	if policies != "" {
-		t.Error("should remain empty for nonexistent session")
-	}
-}
-
-func TestClearSbdPolicies_PreservesOtherFields(t *testing.T) {
-	_, cleanup := setupTestStateDir(t)
-	defer cleanup()
-
-	st := NewSessionState("test-session", "cursor")
-	st.SetModel("gpt-4")
-	st.AddEvaluation("eval-1", "/path/to/file.go")
-	st.SetSbdPolicies("policy", "gen-1")
-
-	st.ClearSbdPolicies()
-
-	// SbD fields cleared
-	policies, _, _ := st.GetSbdState()
-	if policies != "" {
-		t.Error("policies should be cleared")
-	}
-
-	// Other fields preserved
-	if st.GetModel() != "gpt-4" {
-		t.Error("model should be preserved after ClearSbdPolicies")
-	}
-	evals := st.GetPendingEvaluations()
-	if len(evals) != 1 {
-		t.Error("evaluations should be preserved after ClearSbdPolicies")
-	}
-}
-
-func TestSbdState_StateFileLocation(t *testing.T) {
+func TestSessionStateFileLocation(t *testing.T) {
 	tmpDir, cleanup := setupTestStateDir(t)
 	defer cleanup()
 
 	st := NewSessionState("test-session", "cursor")
-	st.SetSbdPolicies("policy", "gen-1")
+	st.SetModel("gpt-5.5")
 
 	// Verify state.json was created in the expected location
 	stateFile := filepath.Join(tmpDir, "state.json")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Removes the Cursor `pre-tool` deny-once policy injection path and all persisted SbD state/config, which changes write-hook behavior from conditional deny/allow to always-allow with telemetry only.
> 
> **Overview**
> Simplifies the Cursor hook flow by turning `pre-tool` into a pure *telemetry observer* that always returns `{"permission":"allow"}` and emits an approval event, removing the prior policy-injection deny-once gate.
> 
> Cleans up the deprecated Secure-by-Design plumbing by deleting `config.IsSecureByDesignEnabled`, removing SbD fields/methods from `state.SessionData`, and dropping `prompt-submit` logic that cleared SbD state/warned about unsupported injection; tests are updated accordingly to validate only telemetry/allow behavior and core state persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621a964ce0fff1bf19e8614723a15116d4291332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->