### PR TITLE
Fix claude harness naming

### DIFF
--- a/collector-builder/exporter/beaconjsonexporter/exporter.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter.go
@@ -117,8 +117,9 @@ func (e *beaconExporter) eventFromLog(resourceAttrs map[string]interface{}, reco
 	if action == "" {
 		action = inferAction(attrs, record.Body().AsString())
 	}
-	event := newBeaconEvent(action, firstString(attrs, "beacon.event.category", "event.category", "category"), severity(record.SeverityText(), record.SeverityNumber().String()), harnessName(attrs), ts)
-	event.Message = firstNonEmpty(record.Body().AsString(), firstString(attrs, "message", "log.message"))
+	message := firstNonEmpty(record.Body().AsString(), firstString(attrs, "message", "log.message"))
+	event := newBeaconEvent(action, firstString(attrs, "beacon.event.category", "event.category", "category"), severity(record.SeverityText(), record.SeverityNumber().String()), harnessName(attrs, message), ts)
+	event.Message = message
 	e.populateCommon(&event, attrs)
 	event.Raw = e.rawPayload(attrs, map[string]interface{}{
 		"otel_signal": "logs",
@@ -133,8 +134,9 @@ func (e *beaconExporter) eventFromSpan(resourceAttrs map[string]interface{}, spa
 	if action == "" {
 		action = inferAction(attrs, span.Name())
 	}
-	event := newBeaconEvent(action, firstString(attrs, "beacon.event.category", "event.category", "tool"), spanSeverity(span.Status().Code().String()), harnessName(attrs), timestamp(span.StartTimestamp().AsTime()))
-	event.Message = firstNonEmpty(firstString(attrs, "message", "gen_ai.prompt", "gen_ai.response"), span.Name())
+	message := firstNonEmpty(firstString(attrs, "message", "gen_ai.prompt", "gen_ai.response"), span.Name())
+	event := newBeaconEvent(action, firstString(attrs, "beacon.event.category", "event.category", "tool"), spanSeverity(span.Status().Code().String()), harnessName(attrs, message, span.Name()), timestamp(span.StartTimestamp().AsTime()))
+	event.Message = message
 	e.populateCommon(&event, attrs)
 	event.Raw = e.rawPayload(attrs, map[string]interface{}{
 		"otel_signal": "traces",
@@ -147,7 +149,7 @@ func (e *beaconExporter) eventFromSpan(resourceAttrs map[string]interface{}, spa
 
 func (e *beaconExporter) eventFromMetric(resourceAttrs map[string]interface{}, metric pmetric.Metric) beaconEvent {
 	attrs := mergeMaps(resourceAttrs, map[string]interface{}{})
-	event := newBeaconEvent(firstString(attrs, "beacon.event.action", "event.action", "metric.observed"), "metric", "info", harnessName(attrs), time.Now().UTC())
+	event := newBeaconEvent(firstString(attrs, "beacon.event.action", "event.action", "metric.observed"), "metric", "info", harnessName(attrs, metric.Name()), time.Now().UTC())
 	event.Message = metric.Name()
 	e.populateCommon(&event, attrs)
 	event.Raw = e.rawPayload(attrs, map[string]interface{}{
@@ -308,17 +310,40 @@ func spanSeverity(status string) string {
 	return "info"
 }
 
-func harnessName(attrs map[string]interface{}) string {
+func harnessName(attrs map[string]interface{}, hints ...string) string {
 	name := firstString(attrs, "beacon.harness.name", "harness.name", "service.name", "telemetry.sdk.name")
+	if explicit := firstString(attrs, "beacon.harness.name", "harness.name"); explicit != "" {
+		return normalizeHarnessName(explicit)
+	}
+	candidates := append([]string{name}, hints...)
+	for _, candidate := range candidates {
+		if normalized := normalizeHarnessName(candidate); normalized != "" {
+			return normalized
+		}
+	}
+	if name != "" {
+		return name
+	}
+	return "otel"
+}
+
+func normalizeHarnessName(name string) string {
+	lower := strings.ToLower(strings.TrimSpace(name))
 	switch {
-	case strings.Contains(strings.ToLower(name), "claude"):
+	case lower == "":
+		return ""
+	case strings.Contains(lower, "cowork") || strings.Contains(lower, "co-work"):
 		return "claude_cowork"
-	case strings.Contains(strings.ToLower(name), "codex"):
+	case strings.Contains(lower, "claude_code") || strings.Contains(lower, "claude-code") || strings.Contains(lower, "claude code") || strings.HasPrefix(lower, "claude_code."):
+		return "claude_code"
+	case lower == "claude" || strings.Contains(lower, "claude"):
+		return "claude_code"
+	case strings.Contains(lower, "codex"):
 		return "codex_cli"
 	case name != "":
 		return name
 	default:
-		return "otel"
+		return ""
 	}
 }
 

--- a/collector-builder/exporter/beaconjsonexporter/exporter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter_test.go
@@ -92,3 +92,43 @@ func TestMetadataRetentionDropsRawAttributes(t *testing.T) {
 		t.Fatalf("attribute count missing: %#v", raw)
 	}
 }
+
+func TestHarnessNameSeparatesClaudeCodeAndCowork(t *testing.T) {
+	tests := []struct {
+		name  string
+		attrs map[string]interface{}
+		hints []string
+		want  string
+	}{
+		{
+			name:  "claude code log body",
+			attrs: map[string]interface{}{"service.name": "claude"},
+			hints: []string{"claude_code.api_request"},
+			want:  "claude_code",
+		},
+		{
+			name:  "claude code metric",
+			attrs: map[string]interface{}{"service.name": "claude-code"},
+			hints: []string{"claude_code.token.usage"},
+			want:  "claude_code",
+		},
+		{
+			name:  "claude cowork service",
+			attrs: map[string]interface{}{"service.name": "claude-cowork"},
+			want:  "claude_cowork",
+		},
+		{
+			name:  "codex service",
+			attrs: map[string]interface{}{"service.name": "codex-cli"},
+			want:  "codex_cli",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := harnessName(tt.attrs, tt.hints...); got != tt.want {
+				t.Fatalf("harnessName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `Harness.Name` is derived for logs/spans/metrics (including new hint-based inference), which can affect downstream routing/aggregation of telemetry. Logic is localized and covered by new unit tests, but misclassification would be user-visible in event labeling.
> 
> **Overview**
> Improves `Harness.Name` derivation in `beaconjsonexporter` by adding hint-based normalization and separating **Claude Code** vs **Claude Cowork** (while still respecting explicitly provided harness names).
> 
> Updates event construction for logs, spans, and metrics to pass message/span/metric-name hints into `harnessName`, and adds unit tests to lock in the expected mappings (e.g., `claude` + `claude_code.*` hint => `claude_code`, `claude-cowork` => `claude_cowork`, `codex*` => `codex_cli`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bff090ef718113494429f83371ddabb443252c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->