### PR TITLE
Local dashboard cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,12 @@ Uninstall:
 
 ## Release Readiness
 
-Production pilots should use versioned artifacts rather than asking users to
-build Beacon from source. A release should include the `beacon` CLI with a
-platform-matched embedded hook adapter, the `beacon-otelcol` collector
-distribution, Wazuh content, SHA-256 checksums, and concise notes covering
-supported runtimes, content-retention defaults, log paths, and uninstall
-behavior.
+Release builds should include the `beacon` CLI with a platform-matched embedded
+hook adapter, the `beacon-otelcol` collector distribution, Wazuh content,
+SHA-256 checksums, and concise notes covering supported runtimes,
+content-retention defaults, log paths, and uninstall behavior.
 
-For macOS pilots, ship a signed and notarized package or Homebrew formula that
+For macOS, publish a signed and notarized package or Homebrew formula that
 installs the CLI, collector, Wazuh content pack, and deployment scripts. The
 package should apply explicit endpoint settings, for example:
 
@@ -134,8 +132,8 @@ package should apply explicit endpoint settings, for example:
 beacon endpoint install --harness claude,codex --content-retention metadata
 ```
 
-Before handing a build to a security team, verify the release from a clean
-checkout and clean macOS host or VM:
+Before publishing a release, verify the build from a clean checkout and clean
+macOS host or VM:
 
 - `beacon version` reports the expected version, commit, and build date.
 - `beacon endpoint install --user --no-start` succeeds without developer
@@ -143,7 +141,9 @@ checkout and clean macOS host or VM:
 - `beacon endpoint status --user` reports config, collector, service, harness,
   diagnostic, and runtime log paths.
 - `beacon endpoint wazuh validate --user` writes a valid Beacon JSONL event.
-- `beacon endpoint dashboard --user` starts on `127.0.0.1`.
+- `beacon endpoint dashboard --user` starts on `127.0.0.1`, serves a read-only
+  dashboard, and can search local telemetry without external network
+  dependencies.
 - `beacon endpoint uninstall --user` removes managed service and config files.
 - macOS package signature and notarization are valid when distributing a `.pkg`.
 

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -27,8 +27,14 @@ make build
 ./beacon endpoint dashboard --user --open
 ```
 
-The dashboard is local-only, binds to loopback, and reads the configured
-runtime JSONL log.
+The dashboard reads the configured runtime JSONL log and serves a local,
+read-only view on loopback. It has no external network dependency during normal
+use.
+
+Use the search bar to find events by action, command, file path, MCP tool,
+approval decision, repository, session, or message. Quick filters surface
+high-severity events, failures, approvals, MCP activity, file changes, and events
+that may need review.
 
 ## Wazuh
 

--- a/cli/beacon/internal/endpoint/dashboard/events.go
+++ b/cli/beacon/internal/endpoint/dashboard/events.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,29 +20,43 @@ const (
 )
 
 type EventRecord struct {
-	ID     string          `json:"id"`
-	Line   int             `json:"line"`
-	Event  schema.Event    `json:"event"`
-	Raw    json.RawMessage `json:"raw"`
-	Parsed time.Time       `json:"parsed_timestamp,omitempty"`
+	ID         string          `json:"id"`
+	Line       int             `json:"line"`
+	Event      schema.Event    `json:"event"`
+	Raw        json.RawMessage `json:"-"`
+	Parsed     time.Time       `json:"parsed_timestamp,omitempty"`
+	WazuhLevel int             `json:"wazuh_level,omitempty"`
 }
 
 type EventQuery struct {
 	Limit      int
 	Since      time.Time
+	Q          string
 	Harness    string
 	Action     string
+	Severity   string
+	Category   string
 	Repository string
 	Session    string
 	File       string
 	Command    string
+	MCP        string
+	Approval   string
+	Decision   string
+	Policy     string
+	Review     string
+	WazuhLevel string
 }
 
 type EventResult struct {
-	Events         []EventRecord `json:"events"`
-	TotalMatched   int           `json:"total_matched"`
-	MalformedLines int           `json:"malformed_lines"`
-	Limit          int           `json:"limit"`
+	Events         []EventRecord     `json:"events"`
+	TotalMatched   int               `json:"total_matched"`
+	MalformedLines int               `json:"malformed_lines"`
+	Limit          int               `json:"limit"`
+	Query          string            `json:"query,omitempty"`
+	Filters        map[string]string `json:"filters,omitempty"`
+	Returned       int               `json:"returned"`
+	Truncated      bool              `json:"truncated"`
 }
 
 func ReadEvents(path string, query EventQuery) (EventResult, error) {
@@ -55,7 +70,7 @@ func ReadEvents(path string, query EventQuery) (EventResult, error) {
 	}
 	defer file.Close()
 
-	result := EventResult{Limit: limit}
+	result := EventResult{Limit: limit, Query: strings.TrimSpace(query.Q), Filters: activeFilters(query)}
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 
@@ -73,11 +88,12 @@ func ReadEvents(path string, query EventQuery) (EventResult, error) {
 		}
 		parsed, _ := time.Parse(time.RFC3339, event.Timestamp)
 		record := EventRecord{
-			ID:     fmt.Sprintf("line-%d", lineNo),
-			Line:   lineNo,
-			Event:  event,
-			Raw:    append(json.RawMessage(nil), line...),
-			Parsed: parsed,
+			ID:         fmt.Sprintf("line-%d", lineNo),
+			Line:       lineNo,
+			Event:      event,
+			Raw:        append(json.RawMessage(nil), line...),
+			Parsed:     parsed,
+			WazuhLevel: WazuhLevel(event.Event.Action),
 		}
 		if !matchesQuery(record, query) {
 			continue
@@ -96,18 +112,53 @@ func ReadEvents(path string, query EventQuery) (EventResult, error) {
 	sort.SliceStable(result.Events, func(i, j int) bool {
 		return result.Events[i].Line > result.Events[j].Line
 	})
+	result.Returned = len(result.Events)
+	result.Truncated = result.TotalMatched > len(result.Events)
 	return result, nil
 }
 
 func FindEvent(path, id string) (EventRecord, bool, error) {
-	result, err := ReadEvents(path, EventQuery{Limit: maxEventLimit})
+	lineNo, ok := parseLineID(id)
+	if !ok {
+		return EventRecord{}, false, nil
+	}
+	file, err := os.Open(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return EventRecord{}, false, nil
+		}
 		return EventRecord{}, false, err
 	}
-	for _, record := range result.Events {
-		if record.ID == id {
-			return record, true, nil
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	currentLine := 0
+	for scanner.Scan() {
+		currentLine++
+		if currentLine != lineNo {
+			continue
 		}
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			return EventRecord{}, false, nil
+		}
+		var event schema.Event
+		if err := json.Unmarshal(line, &event); err != nil {
+			return EventRecord{}, false, nil
+		}
+		parsed, _ := time.Parse(time.RFC3339, event.Timestamp)
+		return EventRecord{
+			ID:         id,
+			Line:       lineNo,
+			Event:      event,
+			Raw:        append(json.RawMessage(nil), line...),
+			Parsed:     parsed,
+			WazuhLevel: WazuhLevel(event.Event.Action),
+		}, true, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return EventRecord{}, false, err
 	}
 	return EventRecord{}, false, nil
 }
@@ -135,6 +186,12 @@ func matchesQuery(record EventRecord, query EventQuery) bool {
 	if query.Action != "" && !strings.EqualFold(event.Event.Action, query.Action) {
 		return false
 	}
+	if query.Severity != "" && !strings.EqualFold(string(event.Severity), query.Severity) {
+		return false
+	}
+	if query.Category != "" && !strings.EqualFold(event.Event.Category, query.Category) {
+		return false
+	}
 	if query.Repository != "" && !containsFold(event.Repository, query.Repository) {
 		return false
 	}
@@ -148,18 +205,215 @@ func matchesQuery(record EventRecord, query EventQuery) bool {
 			return false
 		}
 	}
-	if query.Command != "" {
-		if event.Command != nil && containsFold(event.Command.Command, query.Command) {
-			return true
+	if query.Command != "" && !matchesCommand(event, query.Command) {
+		return false
+	}
+	if query.MCP != "" {
+		if event.MCP == nil || (!containsFold(event.MCP.Server, query.MCP) && !containsFold(event.MCP.Tool, query.MCP)) {
+			return false
 		}
-		if event.Tool != nil && (containsFold(event.Tool.Name, query.Command) || containsFold(event.Tool.Command, query.Command)) {
-			return true
+	}
+	if query.Approval != "" {
+		if event.Approval == nil || (!containsFold(event.Approval.Decision, query.Approval) && !containsFold(event.Approval.Reason, query.Approval)) {
+			return false
 		}
+	}
+	if query.Decision != "" {
+		if !matchesDecision(event, query.Decision) {
+			return false
+		}
+	}
+	if query.Policy != "" {
+		if event.Policy == nil || (!containsFold(event.Policy.ID, query.Policy) && !containsFold(event.Policy.Name, query.Policy) && !containsFold(event.Policy.Decision, query.Policy) && !containsFold(event.Policy.Reason, query.Policy)) {
+			return false
+		}
+	}
+	if query.Review != "" && truthy(query.Review) && !isNeedsReview(record) {
+		return false
+	}
+	if query.WazuhLevel != "" && !strings.EqualFold(strconv.Itoa(record.WazuhLevel), query.WazuhLevel) {
+		return false
+	}
+	if query.Q != "" && !matchesFreeText(record, query.Q) {
 		return false
 	}
 	return true
 }
 
 func containsFold(value, needle string) bool {
-	return strings.Contains(strings.ToLower(value), strings.ToLower(needle))
+	return strings.Contains(strings.ToLower(value), strings.ToLower(strings.TrimSpace(needle)))
+}
+
+func matchesDecision(event schema.Event, decision string) bool {
+	if event.Approval != nil && containsFold(event.Approval.Decision, decision) {
+		return true
+	}
+	if event.Policy != nil && containsFold(event.Policy.Decision, decision) {
+		return true
+	}
+	return false
+}
+
+func matchesCommand(event schema.Event, command string) bool {
+	if event.Command != nil && containsFold(event.Command.Command, command) {
+		return true
+	}
+	if event.Tool != nil && (containsFold(event.Tool.Name, command) || containsFold(event.Tool.Command, command)) {
+		return true
+	}
+	return false
+}
+
+func matchesFreeText(record EventRecord, query string) bool {
+	haystack := strings.ToLower(strings.Join(searchFields(record), "\x00"))
+	for _, term := range strings.Fields(strings.ToLower(strings.TrimSpace(query))) {
+		if !strings.Contains(haystack, term) {
+			return false
+		}
+	}
+	return true
+}
+
+func searchFields(record EventRecord) []string {
+	event := record.Event
+	fields := []string{
+		record.ID,
+		strconv.Itoa(record.Line),
+		strconv.Itoa(record.WazuhLevel),
+		event.Timestamp,
+		event.Event.Kind,
+		event.Event.Action,
+		event.Event.Category,
+		string(event.Severity),
+		event.Endpoint.Hostname,
+		event.Endpoint.OS,
+		event.Endpoint.AgentVersion,
+		event.User.Name,
+		event.User.UID,
+		event.Harness.Name,
+		event.Harness.Version,
+		event.Harness.ExecutablePath,
+		event.Harness.ConfigPath,
+		event.Model,
+		event.Repository,
+		event.Branch,
+		event.Message,
+	}
+	if event.Session != nil {
+		fields = append(fields, event.Session.ID, event.Session.WorkingDirectory)
+	}
+	if event.Tool != nil {
+		fields = append(fields, event.Tool.Name, event.Tool.Command, event.Tool.Path)
+	}
+	if event.File != nil {
+		fields = append(fields, event.File.Path, event.File.Operation, event.File.Language, event.File.DiffHash, strconv.Itoa(event.File.DiffBytes))
+	}
+	if event.Command != nil {
+		fields = append(fields, event.Command.Command, strconv.FormatInt(event.Command.DurationMS, 10))
+		if event.Command.ExitCode != nil {
+			fields = append(fields, strconv.Itoa(*event.Command.ExitCode))
+		}
+	}
+	if event.MCP != nil {
+		fields = append(fields, event.MCP.Server, event.MCP.Tool)
+	}
+	if event.Approval != nil {
+		fields = append(fields, event.Approval.Decision, event.Approval.Reason)
+	}
+	if event.Policy != nil {
+		fields = append(fields, event.Policy.ID, event.Policy.Name, event.Policy.Decision, event.Policy.Enforcement, event.Policy.Reason)
+	}
+	if event.Content != nil {
+		fields = append(fields, event.Content.Retention)
+		if event.Content.Included {
+			fields = append(fields, "content included")
+		}
+		if event.Content.Redacted {
+			fields = append(fields, "redacted")
+		}
+		if event.Content.Truncated {
+			fields = append(fields, "truncated")
+		}
+	}
+	if event.Destination != nil {
+		fields = append(fields, event.Destination.Type, event.Destination.Mode, event.Destination.Status)
+	}
+	if event.Health != nil {
+		fields = append(fields, event.Health.Component, event.Health.Status, event.Health.Reason)
+	}
+	if event.Truncated {
+		fields = append(fields, "truncated")
+	}
+	return fields
+}
+
+func activeFilters(query EventQuery) map[string]string {
+	filters := map[string]string{}
+	add := func(key, value string) {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			filters[key] = value
+		}
+	}
+	add("harness", query.Harness)
+	add("action", query.Action)
+	add("severity", query.Severity)
+	add("category", query.Category)
+	add("repository", query.Repository)
+	add("session", query.Session)
+	add("file", query.File)
+	add("command", query.Command)
+	add("mcp", query.MCP)
+	add("approval", query.Approval)
+	add("decision", query.Decision)
+	add("policy", query.Policy)
+	add("review", query.Review)
+	add("wazuh_level", query.WazuhLevel)
+	if !query.Since.IsZero() {
+		filters["since"] = query.Since.Format(time.RFC3339)
+	}
+	if len(filters) == 0 {
+		return nil
+	}
+	return filters
+}
+
+func truthy(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "review", "needs_review":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseLineID(id string) (int, bool) {
+	line, ok := strings.CutPrefix(id, "line-")
+	if !ok {
+		return 0, false
+	}
+	lineNo, err := strconv.Atoi(line)
+	if err != nil || lineNo <= 0 {
+		return 0, false
+	}
+	return lineNo, true
+}
+
+func WazuhLevel(action string) int {
+	switch action {
+	case "endpoint.tamper_detected", "endpoint.health_failed":
+		return 12
+	case "approval.denied", "policy.blocked":
+		return 10
+	case "tool.failed":
+		return 9
+	case "command.executed", "mcp.tool_invoked":
+		return 7
+	case "telemetry.disabled", "telemetry.misconfigured", "prompt.submitted", "tool.invoked", "tool.completed", "file.read", "file.modified":
+		return 5
+	case "":
+		return 0
+	default:
+		return 3
+	}
 }

--- a/cli/beacon/internal/endpoint/dashboard/events_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/events_test.go
@@ -36,7 +36,7 @@ func TestReadEventsSkipsMalformedLinesAndFilters(t *testing.T) {
 
 func TestBuildSummaryAggregatesSignals(t *testing.T) {
 	result := EventResult{
-		TotalMatched: 2,
+		TotalMatched: 4,
 		Events: []EventRecord{
 			{Event: schema.Event{
 				Timestamp: "2026-05-13T01:00:00Z",
@@ -53,19 +53,159 @@ func TestBuildSummaryAggregatesSignals(t *testing.T) {
 				Harness:   schema.HarnessInfo{Name: "cursor"},
 				Session:   &schema.SessionInfo{ID: "s2"},
 				MCP:       &schema.MCPInfo{Server: "github", Tool: "get_issue"},
+			}, WazuhLevel: WazuhLevel("mcp.tool_invoked")},
+			{Event: schema.Event{
+				Timestamp: "2026-05-13T01:02:00Z",
+				Event:     schema.EventInfo{Action: "approval.denied", Category: "approval"},
+				Severity:  schema.SeverityMedium,
+				Harness:   schema.HarnessInfo{Name: "cursor"},
+				Session:   &schema.SessionInfo{ID: "s3"},
+				Approval:  &schema.ApprovalInfo{Decision: "denied"},
+			}, WazuhLevel: WazuhLevel("approval.denied")},
+			{Event: schema.Event{
+				Timestamp:  "2026-05-13T01:03:00Z",
+				Event:      schema.EventInfo{Action: "policy.blocked", Category: "approval"},
+				Severity:   schema.SeverityCritical,
+				Harness:    schema.HarnessInfo{Name: "cursor"},
+				Repository: "repo-a",
+				Policy:     &schema.PolicyInfo{Decision: "blocked", Name: "dangerous command"},
 			}},
 		},
 	}
 
 	summary := BuildSummary(result)
-	if summary.TotalEvents != 2 || summary.ActiveSessions != 2 {
-		t.Fatalf("summary totals = events %d sessions %d, want 2/2", summary.TotalEvents, summary.ActiveSessions)
+	if summary.TotalEvents != 4 || summary.ActiveSessions != 3 {
+		t.Fatalf("summary totals = events %d sessions %d, want 4/3", summary.TotalEvents, summary.ActiveSessions)
 	}
 	if summary.CommandEvents != 1 || summary.MCPEvents != 1 {
 		t.Fatalf("signal counts = command %d mcp %d, want 1/1", summary.CommandEvents, summary.MCPEvents)
 	}
-	if summary.CountsByHarness["cursor"] != 2 {
-		t.Fatalf("cursor harness count = %d, want 2", summary.CountsByHarness["cursor"])
+	if summary.CountsByHarness["cursor"] != 4 {
+		t.Fatalf("cursor harness count = %d, want 4", summary.CountsByHarness["cursor"])
+	}
+	if summary.NeedsReviewEvents != 3 || summary.DeniedApprovalEvents != 1 || summary.PolicyBlockedEvents != 1 {
+		t.Fatalf("review counts = needs %d denied %d blocked %d, want 3/1/1", summary.NeedsReviewEvents, summary.DeniedApprovalEvents, summary.PolicyBlockedEvents)
+	}
+}
+
+func TestReadEventsFreeTextSearchMatchesStructuredFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	events := []schema.Event{
+		testSchemaEvent("2026-05-13T01:00:00Z", "cursor", "command.executed", "command", "repo-a"),
+		testSchemaEvent("2026-05-13T01:01:00Z", "cursor", "file.modified", "file", "repo-b"),
+		testSchemaEvent("2026-05-13T01:02:00Z", "cursor", "mcp.tool_invoked", "mcp", "repo-c"),
+		testSchemaEvent("2026-05-13T01:03:00Z", "cursor", "approval.denied", "approval", "repo-d"),
+	}
+	events[0].Command = &schema.CommandInfo{Command: "go test ./internal/endpoint/dashboard"}
+	events[0].Session = &schema.SessionInfo{ID: "session-command"}
+	events[1].File = &schema.FileInfo{Path: "cmd/server.go", Operation: "write", Language: "go"}
+	events[2].MCP = &schema.MCPInfo{Server: "github", Tool: "get_issue"}
+	events[3].Approval = &schema.ApprovalInfo{Decision: "denied", Reason: "dangerous shell"}
+	events[3].Message = "approval blocked for review"
+	writeTestLog(t, path, marshalEvents(t, events...)...)
+
+	for _, query := range []string{"dashboard", "cmd/server.go", "github get_issue", "dangerous shell", "session-command", "repo-c", "blocked review"} {
+		result, err := ReadEvents(path, EventQuery{Q: query, Limit: 10})
+		if err != nil {
+			t.Fatalf("ReadEvents(%q) returned error: %v", query, err)
+		}
+		if result.TotalMatched != 1 {
+			t.Fatalf("ReadEvents(%q) matched %d events, want 1", query, result.TotalMatched)
+		}
+	}
+}
+
+func TestReadEventsSecurityFilters(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	events := []schema.Event{
+		testSchemaEvent("2026-05-13T01:00:00Z", "cursor", "command.executed", "command", "repo-a"),
+		testSchemaEvent("2026-05-13T01:01:00Z", "cursor", "mcp.tool_invoked", "mcp", "repo-b"),
+		testSchemaEvent("2026-05-13T01:02:00Z", "cursor", "approval.denied", "approval", "repo-c"),
+		testSchemaEvent("2026-05-13T01:03:00Z", "cursor", "policy.blocked", "approval", "repo-d"),
+	}
+	events[0].Severity = schema.SeverityHigh
+	events[1].MCP = &schema.MCPInfo{Server: "github", Tool: "get_issue"}
+	events[2].Approval = &schema.ApprovalInfo{Decision: "denied", Reason: "blocked command"}
+	events[3].Policy = &schema.PolicyInfo{Name: "shell guard", Decision: "blocked", Reason: "unsafe"}
+	writeTestLog(t, path, marshalEvents(t, events...)...)
+
+	cases := []struct {
+		name  string
+		query EventQuery
+		want  string
+	}{
+		{name: "severity", query: EventQuery{Severity: "high", Limit: 10}, want: "command.executed"},
+		{name: "category", query: EventQuery{Category: "mcp", Limit: 10}, want: "mcp.tool_invoked"},
+		{name: "mcp", query: EventQuery{MCP: "github", Limit: 10}, want: "mcp.tool_invoked"},
+		{name: "decision", query: EventQuery{Decision: "denied", Limit: 10}, want: "approval.denied"},
+		{name: "policy", query: EventQuery{Policy: "shell guard", Limit: 10}, want: "policy.blocked"},
+		{name: "wazuh", query: EventQuery{WazuhLevel: "10", Policy: "shell guard", Limit: 10}, want: "policy.blocked"},
+		{name: "review", query: EventQuery{Review: "true", Action: "tool.failed", Limit: 10}, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ReadEvents(path, tc.query)
+			if err != nil {
+				t.Fatalf("ReadEvents returned error: %v", err)
+			}
+			if tc.want == "" {
+				if result.TotalMatched != 0 {
+					t.Fatalf("matched %d events, want 0", result.TotalMatched)
+				}
+				return
+			}
+			if result.TotalMatched != 1 || result.Events[0].Event.Event.Action != tc.want {
+				t.Fatalf("matched %d action %q, want 1 %q", result.TotalMatched, result.Events[0].Event.Event.Action, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindEventCanReadOutsideTailWindow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	lines := make([][]byte, 0, maxEventLimit+1)
+	lines = append(lines, testEvent("2026-05-13T01:00:00Z", "cursor", "command.executed", "command", "repo-a"))
+	for i := 0; i < maxEventLimit; i++ {
+		lines = append(lines, testEvent("2026-05-13T01:01:00Z", "cursor", "file.modified", "file", "repo-b"))
+	}
+	writeTestLog(t, path, lines...)
+
+	record, ok, err := FindEvent(path, "line-1")
+	if err != nil {
+		t.Fatalf("FindEvent returned error: %v", err)
+	}
+	if !ok || record.Event.Event.Action != "command.executed" {
+		t.Fatalf("FindEvent returned ok=%t action=%q, want line-1 command.executed", ok, record.Event.Event.Action)
+	}
+}
+
+func TestHandlerEventEndpointOmitsRawAndSetsSecurityHeaders(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	writeTestLog(t, path, testEvent("2026-05-13T01:00:00Z", "cursor", "prompt.submitted", "prompt", "repo-a"))
+
+	handler, err := Handler(Options{LogPath: path, UserMode: true})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/event?id=line-1", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Security-Policy"); got == "" {
+		t.Fatal("Content-Security-Policy header missing")
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := response["raw"]; ok {
+		t.Fatal("event response unexpectedly included raw JSONL bytes")
 	}
 }
 
@@ -115,7 +255,13 @@ func writeTestLog(t *testing.T, path string, lines ...[]byte) {
 }
 
 func testEvent(ts, harness, action, category, repo string) []byte {
-	event := schema.Event{
+	event := testSchemaEvent(ts, harness, action, category, repo)
+	data, _ := json.Marshal(event)
+	return data
+}
+
+func testSchemaEvent(ts, harness, action, category, repo string) schema.Event {
+	return schema.Event{
 		Timestamp:     ts,
 		Vendor:        schema.Vendor,
 		Product:       schema.Product,
@@ -127,6 +273,17 @@ func testEvent(ts, harness, action, category, repo string) []byte {
 		Repository:    repo,
 		Message:       action,
 	}
-	data, _ := json.Marshal(event)
-	return data
+}
+
+func marshalEvents(t *testing.T, events ...schema.Event) [][]byte {
+	t.Helper()
+	lines := make([][]byte, 0, len(events))
+	for _, event := range events {
+		data, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("marshal event: %v", err)
+		}
+		lines = append(lines, data)
+	}
+	return lines
 }

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
@@ -114,7 +115,7 @@ func Handler(opts Options) (http.Handler, error) {
 		writeJSON(w, record)
 	})
 	mux.Handle("/", http.FileServer(http.FS(staticRoot)))
-	return mux, nil
+	return securityHeaders(mux), nil
 }
 
 func ListenAndServe(opts Options) error {
@@ -176,12 +177,21 @@ func parseQuery(r *http.Request, fallbackLimit int) EventQuery {
 	}
 	query := EventQuery{
 		Limit:      limit,
+		Q:          q.Get("q"),
 		Harness:    q.Get("harness"),
 		Action:     q.Get("action"),
+		Severity:   q.Get("severity"),
+		Category:   q.Get("category"),
 		Repository: q.Get("repository"),
 		Session:    q.Get("session"),
 		File:       q.Get("file"),
 		Command:    q.Get("command"),
+		MCP:        q.Get("mcp"),
+		Approval:   q.Get("approval"),
+		Decision:   q.Get("decision"),
+		Policy:     q.Get("policy"),
+		Review:     q.Get("review"),
+		WazuhLevel: q.Get("wazuh_level"),
 	}
 	if since := q.Get("since"); since != "" {
 		if parsed, err := time.Parse(time.RFC3339, since); err == nil {
@@ -204,4 +214,17 @@ func writeError(w http.ResponseWriter, status int, err error) {
 
 func methodNotAllowed(w http.ResponseWriter) {
 	writeError(w, http.StatusMethodNotAllowed, fmt.Errorf("method not allowed"))
+}
+
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("X-Frame-Options", "DENY")
+		if strings.HasPrefix(r.URL.Path, "/api/") {
+			w.Header().Set("Cache-Control", "no-store")
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/cli/beacon/internal/endpoint/dashboard/static/app.js
+++ b/cli/beacon/internal/endpoint/dashboard/static/app.js
@@ -2,14 +2,54 @@ const state = {
   status: null,
   summary: null,
   events: [],
+  eventResult: null,
+  loading: false,
+  error: null,
 };
 
 const $ = (selector) => document.querySelector(selector);
+const $$ = (selector) => Array.from(document.querySelectorAll(selector));
+const formFields = [
+  "q",
+  "harness",
+  "action",
+  "severity",
+  "category",
+  "repository",
+  "session",
+  "file",
+  "command",
+  "mcp",
+  "approval",
+  "decision",
+  "policy",
+  "wazuh_level",
+  "since",
+  "limit",
+  "review",
+];
+
+const presets = {
+  review: { review: "true", limit: "500" },
+  commands: { action: "command.executed", limit: "500" },
+  files: { action: "file.modified", limit: "500" },
+  mcp: { action: "mcp.tool_invoked", limit: "500" },
+  approvals: { category: "approval", limit: "500" },
+  failures: { action: "tool.failed", limit: "500" },
+  high: { severity: "high", limit: "500" },
+};
 
 async function getJSON(path) {
   const response = await fetch(path);
   if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
+    let message = `${response.status} ${response.statusText}`;
+    try {
+      const body = await response.json();
+      if (body.error) message = body.error;
+    } catch (_) {
+      // Keep the HTTP status when the body is not JSON.
+    }
+    throw new Error(message);
   }
   return response.json();
 }
@@ -18,29 +58,57 @@ function queryFromFilters() {
   const data = new FormData($("#filters"));
   const params = new URLSearchParams();
   for (const [key, value] of data.entries()) {
-    if (value) params.set(key, value);
+    const trimmed = String(value).trim();
+    if (trimmed) params.set(key, trimmed);
   }
   return params.toString();
 }
 
-async function load() {
+function hydrateFiltersFromURL() {
+  const params = new URLSearchParams(window.location.search);
+  for (const field of formFields) {
+    const input = $(`[name="${field}"]`);
+    if (!input) continue;
+    if (params.has(field)) input.value = params.get(field);
+  }
+}
+
+function updateURL(query) {
+  const next = query ? `${window.location.pathname}?${query}` : window.location.pathname;
+  window.history.replaceState(null, "", next);
+}
+
+async function load({ updateLocation = false } = {}) {
   const query = queryFromFilters();
+  if (updateLocation) updateURL(query);
   const suffix = query ? `?${query}` : "";
-  const [status, summary, events] = await Promise.all([
-    getJSON("/api/status"),
-    getJSON(`/api/summary${suffix}`),
-    getJSON(`/api/events${suffix}`),
-  ]);
-  state.status = status;
-  state.summary = summary;
-  state.events = events.events || [];
-  render();
+  state.loading = true;
+  state.error = null;
+  renderLoading();
+  try {
+    const [status, summary, events] = await Promise.all([
+      getJSON("/api/status"),
+      getJSON(`/api/summary${suffix}`),
+      getJSON(`/api/events${suffix}`),
+    ]);
+    state.status = status;
+    state.summary = summary;
+    state.eventResult = events;
+    state.events = events.events || [];
+  } catch (err) {
+    state.error = err;
+  } finally {
+    state.loading = false;
+    render();
+  }
 }
 
 function render() {
   $("#log-path").textContent = state.status?.log_path || "Runtime log unavailable";
   $("#retention").textContent = `retention: ${state.status?.content_retention || "metadata"}`;
   renderCards();
+  renderInsights();
+  renderSearchState();
   renderHarnesses();
   renderEvents();
 }
@@ -48,6 +116,10 @@ function render() {
 function renderCards() {
   const cards = [
     ["Events", state.summary?.total_events || 0],
+    ["Needs Review", state.summary?.needs_review_events || 0, "danger"],
+    ["High/Critical", (state.summary?.high_severity_events || 0) + (state.summary?.critical_severity_events || 0), "danger"],
+    ["Denied/Blocked", (state.summary?.denied_approval_events || 0) + (state.summary?.policy_blocked_events || 0), "danger"],
+    ["Failed Tools", state.summary?.failed_tool_events || 0, "warn"],
     ["Sessions", state.summary?.active_sessions || 0],
     ["Commands", state.summary?.command_events || 0],
     ["Files", state.summary?.file_events || 0],
@@ -56,8 +128,59 @@ function renderCards() {
     ["Malformed", state.summary?.malformed_lines || 0],
   ];
   $("#cards").innerHTML = cards
-    .map(([label, value]) => `<div class="card"><span class="muted">${escapeHTML(label)}</span><span class="value">${value}</span></div>`)
+    .map(([label, value, tone]) => `<div class="card ${tone ? `card-${tone}` : ""}"><span class="muted">${escapeHTML(label)}</span><span class="value">${value}</span></div>`)
     .join("");
+}
+
+function renderInsights() {
+  const sections = [
+    ["Top Actions", state.summary?.top_actions || []],
+    ["Top Repositories", state.summary?.top_repositories || []],
+    ["MCP Servers", state.summary?.top_mcp_servers || []],
+  ];
+  $("#insights").innerHTML = sections
+    .map(([title, values]) => `
+      <div class="panel insight">
+        <h2>${escapeHTML(title)}</h2>
+        <div class="stack">
+          ${values.length ? values.map((item) => `<button type="button" data-insight="${escapeHTML(title)}" data-value="${escapeHTML(item.name)}"><span>${escapeHTML(item.name)}</span><strong>${item.count}</strong></button>`).join("") : `<span class="muted">No data yet</span>`}
+        </div>
+      </div>
+    `)
+    .join("");
+  $$("[data-insight]").forEach((button) => {
+    button.addEventListener("click", () => applyInsight(button.dataset.insight, button.dataset.value));
+  });
+}
+
+function renderSearchState() {
+  const result = state.eventResult || {};
+  const returned = result.returned ?? state.events.length;
+  const total = result.total_matched ?? 0;
+  $("#result-meta").textContent = state.loading ? "Loading..." : `${returned} shown of ${total} matched`;
+
+  const notice = $("#notice");
+  if (state.error) {
+    notice.hidden = false;
+    notice.textContent = `Failed to load dashboard: ${state.error.message}`;
+  } else if (result.truncated) {
+    notice.hidden = false;
+    notice.textContent = `Showing the latest ${returned} matching events. Narrow the search or raise the limit to see more.`;
+  } else if (result.malformed_lines) {
+    notice.hidden = false;
+    notice.textContent = `${result.malformed_lines} malformed log line${result.malformed_lines === 1 ? "" : "s"} skipped.`;
+  } else {
+    notice.hidden = true;
+    notice.textContent = "";
+  }
+
+  const params = new URLSearchParams(queryFromFilters());
+  const chips = [];
+  for (const [key, value] of params.entries()) {
+    if (key === "limit") continue;
+    chips.push(`<span class="chip"><strong>${escapeHTML(labelForParam(key))}</strong>${escapeHTML(value)}</span>`);
+  }
+  $("#active-filters").innerHTML = chips.join("");
 }
 
 function renderHarnesses() {
@@ -75,20 +198,32 @@ function renderHarnesses() {
 }
 
 function renderEvents() {
+  if (state.loading) {
+    renderLoading();
+    return;
+  }
+  if (state.error) {
+    $("#events").innerHTML = `<tr><td colspan="8">Failed to load dashboard: ${escapeHTML(state.error.message)}</td></tr>`;
+    return;
+  }
+  if (!state.events.length) {
+    $("#events").innerHTML = `<tr><td colspan="8">No events match this search. Clear filters or broaden the query.</td></tr>`;
+    return;
+  }
   $("#events").innerHTML = state.events
     .map((record) => {
       const event = record.event || {};
       const info = event.event || {};
       const session = event.session || {};
-      const harness = event.harness || {};
       return `
         <tr data-id="${escapeHTML(record.id)}">
-          <td>${escapeHTML(event.timestamp || "")}</td>
-          <td>${escapeHTML(harness.name || "")}</td>
-          <td>${escapeHTML(info.action || "")}</td>
-          <td class="severity-${escapeHTML(event.severity || "")}">${escapeHTML(event.severity || "")}</td>
-          <td>${escapeHTML(session.id || "")}</td>
-          <td>${escapeHTML(event.repository || "")}</td>
+          <td class="nowrap">${escapeHTML(formatTime(event.timestamp))}</td>
+          <td>${signalCell(record)}</td>
+          <td>${escapeHTML(primaryArtifact(event))}</td>
+          <td>${badge(event.severity || "unknown", `severity-${event.severity || "unknown"}`)}</td>
+          <td>${reviewCell(record)}</td>
+          <td class="mono">${escapeHTML(session.id || "")}</td>
+          <td>${escapeHTML(repositoryLabel(event))}</td>
           <td>${escapeHTML(event.message || "")}</td>
         </tr>
       `;
@@ -101,6 +236,7 @@ function renderEvents() {
 
 async function showEvent(id) {
   const record = await getJSON(`/api/event?id=${encodeURIComponent(id)}`);
+  $("#event-summary").innerHTML = detailSummary(record);
   $("#event-json").textContent = JSON.stringify(record.event, null, 2);
   $("#drawer").classList.add("open");
   $("#drawer").setAttribute("aria-hidden", "false");
@@ -109,6 +245,85 @@ async function showEvent(id) {
 function closeDrawer() {
   $("#drawer").classList.remove("open");
   $("#drawer").setAttribute("aria-hidden", "true");
+}
+
+function renderLoading() {
+  $("#result-meta").textContent = "Loading...";
+  $("#events").innerHTML = `<tr><td colspan="8">Loading events...</td></tr>`;
+}
+
+function signalCell(record) {
+  const event = record.event || {};
+  const info = event.event || {};
+  const harness = event.harness || {};
+  const parts = [
+    `<strong>${escapeHTML(info.action || "unknown")}</strong>`,
+    `<span class="muted">${escapeHTML(info.category || "uncategorized")} · ${escapeHTML(harness.name || "unknown")}</span>`,
+    record.wazuh_level ? `<span class="muted">Wazuh level ${escapeHTML(record.wazuh_level)}</span>` : "",
+  ].filter(Boolean);
+  return parts.join("<br />");
+}
+
+function primaryArtifact(event) {
+  if (event.command?.command) return event.command.command;
+  if (event.file?.path) return `${event.file.operation || "file"} ${event.file.path}`;
+  if (event.mcp?.server || event.mcp?.tool) return [event.mcp.server, event.mcp.tool].filter(Boolean).join(" / ");
+  if (event.tool?.name || event.tool?.command) return [event.tool.name, event.tool.command].filter(Boolean).join(" ");
+  if (event.approval?.decision || event.approval?.reason) return [event.approval.decision, event.approval.reason].filter(Boolean).join(": ");
+  if (event.policy?.decision || event.policy?.name) return [event.policy.decision, event.policy.name].filter(Boolean).join(": ");
+  return event.model || event.branch || "";
+}
+
+function reviewCell(record) {
+  const event = record.event || {};
+  const labels = [];
+  if (event.severity === "critical" || event.severity === "high") labels.push(badge(event.severity, "badge-danger"));
+  if (record.wazuh_level >= 9) labels.push(badge(`L${record.wazuh_level}`, "badge-danger"));
+  if (event.event?.action === "tool.failed") labels.push(badge("failed", "badge-warn"));
+  if (event.event?.action === "policy.blocked") labels.push(badge("blocked", "badge-danger"));
+  if (event.event?.action === "approval.denied" || event.approval?.decision === "denied") labels.push(badge("denied", "badge-danger"));
+  if (event.content?.truncated || event.field_truncated) labels.push(badge("truncated", "badge-warn"));
+  if (event.content?.retention) labels.push(badge(event.content.retention, "badge-muted"));
+  return labels.join(" ") || badge("normal", "badge-muted");
+}
+
+function detailSummary(record) {
+  const event = record.event || {};
+  const info = event.event || {};
+  const rows = [
+    ["Action", info.action],
+    ["Category", info.category],
+    ["Severity", event.severity],
+    ["Wazuh level", record.wazuh_level || ""],
+    ["Session", event.session?.id],
+    ["Repository", repositoryLabel(event)],
+    ["Artifact", primaryArtifact(event)],
+    ["Approval", event.approval ? [event.approval.decision, event.approval.reason].filter(Boolean).join(": ") : ""],
+    ["Policy", event.policy ? [event.policy.decision, event.policy.name, event.policy.reason].filter(Boolean).join(": ") : ""],
+    ["Content", event.content ? `${event.content.retention}${event.content.redacted ? ", redacted" : ""}${event.content.truncated ? ", truncated" : ""}` : ""],
+  ].filter(([, value]) => value);
+  return rows
+    .map(([label, value]) => `<div><span class="muted">${escapeHTML(label)}</span><strong>${escapeHTML(value)}</strong></div>`)
+    .join("");
+}
+
+function repositoryLabel(event) {
+  return [event.repository, event.branch].filter(Boolean).join(" @ ");
+}
+
+function badge(value, className) {
+  return `<span class="badge ${escapeHTML(className)}">${escapeHTML(value)}</span>`;
+}
+
+function formatTime(timestamp) {
+  if (!timestamp) return "";
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) return timestamp;
+  return parsed.toLocaleString();
+}
+
+function labelForParam(key) {
+  return key.replaceAll("_", " ");
 }
 
 function escapeHTML(value) {
@@ -120,14 +335,45 @@ function escapeHTML(value) {
     .replaceAll("'", "&#039;");
 }
 
+function applyPreset(name) {
+  for (const field of formFields) {
+    const input = $(`[name="${field}"]`);
+    if (input) input.value = field === "limit" ? "500" : "";
+  }
+  const preset = presets[name] || {};
+  for (const [key, value] of Object.entries(preset)) {
+    const input = $(`[name="${key}"]`);
+    if (input) input.value = value;
+  }
+  load({ updateLocation: true }).catch(console.error);
+}
+
+function applyInsight(kind, value) {
+  const key = kind === "Top Actions" ? "action" : kind === "Top Repositories" ? "repository" : "mcp";
+  const input = $(`[name="${key}"]`);
+  if (input) input.value = value;
+  load({ updateLocation: true }).catch(console.error);
+}
+
+function clearSearch() {
+  for (const field of formFields) {
+    const input = $(`[name="${field}"]`);
+    if (input) input.value = field === "limit" ? "500" : "";
+  }
+  load({ updateLocation: true }).catch(console.error);
+}
+
 $("#refresh").addEventListener("click", () => load().catch(console.error));
 $("#filters").addEventListener("submit", (event) => {
   event.preventDefault();
-  load().catch(console.error);
+  load({ updateLocation: true }).catch(console.error);
 });
+$("#clear-search").addEventListener("click", clearSearch);
 $("#close-drawer").addEventListener("click", closeDrawer);
-
-load().catch((err) => {
-  $("#events").innerHTML = `<tr><td colspan="7">Failed to load dashboard: ${escapeHTML(err.message)}</td></tr>`;
+$$("[data-preset]").forEach((button) => {
+  button.addEventListener("click", () => applyPreset(button.dataset.preset));
 });
+
+hydrateFiltersFromURL();
+load().catch(console.error);
 setInterval(() => load().catch(console.error), 10000);

--- a/cli/beacon/internal/endpoint/dashboard/static/index.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/index.html
@@ -26,35 +26,94 @@
 
       <section class="cards" id="cards"></section>
 
+      <section class="insights" id="insights"></section>
+
       <section class="panel">
         <div class="section-head">
           <div>
-            <h2>Activity Timeline</h2>
-            <p class="muted">Prompt, tool, command, MCP, approval, and file events from the local JSONL log.</p>
+            <h2>Investigation Search</h2>
+            <p class="muted">Search actions, commands, files, MCP tools, approvals, sessions, repositories, and event messages.</p>
           </div>
+          <div id="result-meta" class="muted"></div>
         </div>
-        <form id="filters" class="filters">
-          <input name="harness" placeholder="Harness" />
-          <input name="action" placeholder="Action" />
-          <input name="repository" placeholder="Repository" />
-          <input name="session" placeholder="Session" />
-          <input name="file" placeholder="File path" />
-          <input name="command" placeholder="Command or tool" />
-          <select name="limit">
-            <option value="100">100 events</option>
-            <option value="500" selected>500 events</option>
-            <option value="1000">1000 events</option>
-          </select>
-          <button type="submit">Apply</button>
+        <form id="filters" class="search-form">
+          <div class="search-row">
+            <input class="search-input" name="q" placeholder="Search session, command, file path, MCP tool, approval reason, repository, or action" autocomplete="off" />
+            <button type="submit">Search</button>
+            <button type="button" id="clear-search">Clear</button>
+          </div>
+          <div class="quick-filters" aria-label="Quick filters">
+            <button type="button" data-preset="review">Needs Review</button>
+            <button type="button" data-preset="commands">Commands</button>
+            <button type="button" data-preset="files">File Changes</button>
+            <button type="button" data-preset="mcp">MCP</button>
+            <button type="button" data-preset="approvals">Approvals</button>
+            <button type="button" data-preset="failures">Failures</button>
+            <button type="button" data-preset="high">High Severity</button>
+          </div>
+          <details class="advanced-filters">
+            <summary>Advanced filters</summary>
+            <div class="filters">
+              <input name="harness" placeholder="Harness" />
+              <input name="action" placeholder="Action" />
+              <select name="severity">
+                <option value="">Any severity</option>
+                <option value="info">Info</option>
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="critical">Critical</option>
+              </select>
+              <select name="category">
+                <option value="">Any category</option>
+                <option value="prompt">Prompt</option>
+                <option value="tool">Tool</option>
+                <option value="command">Command</option>
+                <option value="file">File</option>
+                <option value="mcp">MCP</option>
+                <option value="approval">Approval</option>
+                <option value="session">Session</option>
+                <option value="inventory">Inventory</option>
+                <option value="validation">Validation</option>
+              </select>
+              <input name="repository" placeholder="Repository" />
+              <input name="session" placeholder="Session" />
+              <input name="file" placeholder="File path" />
+              <input name="command" placeholder="Command or tool" />
+              <input name="mcp" placeholder="MCP server or tool" />
+              <input name="approval" placeholder="Approval decision or reason" />
+              <input name="decision" placeholder="Approval/policy decision" />
+              <input name="policy" placeholder="Policy id, name, or reason" />
+              <select name="wazuh_level">
+                <option value="">Any Wazuh level</option>
+                <option value="5">Level 5 workflow</option>
+                <option value="7">Level 7 command/MCP</option>
+                <option value="9">Level 9 failure</option>
+                <option value="10">Level 10 block/denial</option>
+                <option value="12">Level 12 health/tamper</option>
+              </select>
+              <input name="since" placeholder="Since RFC3339, e.g. 2026-05-13T12:00:00Z" />
+              <select name="limit">
+                <option value="100">100 events</option>
+                <option value="500" selected>500 events</option>
+                <option value="1000">1000 events</option>
+                <option value="2000">2000 events</option>
+              </select>
+            </div>
+          </details>
+          <input type="hidden" name="review" />
         </form>
+        <div id="active-filters" class="chips"></div>
+        <div id="notice" class="notice" hidden></div>
         <div class="table-wrap">
           <table>
             <thead>
               <tr>
                 <th>Time</th>
-                <th>Harness</th>
-                <th>Action</th>
+                <th>Signal</th>
+                <th>Artifact</th>
                 <th>Severity</th>
+                <th>Review</th>
                 <th>Session</th>
                 <th>Repository</th>
                 <th>Message</th>
@@ -76,6 +135,7 @@
         <h2>Event Detail</h2>
         <button id="close-drawer">Close</button>
       </div>
+      <div id="event-summary" class="event-summary"></div>
       <pre id="event-json"></pre>
     </aside>
 

--- a/cli/beacon/internal/endpoint/dashboard/static/styles.css
+++ b/cli/beacon/internal/endpoint/dashboard/static/styles.css
@@ -9,6 +9,7 @@
   --accent: #7dd3fc;
   --danger: #fca5a5;
   --warn: #fcd34d;
+  --ok: #86efac;
 }
 
 * {
@@ -104,11 +105,48 @@ main {
   gap: 1rem;
 }
 
+.insights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.insight {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.stack {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.stack button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  text-align: left;
+}
+
+.stack span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .card .value {
   display: block;
   font-size: 1.8rem;
   font-weight: 700;
   margin-top: 0.35rem;
+}
+
+.card-danger {
+  border-color: rgba(252, 165, 165, 0.55);
+}
+
+.card-warn {
+  border-color: rgba(252, 211, 77, 0.55);
 }
 
 .pill {
@@ -122,11 +160,77 @@ main {
   white-space: nowrap;
 }
 
+.search-form {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.search-row {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) auto auto;
+  gap: 0.75rem;
+}
+
+.search-input {
+  width: 100%;
+}
+
+.quick-filters,
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.quick-filters button {
+  padding: 0.45rem 0.65rem;
+}
+
+.advanced-filters {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: rgba(31, 41, 55, 0.45);
+}
+
+.advanced-filters summary {
+  cursor: pointer;
+  color: var(--accent);
+}
+
 .filters {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 0.75rem;
-  margin: 1rem 0;
+  margin-top: 0.75rem;
+}
+
+.chip,
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.25rem 0.55rem;
+  background: var(--panel-soft);
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.chip strong {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.notice {
+  border: 1px solid var(--warn);
+  border-radius: 12px;
+  color: var(--warn);
+  background: rgba(252, 211, 77, 0.08);
+  padding: 0.75rem;
+  margin-bottom: 1rem;
 }
 
 .table-wrap {
@@ -147,6 +251,14 @@ td {
   font-size: 0.9rem;
 }
 
+.nowrap {
+  white-space: nowrap;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+
 th {
   color: var(--muted);
   font-weight: 600;
@@ -161,12 +273,20 @@ tr:hover {
 }
 
 .severity-high,
-.severity-critical {
+.severity-critical,
+.badge-danger {
   color: var(--danger);
 }
 
-.severity-medium {
+.severity-medium,
+.badge-warn {
   color: var(--warn);
+}
+
+.severity-info,
+.severity-low,
+.badge-muted {
+  color: var(--muted);
 }
 
 .harnesses {
@@ -210,6 +330,24 @@ tr:hover {
   border-bottom: 1px solid var(--line);
 }
 
+.event-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.event-summary div {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.event-summary strong {
+  overflow-wrap: anywhere;
+}
+
 pre {
   margin: 0;
   padding: 1rem;
@@ -217,4 +355,21 @@ pre {
   white-space: pre-wrap;
   word-break: break-word;
   font-size: 0.85rem;
+}
+
+@media (max-width: 760px) {
+  .topbar,
+  .status-panel,
+  .section-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .search-row {
+    grid-template-columns: 1fr;
+  }
+
+  main {
+    padding: 1rem;
+  }
 }

--- a/cli/beacon/internal/endpoint/dashboard/summary.go
+++ b/cli/beacon/internal/endpoint/dashboard/summary.go
@@ -1,28 +1,52 @@
 package dashboard
 
+import "sort"
+
+type Count struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
 type Summary struct {
-	TotalEvents      int            `json:"total_events"`
-	LastEventTime    string         `json:"last_event_time,omitempty"`
-	ActiveSessions   int            `json:"active_sessions"`
-	MalformedLines   int            `json:"malformed_lines"`
-	CountsByAction   map[string]int `json:"counts_by_action"`
-	CountsByHarness  map[string]int `json:"counts_by_harness"`
-	CountsBySeverity map[string]int `json:"counts_by_severity"`
-	PromptEvents     int            `json:"prompt_events"`
-	ToolEvents       int            `json:"tool_events"`
-	CommandEvents    int            `json:"command_events"`
-	FileEvents       int            `json:"file_events"`
-	MCPEvents        int            `json:"mcp_events"`
-	ApprovalEvents   int            `json:"approval_events"`
+	TotalEvents              int            `json:"total_events"`
+	LastEventTime            string         `json:"last_event_time,omitempty"`
+	ActiveSessions           int            `json:"active_sessions"`
+	MalformedLines           int            `json:"malformed_lines"`
+	CountsByAction           map[string]int `json:"counts_by_action"`
+	CountsByHarness          map[string]int `json:"counts_by_harness"`
+	CountsBySeverity         map[string]int `json:"counts_by_severity"`
+	CountsByCategory         map[string]int `json:"counts_by_category"`
+	CountsByApprovalDecision map[string]int `json:"counts_by_approval_decision"`
+	CountsByMCPServer        map[string]int `json:"counts_by_mcp_server"`
+	CountsByRepository       map[string]int `json:"counts_by_repository"`
+	PromptEvents             int            `json:"prompt_events"`
+	ToolEvents               int            `json:"tool_events"`
+	CommandEvents            int            `json:"command_events"`
+	FileEvents               int            `json:"file_events"`
+	MCPEvents                int            `json:"mcp_events"`
+	ApprovalEvents           int            `json:"approval_events"`
+	HighSeverityEvents       int            `json:"high_severity_events"`
+	CriticalSeverityEvents   int            `json:"critical_severity_events"`
+	NeedsReviewEvents        int            `json:"needs_review_events"`
+	FailedToolEvents         int            `json:"failed_tool_events"`
+	DeniedApprovalEvents     int            `json:"denied_approval_events"`
+	PolicyBlockedEvents      int            `json:"policy_blocked_events"`
+	TopActions               []Count        `json:"top_actions"`
+	TopRepositories          []Count        `json:"top_repositories"`
+	TopMCPServers            []Count        `json:"top_mcp_servers"`
 }
 
 func BuildSummary(result EventResult) Summary {
 	summary := Summary{
-		TotalEvents:      result.TotalMatched,
-		MalformedLines:   result.MalformedLines,
-		CountsByAction:   map[string]int{},
-		CountsByHarness:  map[string]int{},
-		CountsBySeverity: map[string]int{},
+		TotalEvents:              result.TotalMatched,
+		MalformedLines:           result.MalformedLines,
+		CountsByAction:           map[string]int{},
+		CountsByHarness:          map[string]int{},
+		CountsBySeverity:         map[string]int{},
+		CountsByCategory:         map[string]int{},
+		CountsByApprovalDecision: map[string]int{},
+		CountsByMCPServer:        map[string]int{},
+		CountsByRepository:       map[string]int{},
 	}
 	sessions := map[string]bool{}
 	for _, record := range result.Events {
@@ -33,6 +57,9 @@ func BuildSummary(result EventResult) Summary {
 		if event.Event.Action != "" {
 			summary.CountsByAction[event.Event.Action]++
 		}
+		if event.Event.Category != "" {
+			summary.CountsByCategory[event.Event.Category]++
+		}
 		if event.Harness.Name != "" {
 			summary.CountsByHarness[event.Harness.Name]++
 		}
@@ -41,6 +68,15 @@ func BuildSummary(result EventResult) Summary {
 		}
 		if event.Session != nil && event.Session.ID != "" {
 			sessions[event.Session.ID] = true
+		}
+		if event.Repository != "" {
+			summary.CountsByRepository[event.Repository]++
+		}
+		if event.MCP != nil && event.MCP.Server != "" {
+			summary.CountsByMCPServer[event.MCP.Server]++
+		}
+		if event.Approval != nil && event.Approval.Decision != "" {
+			summary.CountsByApprovalDecision[event.Approval.Decision]++
 		}
 		promptEvent := event.Event.Category == "prompt"
 		commandEvent := event.Event.Category == "command" || event.Command != nil
@@ -68,7 +104,63 @@ func BuildSummary(result EventResult) Summary {
 		if approvalEvent {
 			summary.ApprovalEvents++
 		}
+		switch event.Severity {
+		case "high":
+			summary.HighSeverityEvents++
+		case "critical":
+			summary.CriticalSeverityEvents++
+		}
+		if event.Event.Action == "tool.failed" {
+			summary.FailedToolEvents++
+		}
+		if event.Event.Action == "policy.blocked" {
+			summary.PolicyBlockedEvents++
+		}
+		if event.Event.Action == "approval.denied" || (event.Approval != nil && event.Approval.Decision == "denied") {
+			summary.DeniedApprovalEvents++
+		}
+		if isNeedsReview(record) {
+			summary.NeedsReviewEvents++
+		}
 	}
 	summary.ActiveSessions = len(sessions)
+	summary.TopActions = topCounts(summary.CountsByAction, 5)
+	summary.TopRepositories = topCounts(summary.CountsByRepository, 5)
+	summary.TopMCPServers = topCounts(summary.CountsByMCPServer, 5)
 	return summary
+}
+
+func isNeedsReview(record EventRecord) bool {
+	event := record.Event
+	if event.Severity == "high" || event.Severity == "critical" {
+		return true
+	}
+	switch event.Event.Action {
+	case "approval.denied", "policy.blocked", "tool.failed", "endpoint.tamper_detected", "endpoint.health_failed":
+		return true
+	}
+	if event.Approval != nil && event.Approval.Decision == "denied" {
+		return true
+	}
+	if record.WazuhLevel >= 9 {
+		return true
+	}
+	return false
+}
+
+func topCounts(counts map[string]int, limit int) []Count {
+	values := make([]Count, 0, len(counts))
+	for name, count := range counts {
+		values = append(values, Count{Name: name, Count: count})
+	}
+	sort.Slice(values, func(i, j int) bool {
+		if values[i].Count == values[j].Count {
+			return values[i].Name < values[j].Name
+		}
+		return values[i].Count > values[j].Count
+	})
+	if len(values) > limit {
+		values = values[:limit]
+	}
+	return values
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk due to new query/filtering logic and changed API response shapes for the dashboard, which could affect search correctness and performance on large logs. Also adds HTTP security headers and changes event lookup behavior, requiring careful review of client/server compatibility.
> 
> **Overview**
> The local dashboard UI is revamped into an investigation-focused search experience with free-text query (`q`), quick presets, advanced filters (severity/category/MCP/approval/policy/Wazuh level/since), active filter chips, truncation/malformed notices, and a richer event table + detail drawer summary.
> 
> Backend event APIs now support the expanded query model, compute `wazuh_level`, omit `raw` JSONL bytes from responses, return additional result metadata (`returned`, `truncated`, `filters`), and make `FindEvent` read a specific log line (instead of relying on the tail window). Summary generation is expanded with *needs review* heuristics, additional counts/top lists (actions/repos/MCP servers), and the dashboard server adds strict security headers (CSP, nosniff, no-referrer, frame deny; `no-store` for `/api/*`).
> 
> Docs are updated to clarify the dashboard is read-only, loopback-only, and usable without external network dependencies, with guidance for searching local telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730623fc2847c9c9548729eaca171d4cc5cce2d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->