### PR TITLE
Add cowork integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,14 @@ Optional integrations:
 
 ```bash
 ./beacon endpoint hooks install --harness cursor --user
-./beacon endpoint integrations claude-cowork print-config --user
+./beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --user --open
+./beacon endpoint integrations claude-cowork setup --ngrok --user --open
 ```
+
+Claude Cowork OpenTelemetry export is configured in the Claude admin console and
+requires a Team/Enterprise admin. Use `--endpoint` for a durable public HTTPS
+Collector endpoint. Use `--ngrok` only for a temporary authenticated local test
+tunnel to Beacon's local OTLP HTTP receiver.
 
 Run the local dashboard:
 
@@ -105,7 +111,7 @@ Uninstall:
 - `beacon endpoint discover`: list supported local AI runtimes.
 - `beacon endpoint dashboard`: run a localhost-only dashboard over the runtime JSONL log.
 - `beacon endpoint hooks`: install, check, or remove hook-based integrations such as Cursor.
-- `beacon endpoint integrations claude-cowork`: print setup and validate admin-configured Cowork OTLP export.
+- `beacon endpoint integrations claude-cowork`: set up and validate admin-configured Cowork OTLP export.
 - `beacon endpoint wazuh`: print/install Wazuh content and write a validation event.
 - `beacon endpoint uninstall`: stop services and remove managed endpoint files.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,21 @@ Beacon is visibility-first. The current public build focuses on observing local
 agent runtime activity, normalizing it into endpoint events, and leaving
 forwarding to existing localfile/Wazuh or customer-managed pipelines.
 
-## What It Captures
+## Table Of Contents
+
+- [What Beacon Does](#what-beacon-does)
+- [Privacy And Retention](#privacy-and-retention)
+- [What Beacon Does Not Do](#what-beacon-does-not-do)
+- [Quick Start](#quick-start)
+- [Optional Integrations](#optional-integrations)
+- [Claude Cowork Durable Collector](#claude-cowork-durable-collector)
+- [Dashboard](#dashboard)
+- [Command Reference](#command-reference)
+- [Repository Layout](#repository-layout)
+- [Release Readiness](#release-readiness)
+- [Testing](#testing)
+
+## What Beacon Does
 
 Beacon can currently:
 
@@ -28,6 +42,8 @@ Beacon can currently:
   timelines, filters, and event details from the JSONL log.
 - Generate Wazuh localfile/rule content for the Beacon event schema.
 
+## Privacy And Retention
+
 Beacon records metadata by default. Content retention is configurable with:
 
 - `metadata`: default; no prompt text, raw attributes, command output, or raw
@@ -37,6 +53,8 @@ Beacon records metadata by default. Content retention is configurable with:
 - `full`: include configured content fields in local/customer-controlled logs,
   still subject to event size limits.
 
+## What Beacon Does Not Do
+
 Beacon does not currently provide kernel/process monitoring, shell history
 collection, cloud audit ingestion, browser/SaaS telemetry, credential-use
 attribution, MCP configuration inventory, or direct Datadog/Splunk/Elastic/etc.
@@ -44,51 +62,97 @@ exporters.
 
 ## Quick Start
 
-Build the CLI:
+### Build The CLI
 
 ```bash
 cd cli/beacon
 make build
 ```
 
-Install in user mode:
+### Install In User Mode
 
 ```bash
 ./beacon endpoint install --user
 ./beacon endpoint status
 ```
 
-Install with explicit content retention:
+### Set Content Retention
 
 ```bash
 ./beacon endpoint install --user --content-retention metadata
 ```
 
-Print Wazuh config and validate event output:
+### Configure Wazuh Output
 
 ```bash
 ./beacon endpoint wazuh print-config --user
 ./beacon endpoint wazuh validate --user
 ```
 
-Run the macOS endpoint smoke test:
+### Run The macOS Smoke Test
 
 ```bash
 sh packaging/macos/smoke-endpoint.sh
 ```
 
-Optional integrations:
+## Optional Integrations
+
+### Cursor Hooks
 
 ```bash
 ./beacon endpoint hooks install --harness cursor --user
+```
+
+### Claude Cowork
+
+Claude Cowork OpenTelemetry export is configured in the Claude admin console and
+requires a Team/Enterprise admin.
+
+```bash
 ./beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --user --open
+./beacon endpoint integrations claude-cowork validate --user --since 10m
+```
+
+For local testing only, Beacon can create a temporary authenticated ngrok tunnel
+to the local OTLP HTTP receiver:
+
+```bash
 ./beacon endpoint integrations claude-cowork setup --ngrok --user --open
 ```
 
-Claude Cowork OpenTelemetry export is configured in the Claude admin console and
-requires a Team/Enterprise admin. Use `--endpoint` for a durable public HTTPS
-Collector endpoint. Use `--ngrok` only for a temporary authenticated local test
-tunnel to Beacon's local OTLP HTTP receiver.
+## Claude Cowork Durable Collector
+
+Claude Cowork exports telemetry from Anthropic's service, so the OTLP endpoint
+must be reachable from the public internet. Do not use `127.0.0.1`, a laptop, or
+an ngrok URL for production monitoring.
+
+For ongoing use, run a customer-managed HTTPS OpenTelemetry Collector endpoint:
+
+```text
+https://otel.example.com
+```
+
+Configure Claude Cowork with:
+
+- `OTLP endpoint`: `https://otel.example.com`
+- `OTLP protocol`: `HTTP/protobuf`
+- `OTLP headers`: `Authorization=Bearer <customer-generated-token>`
+- `Resource attributes`: `deployment.environment=prod,service.name=claude-cowork`
+
+Recommended production shape:
+
+- Use a real DNS name with TLS, such as `https://otel.company.com`.
+- Require authentication at the public edge, commonly with an
+  `Authorization=Bearer ...` header.
+- Terminate TLS at a hardened reverse proxy or load balancer, then forward OTLP
+  HTTP paths such as `/v1/logs`, `/v1/metrics`, and `/v1/traces` to the
+  Collector's local `4318` receiver.
+- Treat Cowork telemetry as sensitive. Prompt text, tool parameters, file paths,
+  user email addresses, model usage, and errors may be present before Beacon
+  redaction/export.
+- Use `--ngrok` only for demos, validation, or local development.
+
+## Dashboard
 
 Run the local dashboard:
 
@@ -97,13 +161,10 @@ Run the local dashboard:
 ./beacon endpoint dashboard --user --open
 ```
 
-Uninstall:
+The dashboard binds to loopback by default and reads the local runtime JSONL log.
+It is intended for local inspection, not remote administration.
 
-```bash
-./beacon endpoint uninstall --user --keep-logs
-```
-
-## Commands
+## Command Reference
 
 - `beacon endpoint install`: configure the endpoint agent, Collector service, and Claude/Codex telemetry.
 - `beacon endpoint repair`: reapply service/config files and repair telemetry drift.
@@ -114,6 +175,12 @@ Uninstall:
 - `beacon endpoint integrations claude-cowork`: set up and validate admin-configured Cowork OTLP export.
 - `beacon endpoint wazuh`: print/install Wazuh content and write a validation event.
 - `beacon endpoint uninstall`: stop services and remove managed endpoint files.
+
+Uninstall while keeping logs:
+
+```bash
+./beacon endpoint uninstall --user --keep-logs
+```
 
 ## Repository Layout
 
@@ -164,7 +231,7 @@ install with `--no-start`, validates status and Wazuh output, checks Cursor hook
 install/status, uninstalls, and preserves the runtime log long enough to assert
 expected events were written. The script skips automatically on non-macOS hosts.
 
-## Test
+## Testing
 
 ```bash
 cd cli/beacon

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -50,9 +50,16 @@ that may need review.
 ./beacon endpoint hooks install --harness cursor --user
 ./beacon endpoint hooks status --harness cursor --user
 
-./beacon endpoint integrations claude-cowork print-config --user
-./beacon endpoint integrations claude-cowork validate --user
+./beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --user --open
+./beacon endpoint integrations claude-cowork setup --ngrok --user --open
+./beacon endpoint integrations claude-cowork validate --user --since 10m
 ```
+
+Claude Cowork monitoring is configured in the Claude admin console at
+`https://claude.ai/admin-settings/cowork`. The OTLP endpoint must be reachable
+by Claude Cowork, so use a durable public HTTPS Collector endpoint for ongoing
+monitoring. The `--ngrok` mode is for short-lived local testing and prints an
+authenticated tunnel URL plus the matching `Authorization` header.
 
 ## Test
 

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -21,23 +21,28 @@ import (
 )
 
 var endpointOpts struct {
-	userMode         bool
-	logPath          string
-	harnesses        string
-	hookHarnesses    string
-	outputDir        string
-	jsonOutput       bool
-	grpcPort         int
-	httpPort         int
-	collectorPath    string
-	keepLogs         bool
-	keepConfig       bool
-	noStart          bool
-	coworkHeaders    string
-	hookLevel        string
-	contentRetention string
-	dashboardAddr    string
-	dashboardOpen    bool
+	userMode                 bool
+	logPath                  string
+	harnesses                string
+	hookHarnesses            string
+	outputDir                string
+	jsonOutput               bool
+	grpcPort                 int
+	httpPort                 int
+	collectorPath            string
+	keepLogs                 bool
+	keepConfig               bool
+	noStart                  bool
+	coworkHeaders            string
+	coworkEndpoint           string
+	coworkResourceAttributes string
+	coworkNgrok              bool
+	coworkOpen               bool
+	coworkSince              string
+	hookLevel                string
+	contentRetention         string
+	dashboardAddr            string
+	dashboardOpen            bool
 }
 
 var endpointCmd = &cobra.Command{
@@ -135,11 +140,25 @@ var endpointCoworkPrintConfigCmd = &cobra.Command{
 	Short: "Print Claude Cowork OTLP setup guidance",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := loadOrDefaultConfig()
+		endpoint := endpointOpts.coworkEndpoint
+		if endpoint == "" {
+			endpoint = fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort)
+		}
 		fmt.Print(cowork.PrintConfig(cowork.Config{
-			Endpoint: fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort),
-			Protocol: "HTTP/protobuf",
-			Headers:  endpointOpts.coworkHeaders,
+			Endpoint:           endpoint,
+			Protocol:           "HTTP/protobuf",
+			Headers:            endpointOpts.coworkHeaders,
+			ResourceAttributes: endpointOpts.coworkResourceAttributes,
 		}))
+	},
+}
+
+var endpointCoworkSetupCmd = &cobra.Command{
+	Use:          "setup",
+	Short:        "Print or create Claude Cowork OTLP admin settings",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runEndpointCoworkSetup(cmd.Context())
 	},
 }
 
@@ -153,7 +172,11 @@ var endpointCoworkStatusCmd = &cobra.Command{
 			_ = json.NewEncoder(os.Stdout).Encode(status)
 			return
 		}
-		fmt.Printf("%s: detected=%t observed=%t\n", status.DisplayName, status.Detected, status.LastEventObserved)
+		fmt.Printf("%s: detected=%t observed=%t", status.DisplayName, status.Detected, status.LastEventObserved)
+		if status.LastEventObservedAt != "" {
+			fmt.Printf(" last=%s", status.LastEventObservedAt)
+		}
+		fmt.Println()
 		fmt.Println(status.Message)
 	},
 }
@@ -162,20 +185,7 @@ var endpointCoworkValidateCmd = &cobra.Command{
 	Use:          "validate",
 	Short:        "Validate whether Claude Cowork events are arriving",
 	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg := loadOrDefaultConfig()
-		status := cowork.GetStatus(cfg.LogPath)
-		if !status.LastEventObserved {
-			fmt.Print(cowork.PrintConfig(cowork.Config{
-				Endpoint: fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort),
-				Protocol: "HTTP/protobuf",
-				Headers:  endpointOpts.coworkHeaders,
-			}))
-			return fmt.Errorf("no Claude Cowork events observed in %s", cfg.LogPath)
-		}
-		fmt.Println("Claude Cowork events observed in endpoint runtime log.")
-		return nil
-	},
+	RunE:         func(cmd *cobra.Command, args []string) error { return runEndpointCoworkValidate() },
 }
 
 var endpointWazuhPrintConfigCmd = &cobra.Command{
@@ -231,6 +241,7 @@ func init() {
 	endpointHooksCmd.AddCommand(endpointHooksUninstallCmd)
 	endpointHooksCmd.AddCommand(endpointHooksStatusCmd)
 	endpointCoworkCmd.AddCommand(endpointCoworkPrintConfigCmd)
+	endpointCoworkCmd.AddCommand(endpointCoworkSetupCmd)
 	endpointCoworkCmd.AddCommand(endpointCoworkStatusCmd)
 	endpointCoworkCmd.AddCommand(endpointCoworkValidateCmd)
 
@@ -264,12 +275,22 @@ func init() {
 	endpointWazuhInstallPackCmd.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
 	endpointWazuhValidateCmd.Flags().BoolVar(&endpointOpts.userMode, "user", false, "Use per-user endpoint paths instead of system paths")
 	endpointWazuhValidateCmd.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
-	for _, c := range []*cobra.Command{endpointCoworkPrintConfigCmd, endpointCoworkStatusCmd, endpointCoworkValidateCmd} {
+	for _, c := range []*cobra.Command{endpointCoworkPrintConfigCmd, endpointCoworkSetupCmd, endpointCoworkStatusCmd, endpointCoworkValidateCmd} {
 		c.Flags().BoolVar(&endpointOpts.userMode, "user", false, "Use per-user endpoint paths instead of system paths")
 		c.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
 	}
 	endpointCoworkPrintConfigCmd.Flags().StringVar(&endpointOpts.coworkHeaders, "headers", "", "Optional OTLP headers to show in setup guidance")
+	endpointCoworkPrintConfigCmd.Flags().StringVar(&endpointOpts.coworkEndpoint, "endpoint", "", "Public OTLP HTTPS endpoint to show in setup guidance")
+	endpointCoworkPrintConfigCmd.Flags().StringVar(&endpointOpts.coworkResourceAttributes, "resource-attributes", "", "Optional Claude Cowork resource attributes")
+	endpointCoworkSetupCmd.Flags().StringVar(&endpointOpts.coworkEndpoint, "endpoint", "", "Public OTLP HTTPS endpoint reachable by Claude Cowork")
+	endpointCoworkSetupCmd.Flags().StringVar(&endpointOpts.coworkHeaders, "headers", "", "Optional OTLP headers for the Claude admin settings")
+	endpointCoworkSetupCmd.Flags().StringVar(&endpointOpts.coworkResourceAttributes, "resource-attributes", "", "Optional Claude Cowork resource attributes")
+	endpointCoworkSetupCmd.Flags().BoolVar(&endpointOpts.coworkNgrok, "ngrok", false, "Create a temporary authenticated ngrok tunnel to the local OTLP HTTP receiver")
+	endpointCoworkSetupCmd.Flags().BoolVar(&endpointOpts.coworkOpen, "open", false, "Open Claude Cowork admin settings in a browser")
 	endpointCoworkValidateCmd.Flags().StringVar(&endpointOpts.coworkHeaders, "headers", "", "Optional OTLP headers to show when validation fails")
+	endpointCoworkValidateCmd.Flags().StringVar(&endpointOpts.coworkEndpoint, "endpoint", "", "Public OTLP HTTPS endpoint to show when validation fails")
+	endpointCoworkValidateCmd.Flags().StringVar(&endpointOpts.coworkResourceAttributes, "resource-attributes", "", "Optional Claude Cowork resource attributes")
+	endpointCoworkValidateCmd.Flags().StringVar(&endpointOpts.coworkSince, "since", "", "Require a Claude Cowork event within this duration, such as 10m")
 	endpointCoworkStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
 	for _, c := range []*cobra.Command{endpointHooksInstallCmd, endpointHooksUninstallCmd, endpointHooksStatusCmd} {
 		c.Flags().BoolVar(&endpointOpts.userMode, "user", false, "Use per-user endpoint paths instead of system paths")

--- a/cli/beacon/cmd/endpoint_cowork.go
+++ b/cli/beacon/cmd/endpoint_cowork.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/dashboard"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations/cowork"
+)
+
+const (
+	defaultCoworkProtocol                = "HTTP/protobuf"
+	defaultCoworkProdResourceAttributes  = "deployment.environment=prod,service.name=claude-cowork"
+	defaultCoworkLocalResourceAttributes = "deployment.environment=local,service.name=claude-cowork"
+	defaultCoworkTunnelUser              = "beacon"
+	defaultCoworkNgrokStartupTimeout     = 20 * time.Second
+)
+
+var ngrokURLPattern = regexp.MustCompile(`url="?((?:https)://[^"\s]+)`)
+
+func runEndpointCoworkSetup(cmdCtx context.Context) error {
+	cfg := loadOrDefaultConfig()
+	resourceAttributes := endpointOpts.coworkResourceAttributes
+	if endpointOpts.coworkNgrok {
+		if endpointOpts.coworkEndpoint != "" {
+			return fmt.Errorf("--endpoint cannot be combined with --ngrok")
+		}
+		if resourceAttributes == "" {
+			resourceAttributes = defaultCoworkLocalResourceAttributes
+		}
+		if err := requireLocalOTLPHTTP(cfg.Collector.HTTPPort); err != nil {
+			return err
+		}
+		password, err := randomTunnelPassword()
+		if err != nil {
+			return err
+		}
+		tunnel, err := startNgrokTunnel(cmdCtx, cfg.Collector.HTTPPort, defaultCoworkTunnelUser, password)
+		if err != nil {
+			return err
+		}
+		headers := basicAuthHeader(defaultCoworkTunnelUser, password)
+		printCoworkSetup(cowork.Config{
+			Endpoint:           tunnel.URL,
+			Protocol:           defaultCoworkProtocol,
+			Headers:            headers,
+			ResourceAttributes: resourceAttributes,
+		})
+		if endpointOpts.coworkOpen {
+			if err := dashboard.OpenBrowser(cowork.AdminURL); err != nil {
+				_ = tunnel.Stop()
+				return err
+			}
+		}
+		fmt.Println("Temporary ngrok tunnel is running. Press Ctrl-C to stop it.")
+		return tunnel.Wait()
+	}
+
+	if endpointOpts.coworkEndpoint == "" {
+		return fmt.Errorf("--endpoint is required unless --ngrok is set")
+	}
+	if !strings.HasPrefix(strings.ToLower(endpointOpts.coworkEndpoint), "https://") {
+		return fmt.Errorf("--endpoint must be a public HTTPS URL reachable by Claude Cowork")
+	}
+	if resourceAttributes == "" {
+		resourceAttributes = defaultCoworkProdResourceAttributes
+	}
+	printCoworkSetup(cowork.Config{
+		Endpoint:           endpointOpts.coworkEndpoint,
+		Protocol:           defaultCoworkProtocol,
+		Headers:            endpointOpts.coworkHeaders,
+		ResourceAttributes: resourceAttributes,
+	})
+	if endpointOpts.coworkOpen {
+		return dashboard.OpenBrowser(cowork.AdminURL)
+	}
+	return nil
+}
+
+func runEndpointCoworkValidate() error {
+	cfg := loadOrDefaultConfig()
+	status := cowork.GetStatus(cfg.LogPath)
+	if endpointOpts.coworkSince != "" {
+		duration, err := time.ParseDuration(endpointOpts.coworkSince)
+		if err != nil {
+			return fmt.Errorf("--since must be a duration such as 10m: %w", err)
+		}
+		since := time.Now().Add(-duration)
+		if !cowork.HasCoworkEventSince(cfg.LogPath, since) {
+			fmt.Print(cowork.PrintConfig(cowork.Config{
+				Endpoint:           endpointOpts.coworkEndpoint,
+				Protocol:           defaultCoworkProtocol,
+				Headers:            endpointOpts.coworkHeaders,
+				ResourceAttributes: endpointOpts.coworkResourceAttributes,
+			}))
+			return fmt.Errorf("no Claude Cowork events observed in %s since %s", cfg.LogPath, since.UTC().Format(time.RFC3339))
+		}
+		fmt.Printf("Claude Cowork events observed in endpoint runtime log since %s.\n", since.UTC().Format(time.RFC3339))
+		return nil
+	}
+	if !status.LastEventObserved {
+		fmt.Print(cowork.PrintConfig(cowork.Config{
+			Endpoint:           endpointOpts.coworkEndpoint,
+			Protocol:           defaultCoworkProtocol,
+			Headers:            endpointOpts.coworkHeaders,
+			ResourceAttributes: endpointOpts.coworkResourceAttributes,
+		}))
+		return fmt.Errorf("no Claude Cowork events observed in %s", cfg.LogPath)
+	}
+	if status.LastEventObservedAt != "" {
+		fmt.Printf("Claude Cowork events observed in endpoint runtime log. Last observed: %s.\n", status.LastEventObservedAt)
+	} else {
+		fmt.Println("Claude Cowork events observed in endpoint runtime log.")
+	}
+	return nil
+}
+
+func printCoworkSetup(cfg cowork.Config) {
+	fmt.Print(cowork.PrintConfig(cfg))
+	fmt.Println("Copy these values into the Claude Cowork monitoring settings and save:")
+	fmt.Printf("  OTLP endpoint: %s\n", cfg.Endpoint)
+	fmt.Printf("  OTLP protocol: %s\n", cfg.Protocol)
+	fmt.Printf("  OTLP headers: %s\n", displayValue(cfg.Headers))
+	fmt.Printf("  Resource attributes: %s\n", displayValue(cfg.ResourceAttributes))
+}
+
+func displayValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "(none)"
+	}
+	return value
+}
+
+func requireLocalOTLPHTTP(port int) error {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), time.Second)
+	if err != nil {
+		return fmt.Errorf("local OTLP HTTP receiver is not listening on 127.0.0.1:%d; run `beacon endpoint install --user` or `beacon endpoint repair --user` first", port)
+	}
+	_ = conn.Close()
+	return nil
+}
+
+type ngrokTunnel struct {
+	URL string
+	cmd *exec.Cmd
+}
+
+func startNgrokTunnel(ctx context.Context, port int, username, password string) (*ngrokTunnel, error) {
+	if _, err := exec.LookPath("ngrok"); err != nil {
+		return nil, fmt.Errorf("ngrok was not found on PATH; install ngrok or use --endpoint with a public HTTPS collector")
+	}
+	cmd := exec.CommandContext(ctx, "ngrok", "http", strconv.Itoa(port), "--basic-auth", username+":"+password, "--log", "stdout", "--log-format", "logfmt")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	urlCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		reportedURL := false
+		for scanner.Scan() {
+			line := scanner.Text()
+			if url := parseNgrokURL(line); url != "" && !reportedURL {
+				reportedURL = true
+				urlCh <- url
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			errCh <- err
+			return
+		}
+		errCh <- fmt.Errorf("ngrok exited before reporting a public URL")
+	}()
+	select {
+	case url := <-urlCh:
+		return &ngrokTunnel{URL: url, cmd: cmd}, nil
+	case err := <-errCh:
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, err
+	case <-time.After(defaultCoworkNgrokStartupTimeout):
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("timed out waiting for ngrok public URL")
+	case <-ctx.Done():
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, ctx.Err()
+	}
+}
+
+func (t *ngrokTunnel) Wait() error {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(signals)
+	wait := make(chan error, 1)
+	go func() {
+		wait <- t.cmd.Wait()
+	}()
+	select {
+	case <-signals:
+		if t.cmd.Process != nil {
+			_ = t.cmd.Process.Signal(os.Interrupt)
+		}
+		err := <-wait
+		if err != nil {
+			return nil
+		}
+		return nil
+	case err := <-wait:
+		return err
+	}
+}
+
+func (t *ngrokTunnel) Stop() error {
+	if t == nil || t.cmd == nil || t.cmd.Process == nil {
+		return nil
+	}
+	return t.cmd.Process.Kill()
+}
+
+func parseNgrokURL(line string) string {
+	matches := ngrokURLPattern.FindStringSubmatch(line)
+	if len(matches) < 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+func randomTunnelPassword() (string, error) {
+	var b [18]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+}
+
+func basicAuthHeader(username, password string) string {
+	token := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	return "Authorization=Basic " + token
+}

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -31,6 +31,45 @@ func TestEndpointDashboardCommandRegistered(t *testing.T) {
 	}
 }
 
+func TestEndpointCoworkSetupCommandRegistered(t *testing.T) {
+	cmd, _, err := endpointCmd.Find([]string{"integrations", "claude-cowork", "setup"})
+	if err != nil {
+		t.Fatalf("Find cowork setup returned error: %v", err)
+	}
+	if cmd == nil || cmd.Use != "setup" {
+		t.Fatalf("cowork setup command not registered: %#v", cmd)
+	}
+	for _, name := range []string{"endpoint", "headers", "resource-attributes", "ngrok", "open"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("cowork setup command missing --%s flag", name)
+		}
+	}
+}
+
+func TestEndpointCoworkValidateSinceFlagRegistered(t *testing.T) {
+	cmd, _, err := endpointCmd.Find([]string{"integrations", "claude-cowork", "validate"})
+	if err != nil {
+		t.Fatalf("Find cowork validate returned error: %v", err)
+	}
+	if cmd.Flags().Lookup("since") == nil {
+		t.Fatal("cowork validate command missing --since flag")
+	}
+}
+
+func TestParseNgrokURL(t *testing.T) {
+	line := `lvl=info msg="started tunnel" obj=tunnels name=command_line addr=http://localhost:4318 url=https://abc-123.ngrok-free.app`
+	if got, want := parseNgrokURL(line), "https://abc-123.ngrok-free.app"; got != want {
+		t.Fatalf("parseNgrokURL = %q, want %q", got, want)
+	}
+}
+
+func TestBasicAuthHeader(t *testing.T) {
+	got := basicAuthHeader("beacon", "secret")
+	if got != "Authorization=Basic YmVhY29uOnNlY3JldA==" {
+		t.Fatalf("basicAuthHeader = %q", got)
+	}
+}
+
 func TestEndpointHarnessDefaultsDoNotClobberInstall(t *testing.T) {
 	installFlag := endpointInstallCmd.Flags().Lookup("harness")
 	if installFlag == nil {

--- a/cli/beacon/internal/endpoint/integrations/cowork/cowork.go
+++ b/cli/beacon/internal/endpoint/integrations/cowork/cowork.go
@@ -8,29 +8,34 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 const (
-	Name        = "claude_cowork"
+	Name     = "claude_cowork"
+	AdminURL = "https://claude.ai/admin-settings/cowork"
+
 	DisplayName = "Claude Cowork"
 	MinVersion  = "1.1.4173"
 )
 
 type Config struct {
-	Endpoint string `json:"endpoint"`
-	Protocol string `json:"protocol"`
-	Headers  string `json:"headers,omitempty"`
+	Endpoint           string `json:"endpoint"`
+	Protocol           string `json:"protocol"`
+	Headers            string `json:"headers,omitempty"`
+	ResourceAttributes string `json:"resource_attributes,omitempty"`
 }
 
 type Status struct {
-	Name              string `json:"name"`
-	DisplayName       string `json:"display_name"`
-	Detected          bool   `json:"detected"`
-	DesktopPath       string `json:"desktop_path,omitempty"`
-	MinimumVersion    string `json:"minimum_version"`
-	Configuration     string `json:"configuration"`
-	LastEventObserved bool   `json:"last_event_observed"`
-	Message           string `json:"message"`
+	Name                string `json:"name"`
+	DisplayName         string `json:"display_name"`
+	Detected            bool   `json:"detected"`
+	DesktopPath         string `json:"desktop_path,omitempty"`
+	MinimumVersion      string `json:"minimum_version"`
+	Configuration       string `json:"configuration"`
+	LastEventObserved   bool   `json:"last_event_observed"`
+	LastEventObservedAt string `json:"last_event_observed_at,omitempty"`
+	Message             string `json:"message"`
 }
 
 func DefaultConfig(grpcPort, httpPort int) Config {
@@ -42,13 +47,16 @@ func DefaultConfig(grpcPort, httpPort int) Config {
 
 func PrintConfig(cfg Config) string {
 	if cfg.Endpoint == "" {
-		cfg = DefaultConfig(4317, 4318)
+		cfg.Endpoint = DefaultConfig(4317, 4318).Endpoint
+	}
+	if cfg.Protocol == "" {
+		cfg.Protocol = "HTTP/protobuf"
 	}
 	return fmt.Sprintf(`Claude Cowork OpenTelemetry setup
 
 Configure this in Claude Desktop:
 
-  Organization settings > Cowork > OpenTelemetry
+  %s
 
 OTLP endpoint:
   %s
@@ -59,11 +67,15 @@ OTLP protocol:
 Headers:
   %s
 
+Resource attributes:
+  %s
+
 Notes:
 - Claude Cowork export is configured by a Team/Enterprise admin.
 - Claude Desktop must be version %s or newer.
+- The OTLP endpoint must be reachable by Claude Cowork. Use a public HTTPS collector or an authenticated tunnel for local testing.
 - Cowork may include prompt text and tool parameters. Beacon's collector should redact/drop content by default before writing Wazuh JSONL.
-`, cfg.Endpoint, cfg.Protocol, headerText(cfg.Headers), MinVersion)
+`, AdminURL, cfg.Endpoint, cfg.Protocol, headerText(cfg.Headers), resourceAttributesText(cfg.ResourceAttributes), MinVersion)
 }
 
 func GetStatus(logPath string) Status {
@@ -86,7 +98,12 @@ func GetStatus(logPath string) Status {
 			}
 		}
 	}
-	status.LastEventObserved = HasRecentCoworkEvent(logPath)
+	if last, ok := LastCoworkEvent(logPath); ok {
+		status.LastEventObserved = true
+		if !last.IsZero() {
+			status.LastEventObservedAt = last.UTC().Format(time.RFC3339)
+		}
+	}
 	if status.LastEventObserved {
 		status.Message = "Claude Cowork events have been observed in the endpoint runtime log"
 	}
@@ -94,14 +111,29 @@ func GetStatus(logPath string) Status {
 }
 
 func HasRecentCoworkEvent(logPath string) bool {
-	if logPath == "" {
+	_, ok := LastCoworkEvent(logPath)
+	return ok
+}
+
+func HasCoworkEventSince(logPath string, since time.Time) bool {
+	last, ok := LastCoworkEvent(logPath)
+	if !ok || last.IsZero() {
 		return false
+	}
+	return !last.Before(since)
+}
+
+func LastCoworkEvent(logPath string) (time.Time, bool) {
+	if logPath == "" {
+		return time.Time{}, false
 	}
 	file, err := os.Open(logPath)
 	if err != nil {
-		return false
+		return time.Time{}, false
 	}
 	defer file.Close()
+	var last time.Time
+	found := false
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
@@ -111,11 +143,16 @@ func HasRecentCoworkEvent(logPath string) bool {
 		}
 		if harness, ok := event["harness"].(map[string]interface{}); ok {
 			if name, _ := harness["name"].(string); strings.EqualFold(name, Name) {
-				return true
+				found = true
+				if ts, ok := event["timestamp"].(string); ok {
+					if parsed, err := time.Parse(time.RFC3339Nano, ts); err == nil && parsed.After(last) {
+						last = parsed
+					}
+				}
 			}
 		}
 	}
-	return false
+	return last, found
 }
 
 func headerText(headers string) string {
@@ -123,4 +160,11 @@ func headerText(headers string) string {
 		return "(none)"
 	}
 	return headers
+}
+
+func resourceAttributesText(attrs string) string {
+	if strings.TrimSpace(attrs) == "" {
+		return "(none)"
+	}
+	return attrs
 }

--- a/cli/beacon/internal/endpoint/integrations/cowork/cowork_test.go
+++ b/cli/beacon/internal/endpoint/integrations/cowork/cowork_test.go
@@ -5,25 +5,73 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPrintConfigIncludesEndpointAndPrivacyNote(t *testing.T) {
-	out := PrintConfig(Config{Endpoint: "http://127.0.0.1:4318", Protocol: "HTTP/protobuf"})
-	if !strings.Contains(out, "http://127.0.0.1:4318") {
+	out := PrintConfig(Config{
+		Endpoint:           "https://collector.example.com",
+		Protocol:           "HTTP/protobuf",
+		Headers:            "Authorization=Bearer token",
+		ResourceAttributes: "deployment.environment=prod,service.name=claude-cowork",
+	})
+	if !strings.Contains(out, "https://collector.example.com") {
 		t.Fatalf("missing endpoint: %s", out)
+	}
+	if !strings.Contains(out, AdminURL) {
+		t.Fatalf("missing admin URL: %s", out)
+	}
+	if !strings.Contains(out, "Authorization=Bearer token") {
+		t.Fatalf("missing headers: %s", out)
+	}
+	if !strings.Contains(out, "deployment.environment=prod,service.name=claude-cowork") {
+		t.Fatalf("missing resource attributes: %s", out)
 	}
 	if !strings.Contains(out, "prompt text") {
 		t.Fatalf("missing privacy note: %s", out)
 	}
 }
 
-func TestHasRecentCoworkEvent(t *testing.T) {
+func TestLastCoworkEventAndSince(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "runtime.jsonl")
-	data := `{"harness":{"name":"claude_cowork"}}` + "\n"
+	data := strings.Join([]string{
+		`{"timestamp":"2026-05-13T16:18:40Z","harness":{"name":"claude_cowork"}}`,
+		`{"timestamp":"2026-05-13T16:19:40Z","harness":{"name":"cursor"}}`,
+		`{"timestamp":"2026-05-13T16:20:40Z","harness":{"name":"claude_cowork"}}`,
+		"",
+	}, "\n")
 	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if !HasRecentCoworkEvent(path) {
 		t.Fatal("expected cowork event to be detected")
+	}
+	last, ok := LastCoworkEvent(path)
+	if !ok {
+		t.Fatal("expected last cowork event")
+	}
+	if got, want := last.UTC().Format(time.RFC3339), "2026-05-13T16:20:40Z"; got != want {
+		t.Fatalf("LastCoworkEvent = %s, want %s", got, want)
+	}
+	if !HasCoworkEventSince(path, time.Date(2026, 5, 13, 16, 20, 0, 0, time.UTC)) {
+		t.Fatal("expected event after since timestamp")
+	}
+	if HasCoworkEventSince(path, time.Date(2026, 5, 13, 16, 21, 0, 0, time.UTC)) {
+		t.Fatal("did not expect event after later since timestamp")
+	}
+}
+
+func TestGetStatusIncludesLastEventObservedAt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	data := `{"timestamp":"2026-05-13T16:20:40Z","harness":{"name":"claude_cowork"}}` + "\n"
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+	status := GetStatus(path)
+	if !status.LastEventObserved {
+		t.Fatal("expected event to be observed")
+	}
+	if got, want := status.LastEventObservedAt, "2026-05-13T16:20:40Z"; got != want {
+		t.Fatalf("LastEventObservedAt = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new CLI surface area that can start external `ngrok` processes and guides configuration of a public OTLP endpoint, so misconfiguration or tunnel exposure is possible. Changes are mostly additive and covered by unit tests/documentation updates.
> 
> **Overview**
> Adds a first-class `beacon endpoint integrations claude-cowork setup` flow that prints admin settings for Claude Cowork and can optionally start a temporary authenticated `ngrok` tunnel to the local OTLP HTTP receiver (with `--open` to jump to the admin page).
> 
> Extends Cowork validation/status to support `--since` checks and to report `last_event_observed_at`, and expands Cowork config guidance to include `resource-attributes` plus the Claude admin URL. Updates top-level and CLI READMEs and adds unit tests for the new command/flags and ngrok helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f81e5fb59c524832d35fcb319f994d658953ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->