### PR TITLE
Add docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Beacon Endpoint Agent configures local telemetry for tools like Claude Code,
 Codex CLI, Claude Cowork, and Cursor, then writes Wazuh-compatible JSONL logs.
 It runs local-only and does not require a Beacon account.
 
+Read the [Beacon CLI documentation](https://docs.asymptotelabs.ai/cli) for setup
+guides and command details.
+
 Beacon is visibility-first. The current public build focuses on observing local
 agent runtime activity, normalizing it into endpoint events, and leaving
 forwarding to existing localfile/Wazuh or customer-managed pipelines.
@@ -15,6 +18,7 @@ forwarding to existing localfile/Wazuh or customer-managed pipelines.
 - [What Beacon Does](#what-beacon-does)
 - [Privacy And Retention](#privacy-and-retention)
 - [What Beacon Does Not Do](#what-beacon-does-not-do)
+- [Documentation](#documentation)
 - [Quick Start](#quick-start)
 - [Install With Homebrew](#install-with-homebrew)
 - [Optional Integrations](#optional-integrations)
@@ -63,6 +67,11 @@ Beacon does not currently provide kernel/process monitoring, shell history
 collection, cloud audit ingestion, browser/SaaS telemetry, credential-use
 attribution, MCP configuration inventory, or direct Datadog/Splunk/Elastic/etc.
 exporters.
+
+## Documentation
+
+See the [Beacon CLI documentation](https://docs.asymptotelabs.ai/cli) for setup
+guides and command details.
 
 ## Quick Start
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a link and section pointer; no runtime or build behavior is affected.
> 
> **Overview**
> Adds prominent links to the external **Beacon CLI documentation** in `README.md`, including a new `Documentation` section and a Table of Contents entry to help readers find setup guides and command details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609fbda2b5f12fe35733b9061ba5562e21407545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->