### PR TITLE
Update codex telemetry defaults, filter noisy traces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Run the local dashboard during manual testing:
 
 ```bash
 cd cli/beacon
-go run . endpoint dashboard --user
+go run . endpoint dashboard
 ```
 
 ## Implementation Notes

--- a/README.md
+++ b/README.md
@@ -110,24 +110,29 @@ cd cli/beacon
 make build
 ```
 
-### Install In User Mode
+### Install Locally
 
 ```bash
-beacon endpoint install --user
-beacon endpoint status --user
+beacon endpoint install
+beacon endpoint status
 ```
+
+The normal CLI flow uses per-user endpoint paths by default. Cursor hooks,
+Claude Code OTLP, and Codex OTLP all write to the same user runtime log:
+`~/.beacon/endpoint/logs/runtime.jsonl`. Use `--system` only for root-managed
+package or MDM deployments.
 
 ### Set Content Retention
 
 ```bash
-beacon endpoint install --user --content-retention metadata
+beacon endpoint install --content-retention metadata
 ```
 
 ### Configure Wazuh Output
 
 ```bash
-beacon endpoint wazuh print-config --user
-beacon endpoint wazuh validate --user
+beacon endpoint wazuh print-config
+beacon endpoint wazuh validate
 ```
 
 ### Run The macOS Smoke Test
@@ -141,7 +146,7 @@ sh packaging/macos/smoke-endpoint.sh
 ### Cursor Hooks
 
 ```bash
-beacon endpoint hooks install --harness cursor --user
+beacon endpoint hooks install --harness cursor
 ```
 
 ### Claude Cowork
@@ -150,15 +155,15 @@ Claude Cowork OpenTelemetry export is configured in the Claude admin console and
 requires a Team/Enterprise admin.
 
 ```bash
-beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --user --open
-beacon endpoint integrations claude-cowork validate --user --since 10m
+beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --open
+beacon endpoint integrations claude-cowork validate --since 10m
 ```
 
 For local testing only, Beacon can create a temporary authenticated ngrok tunnel
 to the local OTLP HTTP receiver:
 
 ```bash
-beacon endpoint integrations claude-cowork setup --ngrok --user --open
+beacon endpoint integrations claude-cowork setup --ngrok --open
 ```
 
 ## Claude Cowork Durable Collector
@@ -198,12 +203,13 @@ Recommended production shape:
 Run the local dashboard:
 
 ```bash
-beacon endpoint dashboard --user
-beacon endpoint dashboard --user --open
+beacon endpoint dashboard
+beacon endpoint dashboard --open
 ```
 
 The dashboard binds to loopback by default and reads the local runtime JSONL log.
-It is intended for local inspection, not remote administration.
+It is intended for local inspection, not remote administration. In the default
+CLI setup it reads the same user log used by hook and OTLP telemetry.
 
 ## Command Reference
 
@@ -211,16 +217,16 @@ Common commands:
 
 ```bash
 beacon version
-beacon endpoint install --user
-beacon endpoint status --user
+beacon endpoint install
+beacon endpoint status
 beacon endpoint discover
-beacon endpoint dashboard --user --open
-beacon endpoint wazuh print-config --user
-beacon endpoint wazuh validate --user
-beacon endpoint hooks install --harness cursor --user
-beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --user --open
-beacon endpoint integrations claude-cowork validate --user --since 10m
-beacon endpoint uninstall --user --keep-logs
+beacon endpoint dashboard --open
+beacon endpoint wazuh print-config
+beacon endpoint wazuh validate
+beacon endpoint hooks install --harness cursor
+beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --open
+beacon endpoint integrations claude-cowork validate --since 10m
+beacon endpoint uninstall --keep-logs
 ```
 
 - `beacon endpoint install`: configure the endpoint agent, Collector service, and Claude/Codex telemetry.
@@ -236,7 +242,7 @@ beacon endpoint uninstall --user --keep-logs
 Uninstall while keeping logs:
 
 ```bash
-beacon endpoint uninstall --user --keep-logs
+beacon endpoint uninstall --keep-logs
 ```
 
 ## Repository Layout
@@ -256,25 +262,25 @@ content-retention defaults, log paths, and uninstall behavior.
 
 For macOS, publish a signed and notarized package or Homebrew formula that
 installs the CLI, collector, Wazuh content pack, and deployment scripts. The
-package should apply explicit endpoint settings, for example:
+package should apply explicit system endpoint settings, for example:
 
 ```bash
-beacon endpoint install --harness claude,codex --content-retention metadata
+beacon endpoint install --system --harness claude,codex --content-retention metadata
 ```
 
 Before publishing a release, verify the build from a clean checkout and clean
 macOS host or VM:
 
 - `beacon version` reports the expected version, commit, and build date.
-- `beacon endpoint install --user --no-start` succeeds without developer
+- `beacon endpoint install --no-start` succeeds without developer
   tooling.
-- `beacon endpoint status --user` reports config, collector, service, harness,
+- `beacon endpoint status` reports config, collector, service, harness,
   diagnostic, and runtime log paths.
-- `beacon endpoint wazuh validate --user` writes a valid Beacon JSONL event.
-- `beacon endpoint dashboard --user` starts on `127.0.0.1`, serves a read-only
+- `beacon endpoint wazuh validate` writes a valid Beacon JSONL event.
+- `beacon endpoint dashboard` starts on `127.0.0.1`, serves a read-only
   dashboard, and can search local telemetry without external network
   dependencies.
-- `beacon endpoint uninstall --user` removes managed service and config files.
+- `beacon endpoint uninstall` removes managed service and config files.
 - macOS package signature and notarization are valid when distributing a `.pkg`.
 
 The repository smoke test keeps this flow local and non-root:

--- a/cli/beacon/.goreleaser.yaml
+++ b/cli/beacon/.goreleaser.yaml
@@ -85,7 +85,7 @@ brews:
       bin.install "beacon"
     caveats: |
       To configure local endpoint telemetry, run:
-        beacon endpoint install --user
+        beacon endpoint install
     test: |
       system "#{bin}/beacon", "version"
 
@@ -110,7 +110,7 @@ release:
 
     ## Quick Start
     ```bash
-    beacon endpoint install --user
+    beacon endpoint install
     beacon endpoint status
     beacon endpoint wazuh print-config
     ```

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -11,20 +11,24 @@ make build
 ## Common Commands
 
 ```bash
-./beacon endpoint install --user
+./beacon endpoint install
 ./beacon endpoint status --json
 ./beacon endpoint discover --json
-./beacon endpoint repair --user
-./beacon endpoint dashboard --user
-./beacon endpoint uninstall --user --keep-logs
+./beacon endpoint repair
+./beacon endpoint dashboard
+./beacon endpoint uninstall --keep-logs
 ```
+
+Endpoint commands use per-user paths by default so hook and OTLP telemetry share
+`~/.beacon/endpoint/logs/runtime.jsonl`. Use `--system` for root-managed
+deployment paths.
 
 ## Dashboard
 
 ```bash
-./beacon endpoint dashboard --user
-./beacon endpoint dashboard --user --addr 127.0.0.1:8765
-./beacon endpoint dashboard --user --open
+./beacon endpoint dashboard
+./beacon endpoint dashboard --addr 127.0.0.1:8765
+./beacon endpoint dashboard --open
 ```
 
 The dashboard reads the configured runtime JSONL log and serves a local,
@@ -39,20 +43,20 @@ that may need review.
 ## Wazuh
 
 ```bash
-./beacon endpoint wazuh print-config --user
-./beacon endpoint wazuh install-pack --output ./beacon-wazuh --user
-./beacon endpoint wazuh validate --user
+./beacon endpoint wazuh print-config
+./beacon endpoint wazuh install-pack --output ./beacon-wazuh
+./beacon endpoint wazuh validate
 ```
 
 ## Optional Integrations
 
 ```bash
-./beacon endpoint hooks install --harness cursor --user
-./beacon endpoint hooks status --harness cursor --user
+./beacon endpoint hooks install --harness cursor
+./beacon endpoint hooks status --harness cursor
 
-./beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --user --open
-./beacon endpoint integrations claude-cowork setup --ngrok --user --open
-./beacon endpoint integrations claude-cowork validate --user --since 10m
+./beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --open
+./beacon endpoint integrations claude-cowork setup --ngrok --open
+./beacon endpoint integrations claude-cowork validate --since 10m
 ```
 
 Claude Cowork monitoring is configured in the Claude admin console at

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -22,6 +22,7 @@ import (
 
 var endpointOpts struct {
 	userMode                 bool
+	systemMode               bool
 	logPath                  string
 	harnesses                string
 	hookHarnesses            string
@@ -246,7 +247,8 @@ func init() {
 	endpointCoworkCmd.AddCommand(endpointCoworkValidateCmd)
 
 	for _, c := range []*cobra.Command{endpointInstallCmd, endpointStatusCmd, endpointDiscoverCmd, endpointUninstallCmd, endpointRepairCmd} {
-		c.Flags().BoolVar(&endpointOpts.userMode, "user", false, "Use per-user endpoint paths instead of system paths")
+		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
+		c.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 		c.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
 	}
 
@@ -261,22 +263,27 @@ func init() {
 	endpointRepairCmd.Flags().IntVar(&endpointOpts.httpPort, "otlp-http-port", endpointconfig.DefaultHTTPPort, "Local OTLP HTTP port")
 	endpointRepairCmd.Flags().StringVar(&endpointOpts.collectorPath, "collector", "", "Path to a beacon-otelcol binary")
 	endpointRepairCmd.Flags().StringVar(&endpointOpts.contentRetention, "content-retention", "metadata", "Content retention mode: metadata, redacted, or full")
-	endpointDashboardCmd.Flags().BoolVar(&endpointOpts.userMode, "user", false, "Use per-user endpoint paths instead of system paths")
+	endpointDashboardCmd.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
+	endpointDashboardCmd.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 	endpointDashboardCmd.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
 	endpointDashboardCmd.Flags().StringVar(&endpointOpts.dashboardAddr, "addr", dashboard.DefaultAddr, "Local dashboard listen address")
 	endpointDashboardCmd.Flags().BoolVar(&endpointOpts.dashboardOpen, "open", false, "Open the dashboard in a browser")
 
 	endpointDiscoverCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print discovery as JSON")
 	endpointStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
-	endpointWazuhPrintConfigCmd.Flags().BoolVar(&endpointOpts.userMode, "user", false, "Use per-user endpoint paths instead of system paths")
+	endpointWazuhPrintConfigCmd.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
+	endpointWazuhPrintConfigCmd.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 	endpointWazuhPrintConfigCmd.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
 	endpointWazuhInstallPackCmd.Flags().StringVar(&endpointOpts.outputDir, "output", "", "Output directory for Wazuh content pack")
-	endpointWazuhInstallPackCmd.Flags().BoolVar(&endpointOpts.userMode, "user", false, "Use per-user endpoint paths instead of system paths")
+	endpointWazuhInstallPackCmd.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
+	endpointWazuhInstallPackCmd.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 	endpointWazuhInstallPackCmd.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
-	endpointWazuhValidateCmd.Flags().BoolVar(&endpointOpts.userMode, "user", false, "Use per-user endpoint paths instead of system paths")
+	endpointWazuhValidateCmd.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
+	endpointWazuhValidateCmd.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 	endpointWazuhValidateCmd.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
 	for _, c := range []*cobra.Command{endpointCoworkPrintConfigCmd, endpointCoworkSetupCmd, endpointCoworkStatusCmd, endpointCoworkValidateCmd} {
-		c.Flags().BoolVar(&endpointOpts.userMode, "user", false, "Use per-user endpoint paths instead of system paths")
+		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
+		c.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 		c.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
 	}
 	endpointCoworkPrintConfigCmd.Flags().StringVar(&endpointOpts.coworkHeaders, "headers", "", "Optional OTLP headers to show in setup guidance")
@@ -293,7 +300,8 @@ func init() {
 	endpointCoworkValidateCmd.Flags().StringVar(&endpointOpts.coworkSince, "since", "", "Require a Claude Cowork event within this duration, such as 10m")
 	endpointCoworkStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
 	for _, c := range []*cobra.Command{endpointHooksInstallCmd, endpointHooksUninstallCmd, endpointHooksStatusCmd} {
-		c.Flags().BoolVar(&endpointOpts.userMode, "user", false, "Use per-user endpoint paths instead of system paths")
+		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
+		c.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 		c.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
 		c.Flags().StringVar(&endpointOpts.hookHarnesses, "harness", "cursor", "Comma-separated hook harnesses")
 		c.Flags().StringVar(&endpointOpts.hookLevel, "level", "user", "Hook install level: user or project")
@@ -378,6 +386,10 @@ func runEndpointWazuhValidate(cmd *cobra.Command, args []string) error {
 
 func runEndpointDashboard(cmd *cobra.Command, args []string) error {
 	cfg := loadOrDefaultConfig()
+	userMode := endpointUserMode()
+	runtimeLog := lifecycle.ResolveRuntimeLog(userMode, endpointOpts.logPath)
+	cfg.UserMode = runtimeLog.EffectiveUserMode
+	cfg.LogPath = runtimeLog.EffectiveLogPath
 	if endpointOpts.dashboardAddr == "" {
 		endpointOpts.dashboardAddr = dashboard.DefaultAddr
 	}
@@ -387,6 +399,9 @@ func runEndpointDashboard(cmd *cobra.Command, args []string) error {
 	url := dashboard.URL(endpointOpts.dashboardAddr)
 	fmt.Printf("Beacon endpoint dashboard: %s\n", url)
 	fmt.Printf("Runtime log: %s\n", cfg.LogPath)
+	if runtimeLog.Warning != "" {
+		fmt.Printf("Runtime log source: %s\n", runtimeLog.Warning)
+	}
 	if endpointOpts.dashboardOpen {
 		if err := dashboard.OpenBrowser(url); err != nil {
 			return err
@@ -401,7 +416,7 @@ func runEndpointDashboard(cmd *cobra.Command, args []string) error {
 
 func runEndpointInstall(cmd *cobra.Command, args []string) error {
 	result, err := lifecycle.Install(lifecycle.InstallOptions{
-		UserMode:         endpointOpts.userMode,
+		UserMode:         endpointUserMode(),
 		LogPath:          endpointOpts.logPath,
 		Harnesses:        splitCSV(endpointOpts.harnesses),
 		GRPCPort:         endpointOpts.grpcPort,
@@ -422,13 +437,16 @@ func runEndpointInstall(cmd *cobra.Command, args []string) error {
 }
 
 func runEndpointStatus(cmd *cobra.Command, args []string) error {
-	status := lifecycle.GetStatus(endpointOpts.userMode, endpointOpts.logPath)
+	status := lifecycle.GetStatus(endpointUserMode(), endpointOpts.logPath)
 	if endpointOpts.jsonOutput {
 		return json.NewEncoder(os.Stdout).Encode(status)
 	}
 	fmt.Printf("Beacon Endpoint Agent %s\n", status.Version)
 	fmt.Printf("Config: %s\n", status.ConfigPath)
 	fmt.Printf("Runtime log: %s\n", status.LogPath)
+	if status.RuntimeLog.Warning != "" {
+		fmt.Printf("Runtime log source: %s\n", status.RuntimeLog.Warning)
+	}
 	fmt.Printf("Collector: grpc=%t http=%t", status.Collector.GRPCReady, status.Collector.HTTPReady)
 	if status.Collector.Message != "" {
 		fmt.Printf(" (%s)", status.Collector.Message)
@@ -509,7 +527,7 @@ func writeValidationEvent(cfg endpointconfig.Config, destination string) (string
 }
 
 func runEndpointUninstall(cmd *cobra.Command, args []string) error {
-	if err := lifecycle.Uninstall(lifecycle.UninstallOptions{UserMode: endpointOpts.userMode, LogPath: endpointOpts.logPath, KeepLogs: endpointOpts.keepLogs, KeepConfig: endpointOpts.keepConfig}); err != nil {
+	if err := lifecycle.Uninstall(lifecycle.UninstallOptions{UserMode: endpointUserMode(), LogPath: endpointOpts.logPath, KeepLogs: endpointOpts.keepLogs, KeepConfig: endpointOpts.keepConfig}); err != nil {
 		return err
 	}
 	fmt.Println("Endpoint service, config, and managed files removed.")
@@ -518,7 +536,7 @@ func runEndpointUninstall(cmd *cobra.Command, args []string) error {
 
 func runEndpointRepair(cmd *cobra.Command, args []string) error {
 	result, err := lifecycle.Repair(lifecycle.InstallOptions{
-		UserMode:         endpointOpts.userMode,
+		UserMode:         endpointUserMode(),
 		LogPath:          endpointOpts.logPath,
 		Harnesses:        splitCSV(endpointOpts.harnesses),
 		GRPCPort:         endpointOpts.grpcPort,
@@ -535,7 +553,8 @@ func runEndpointRepair(cmd *cobra.Command, args []string) error {
 }
 
 func loadOrDefaultConfig() endpointconfig.Config {
-	if cfg, err := endpointconfig.Load(endpointOpts.userMode); err == nil {
+	userMode := endpointUserMode()
+	if cfg, err := endpointconfig.Load(userMode); err == nil {
 		if endpointOpts.logPath != "" {
 			cfg.LogPath = endpointOpts.logPath
 		}
@@ -543,9 +562,13 @@ func loadOrDefaultConfig() endpointconfig.Config {
 	}
 	logPath := endpointOpts.logPath
 	if logPath == "" {
-		logPath = writer.DefaultPath(endpointOpts.userMode)
+		logPath = writer.DefaultPath(userMode)
 	}
-	return endpointconfig.Default(endpointOpts.userMode, logPath)
+	return endpointconfig.Default(userMode, logPath)
+}
+
+func endpointUserMode() bool {
+	return endpointOpts.userMode && !endpointOpts.systemMode
 }
 
 func splitCSV(value string) []string {

--- a/cli/beacon/cmd/endpoint_cowork.go
+++ b/cli/beacon/cmd/endpoint_cowork.go
@@ -146,7 +146,7 @@ func displayValue(value string) string {
 func requireLocalOTLPHTTP(port int) error {
 	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), time.Second)
 	if err != nil {
-		return fmt.Errorf("local OTLP HTTP receiver is not listening on 127.0.0.1:%d; run `beacon endpoint install --user` or `beacon endpoint repair --user` first", port)
+		return fmt.Errorf("local OTLP HTTP receiver is not listening on 127.0.0.1:%d; run `beacon endpoint install` or `beacon endpoint repair` first", port)
 	}
 	_ = conn.Close()
 	return nil

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
 
 func TestSplitCSV(t *testing.T) {
 	got := splitCSV("cursor, claude-cowork,,codex")
@@ -85,5 +89,20 @@ func TestEndpointHarnessDefaultsDoNotClobberInstall(t *testing.T) {
 	}
 	if got, want := hooksFlag.DefValue, "cursor"; got != want {
 		t.Fatalf("hooks install --harness default = %q, want %q", got, want)
+	}
+}
+
+func TestEndpointCommandsDefaultToUserMode(t *testing.T) {
+	for _, cmd := range []*cobra.Command{endpointInstallCmd, endpointStatusCmd, endpointDashboardCmd, endpointHooksInstallCmd} {
+		userFlag := cmd.Flags().Lookup("user")
+		if userFlag == nil {
+			t.Fatalf("%s missing --user flag", cmd.Use)
+		}
+		if userFlag.DefValue != "true" {
+			t.Fatalf("%s --user default = %q, want true", cmd.Use, userFlag.DefValue)
+		}
+		if cmd.Flags().Lookup("system") == nil {
+			t.Fatalf("%s missing --system flag", cmd.Use)
+		}
 	}
 }

--- a/cli/beacon/cmd/root.go
+++ b/cli/beacon/cmd/root.go
@@ -20,7 +20,7 @@ Beacon-hosted backend.`,
 		fmt.Println("Beacon Endpoint Agent")
 		fmt.Println()
 		fmt.Println("Start with:")
-		fmt.Println("  beacon endpoint install --user")
+		fmt.Println("  beacon endpoint install")
 		fmt.Println("  beacon endpoint status")
 		fmt.Println("  beacon endpoint wazuh print-config")
 		fmt.Println()

--- a/cli/beacon/internal/endpoint/dashboard/events.go
+++ b/cli/beacon/internal/endpoint/dashboard/events.go
@@ -86,6 +86,9 @@ func ReadEvents(path string, query EventQuery) (EventResult, error) {
 			result.MalformedLines++
 			continue
 		}
+		if event.Event.Category == "" {
+			event.Event.Category = inferEventCategory(event.Event.Action)
+		}
 		parsed, _ := time.Parse(time.RFC3339, event.Timestamp)
 		record := EventRecord{
 			ID:         fmt.Sprintf("line-%d", lineNo),
@@ -146,6 +149,9 @@ func FindEvent(path, id string) (EventRecord, bool, error) {
 		var event schema.Event
 		if err := json.Unmarshal(line, &event); err != nil {
 			return EventRecord{}, false, nil
+		}
+		if event.Event.Category == "" {
+			event.Event.Category = inferEventCategory(event.Event.Action)
 		}
 		parsed, _ := time.Parse(time.RFC3339, event.Timestamp)
 		return EventRecord{
@@ -262,6 +268,27 @@ func matchesCommand(event schema.Event, command string) bool {
 		return true
 	}
 	return false
+}
+
+func inferEventCategory(action string) string {
+	switch {
+	case strings.HasPrefix(action, "prompt."):
+		return "prompt"
+	case strings.HasPrefix(action, "command."):
+		return "command"
+	case strings.HasPrefix(action, "file."):
+		return "file"
+	case strings.HasPrefix(action, "mcp."):
+		return "mcp"
+	case strings.HasPrefix(action, "approval.") || strings.HasPrefix(action, "policy."):
+		return "approval"
+	case strings.HasPrefix(action, "metric."):
+		return "metric"
+	case strings.HasPrefix(action, "tool."):
+		return "tool"
+	default:
+		return ""
+	}
 }
 
 func matchesFreeText(record EventRecord, query string) bool {

--- a/cli/beacon/internal/endpoint/dashboard/events_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/events_test.go
@@ -34,6 +34,23 @@ func TestReadEventsSkipsMalformedLinesAndFilters(t *testing.T) {
 	}
 }
 
+func TestReadEventsInfersMissingCategory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	event := testSchemaEvent("2026-05-13T01:00:00Z", "codex_cli", "tool.invoked", "", "repo-a")
+	writeTestLog(t, path, marshalEvents(t, event)...)
+
+	result, err := ReadEvents(path, EventQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events length = %d, want 1", len(result.Events))
+	}
+	if got := result.Events[0].Event.Event.Category; got != "tool" {
+		t.Fatalf("Category = %q, want tool", got)
+	}
+}
+
 func TestBuildSummaryAggregatesSignals(t *testing.T) {
 	result := EventResult{
 		TotalMatched: 4,

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -15,7 +15,6 @@ import (
 
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
-	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/writer"
 )
 
 const DefaultAddr = "127.0.0.1:8765"
@@ -33,6 +32,7 @@ type StatusResponse struct {
 	Version          string                          `json:"version"`
 	ConfigPath       string                          `json:"config_path"`
 	LogPath          string                          `json:"log_path"`
+	RuntimeLog       lifecycle.RuntimeLogSource      `json:"runtime_log"`
 	ContentRetention endpointconfig.ContentRetention `json:"content_retention"`
 	Harnesses        interface{}                     `json:"harnesses"`
 	Collector        interface{}                     `json:"collector"`
@@ -41,9 +41,9 @@ type StatusResponse struct {
 }
 
 func Handler(opts Options) (http.Handler, error) {
-	if opts.LogPath == "" {
-		opts.LogPath = writer.DefaultPath(opts.UserMode)
-	}
+	runtimeLog := lifecycle.ResolveRuntimeLog(opts.UserMode, opts.LogPath)
+	opts.LogPath = runtimeLog.EffectiveLogPath
+	opts.UserMode = runtimeLog.EffectiveUserMode
 	staticRoot, err := fs.Sub(staticFiles, "static")
 	if err != nil {
 		return nil, err
@@ -66,6 +66,7 @@ func Handler(opts Options) (http.Handler, error) {
 			Version:          status.Version,
 			ConfigPath:       status.ConfigPath,
 			LogPath:          status.LogPath,
+			RuntimeLog:       runtimeLog,
 			ContentRetention: cfg.ContentRetention,
 			Harnesses:        status.Harnesses,
 			Collector:        status.Collector,

--- a/cli/beacon/internal/endpoint/dashboard/server_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/server_test.go
@@ -1,0 +1,35 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func TestStatusUsesExplicitRuntimeLogPath(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	handler, err := Handler(Options{UserMode: true, LogPath: logPath})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var status StatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &status); err != nil {
+		t.Fatalf("unmarshal status response: %v", err)
+	}
+	if status.LogPath != logPath {
+		t.Fatalf("LogPath = %q, want %q", status.LogPath, logPath)
+	}
+	if status.RuntimeLog.EffectiveLogPath != logPath {
+		t.Fatalf("RuntimeLog.EffectiveLogPath = %q, want %q", status.RuntimeLog.EffectiveLogPath, logPath)
+	}
+}

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -225,11 +225,12 @@ func mergeCodexOTEL(existing, endpoint string) string {
 	for _, line := range lines {
 		trim := strings.TrimSpace(line)
 		if strings.HasPrefix(trim, "[") && strings.HasSuffix(trim, "]") {
-			if inOTEL && !wroteOTEL {
+			isOTELHeader := codexOTELHeader(trim)
+			if inOTEL && !isOTELHeader && !wroteOTEL {
 				out = append(out, codexOTELBlock(endpoint)...)
 				wroteOTEL = true
 			}
-			inOTEL = trim == "[otel]"
+			inOTEL = isOTELHeader
 			if !inOTEL {
 				out = append(out, line)
 			}
@@ -253,13 +254,24 @@ func mergeCodexOTEL(existing, endpoint string) string {
 	return strings.TrimRight(strings.Join(out, "\n"), "\n") + "\n"
 }
 
+func codexOTELHeader(header string) bool {
+	return header == "[otel]" || strings.HasPrefix(header, "[otel.")
+}
+
 func codexOTELBlock(endpoint string) []string {
 	return []string{
 		"[otel]",
-		"enabled = true",
+		"environment = \"dev\"",
+		"log_user_prompt = false",
+		"",
+		"[otel.exporter.\"otlp-grpc\"]",
 		fmt.Sprintf("endpoint = %q", endpoint),
-		"service_name = \"codex-cli\"",
-		"sampling_ratio = 1.0",
+		"",
+		"[otel.trace_exporter.\"otlp-grpc\"]",
+		fmt.Sprintf("endpoint = %q", endpoint),
+		"",
+		"[otel.metrics_exporter.\"otlp-grpc\"]",
+		fmt.Sprintf("endpoint = %q", endpoint),
 	}
 }
 
@@ -295,8 +307,8 @@ func codexStatus(path string) (TelemetryStatus, string) {
 	if !strings.Contains(text, "[otel]") {
 		return TelemetryDisabled, "Codex [otel] config is missing"
 	}
-	if !strings.Contains(text, "enabled = true") {
-		return TelemetryDisabled, "Codex OTEL is not enabled"
+	if !strings.Contains(text, "otlp-grpc") && !strings.Contains(text, "otlp-http") {
+		return TelemetryDisabled, "Codex OTEL exporter is not configured"
 	}
 	if !strings.Contains(text, "127.0.0.1") && !strings.Contains(text, "localhost") {
 		return TelemetryMisconfigured, "Codex OTLP endpoint does not point to localhost"

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -13,7 +13,8 @@ func TestMergeCodexOTELAddsBlock(t *testing.T) {
 	if !strings.Contains(got, "[otel]") {
 		t.Fatalf("expected otel block: %s", got)
 	}
-	if !strings.Contains(got, "endpoint = \"http://127.0.0.1:4317\"") {
+	if !strings.Contains(got, `[otel.exporter."otlp-grpc"]`) ||
+		!strings.Contains(got, `endpoint = "http://127.0.0.1:4317"`) {
 		t.Fatalf("expected endpoint: %s", got)
 	}
 	if !strings.Contains(got, "model = \"gpt-5\"") {
@@ -22,9 +23,9 @@ func TestMergeCodexOTELAddsBlock(t *testing.T) {
 }
 
 func TestMergeCodexOTELReplacesExistingBlock(t *testing.T) {
-	input := "[otel]\nenabled = false\nendpoint = \"https://example.com\"\n\n[profile]\nname = \"default\"\n"
+	input := "[otel]\nenabled = false\nendpoint = \"https://example.com\"\n\n[otel.exporter.\"otlp-http\"]\nendpoint = \"https://old.example.com/v1/logs\"\n\n[profile]\nname = \"default\"\n"
 	got := mergeCodexOTEL(input, "http://127.0.0.1:4317")
-	if strings.Contains(got, "https://example.com") || strings.Contains(got, "enabled = false") {
+	if strings.Contains(got, "https://example.com") || strings.Contains(got, "old.example.com") || strings.Contains(got, "enabled = false") {
 		t.Fatalf("old otel config was not replaced: %s", got)
 	}
 	if !strings.Contains(got, "[profile]\nname = \"default\"") {
@@ -135,9 +136,12 @@ func TestConfigureCodexWritesTelemetryBlockAndBackup(t *testing.T) {
 	for _, want := range []string{
 		"model = \"gpt-5\"",
 		"[otel]",
-		"enabled = true",
+		"environment = \"dev\"",
+		"log_user_prompt = false",
+		"[otel.exporter.\"otlp-grpc\"]",
+		"[otel.trace_exporter.\"otlp-grpc\"]",
+		"[otel.metrics_exporter.\"otlp-grpc\"]",
 		"endpoint = \"http://127.0.0.1:4317\"",
-		"service_name = \"codex-cli\"",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("codex config missing %q:\n%s", want, text)
@@ -160,9 +164,12 @@ func TestCodexStatusVariants(t *testing.T) {
 		status TelemetryStatus
 	}{
 		{name: "missing block", body: `model = "gpt-5"`, status: TelemetryDisabled},
-		{name: "disabled", body: "[otel]\nenabled = false\nendpoint = \"http://127.0.0.1:4317\"\n", status: TelemetryDisabled},
-		{name: "remote endpoint", body: "[otel]\nenabled = true\nendpoint = \"https://example.com\"\n", status: TelemetryMisconfigured},
-		{name: "enabled", body: "[otel]\nenabled = true\nendpoint = \"http://localhost:4317\"\n", status: TelemetryEnabled},
+		{name: "old shape", body: "[otel]\nenabled = true\nendpoint = \"http://127.0.0.1:4317\"\n", status: TelemetryDisabled},
+		{name: "exporter none", body: "[otel]\nexporter = \"none\"\n", status: TelemetryDisabled},
+		{name: "remote endpoint", body: "[otel]\nexporter = { otlp-grpc = { endpoint = \"https://example.com:4317\" } }\n", status: TelemetryMisconfigured},
+		{name: "grpc enabled", body: "[otel]\nexporter = { otlp-grpc = { endpoint = \"http://localhost:4317\" } }\n", status: TelemetryEnabled},
+		{name: "grpc table enabled", body: "[otel]\nlog_user_prompt = false\n\n[otel.exporter.\"otlp-grpc\"]\nendpoint = \"http://localhost:4317\"\n", status: TelemetryEnabled},
+		{name: "http enabled", body: "[otel]\nexporter = { otlp-http = { endpoint = \"http://127.0.0.1:4318/v1/logs\" } }\n", status: TelemetryEnabled},
 	}
 
 	for _, tt := range tests {

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -49,11 +49,21 @@ type Status struct {
 	Version     string                   `json:"version"`
 	ConfigPath  string                   `json:"config_path"`
 	LogPath     string                   `json:"log_path"`
+	RuntimeLog  RuntimeLogSource         `json:"runtime_log"`
 	Collector   endpointcollector.Status `json:"collector"`
 	Service     service.Status           `json:"service"`
 	Harnesses   []harness.Harness        `json:"harnesses"`
 	Diagnostics []diagnostics.Check      `json:"diagnostics"`
 	LastEvent   string                   `json:"last_event,omitempty"`
+}
+
+type RuntimeLogSource struct {
+	RequestedUserMode bool   `json:"requested_user_mode"`
+	EffectiveUserMode bool   `json:"effective_user_mode"`
+	RequestedLogPath  string `json:"requested_log_path"`
+	EffectiveLogPath  string `json:"effective_log_path"`
+	Reason            string `json:"reason,omitempty"`
+	Warning           string `json:"warning,omitempty"`
 }
 
 type Manifest struct {
@@ -174,17 +184,69 @@ func Repair(opts InstallOptions) (InstallResult, error) {
 
 func GetStatus(userMode bool, logPath string) Status {
 	cfg := loadOrDefault(userMode, logPath)
-	last, _ := writer.LastLine(cfg.LogPath)
+	runtimeLog := ResolveRuntimeLog(userMode, logPath)
+	effectiveCfg := cfg
+	effectiveCfg.UserMode = runtimeLog.EffectiveUserMode
+	if runtimeLog.EffectiveUserMode != cfg.UserMode {
+		effectiveCfg = loadOrDefault(runtimeLog.EffectiveUserMode, runtimeLog.EffectiveLogPath)
+	}
+	effectiveCfg.LogPath = runtimeLog.EffectiveLogPath
+	last, _ := writer.LastLine(effectiveCfg.LogPath)
+	checks := diagnostics.Run(effectiveCfg)
+	if runtimeLog.Warning != "" {
+		checks = append(checks, diagnostics.Check{
+			Name:     "runtime_log_source",
+			Status:   "warn",
+			Severity: "medium",
+			Message:  runtimeLog.Warning,
+		})
+	}
 	return Status{
 		Version:     version.GetVersion(),
-		ConfigPath:  endpointconfig.ConfigPath(cfg.UserMode),
-		LogPath:     cfg.LogPath,
-		Collector:   endpointcollector.CheckStatus(cfg),
-		Service:     service.Manager{UserMode: cfg.UserMode}.Status(),
+		ConfigPath:  endpointconfig.ConfigPath(effectiveCfg.UserMode),
+		LogPath:     effectiveCfg.LogPath,
+		RuntimeLog:  runtimeLog,
+		Collector:   endpointcollector.CheckStatus(effectiveCfg),
+		Service:     service.Manager{UserMode: effectiveCfg.UserMode}.Status(),
 		Harnesses:   harness.DiscoverAll(),
-		Diagnostics: diagnostics.Run(cfg),
+		Diagnostics: checks,
 		LastEvent:   last,
 	}
+}
+
+func ResolveRuntimeLog(userMode bool, logPath string) RuntimeLogSource {
+	cfg := loadOrDefault(userMode, logPath)
+	source := RuntimeLogSource{
+		RequestedUserMode: userMode,
+		EffectiveUserMode: userMode,
+		RequestedLogPath:  cfg.LogPath,
+		EffectiveLogPath:  cfg.LogPath,
+		Reason:            "requested endpoint configuration",
+	}
+	if logPath != "" {
+		source.Reason = "explicit runtime log path"
+		return source
+	}
+	if !userMode {
+		return source
+	}
+	systemCfg, err := endpointconfig.Load(false)
+	if err != nil || !sameCollectorPorts(cfg, systemCfg) || systemCfg.LogPath == "" || systemCfg.LogPath == cfg.LogPath {
+		return source
+	}
+	return selectRuntimeLog(source, service.Manager{UserMode: true}.Status(), service.Manager{UserMode: false}.Status(), systemCfg)
+}
+
+func selectRuntimeLog(source RuntimeLogSource, requestedService, systemService service.Status, systemCfg endpointconfig.Config) RuntimeLogSource {
+	if systemService.Running && !requestedService.Running {
+		source.Reason = "requested endpoint configuration; system collector is also running on the configured OTLP ports"
+		source.Warning = fmt.Sprintf("system collector is writing OTLP events to %s instead of the user runtime log %s; stop the system collector or install user mode to keep all events in one file", systemCfg.LogPath, source.RequestedLogPath)
+	}
+	return source
+}
+
+func sameCollectorPorts(left, right endpointconfig.Config) bool {
+	return left.Collector.GRPCPort == right.Collector.GRPCPort && left.Collector.HTTPPort == right.Collector.HTTPPort
 }
 
 func buildConfig(opts InstallOptions) endpointconfig.Config {
@@ -230,7 +292,7 @@ func preflight(cfg endpointconfig.Config, startService bool) error {
 		return fmt.Errorf("production endpoint install is currently supported only on macOS")
 	}
 	if !cfg.UserMode && os.Geteuid() != 0 {
-		return fmt.Errorf("system install requires root; rerun with sudo or use --user")
+		return fmt.Errorf("system install requires root; rerun with sudo or omit --system for the default user install")
 	}
 	if !startService {
 		return nil

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/service"
 )
 
 func TestRestoreTargetTimestampedBackup(t *testing.T) {
@@ -53,6 +54,64 @@ func TestBuildConfigAppliesInstallOptions(t *testing.T) {
 	}
 	if cfg.Collector.BinaryPath != collectorPath {
 		t.Fatalf("BinaryPath = %q, want %q", cfg.Collector.BinaryPath, collectorPath)
+	}
+}
+
+func TestSelectRuntimeLogWarnsWhenSystemCollectorConflictsWithUserMode(t *testing.T) {
+	userLog := filepath.Join(t.TempDir(), "user-runtime.jsonl")
+	systemLog := filepath.Join(t.TempDir(), "system-runtime.jsonl")
+	source := RuntimeLogSource{
+		RequestedUserMode: true,
+		EffectiveUserMode: true,
+		RequestedLogPath:  userLog,
+		EffectiveLogPath:  userLog,
+	}
+	systemCfg := endpointconfig.Config{LogPath: systemLog}
+
+	got := selectRuntimeLog(
+		source,
+		service.Status{Label: service.UserLabel, Loaded: false, Running: false},
+		service.Status{Label: service.SystemLabel, Loaded: true, Running: true},
+		systemCfg,
+	)
+
+	if !got.EffectiveUserMode {
+		t.Fatal("expected effective user mode")
+	}
+	if got.EffectiveLogPath != userLog {
+		t.Fatalf("EffectiveLogPath = %q, want %q", got.EffectiveLogPath, userLog)
+	}
+	if got.Warning == "" || !strings.Contains(got.Warning, userLog) || !strings.Contains(got.Warning, systemLog) {
+		t.Fatalf("Warning = %q, want user/system log paths", got.Warning)
+	}
+}
+
+func TestSelectRuntimeLogKeepsUserLogWhenUserCollectorIsRunning(t *testing.T) {
+	userLog := filepath.Join(t.TempDir(), "user-runtime.jsonl")
+	systemLog := filepath.Join(t.TempDir(), "system-runtime.jsonl")
+	source := RuntimeLogSource{
+		RequestedUserMode: true,
+		EffectiveUserMode: true,
+		RequestedLogPath:  userLog,
+		EffectiveLogPath:  userLog,
+	}
+	systemCfg := endpointconfig.Config{LogPath: systemLog}
+
+	got := selectRuntimeLog(
+		source,
+		service.Status{Label: service.UserLabel, Loaded: true, Running: true},
+		service.Status{Label: service.SystemLabel, Loaded: true, Running: true},
+		systemCfg,
+	)
+
+	if !got.EffectiveUserMode {
+		t.Fatal("expected effective user mode")
+	}
+	if got.EffectiveLogPath != userLog {
+		t.Fatalf("EffectiveLogPath = %q, want %q", got.EffectiveLogPath, userLog)
+	}
+	if got.Warning != "" {
+		t.Fatalf("Warning = %q, want empty", got.Warning)
 	}
 }
 

--- a/collector-builder/exporter/beaconjsonexporter/exporter.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter.go
@@ -80,6 +80,9 @@ func (e *beaconExporter) consumeTraces(ctx context.Context, traces ptrace.Traces
 			scopeSpans := resourceSpans.ScopeSpans().At(j)
 			for k := 0; k < scopeSpans.Spans().Len(); k++ {
 				span := scopeSpans.Spans().At(k)
+				if shouldDropSpan(resourceAttrs, span) {
+					continue
+				}
 				event := e.eventFromSpan(resourceAttrs, span)
 				if err := e.writer.append(event); err != nil && firstErr == nil {
 					firstErr = err
@@ -118,7 +121,7 @@ func (e *beaconExporter) eventFromLog(resourceAttrs map[string]interface{}, reco
 		action = inferAction(attrs, record.Body().AsString())
 	}
 	message := firstNonEmpty(record.Body().AsString(), firstString(attrs, "message", "log.message"))
-	event := newBeaconEvent(action, firstString(attrs, "beacon.event.category", "event.category", "category"), severity(record.SeverityText(), record.SeverityNumber().String()), harnessName(attrs, message), ts)
+	event := newBeaconEvent(action, eventCategory(action, firstString(attrs, "beacon.event.category", "event.category", "category")), severity(record.SeverityText(), record.SeverityNumber().String()), harnessName(attrs, message), ts)
 	event.Message = message
 	e.populateCommon(&event, attrs)
 	event.Raw = e.rawPayload(attrs, map[string]interface{}{
@@ -135,7 +138,7 @@ func (e *beaconExporter) eventFromSpan(resourceAttrs map[string]interface{}, spa
 		action = inferAction(attrs, span.Name())
 	}
 	message := firstNonEmpty(firstString(attrs, "message", "gen_ai.prompt", "gen_ai.response"), span.Name())
-	event := newBeaconEvent(action, firstString(attrs, "beacon.event.category", "event.category", "tool"), spanSeverity(span.Status().Code().String()), harnessName(attrs, message, span.Name()), timestamp(span.StartTimestamp().AsTime()))
+	event := newBeaconEvent(action, eventCategory(action, firstString(attrs, "beacon.event.category", "event.category", "tool")), spanSeverity(span.Status().Code().String()), harnessName(attrs, message, span.Name()), timestamp(span.StartTimestamp().AsTime()))
 	event.Message = message
 	e.populateCommon(&event, attrs)
 	event.Raw = e.rawPayload(attrs, map[string]interface{}{
@@ -145,6 +148,69 @@ func (e *beaconExporter) eventFromSpan(resourceAttrs map[string]interface{}, spa
 		"status":      span.Status().Code().String(),
 	})
 	return event
+}
+
+func shouldDropSpan(resourceAttrs map[string]interface{}, span ptrace.Span) bool {
+	attrs := mergeMaps(resourceAttrs, attrsToMap(span.Attributes()))
+	if harnessName(attrs, span.Name()) != "codex_cli" {
+		return false
+	}
+	return isCodexInternalSpan(span.Name())
+}
+
+func isCodexInternalSpan(name string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "" {
+		return true
+	}
+	keepPrefixes := []string{
+		"codex.",
+		"op.dispatch",
+		"session_task.",
+		"model_client.",
+		"run_turn",
+		"run_sampling_request",
+		"try_run_sampling_request",
+		"stream_request",
+		"handle_responses",
+	}
+	for _, prefix := range keepPrefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return false
+		}
+	}
+	dropExact := map[string]struct{}{
+		"receiving":                     {},
+		"receiving_stream":              {},
+		"poll":                          {},
+		"poll_ready":                    {},
+		"popped":                        {},
+		"pop_frame":                     {},
+		"reserve_capacity":              {},
+		"try_assign_capacity":           {},
+		"try_reclaim_frame":             {},
+		"assign_connection_capacity":    {},
+		"updating stream flow":          {},
+		"updating connection flow":      {},
+		"recv_stream_window_update":     {},
+		"recv_connection_window_update": {},
+		"send_data":                     {},
+	}
+	if _, ok := dropExact[normalized]; ok {
+		return true
+	}
+	dropPrefixes := []string{
+		"framedread::",
+		"framedwrite::",
+		"hpack::",
+		"prioritize::",
+	}
+	for _, prefix := range dropPrefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *beaconExporter) eventFromMetric(resourceAttrs map[string]interface{}, metric pmetric.Metric) beaconEvent {
@@ -363,5 +429,29 @@ func inferAction(attrs map[string]interface{}, fallback string) string {
 		return "approval.requested"
 	default:
 		return "tool.invoked"
+	}
+}
+
+func eventCategory(action, explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+	switch {
+	case strings.HasPrefix(action, "prompt."):
+		return "prompt"
+	case strings.HasPrefix(action, "command."):
+		return "command"
+	case strings.HasPrefix(action, "file."):
+		return "file"
+	case strings.HasPrefix(action, "mcp."):
+		return "mcp"
+	case strings.HasPrefix(action, "approval.") || strings.HasPrefix(action, "policy."):
+		return "approval"
+	case strings.HasPrefix(action, "metric."):
+		return "metric"
+	case strings.HasPrefix(action, "tool."):
+		return "tool"
+	default:
+		return ""
 	}
 }

--- a/collector-builder/exporter/beaconjsonexporter/exporter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter_test.go
@@ -10,6 +10,7 @@ import (
 
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
 func TestConfigValidateRequiresPath(t *testing.T) {
@@ -64,11 +65,35 @@ func TestConsumeLogsWritesBeaconJSONL(t *testing.T) {
 	if event.Vendor != vendor || event.Event.Action != "tool.invoked" || event.Harness.Name != "claude_cowork" {
 		t.Fatalf("unexpected event: %#v", event)
 	}
+	if event.Event.Category != "tool" {
+		t.Fatalf("event category = %q, want tool", event.Event.Category)
+	}
 	if event.Session == nil || event.Session.ID != "session-1" {
 		t.Fatalf("session missing from event: %#v", event.Session)
 	}
 	if event.Command == nil || event.Command.Command != "kubectl get pods" {
 		t.Fatalf("command missing from event: %#v", event.Command)
+	}
+}
+
+func TestEventCategoryInfersFromAction(t *testing.T) {
+	tests := map[string]string{
+		"tool.invoked":       "tool",
+		"file.modified":      "file",
+		"command.executed":   "command",
+		"mcp.tool_invoked":   "mcp",
+		"approval.requested": "approval",
+		"policy.blocked":     "approval",
+		"prompt.submitted":   "prompt",
+		"metric.observed":    "metric",
+	}
+	for action, want := range tests {
+		if got := eventCategory(action, ""); got != want {
+			t.Fatalf("eventCategory(%q) = %q, want %q", action, got, want)
+		}
+	}
+	if got := eventCategory("tool.invoked", "custom"); got != "custom" {
+		t.Fatalf("explicit category = %q, want custom", got)
 	}
 }
 
@@ -91,6 +116,63 @@ func TestMetadataRetentionDropsRawAttributes(t *testing.T) {
 	if raw["attribute_count"] != 1 {
 		t.Fatalf("attribute count missing: %#v", raw)
 	}
+}
+
+func TestCodexInternalSpanFilter(t *testing.T) {
+	codexAttrs := map[string]interface{}{"service.name": "codex-cli"}
+
+	if !shouldDropSpan(codexAttrs, testSpan("FramedRead::poll_next")) {
+		t.Fatal("expected Codex transport span to be dropped")
+	}
+	if shouldDropSpan(codexAttrs, testSpan("session_task.turn")) {
+		t.Fatal("expected meaningful Codex session span to be kept")
+	}
+	if shouldDropSpan(map[string]interface{}{"service.name": "other-agent"}, testSpan("FramedRead::poll_next")) {
+		t.Fatal("expected non-Codex span to be kept")
+	}
+}
+
+func TestConsumeTracesDropsCodexInternalSpans(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:             path,
+		MaxEventBytes:    defaultMaxEventBytes,
+		RotateBytes:      defaultRotateBytes,
+		RedactSecrets:    true,
+		ContentRetention: "metadata",
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "codex-cli")
+	spans := rs.ScopeSpans().AppendEmpty().Spans()
+	spans.AppendEmpty().SetName("FramedRead::poll_next")
+	spans.AppendEmpty().SetName("session_task.turn")
+
+	if err := exp.consumeTraces(context.Background(), traces); err != nil {
+		t.Fatalf("consumeTraces returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime log: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "FramedRead::poll_next") {
+		t.Fatalf("transport span was written: %s", text)
+	}
+	if !strings.Contains(text, "session_task.turn") {
+		t.Fatalf("meaningful span was not written: %s", text)
+	}
+}
+
+func testSpan(name string) ptrace.Span {
+	traces := ptrace.NewTraces()
+	span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName(name)
+	return span
 }
 
 func TestHarnessNameSeparatesClaudeCodeAndCowork(t *testing.T) {

--- a/packaging/macos/install-endpoint.sh
+++ b/packaging/macos/install-endpoint.sh
@@ -21,6 +21,7 @@ if [ -z "$BEACON_COLLECTOR" ] && [ -x "/opt/beacon/bin/beacon-otelcol" ]; then
 fi
 
 set -- endpoint install \
+  --system \
   --harness "$BEACON_ENDPOINT_HARNESSES" \
   --content-retention "$BEACON_CONTENT_RETENTION" \
   --otlp-grpc-port "$BEACON_OTLP_GRPC_PORT" \

--- a/packaging/macos/test-endpoint-scripts.sh
+++ b/packaging/macos/test-endpoint-scripts.sh
@@ -34,7 +34,7 @@ STUB_LOG="$STUB_LOG" \
 
 INSTALL_ARGS="$(cat "$STUB_LOG")"
 case "$INSTALL_ARGS" in
-  "endpoint install --harness claude,codex,cursor --content-retention redacted --otlp-grpc-port 5317 --otlp-http-port 5318 --collector /tmp/beacon-otelcol") ;;
+  "endpoint install --system --harness claude,codex,cursor --content-retention redacted --otlp-grpc-port 5317 --otlp-http-port 5318 --collector /tmp/beacon-otelcol") ;;
   *)
     echo "unexpected install args: $INSTALL_ARGS" >&2
     exit 1
@@ -47,7 +47,7 @@ STUB_LOG="$STUB_LOG" \
 
 INSTALL_ARGS="$(cat "$STUB_LOG")"
 case "$INSTALL_ARGS" in
-  "endpoint install --harness claude --content-retention metadata --otlp-grpc-port 6317 --otlp-http-port 6318 --collector /tmp/jamf-otelcol --no-start") ;;
+  "endpoint install --system --harness claude --content-retention metadata --otlp-grpc-port 6317 --otlp-http-port 6318 --collector /tmp/jamf-otelcol --no-start") ;;
   *)
     echo "unexpected Jamf positional install args: $INSTALL_ARGS" >&2
     exit 1
@@ -62,7 +62,7 @@ STUB_LOG="$STUB_LOG" \
 
 UNINSTALL_ARGS="$(cat "$STUB_LOG")"
 case "$UNINSTALL_ARGS" in
-  "endpoint uninstall --keep-logs --keep-config") ;;
+  "endpoint uninstall --system --keep-logs --keep-config") ;;
   *)
     echo "unexpected uninstall args with keep logs: $UNINSTALL_ARGS" >&2
     exit 1
@@ -75,7 +75,7 @@ STUB_LOG="$STUB_LOG" \
 
 UNINSTALL_ARGS="$(cat "$STUB_LOG")"
 case "$UNINSTALL_ARGS" in
-  "endpoint uninstall --keep-logs --keep-config") ;;
+  "endpoint uninstall --system --keep-logs --keep-config") ;;
   *)
     echo "unexpected Jamf positional uninstall args: $UNINSTALL_ARGS" >&2
     exit 1
@@ -117,7 +117,7 @@ STUB_LOG="$STUB_LOG" \
 
 UNINSTALL_ARGS="$(cat "$STUB_LOG")"
 case "$UNINSTALL_ARGS" in
-  "endpoint uninstall") ;;
+  "endpoint uninstall --system") ;;
   *)
     echo "unexpected uninstall args without keep logs: $UNINSTALL_ARGS" >&2
     exit 1

--- a/packaging/macos/uninstall-endpoint.sh
+++ b/packaging/macos/uninstall-endpoint.sh
@@ -12,7 +12,7 @@ fi
 BEACON_KEEP_LOGS="${BEACON_KEEP_LOGS:-${4:-0}}"
 BEACON_KEEP_CONFIG="${BEACON_KEEP_CONFIG:-${5:-0}}"
 
-set -- endpoint uninstall
+set -- endpoint uninstall --system
 
 case "$BEACON_KEEP_LOGS" in
   1|true|TRUE|yes|YES)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default CLI behavior around user vs system installs and introduces runtime-log auto-resolution/warnings, which can affect where telemetry is written and how status/dashboard behave. Also modifies Codex OTEL config generation and drops certain Codex trace spans, which could hide some trace data if the filter is too aggressive.
> 
> **Overview**
> **Makes per-user endpoint mode the default** across `beacon endpoint` commands by defaulting `--user` to true, adding explicit `--system`, and updating docs/release instructions, Homebrew caveats, and packaging scripts to use `--system` only for root/MDM installs.
> 
> **Improves runtime log selection and observability** by introducing `lifecycle.ResolveRuntimeLog` (used by `status`/dashboard API) to detect when a system collector is likely capturing OTLP traffic while the user install is selected, surfacing warnings in CLI output, diagnostics, and `/api/status`.
> 
> **Updates Codex telemetry behavior** by writing a new structured Codex OTEL config block (including exporter tables and disabling user prompt logging) and adjusting status checks to match, while the `beaconjson` exporter now infers missing `event.category` from `event.action` and filters out noisy internal Codex transport spans from trace ingestion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a727b423f0ed36bf2cd901a1704128443d35639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->