### PR TITLE
Stop duplicate hook endpoint telemetry

### DIFF
--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -49,8 +49,6 @@ func runPostTool(cmd *cobra.Command, args []string) {
 
 	var params *evaluationParams
 
-	emitPostToolObserved(logger, input)
-
 	if platformFlag == "cursor" {
 		// Cursor fires two hook types through post-tool:
 		//   - afterFileEdit: has "edits" array and top-level "file_path" (no output supported)
@@ -58,6 +56,7 @@ func runPostTool(cmd *cobra.Command, args []string) {
 		// We use hook_event_name (present in all Cursor hook inputs) to distinguish them.
 		hookEvent, _ := input["hook_event_name"].(string)
 		if hookEvent != "afterFileEdit" {
+			emitPostToolObserved(logger, input)
 			outputJSON(emptyResponse)
 			return
 		}
@@ -68,6 +67,9 @@ func runPostTool(cmd *cobra.Command, args []string) {
 	}
 
 	if params == nil {
+		if platformFlag != "cursor" {
+			emitPostToolObserved(logger, input)
+		}
 		outputJSON(emptyResponse)
 		return
 	}

--- a/cli/beacon-hooks/internal/logging/endpoint_event_test.go
+++ b/cli/beacon-hooks/internal/logging/endpoint_event_test.go
@@ -1,24 +1,38 @@
 package logging
 
-import "testing"
-
-func TestEndpointActionDoesNotClassifyRoutineStopAsBlocked(t *testing.T) {
-	action, severity := endpointAction("stop-async-handler", map[string]interface{}{"message": "stop completed"})
-	if action != "session.ended" || severity != "info" {
-		t.Fatalf("endpointAction() = %s/%s, want session.ended/info", action, severity)
-	}
-}
-
-func TestEndpointActionClassifiesViolationBlock(t *testing.T) {
-	action, severity := endpointAction("stop-async-handler", map[string]interface{}{"message": "Blocking with violations"})
-	if action != "policy.blocked" || severity != "high" {
-		t.Fatalf("endpointAction() = %s/%s, want policy.blocked/high", action, severity)
-	}
-}
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestEndpointRedaction(t *testing.T) {
 	got := redactEndpointString("token=super-secret")
 	if got == "token=super-secret" {
 		t.Fatal("expected token to be redacted")
+	}
+}
+
+func TestRegularLogDoesNotWriteEndpointEventByDefault(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	logger := NewLoggerForPlatform("pre-tool", "test")
+	logger.Info("diagnostic only")
+
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("generic logger wrote endpoint event by default, stat err=%v", err)
+	}
+}
+
+func TestEndpointEventStillWritesStructuredTelemetry(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	logger := NewLoggerForPlatform("pre-tool", "test")
+	logger.EndpointEvent("approval.allowed", "approval", "info", "Pre-tool observed", nil)
+
+	if data, err := os.ReadFile(logPath); err != nil || len(data) == 0 {
+		t.Fatalf("expected structured endpoint event, len=%d err=%v", len(data), err)
 	}
 }

--- a/cli/beacon-hooks/internal/logging/logging.go
+++ b/cli/beacon-hooks/internal/logging/logging.go
@@ -95,67 +95,6 @@ func (l *Logger) write(entry map[string]interface{}) {
 	}
 }
 
-func (l *Logger) writeEndpointEvent(entry map[string]interface{}) {
-	path := endpointLogPath()
-	if path == "" {
-		return
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return
-	}
-	hostname, _ := os.Hostname()
-	action, severity := endpointAction(l.hookName, entry)
-	event := map[string]interface{}{
-		"timestamp":      time.Now().UTC().Format(time.RFC3339),
-		"vendor":         "beacon",
-		"product":        "endpoint-agent",
-		"schema_version": "1.0",
-		"event": map[string]interface{}{
-			"kind":     "agent_runtime",
-			"action":   action,
-			"category": "hook",
-		},
-		"severity": severity,
-		"endpoint": map[string]interface{}{
-			"hostname": hostname,
-			"os":       runtime.GOOS,
-		},
-		"user": map[string]interface{}{
-			"name": os.Getenv("USER"),
-		},
-		"harness": map[string]interface{}{
-			"name": l.platform,
-		},
-		"message": redactEndpointString(truncateEndpoint(fmt.Sprint(entry["message"]), 4096)),
-	}
-	if l.sessionID != "" {
-		event["session"] = map[string]interface{}{"id": l.sessionID}
-	}
-	data, err := json.Marshal(event)
-	if err != nil {
-		return
-	}
-	if len(data) > 64*1024 {
-		event["field_truncated"] = true
-		event["message"] = truncateEndpoint(fmt.Sprint(event["message"]), 1024)
-		data, err = json.Marshal(event)
-		if err != nil {
-			return
-		}
-	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return
-	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		_ = f.Close()
-		return
-	}
-	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-	defer f.Close()
-	_, _ = f.Write(append(data, '\n'))
-}
-
 func (l *Logger) EndpointEvent(action, category, severity, message string, fields map[string]interface{}) {
 	path := endpointLogPath()
 	if path == "" {
@@ -245,31 +184,6 @@ func writeEndpointJSON(path string, event map[string]interface{}) {
 	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 	defer f.Close()
 	_, _ = f.Write(append(data, '\n'))
-}
-
-func endpointAction(hookName string, entry map[string]interface{}) (action, severity string) {
-	message := strings.ToLower(fmt.Sprint(entry["message"]))
-	switch hookName {
-	case "session-start":
-		return "session.started", "info"
-	case "session-end":
-		return "session.ended", "info"
-	case "pre-tool":
-		if strings.Contains(message, "denying") || strings.Contains(message, "block") {
-			return "policy.warned", "medium"
-		}
-		return "tool.invoked", "info"
-	case "stop-async-handler":
-		if strings.Contains(message, "blocking with violations") {
-			return "policy.blocked", "high"
-		}
-		if strings.Contains(message, "warning") {
-			return "policy.warned", "medium"
-		}
-		return "session.ended", "info"
-	default:
-		return "tool.invoked", "info"
-	}
 }
 
 func endpointLogPath() string {


### PR DESCRIPTION
## Summary
- Stop regular hook diagnostic logger entries from writing generic endpoint JSONL rows.
- Keep endpoint telemetry limited to explicit schema-rich `EndpointEvent` calls.
- Prevent Cursor `afterFileEdit` handling from emitting both a generic observed file event and the enriched file metadata event.

## Why
Hook commands already emit structured endpoint telemetry for sessions, prompts, approvals, tool activity, commands, and file edits. The generic logger bridge caused internal debug/info/warn/error messages to appear as additional endpoint events, inflating dashboard and Wazuh counts with noisy duplicate rows.

## Validation
- `go test ./...` from `cli/beacon-hooks`
- Isolated local E2E run with a built `beacon-hooks` binary, temp `HOME`, and temp `BEACON_ENDPOINT_LOG` across `session-start`, `prompt-submit`, `pre-tool`, Cursor `post-tool afterFileEdit`, and `stop`
- Confirmed final endpoint JSONL contained exactly 5 structured rows: `session.started`, `prompt.submitted`, `approval.allowed`, enriched `file.modified`, and `tool.completed`
- Confirmed diagnostic session logs are still written separately and no longer appear in endpoint JSONL

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how endpoint telemetry is emitted, which could affect downstream monitoring/alerting and event counts if behavior differs from expectations. Scope is limited to hook telemetry/logging paths and adds tests to guard against regressions.
> 
> **Overview**
> Prevents duplicate endpoint telemetry by **removing the implicit bridge** from generic `Logger` writes to endpoint JSONL, so only explicit schema-rich `EndpointEvent(...)` calls produce endpoint rows.
> 
> Adjusts `post-tool` handling for Cursor so `afterFileEdit` no longer emits both a generic observed tool event and the enriched `file.modified` event, and adds tests ensuring regular logs don’t create endpoint events while `EndpointEvent` still does (with redaction preserved).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa3ace06572e50de88fab664936eb977a4614cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->