### PR TITLE
Add group-level filtering, nil-map guard

### DIFF
--- a/cli/beacon/internal/endpoint/hooks/factory.go
+++ b/cli/beacon/internal/endpoint/hooks/factory.go
@@ -118,6 +118,9 @@ func readFactorySettings(path string) (factorySettings, error) {
 	} else if !os.IsNotExist(err) {
 		return factorySettings{}, err
 	}
+	if settings.hooks == nil {
+		settings.hooks = map[string][]factoryHookGroup{}
+	}
 	return settings, nil
 }
 
@@ -141,8 +144,12 @@ func (settings factorySettings) marshal() ([]byte, error) {
 func mergeFactoryEndpointHook(existing []factoryHookGroup, group factoryHookGroup) []factoryHookGroup {
 	out := make([]factoryHookGroup, 0, len(existing)+1)
 	for _, item := range existing {
-		if !isFactoryEndpointHookGroup(item) {
+		filtered, changed := filterFactoryEndpointHooks(item)
+		if !changed || len(filtered.Hooks) > 0 {
 			out = append(out, item)
+			if changed {
+				out[len(out)-1] = filtered
+			}
 		}
 	}
 	return append(out, group)
@@ -160,11 +167,14 @@ func removeFactoryEndpointHooks(path string) (bool, error) {
 	for eventName, groups := range settings.hooks {
 		filtered := groups[:0]
 		for _, group := range groups {
-			if isFactoryEndpointHookGroup(group) {
+			withoutEndpointHooks, groupChanged := filterFactoryEndpointHooks(group)
+			if groupChanged {
 				changed = true
+			}
+			if len(withoutEndpointHooks.Hooks) == 0 {
 				continue
 			}
-			filtered = append(filtered, group)
+			filtered = append(filtered, withoutEndpointHooks)
 		}
 		if len(filtered) == 0 {
 			delete(settings.hooks, eventName)
@@ -189,6 +199,20 @@ func isFactoryEndpointHookGroup(group factoryHookGroup) bool {
 		}
 	}
 	return false
+}
+
+func filterFactoryEndpointHooks(group factoryHookGroup) (factoryHookGroup, bool) {
+	filtered := group
+	filtered.Hooks = group.Hooks[:0]
+	changed := false
+	for _, hook := range group.Hooks {
+		if isEndpointHookCommand(hook.Command, "factory") {
+			changed = true
+			continue
+		}
+		filtered.Hooks = append(filtered.Hooks, hook)
+	}
+	return filtered, changed
 }
 
 func isFactoryInstalledAt(path string) bool {

--- a/cli/beacon/internal/endpoint/hooks/factory_test.go
+++ b/cli/beacon/internal/endpoint/hooks/factory_test.go
@@ -67,6 +67,32 @@ func TestInstallFactorySettingsReplacesOldBeaconAndAsymptoteHooks(t *testing.T) 
 	}
 }
 
+func TestInstallFactorySettingsPreservesUserHookInMixedGroup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	existing := `{"hooks":{"PostToolUse":[{"matcher":"Write|Edit","hooks":[{"type":"command","command":"echo keep"},{"type":"command","command":"BEACON_ENDPOINT_MODE=1 old-beacon-hooks --platform factory post-tool"}]}]}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installFactorySettings(path, "/tmp/new-beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installFactorySettings returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "old-beacon-hooks") {
+		t.Fatalf("old endpoint hook was not replaced:\n%s", text)
+	}
+	if !strings.Contains(text, "echo keep") {
+		t.Fatalf("user hook in mixed group was not preserved:\n%s", text)
+	}
+	if !strings.Contains(text, "/tmp/new-beacon-hooks") {
+		t.Fatalf("new endpoint hook was not installed:\n%s", text)
+	}
+}
+
 func TestRemoveFactoryEndpointHooksPreservesOtherHooks(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	existing := `{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo keep"}]},{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform factory session-start"}]}]}}`
@@ -94,6 +120,33 @@ func TestRemoveFactoryEndpointHooksPreservesOtherHooks(t *testing.T) {
 	}
 }
 
+func TestRemoveFactoryEndpointHooksPreservesUserHookInMixedGroup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	existing := `{"hooks":{"PostToolUse":[{"matcher":"Write|Edit","hooks":[{"type":"command","command":"echo keep"},{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform factory post-tool"}]}]}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := removeFactoryEndpointHooks(path)
+	if err != nil {
+		t.Fatalf("removeFactoryEndpointHooks returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected endpoint hook removal")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "echo keep") {
+		t.Fatalf("user hook in mixed group was not preserved:\n%s", text)
+	}
+	if strings.Contains(text, "BEACON_ENDPOINT_MODE=1") {
+		t.Fatalf("endpoint hook was not removed:\n%s", text)
+	}
+}
+
 func TestReadFactorySettingsReturnsCorruptJSONError(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	if err := os.WriteFile(path, []byte("{not json"), 0600); err != nil {
@@ -102,6 +155,24 @@ func TestReadFactorySettingsReturnsCorruptJSONError(t *testing.T) {
 
 	if _, err := readFactorySettings(path); err == nil {
 		t.Fatal("expected corrupt settings error")
+	}
+}
+
+func TestInstallFactorySettingsHandlesNullHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{"hooks":null}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installFactorySettings(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installFactorySettings returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if !strings.Contains(string(data), "UserPromptSubmit") {
+		t.Fatalf("Factory hooks were not installed from hooks:null:\n%s", string(data))
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes hook install/uninstall behavior to selectively remove only Factory endpoint hook entries within a group; mistakes could drop or duplicate user-defined hooks in settings.
> 
> **Overview**
> Improves Factory hook management to **filter endpoint hooks at the hook-entry level** instead of dropping entire hook groups, so user commands in mixed groups are preserved during both install (replacement) and uninstall.
> 
> Adds a nil-map guard when reading settings so `{"hooks": null}` no longer breaks installation, and expands tests to cover mixed-group preservation and `hooks:null` handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f0eccf72811878314792a233e67a73e926f4bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->