### PR TITLE
Reorder dashboard columns

### DIFF
--- a/cli/beacon/internal/endpoint/dashboard/static/app.js
+++ b/cli/beacon/internal/endpoint/dashboard/static/app.js
@@ -5,6 +5,8 @@ const state = {
   eventResult: null,
   loading: false,
   error: null,
+  currentQuery: "",
+  newEventCount: 0,
 };
 
 const $ = (selector) => document.querySelector(selector);
@@ -83,35 +85,46 @@ function updateURL(query) {
   window.history.replaceState(null, "", next);
 }
 
-async function load({ updateLocation = false } = {}) {
+async function load({ updateLocation = false, mode = "replace" } = {}) {
   const query = queryFromFilters();
   if (updateLocation) updateURL(query);
   const suffix = query ? `?${query}` : "";
-  state.loading = true;
+  const quiet = mode === "poll";
+  state.loading = !quiet;
   state.error = null;
-  renderLoading();
+  if (!quiet) renderLoading();
+  let rendered = false;
   try {
     const [status, summary, events] = await Promise.all([
       getJSON("/api/status"),
       getJSON(`/api/summary${suffix}`),
       getJSON(`/api/events${suffix}`),
     ]);
+    const previousEvents = state.events;
+    const previousQuery = state.currentQuery;
     state.status = status;
     state.summary = summary;
     state.eventResult = events;
+    state.currentQuery = query;
     state.events = events.events || [];
+    if (quiet && previousQuery === query && canPatchEvents(previousEvents, state.events)) {
+      patchEvents(previousEvents, state.events);
+      renderSummaryOnly();
+      rendered = true;
+    }
   } catch (err) {
     state.error = err;
   } finally {
     state.loading = false;
-    render();
+    if (!rendered) render();
   }
 }
 
 function render() {
   setText("#log-path", state.status?.log_path || "Runtime log unavailable");
-  setText("#retention", `retention: ${state.status?.content_retention || "metadata"}`);
+  setText("#retention", `Data retention: ${state.status?.content_retention || "metadata"}`);
   setText("#last-updated", state.summary?.last_event_time ? `Last event ${formatTime(state.summary.last_event_time)}` : "");
+  renderNewEventsIndicator();
   renderFilterOptions();
   renderCards();
   renderInsights();
@@ -219,6 +232,18 @@ function renderSearchState() {
   });
 }
 
+function renderSummaryOnly() {
+  setText("#log-path", state.status?.log_path || "Runtime log unavailable");
+  setText("#retention", `Data retention: ${state.status?.content_retention || "metadata"}`);
+  setText("#last-updated", state.summary?.last_event_time ? `Last event ${formatTime(state.summary.last_event_time)}` : "");
+  renderNewEventsIndicator();
+  renderFilterOptions();
+  renderCards();
+  renderInsights();
+  renderSearchState();
+  renderHarnesses();
+}
+
 function renderHarnesses() {
   if (!$("#harnesses")) return;
   const harnesses = state.status?.harnesses || [];
@@ -241,41 +266,106 @@ function renderEvents() {
     return;
   }
   if (state.error) {
-    $("#events").innerHTML = `<tr><td colspan="8">Failed to load dashboard: ${escapeHTML(state.error.message)}</td></tr>`;
+    $("#events").innerHTML = `<tr><td colspan="10">Failed to load dashboard: ${escapeHTML(state.error.message)}</td></tr>`;
     return;
   }
   if (!state.events.length) {
-    $("#events").innerHTML = `<tr><td colspan="8">No events match this search. Clear filters or broaden the query.</td></tr>`;
+    $("#events").innerHTML = `<tr><td colspan="10">No events match this search. Clear filters or broaden the query.</td></tr>`;
     return;
   }
   $("#events").innerHTML = state.events
-    .map((record) => {
-      const event = record.event || {};
-      const info = event.event || {};
-      const session = event.session || {};
-      return `
-        <tr data-id="${escapeHTML(record.id)}">
-          <td class="nowrap">${escapeHTML(formatTime(event.timestamp))}</td>
-          <td>${signalCell(record)}</td>
-          <td>${artifactCell(event)}</td>
-          <td>${badge(event.severity || "unknown", `severity-${event.severity || "unknown"}`)}</td>
-          <td>${reviewCell(record)}</td>
-          <td class="mono">${escapeHTML(session.id || "")}</td>
-          <td>${escapeHTML(repositoryLabel(event))}</td>
-          <td>${escapeHTML(event.message || "")}</td>
-        </tr>
-      `;
-    })
+    .map((record) => eventRowHTML(record))
     .join("");
-  document.querySelectorAll("#events tr").forEach((row) => {
+  bindEventRows();
+}
+
+function eventRowHTML(record) {
+  const event = record.event || {};
+  const session = event.session || {};
+  return `
+    <tr data-id="${escapeHTML(record.id)}">
+      <td class="nowrap col-timestamp">${escapeHTML(formatTime(event.timestamp))}</td>
+      <td class="mono">${escapeHTML(session.id || "")}</td>
+      <td>${escapeHTML(repositoryShortLabel(event))}</td>
+      <td>${tagCell(record)}</td>
+      <td>${badge(event.severity || "unknown", `severity-${event.severity || "unknown"}`)}</td>
+      <td>${retentionCell(record)}</td>
+      <td>${signalCell(record)}</td>
+      <td>${harnessCell(event)}</td>
+      <td class="col-artifact">${artifactCell(event)}</td>
+      <td class="col-message">${escapeHTML(event.message || "")}</td>
+    </tr>
+  `;
+}
+
+function bindEventRows(scope = document) {
+  const rows = scope.matches?.("tr[data-id]") ? [scope] : Array.from(scope.querySelectorAll("#events tr, tr[data-id]"));
+  rows.forEach((row) => {
     row.addEventListener("click", (event) => {
       if (event.target.closest("button")) return;
       showEvent(row.dataset.id);
     });
   });
-  $$("#events [data-apply-filter]").forEach((button) => {
+  Array.from(scope.querySelectorAll("[data-apply-filter]")).forEach((button) => {
     button.addEventListener("click", () => applyFilters({ [button.dataset.applyFilter]: button.dataset.value }));
   });
+}
+
+function canPatchEvents(previousEvents, nextEvents) {
+  return $("#events") && previousEvents.length > 0 && nextEvents.length > 0;
+}
+
+function patchEvents(previousEvents, nextEvents) {
+  const tbody = $("#events");
+  if (!tbody) return;
+  const existing = new Set(previousEvents.map((record) => record.id));
+  const newest = [];
+  for (const record of nextEvents) {
+    if (existing.has(record.id)) break;
+    newest.push(record);
+  }
+  if (!newest.length) return;
+  prependEventRows(newest);
+}
+
+function prependEventRows(records) {
+  const tbody = $("#events");
+  if (!tbody) return;
+  const nearTop = window.scrollY < 160;
+  const beforeTop = tbody.getBoundingClientRect().top;
+  const template = document.createElement("template");
+  template.innerHTML = records.map((record) => eventRowHTML(record)).join("");
+  const rows = Array.from(template.content.children);
+  const fragment = document.createDocumentFragment();
+  rows.forEach((row) => fragment.appendChild(row));
+  tbody.prepend(fragment);
+  rows.forEach((row) => bindEventRows(row));
+  if (!nearTop) {
+    const afterTop = tbody.getBoundingClientRect().top;
+    window.scrollBy(0, afterTop - beforeTop);
+    state.newEventCount += records.length;
+  } else {
+    state.newEventCount = 0;
+  }
+  renderNewEventsIndicator();
+}
+
+function renderNewEventsIndicator() {
+  const button = $("#new-events");
+  if (!button) return;
+  if (state.newEventCount > 0) {
+    button.hidden = false;
+    button.textContent = `${state.newEventCount} new event${state.newEventCount === 1 ? "" : "s"} available`;
+  } else {
+    button.hidden = true;
+    button.textContent = "";
+  }
+}
+
+function showNewEvents() {
+  state.newEventCount = 0;
+  renderNewEventsIndicator();
+  window.scrollTo({ top: 0, behavior: "smooth" });
 }
 
 async function showEvent(id) {
@@ -298,24 +388,31 @@ function closeDrawer() {
 
 function renderLoading() {
   setText("#result-meta", "Loading...");
-  if ($("#events")) $("#events").innerHTML = `<tr><td colspan="8">Loading events...</td></tr>`;
+  if ($("#events")) $("#events").innerHTML = `<tr><td colspan="10">Loading events...</td></tr>`;
 }
 
 function signalCell(record) {
   const event = record.event || {};
   const info = event.event || {};
-  const harness = event.harness || {};
   const parts = [
     `<strong>${escapeHTML(signalAction(record))}</strong>`,
-    `<span class="muted">${escapeHTML(info.category || "uncategorized")} · ${escapeHTML(harness.name || "unknown")}${event.model ? ` · ${escapeHTML(event.model)}` : ""}</span>`,
-    filterButtons([
-      ["harness", harness.name],
-      ["model", event.model],
-      ["action", signalAction(record)],
-    ]),
-    record.wazuh_level ? `<span class="muted">Wazuh level ${escapeHTML(record.wazuh_level)}</span>` : "",
+    `<span class="muted">${escapeHTML(info.category || "uncategorized")}${event.model ? ` · ${escapeHTML(event.model)}` : ""}</span>`,
   ].filter(Boolean);
   return parts.join("<br />");
+}
+
+function tagCell(record) {
+  const event = record.event || {};
+  return filterButtons([
+    ["action", signalAction(record)],
+    ["model", event.model],
+  ]);
+}
+
+function harnessCell(event) {
+  const harness = event.harness || {};
+  if (!harness.name) return "";
+  return escapeHTML(harnessLabel(harness.name));
 }
 
 function signalAction(record) {
@@ -355,17 +452,13 @@ function artifactCell(event) {
   `;
 }
 
-function reviewCell(record) {
+function retentionCell(record) {
   const event = record.event || {};
   const labels = [];
-  if (event.severity === "critical" || event.severity === "high") labels.push(badge(event.severity, "badge-danger"));
-  if (record.wazuh_level >= 9) labels.push(badge(`L${record.wazuh_level}`, "badge-danger"));
-  if (event.event?.action === "tool.failed") labels.push(badge("failed", "badge-warn"));
-  if (event.event?.action === "policy.blocked") labels.push(badge("blocked", "badge-danger"));
-  if (event.event?.action === "approval.denied" || event.approval?.decision === "denied") labels.push(badge("denied", "badge-danger"));
-  if (event.content?.truncated || event.field_truncated) labels.push(badge("truncated", "badge-warn"));
   if (event.content?.retention) labels.push(badge(event.content.retention, "badge-muted"));
-  return labels.join(" ") || badge("normal", "badge-muted");
+  if (event.content?.truncated || event.field_truncated) labels.push(badge("truncated", "badge-warn"));
+  if (event.content?.redacted) labels.push(badge("redacted", "badge-warn"));
+  return labels.join(" ") || badge("default", "badge-muted");
 }
 
 function detailSummary(record) {
@@ -402,6 +495,14 @@ function detailSummary(record) {
 
 function repositoryLabel(event) {
   return [event.repository, event.branch].filter(Boolean).join(" @ ");
+}
+
+function repositoryShortLabel(event) {
+  if (!event.repository) return event.branch || "";
+  const parts = event.repository.split("/").filter(Boolean);
+  const repo = parts[parts.length - 1] || event.repository;
+  const label = parts.length > 1 ? `../${repo}` : repo;
+  return [label, event.branch].filter(Boolean).join(" @ ");
 }
 
 function badge(value, className) {
@@ -536,6 +637,7 @@ function detailFilterKey(label) {
 
 function setFilters(filters, { reset = false } = {}) {
   if (reset) clearFields(false);
+  state.newEventCount = 0;
   for (const [key, value] of Object.entries(filters)) {
     const input = $(`[name="${key}"]`);
     if (input) input.value = value;
@@ -562,6 +664,7 @@ function queryStringFromObject(values) {
 
 function clearFilter(key) {
   if (!$("#filters")) return;
+  state.newEventCount = 0;
   const input = $(`[name="${key}"]`);
   if (input) input.value = "";
   load({ updateLocation: true }).catch(console.error);
@@ -569,6 +672,7 @@ function clearFilter(key) {
 
 function clearFields(loadAfter = true) {
   if (!$("#filters")) return;
+  state.newEventCount = 0;
   for (const field of formFields) {
     const input = $(`[name="${field}"]`);
     if (input) input.value = field === "limit" ? "500" : "";
@@ -617,13 +721,14 @@ $("#filters")?.addEventListener("submit", (event) => {
 });
 $("#clear-search")?.addEventListener("click", clearSearch);
 $("#close-drawer")?.addEventListener("click", closeDrawer);
+$("#new-events")?.addEventListener("click", showNewEvents);
 $$("[data-preset]").forEach((button) => {
   button.addEventListener("click", () => applyPreset(button.dataset.preset));
 });
 
 hydrateFiltersFromURL();
 load().catch(console.error);
-setInterval(() => load().catch(console.error), 10000);
+setInterval(() => load({ mode: "poll" }).catch(console.error), 10000);
 
 function setText(selector, value) {
   const element = $(selector);

--- a/cli/beacon/internal/endpoint/dashboard/static/index.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/index.html
@@ -20,134 +20,126 @@
     </header>
 
     <main>
-      <section class="panel status-panel">
-        <div>
-          <h2>Endpoint</h2>
-          <p id="log-path" class="muted">Loading runtime log...</p>
-        </div>
-        <div id="retention" class="pill">metadata</div>
-      </section>
-
-      <section class="panel">
+      <section class="panel search-panel">
         <div class="section-head">
           <div>
             <h2>Investigation Search</h2>
             <p class="muted">Search commands, files, MCP tools, prompts, approval reasons, sessions, repositories, models, harnesses, and event messages.</p>
           </div>
-          <div id="result-meta" class="muted"></div>
+          <div class="section-actions">
+            <a class="docs-link" href="https://docs.asymptotelabs.ai/cli/event-schema#entity-model" target="_blank" rel="noreferrer">Entity data model docs</a>
+            <div id="result-meta" class="muted"></div>
+          </div>
         </div>
         <form id="filters" class="search-form">
-          <div class="search-row">
-            <input class="search-input" name="q" placeholder="Search session, command, file path, MCP tool, approval reason, repository, or action" autocomplete="off" />
-            <button type="submit">Search</button>
-            <button type="button" id="clear-search">Clear</button>
-          </div>
-          <div class="primary-filters">
-            <label class="harness-filter">
-              <span>Agent harness</span>
-              <select name="harness" id="harness-filter">
-                <option value="">All agent harnesses</option>
-              </select>
-            </label>
-            <label>
-              <span>Model</span>
-              <select name="model" id="model-filter">
-                <option value="">All models</option>
-              </select>
-            </label>
-            <label>
-              <span>Severity</span>
-              <select name="severity">
-                <option value="">Any severity</option>
-                <option value="info">Info</option>
-                <option value="low">Low</option>
-                <option value="medium">Medium</option>
-                <option value="high">High</option>
-                <option value="critical">Critical</option>
-              </select>
-            </label>
-            <label>
-              <span>Category</span>
-              <select name="category">
-                <option value="">Any category</option>
-                <option value="prompt">Prompt</option>
-                <option value="tool">Tool</option>
-                <option value="command">Command</option>
-                <option value="file">File</option>
-                <option value="mcp">MCP</option>
-                <option value="approval">Approval</option>
-                <option value="session">Session</option>
-                <option value="inventory">Inventory</option>
-                <option value="validation">Validation</option>
-                <option value="metric">Metric</option>
-              </select>
-            </label>
-          </div>
-          <div id="facets" class="facets"></div>
-          <div class="quick-filters" aria-label="Quick filters">
-            <button type="button" data-preset="review">Needs Review</button>
-            <button type="button" data-preset="commands">Commands</button>
-            <button type="button" data-preset="files">File Changes</button>
-            <button type="button" data-preset="mcp">MCP</button>
-            <button type="button" data-preset="approvals">Approvals</button>
-            <button type="button" data-preset="failures">Failures</button>
-            <button type="button" data-preset="high">High Severity</button>
-          </div>
-          <details class="advanced-filters">
-            <summary>Advanced filters</summary>
-            <div class="filters">
-              <input name="action" list="action-options" placeholder="Action" />
-              <input name="repository" placeholder="Repository" />
-              <input name="session" placeholder="Session" />
-              <input name="file" placeholder="File path" />
-              <input name="command" placeholder="Command or tool" />
-              <input name="mcp" placeholder="MCP server or tool" />
-              <input name="approval" placeholder="Approval decision or reason" />
-              <input name="decision" placeholder="Approval/policy decision" />
-              <input name="policy" placeholder="Policy id, name, or reason" />
-              <select name="wazuh_level">
-                <option value="">Any Wazuh level</option>
-                <option value="5">Level 5 workflow</option>
-                <option value="7">Level 7 command/MCP</option>
-                <option value="9">Level 9 failure</option>
-                <option value="10">Level 10 block/denial</option>
-                <option value="12">Level 12 health/tamper</option>
-              </select>
-              <input name="since" placeholder="Since RFC3339, e.g. 2026-05-13T12:00:00Z" />
-              <select name="limit">
-                <option value="100">100 events</option>
-                <option value="500" selected>500 events</option>
-                <option value="1000">1000 events</option>
-                <option value="2000">2000 events</option>
-              </select>
+          <div class="filter-section">
+            <div class="filter-main-row">
+              <div class="primary-filters">
+                <label>
+                  <select name="harness" id="harness-filter" aria-label="Agent harness">
+                    <option value="">All agent harnesses</option>
+                  </select>
+                </label>
+                <label>
+                  <select name="model" id="model-filter" aria-label="Model">
+                    <option value="">All models</option>
+                  </select>
+                </label>
+                <label>
+                  <select name="severity" aria-label="Severity">
+                    <option value="">Any severity</option>
+                    <option value="info">Info</option>
+                    <option value="low">Low</option>
+                    <option value="medium">Medium</option>
+                    <option value="high">High</option>
+                    <option value="critical">Critical</option>
+                  </select>
+                </label>
+                <label>
+                  <select name="category" aria-label="Category">
+                    <option value="">Any category</option>
+                    <option value="prompt">Prompt</option>
+                    <option value="tool">Tool</option>
+                    <option value="command">Command</option>
+                    <option value="file">File</option>
+                    <option value="mcp">MCP</option>
+                    <option value="approval">Approval</option>
+                    <option value="session">Session</option>
+                    <option value="inventory">Inventory</option>
+                    <option value="validation">Validation</option>
+                    <option value="metric">Metric</option>
+                  </select>
+                </label>
+              </div>
+              <div class="quick-filters" aria-label="Quick filters">
+                <button type="button" data-preset="review">Needs Review</button>
+                <button type="button" data-preset="commands">Commands</button>
+                <button type="button" data-preset="files">File Changes</button>
+                <button type="button" data-preset="mcp">MCP</button>
+                <button type="button" data-preset="approvals">Approvals</button>
+                <button type="button" data-preset="failures">Failures</button>
+                <button type="button" data-preset="high">High Severity</button>
+              </div>
             </div>
-          </details>
+            <div id="facets" class="facets"></div>
+            <details class="advanced-filters">
+              <summary>Advanced filters</summary>
+              <div class="filters">
+                <input name="action" list="action-options" placeholder="Action" />
+                <input name="repository" placeholder="Repository" />
+                <input name="session" placeholder="Session" />
+                <input name="file" placeholder="File path" />
+                <input name="command" placeholder="Command or tool" />
+                <input name="mcp" placeholder="MCP server or tool" />
+                <input name="approval" placeholder="Approval decision or reason" />
+                <input name="decision" placeholder="Approval/policy decision" />
+                <input name="policy" placeholder="Policy id, name, or reason" />
+                <select name="wazuh_level">
+                  <option value="">Any Wazuh level</option>
+                  <option value="5">Level 5 workflow</option>
+                  <option value="7">Level 7 command/MCP</option>
+                  <option value="9">Level 9 failure</option>
+                  <option value="10">Level 10 block/denial</option>
+                  <option value="12">Level 12 health/tamper</option>
+                </select>
+                <input name="since" placeholder="Since RFC3339, e.g. 2026-05-13T12:00:00Z" />
+                <select name="limit">
+                  <option value="100">100 events</option>
+                  <option value="500" selected>500 events</option>
+                  <option value="1000">1000 events</option>
+                  <option value="2000">2000 events</option>
+                </select>
+              </div>
+            </details>
+          </div>
+          <div class="search-row">
+            <label class="search-field">
+              <span class="search-input-wrap">
+                <span class="search-icon" aria-hidden="true"></span>
+                <input class="search-input" name="q" placeholder="Search logs..." autocomplete="off" aria-label="Search logs" />
+              </span>
+            </label>
+          </div>
           <datalist id="action-options"></datalist>
           <input type="hidden" name="review" />
         </form>
-        <div class="search-help">
-          <strong>Search examples:</strong>
-          <span>model name</span>
-          <span>cursor</span>
-          <span>go test</span>
-          <span>approval denied</span>
-          <span>mcp github</span>
-          <span>src/server.go</span>
-        </div>
         <div id="active-filters" class="chips"></div>
         <div id="notice" class="notice" hidden></div>
+        <button type="button" id="new-events" class="new-events" hidden></button>
         <div class="table-wrap">
           <table>
             <thead>
               <tr>
-                <th>Time</th>
-                <th>Signal</th>
-                <th>Artifact</th>
-                <th>Severity</th>
-                <th>Review</th>
+                <th class="col-timestamp">Timestamp</th>
                 <th>Session</th>
                 <th>Repository</th>
-                <th>Message</th>
+                <th>Tags</th>
+                <th>Severity</th>
+                <th>Data Retention Config</th>
+                <th>Signal</th>
+                <th>Agent Harness</th>
+                <th class="col-artifact">Artifact</th>
+                <th class="col-message">Message</th>
               </tr>
             </thead>
             <tbody id="events"></tbody>
@@ -156,7 +148,14 @@
       </section>
 
       <section class="panel">
-        <h2>Runtime Inventory</h2>
+        <div class="section-head">
+          <div>
+            <h2>Endpoint Diagnostics</h2>
+            <p id="log-path" class="muted">Loading runtime log...</p>
+          </div>
+          <div id="retention" class="pill">metadata</div>
+        </div>
+        <h2 class="subsection-title">Runtime Inventory</h2>
         <div id="harnesses" class="harnesses"></div>
       </section>
     </main>

--- a/cli/beacon/internal/endpoint/dashboard/static/styles.css
+++ b/cli/beacon/internal/endpoint/dashboard/static/styles.css
@@ -1,15 +1,15 @@
 :root {
-  color-scheme: light dark;
-  --bg: #0f172a;
-  --panel: #111827;
-  --panel-soft: #1f2937;
-  --text: #e5e7eb;
-  --muted: #9ca3af;
-  --line: #374151;
-  --accent: #7dd3fc;
-  --danger: #fca5a5;
-  --warn: #fcd34d;
-  --ok: #86efac;
+  color-scheme: light;
+  --bg: #ffffff;
+  --panel: #ffffff;
+  --panel-soft: #f3f4f6;
+  --text: #000000;
+  --muted: #4b5563;
+  --line: #d1d5db;
+  --accent: #0369a1;
+  --danger: #b91c1c;
+  --warn: #92400e;
+  --ok: #047857;
 }
 
 * {
@@ -58,7 +58,7 @@ label span {
   gap: 1rem;
   padding: 1.5rem 2rem;
   border-bottom: 1px solid var(--line);
-  background: rgba(17, 24, 39, 0.9);
+  background: rgba(255, 255, 255, 0.95);
   position: sticky;
   top: 0;
   z-index: 2;
@@ -75,8 +75,8 @@ label span {
   border: 1px solid var(--line);
   border-radius: 16px;
   padding: 0.3rem;
-  background: rgba(31, 41, 55, 0.85);
-  box-shadow: 0 12px 30px rgba(2, 6, 23, 0.28);
+  background: #eef2f7;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
 }
 
 .nav-toggle a {
@@ -92,7 +92,7 @@ label span {
 
 .nav-toggle a.active {
   background: var(--accent);
-  color: #082f49;
+  color: #ffffff;
 }
 
 .nav-toggle a:not(.active):hover {
@@ -149,6 +149,25 @@ main {
   gap: 1rem;
 }
 
+.section-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.docs-link {
+  color: var(--accent);
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.docs-link:hover {
+  text-decoration: underline;
+}
+
 .cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
@@ -179,13 +198,20 @@ main {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.75rem;
   text-align: left;
+  min-width: 0;
 }
 
 .stack span {
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.stack strong {
+  flex: 0 0 auto;
 }
 
 .card .value {
@@ -202,11 +228,11 @@ button.card {
 }
 
 .card-danger {
-  border-color: rgba(252, 165, 165, 0.55);
+  border-color: #fecaca;
 }
 
 .card-warn {
-  border-color: rgba(252, 211, 77, 0.55);
+  border-color: #fde68a;
 }
 
 .pill {
@@ -226,27 +252,90 @@ button.card {
   margin: 1rem 0;
 }
 
+.search-panel {
+  border-color: #bae6fd;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+}
+
 .search-row {
   display: grid;
-  grid-template-columns: minmax(240px, 1fr) auto auto;
+  grid-template-columns: minmax(280px, 1fr);
   gap: 0.75rem;
+  align-items: end;
+}
+
+.filter-main-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
 }
 
 .primary-filters {
   display: grid;
-  grid-template-columns: minmax(260px, 1.4fr) repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.5rem;
+  flex: 1 1 560px;
+  min-width: 320px;
 }
 
-.harness-filter {
-  border: 1px solid rgba(125, 211, 252, 0.45);
-  border-radius: 12px;
-  background: rgba(125, 211, 252, 0.06);
-  padding: 0.75rem;
+.search-input-wrap {
+  position: relative;
+  display: block;
 }
 
 .search-input {
   width: 100%;
+  border-color: #e5e7eb;
+  border-radius: 14px;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  font-size: 0.98rem;
+  padding: 0.85rem 1rem 0.85rem 2.55rem;
+}
+
+.search-input::placeholder {
+  color: #6b7280;
+  opacity: 1;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.18), inset 0 0 0 1px rgba(2, 132, 199, 0.22);
+}
+
+.search-icon {
+  position: absolute;
+  left: 0.9rem;
+  top: 50%;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid #6b7280;
+  border-radius: 999px;
+  transform: translateY(-55%);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.search-icon::after {
+  content: "";
+  position: absolute;
+  right: -0.35rem;
+  bottom: -0.25rem;
+  width: 0.45rem;
+  height: 2px;
+  background: #6b7280;
+  border-radius: 999px;
+  transform: rotate(45deg);
+}
+
+.filter-section {
+  display: grid;
+  gap: 0.5rem;
+  border-radius: 12px;
+  background: #f9fafb;
+  padding: 0.55rem;
 }
 
 .quick-filters,
@@ -284,14 +373,15 @@ button.card {
 }
 
 .quick-filters button {
-  padding: 0.45rem 0.65rem;
+  padding: 0.28rem 0.48rem;
+  font-size: 0.78rem;
 }
 
 .advanced-filters {
   border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: 0.75rem;
-  background: rgba(31, 41, 55, 0.45);
+  border-radius: 10px;
+  padding: 0.55rem;
+  background: #f9fafb;
 }
 
 .advanced-filters summary {
@@ -301,9 +391,9 @@ button.card {
 
 .filters {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 0.75rem;
-  margin-top: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(135px, 1fr));
+  gap: 0.5rem;
+  margin-top: 0.55rem;
 }
 
 .chip,
@@ -332,9 +422,22 @@ button.chip {
   border: 1px solid var(--warn);
   border-radius: 12px;
   color: var(--warn);
-  background: rgba(252, 211, 77, 0.08);
+  background: #fffbeb;
   padding: 0.75rem;
   margin-bottom: 1rem;
+}
+
+.new-events {
+  display: block;
+  width: fit-content;
+  margin: 0 0 1rem;
+  border-color: #0284c7;
+  color: var(--accent);
+  background: #eff6ff;
+}
+
+.new-events[hidden] {
+  display: none;
 }
 
 .table-wrap {
@@ -344,6 +447,7 @@ button.chip {
 table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: auto;
 }
 
 th,
@@ -377,7 +481,22 @@ tr:hover {
 }
 
 .artifact {
-  max-width: 32rem;
+  overflow-wrap: anywhere;
+}
+
+.col-timestamp {
+  width: 11rem;
+}
+
+.mono {
+  max-width: 9rem;
+  overflow-wrap: anywhere;
+}
+
+.col-artifact,
+.col-message {
+  width: 20%;
+  min-width: 14rem;
   overflow-wrap: anywhere;
 }
 
@@ -405,27 +524,15 @@ tr:hover {
   margin-top: 1rem;
 }
 
+.subsection-title {
+  margin-top: 1rem;
+}
+
 .harness {
   border: 1px solid var(--line);
   border-radius: 12px;
   padding: 0.85rem;
   background: var(--panel-soft);
-}
-
-.search-help {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-  color: var(--muted);
-  font-size: 0.85rem;
-  margin-bottom: 1rem;
-}
-
-.search-help span {
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  padding: 0.2rem 0.5rem;
 }
 
 .drawer {
@@ -434,7 +541,7 @@ tr:hover {
   right: 0;
   bottom: 0;
   width: min(680px, 100vw);
-  background: #020617;
+  background: #ffffff;
   border-left: 1px solid var(--line);
   transform: translateX(100%);
   transition: transform 160ms ease;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly UI-only changes, but it alters the 10s refresh path to do incremental DOM patching and new-event counting, which could cause missed/duplicated rows or scroll-jank if the event list ordering/IDs differ from expectations.
> 
> **Overview**
> Reworks the log search dashboard UI: switches to a light theme, reorganizes the search/diagnostics panels, adds a docs link, and updates table styling/layout.
> 
> Reorders and expands the events table to 10 columns (timestamp/session/repo/tags/severity/retention/signal/harness/artifact/message), including new `Tags`, `Agent Harness`, and `Data Retention Config` cells plus shortened repo labels.
> 
> Changes the 10s auto-refresh to a *quiet poll* mode that can prepend only newly-seen events, preserves scroll position, and shows a `#new-events` indicator/button when updates arrive while scrolled down.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2578a65296bb7b714b863140d1ef4081766986d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->