### PR TITLE
Fix width of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ and collection status, while log search helps teams inspect normalized event
 records during rollout, testing, and investigations.
 
 <p align="center">
-  <img src="images/dashboard-overview.png" alt="Beacon dashboard overview" width="420">
-  <img src="images/dashboard-log-search.png" alt="Beacon dashboard log search" width="420">
+  <img src="images/dashboard-overview.png" alt="Beacon dashboard overview" width="860">
+</p>
+
+<p align="center">
+  <img src="images/dashboard-log-search.png" alt="Beacon dashboard log search" width="860">
 </p>
 
 ## Start Here


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that only affects README rendering of images.
> 
> **Overview**
> Updates the README dashboard section to display the two screenshots in separate centered blocks and increases each image width from `420` to `860` for better visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c73781c941860f59a21abf63714867ac83ae374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->