### PR TITLE
Fix OpenCode casing, hyperlink blogpost

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@
 
 ## What Is Beacon?
 
-Beacon is Asymptote's open-source endpoint agent for security and IT teams that
+Beacon is [Asymptote's open-source endpoint agent](https://justindsouza.substack.com/p/introducing-beacon-endpoint-telemetry) for security and IT teams that
 need visibility into local AI agent activity.
 
 It runs locally, captures supported activity from local agent harnesses like
-Claude Code, Codex CLI, opencode, Factory Droid, Claude Cowork, and Cursor, then
+Claude Code, Codex CLI, OpenCode, Factory Droid, Claude Cowork, and Cursor, then
 normalizes that activity into endpoint events your team can inspect and retain
 locally.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; only updates README text/linking and does not affect runtime behavior.
> 
> **Overview**
> Updates `README.md` to link the “open-source endpoint agent” description to an external Beacon introduction post, and fixes the harness name casing from `opencode` to `OpenCode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c51cce9ed6c18a867e0092f9acfeadd58ee1f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->