### PR TITLE
Validate embedded hook binary OS/arch before installing

### DIFF
--- a/cli/beacon/internal/embedded/validate_test.go
+++ b/cli/beacon/internal/embedded/validate_test.go
@@ -13,9 +13,8 @@ func TestValidateArchitecture_CurrentPlatform(t *testing.T) {
 		t.Skip("no real binary embedded (placeholder)")
 	}
 
-	err := ValidateArchitecture()
-	if err != nil {
-		t.Logf("ValidateArchitecture returned error (may be expected in dev): %v", err)
+	if err := ValidateArchitecture(); err != nil {
+		t.Fatalf("embedded hooks binary should match current platform: %v", err)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/hooks/runtime.go
+++ b/cli/beacon/internal/endpoint/hooks/runtime.go
@@ -35,6 +35,9 @@ func installRuntimeHooks(runtime hookRuntime, opts RuntimeOptions) (runtimeStatu
 	if !embedded.HasEmbeddedBinary() {
 		return runtimeStatus{}, fmt.Errorf("no hooks binary embedded")
 	}
+	if err := embedded.ValidateArchitecture(); err != nil {
+		return runtimeStatus{}, fmt.Errorf("embedded hooks binary is not usable on this host: %w", err)
+	}
 	if opts.LogPath == "" {
 		opts.LogPath = defaultLogPath(opts.UserMode)
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a hard preflight check that can block endpoint hook installation when the embedded binary format/architecture is unexpected, affecting setup flows across platforms.
> 
> **Overview**
> Prevents installing endpoint runtime hooks when the embedded hooks binary doesn’t match the host OS/architecture by running `embedded.ValidateArchitecture()` as an early guard in `installRuntimeHooks`.
> 
> Tightens `TestValidateArchitecture_CurrentPlatform` to fail (instead of logging) if the embedded binary is not usable on the current platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcc00749e298b1f1a1cbdb67dd65b918c464e0c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->