### PR TITLE
Add gemini CLI harness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Beacon is [Asymptote's open-source endpoint agent](https://justindsouza.substack
 need visibility into local AI agent activity.
 
 It runs locally, captures supported activity from local agent harnesses like
-Claude Code, Codex CLI, OpenCode, Factory Droid, Claude Cowork, and Cursor, then
-normalizes that activity into endpoint events your team can inspect and retain
-locally.
+Claude Code, Codex CLI, Gemini CLI, OpenCode, Factory Droid, Claude Cowork, and
+Cursor, then normalizes that activity into endpoint events your team can inspect
+and retain locally.
 
 Beacon is built to be easy to deploy for Security and IT teams through
 [MDM deployment](https://docs.asymptotelabs.ai/cli/security-it-teams) and to
@@ -55,6 +55,7 @@ security pipelines.
 | --- | --- |
 | Claude Code | Local OpenTelemetry configuration |
 | Codex CLI | Local OpenTelemetry configuration |
+| Gemini CLI | Opt-in local OpenTelemetry configuration |
 | OpenCode | Beacon hook adapter |
 | Factory Droid | Local OpenTelemetry configuration and optional hook adapter |
 | Claude Cowork | Admin-configured OpenTelemetry setup |

--- a/beacon-release-validation-runbook.md
+++ b/beacon-release-validation-runbook.md
@@ -11,7 +11,7 @@ Run on macOS with:
 - Homebrew available and online.
 - Docker Desktop or Docker Compose available for local Elastic validation.
 - A dedicated test macOS user or a workstation where changing local AI runtime config is acceptable.
-- Authenticated/installable runtimes for the full matrix: Cursor, Claude Code, Codex CLI, and OpenCode.
+- Authenticated/installable runtimes for the full matrix: Cursor, Claude Code, Codex CLI, Gemini CLI, and OpenCode.
 - Repo checkout available locally. Set `BEACON_REPO` to that checkout path for writing notes and later researching fixes.
 - Integration validation is user-assisted for now. The agent prepares Beacon, asks the user to submit unique prompts in each runtime, then self-verifies the resulting events in `runtime.jsonl` and Elastic. Headless/noninteractive runtime commands can be used as an optional fast path only when local auth and CLI behavior are known to be reliable.
 
@@ -31,6 +31,8 @@ which claude || true
 claude --version || true
 which codex || true
 codex --version || true
+which gemini || true
+gemini --version || true
 which opencode || true
 opencode --version || true
 ```
@@ -47,6 +49,7 @@ for path in \
   "$HOME/.beacon" \
   "$HOME/.claude/settings.json" \
   "$HOME/.codex/config.toml" \
+  "$HOME/.gemini/settings.json" \
   "$HOME/.cursor/hooks.json" \
   "$HOME/.config/opencode/plugins/beacon.ts"; do
   if [ -e "$path" ]; then
@@ -270,6 +273,53 @@ Repo areas to research later:
 
 - [`cli/beacon/internal/endpoint/harness/harness.go`](cli/beacon/internal/endpoint/harness/harness.go)
 - [`collector-builder/exporter/beaconjsonexporter/exporter_test.go`](collector-builder/exporter/beaconjsonexporter/exporter_test.go)
+
+## Gemini CLI Integration Test
+Gemini CLI support is opt-in, so repair the endpoint with the Gemini harness included, then ask the user to submit a unique prompt in Gemini CLI:
+
+```bash
+beacon endpoint repair --harness claude,codex,gemini
+python3 -m json.tool < "$HOME/.gemini/settings.json" > "$BEACON_E2E_RUN/gemini-settings.pretty.json" || true
+beacon endpoint status --json > "$BEACON_E2E_RUN/status-before-gemini.json"
+```
+
+Runtime action:
+
+```bash
+export BEACON_E2E_GEMINI_MARKER="Beacon E2E Gemini prompt $(date +%s)"
+printf 'Please submit this prompt in Gemini CLI: %s\n' "$BEACON_E2E_GEMINI_MARKER"
+```
+
+Optional headless fast path, only when Gemini CLI noninteractive mode and auth are known to work:
+
+```bash
+gemini --prompt "$BEACON_E2E_GEMINI_MARKER: answer with exactly the word beacon-ok." \
+  > "$BEACON_E2E_RUN/gemini-headless.out" \
+  2> "$BEACON_E2E_RUN/gemini-headless.err"
+```
+
+If the installed Gemini CLI uses a different noninteractive command or flag set, document the discrepancy and use the current recommended command from `gemini --help`.
+
+Validation:
+
+```bash
+rg "gemini|$BEACON_E2E_GEMINI_MARKER|beacon-ok" "$HOME/.beacon/endpoint/logs/runtime.jsonl" \
+  > "$BEACON_E2E_RUN/gemini-runtime-events.txt"
+```
+
+Acceptance criteria:
+
+- `~/.gemini/settings.json` contains Beacon-managed local OTLP telemetry settings with `target` set to `local`, `otlpProtocol` set to `grpc`, `useCollector` set to `true`, and no `outfile`.
+- The user confirms the prompt was submitted, or the optional noninteractive command exits successfully.
+- Runtime log receives Gemini OTLP-derived events with `harness.name=gemini_cli`.
+- Prompt content appears only when retention mode permits it.
+- If no events appear, check for project Gemini settings or `GEMINI_TELEMETRY_*` environment variables overriding the user settings.
+
+Repo areas to research later:
+
+- [`cli/beacon/internal/endpoint/harness/gemini.go`](cli/beacon/internal/endpoint/harness/gemini.go)
+- [`cli/beacon/internal/endpoint/lifecycle/lifecycle.go`](cli/beacon/internal/endpoint/lifecycle/lifecycle.go)
+- [`collector-builder/exporter/beaconjsonexporter/exporter.go`](collector-builder/exporter/beaconjsonexporter/exporter.go)
 
 ## OpenCode Integration Test
 Install OpenCode hooks, then ask the user to submit a unique prompt in OpenCode:

--- a/cli/beacon/internal/endpoint/harness/gemini.go
+++ b/cli/beacon/internal/endpoint/harness/gemini.go
@@ -1,0 +1,120 @@
+package harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func DiscoverGemini() Harness {
+	h := Harness{Name: "gemini_cli", DisplayName: "Gemini CLI", Capability: "otel_config"}
+	path, err := exec.LookPath("gemini")
+	if err == nil {
+		h.Detected = true
+		h.ExecutablePath = path
+		h.Version = commandVersion(path)
+	}
+	home, _ := os.UserHomeDir()
+	h.ConfigPath = filepath.Join(home, ".gemini", "settings.json")
+	if fileExists(h.ConfigPath) {
+		status, msg := geminiStatus(h.ConfigPath)
+		h.TelemetryStatus = status
+		h.Message = msg
+	} else {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = "Gemini settings file was not found"
+	}
+	return h
+}
+
+func ConfigureGemini(opts ConfigureOptions) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(home, ".gemini", "settings.json")
+	settings := map[string]interface{}{}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return "", fmt.Errorf("Gemini settings JSON is invalid: %w", err)
+		}
+		if err := backup(path, data); err != nil {
+			return "", err
+		}
+	}
+
+	telemetry, _ := settings["telemetry"].(map[string]interface{})
+	if telemetry == nil {
+		telemetry = map[string]interface{}{}
+	}
+	telemetry["enabled"] = true
+	telemetry["target"] = "local"
+	telemetry["otlpEndpoint"] = opts.Endpoint
+	telemetry["otlpProtocol"] = "grpc"
+	telemetry["useCollector"] = true
+	telemetry["logPrompts"] = opts.ContentRetention != "metadata"
+	telemetry["traces"] = opts.ContentRetention != "metadata"
+	delete(telemetry, "outfile")
+	settings["telemetry"] = telemetry
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return "", err
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return path, os.WriteFile(path, data, 0600)
+}
+
+func geminiStatus(path string) (TelemetryStatus, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return TelemetryMissing, err.Error()
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return TelemetryMisconfigured, "Gemini settings JSON is invalid"
+	}
+	telemetry, _ := settings["telemetry"].(map[string]interface{})
+	if telemetry == nil {
+		return TelemetryDisabled, "Gemini telemetry config is missing"
+	}
+	if !truthySetting(telemetry["enabled"]) {
+		return TelemetryDisabled, "Gemini telemetry is not enabled"
+	}
+	if fmt.Sprint(telemetry["target"]) != "local" {
+		return TelemetryMisconfigured, "Gemini telemetry target is not local"
+	}
+	if outfile := strings.TrimSpace(fmt.Sprint(telemetry["outfile"])); outfile != "" && outfile != "<nil>" {
+		return TelemetryMisconfigured, "Gemini telemetry outfile is set and will bypass local OTLP"
+	}
+	endpoint := fmt.Sprint(telemetry["otlpEndpoint"])
+	if !strings.Contains(endpoint, "127.0.0.1") && !strings.Contains(endpoint, "localhost") {
+		return TelemetryMisconfigured, "Gemini OTLP endpoint does not point to localhost"
+	}
+	if fmt.Sprint(telemetry["otlpProtocol"]) != "grpc" {
+		return TelemetryMisconfigured, "Gemini OTLP protocol is not grpc"
+	}
+	if !truthySetting(telemetry["useCollector"]) {
+		return TelemetryDisabled, "Gemini telemetry is not configured to use an external collector"
+	}
+	return TelemetryEnabled, "Gemini telemetry is configured for local OTLP; project settings and environment variables may override this user config"
+}
+
+func truthySetting(value interface{}) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		normalized := strings.ToLower(strings.TrimSpace(typed))
+		return normalized == "true" || normalized == "1"
+	case float64:
+		return typed == 1
+	default:
+		return false
+	}
+}

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -47,6 +47,7 @@ func DiscoverAll() []Harness {
 	return []Harness{
 		DiscoverClaude(),
 		DiscoverCodex(),
+		DiscoverGemini(),
 		DiscoverOpenCode(),
 		DiscoverFactory(),
 		DiscoverCursor(),
@@ -259,6 +260,7 @@ func ConfigureCodex(opts ConfigureOptions) (string, error) {
 func ValidateConfigured(endpoint string) []ValidationResult {
 	claude := DiscoverClaude()
 	codex := DiscoverCodex()
+	gemini := DiscoverGemini()
 	factory := DiscoverFactory()
 	return []ValidationResult{
 		{
@@ -270,6 +272,11 @@ func ValidateConfigured(endpoint string) []ValidationResult {
 			Harness: codex.Name,
 			Status:  codex.TelemetryStatus,
 			Message: validateEndpointMessage(codex.TelemetryStatus, codex.Message, endpoint),
+		},
+		{
+			Harness: gemini.Name,
+			Status:  gemini.TelemetryStatus,
+			Message: validateEndpointMessage(gemini.TelemetryStatus, gemini.Message, endpoint),
 		},
 		{
 			Harness: factory.Name,

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -286,6 +286,167 @@ func TestCodexStatusVariants(t *testing.T) {
 	}
 }
 
+func TestConfigureGeminiWritesTelemetryAndBackup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir gemini config dir: %v", err)
+	}
+	existing := `{"general":{"vimMode":true},"telemetry":{"enabled":false,"outfile":".gemini/telemetry.log"}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatalf("write existing gemini config: %v", err)
+	}
+
+	written, err := ConfigureGemini(ConfigureOptions{Endpoint: "http://127.0.0.1:4317", UserMode: true, ContentRetention: "full"})
+	if err != nil {
+		t.Fatalf("ConfigureGemini returned error: %v", err)
+	}
+	if written != path {
+		t.Fatalf("ConfigureGemini path = %q, want %q", written, path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read gemini config: %v", err)
+	}
+	var settings map[string]map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal gemini config: %v", err)
+	}
+	if settings["general"]["vimMode"] != true {
+		t.Fatalf("unrelated settings were not preserved: %#v", settings)
+	}
+	telemetry := settings["telemetry"]
+	for key, want := range map[string]interface{}{
+		"enabled":      true,
+		"target":       "local",
+		"otlpEndpoint": "http://127.0.0.1:4317",
+		"otlpProtocol": "grpc",
+		"useCollector": true,
+		"logPrompts":   true,
+		"traces":       true,
+	} {
+		if got := telemetry[key]; got != want {
+			t.Fatalf("telemetry[%s] = %#v, want %#v; telemetry=%#v", key, got, want, telemetry)
+		}
+	}
+	if _, ok := telemetry["outfile"]; ok {
+		t.Fatalf("outfile should be removed so OTLP is used: %#v", telemetry)
+	}
+	backups, err := filepath.Glob(path + ".beacon.*.bak")
+	if err != nil {
+		t.Fatalf("glob backups: %v", err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("expected one backup, got %#v", backups)
+	}
+}
+
+func TestConfigureGeminiDisablesPromptLoggingForMetadataRetention(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := ConfigureGemini(ConfigureOptions{
+		Endpoint:         "http://127.0.0.1:4317",
+		UserMode:         true,
+		ContentRetention: "metadata",
+	})
+	if err != nil {
+		t.Fatalf("ConfigureGemini returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read gemini config: %v", err)
+	}
+	var settings map[string]map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal gemini config: %v", err)
+	}
+	telemetry := settings["telemetry"]
+	if telemetry["logPrompts"] != false {
+		t.Fatalf("metadata retention should disable prompt logging: %#v", telemetry)
+	}
+	if telemetry["traces"] != false {
+		t.Fatalf("metadata retention should disable detailed traces: %#v", telemetry)
+	}
+}
+
+func TestDiscoverGeminiDoesNotDetectConfigDirectoryOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	if err := os.MkdirAll(filepath.Join(home, ".gemini"), 0755); err != nil {
+		t.Fatalf("mkdir gemini config dir: %v", err)
+	}
+
+	h := DiscoverGemini()
+	if h.Detected {
+		t.Fatalf("DiscoverGemini detected Gemini from config directory only: %#v", h)
+	}
+	if h.ConfigPath != filepath.Join(home, ".gemini", "settings.json") {
+		t.Fatalf("ConfigPath = %q, want home config path", h.ConfigPath)
+	}
+	if h.TelemetryStatus != TelemetryMissing {
+		t.Fatalf("TelemetryStatus = %q, want %q", h.TelemetryStatus, TelemetryMissing)
+	}
+}
+
+func TestDiscoverGeminiDetectsExecutableOnPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	geminiPath := filepath.Join(binDir, "gemini")
+	if err := os.WriteFile(geminiPath, []byte("#!/bin/sh\necho gemini 0.34.0\n"), 0755); err != nil {
+		t.Fatalf("write fake gemini executable: %v", err)
+	}
+
+	h := DiscoverGemini()
+	if !h.Detected {
+		t.Fatalf("DiscoverGemini did not detect executable on PATH: %#v", h)
+	}
+	if h.ExecutablePath != geminiPath {
+		t.Fatalf("ExecutablePath = %q, want %q", h.ExecutablePath, geminiPath)
+	}
+	if h.Version != "gemini 0.34.0" {
+		t.Fatalf("Version = %q, want fake executable version", h.Version)
+	}
+}
+
+func TestGeminiStatusVariants(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name   string
+		body   string
+		status TelemetryStatus
+	}{
+		{name: "invalid json", body: `{`, status: TelemetryMisconfigured},
+		{name: "missing telemetry", body: `{}`, status: TelemetryDisabled},
+		{name: "disabled", body: `{"telemetry":{"enabled":false}}`, status: TelemetryDisabled},
+		{name: "remote target", body: `{"telemetry":{"enabled":true,"target":"gcp","otlpEndpoint":"http://127.0.0.1:4317","otlpProtocol":"grpc","useCollector":true}}`, status: TelemetryMisconfigured},
+		{name: "outfile", body: `{"telemetry":{"enabled":true,"target":"local","outfile":".gemini/telemetry.log","otlpEndpoint":"http://127.0.0.1:4317","otlpProtocol":"grpc","useCollector":true}}`, status: TelemetryMisconfigured},
+		{name: "remote endpoint", body: `{"telemetry":{"enabled":true,"target":"local","otlpEndpoint":"https://example.com:4317","otlpProtocol":"grpc","useCollector":true}}`, status: TelemetryMisconfigured},
+		{name: "http protocol", body: `{"telemetry":{"enabled":true,"target":"local","otlpEndpoint":"http://127.0.0.1:4317","otlpProtocol":"http","useCollector":true}}`, status: TelemetryMisconfigured},
+		{name: "collector disabled", body: `{"telemetry":{"enabled":true,"target":"local","otlpEndpoint":"http://127.0.0.1:4317","otlpProtocol":"grpc","useCollector":false}}`, status: TelemetryDisabled},
+		{name: "enabled", body: `{"telemetry":{"enabled":true,"target":"local","otlpEndpoint":"http://localhost:4317","otlpProtocol":"grpc","useCollector":true}}`, status: TelemetryEnabled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, strings.ReplaceAll(tt.name, " ", "_")+".json")
+			if err := os.WriteFile(path, []byte(tt.body), 0600); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+			status, _ := geminiStatus(path)
+			if status != tt.status {
+				t.Fatalf("geminiStatus = %q, want %q", status, tt.status)
+			}
+		})
+	}
+}
+
 func TestDiscoverFactoryDetectsExecutableOnPath(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -371,6 +371,12 @@ func configureHarnesses(cfg endpointconfig.Config) ([]string, error) {
 				return paths, err
 			}
 			paths = append(paths, path)
+		case "gemini", "gemini_cli":
+			path, err := harness.ConfigureGemini(harness.ConfigureOptions{Endpoint: grpcEndpoint, UserMode: cfg.UserMode, ContentRetention: string(cfg.ContentRetention)})
+			if err != nil {
+				return paths, err
+			}
+			paths = append(paths, path)
 		case "opencode":
 			return paths, fmt.Errorf("opencode telemetry is installed with `beacon endpoint hooks install --harness opencode`, not endpoint install")
 		case "factory", "droid":

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -156,6 +156,36 @@ func TestConfigureHarnessesRejectsOpenCodeAsHookManaged(t *testing.T) {
 	}
 }
 
+func TestConfigureHarnessesAcceptsGemini(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := endpointconfig.Config{
+		UserMode:         true,
+		Harnesses:        []string{"gemini"},
+		ContentRetention: endpointconfig.ContentRetentionMetadata,
+		Collector: endpointconfig.Collector{
+			GRPCPort: 54317,
+		},
+	}
+
+	paths, err := configureHarnesses(cfg)
+	if err != nil {
+		t.Fatalf("configureHarnesses returned error: %v", err)
+	}
+	wantPath := filepath.Join(home, ".gemini", "settings.json")
+	if len(paths) != 1 || paths[0] != wantPath {
+		t.Fatalf("paths = %#v, want %q", paths, wantPath)
+	}
+	data, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read Gemini settings: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `"otlpEndpoint": "http://127.0.0.1:54317"`) || !strings.Contains(text, `"logPrompts": false`) {
+		t.Fatalf("Gemini settings were not configured for metadata retention:\n%s", text)
+	}
+}
+
 func TestWriteReadManifestRoundTrip(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/collector-builder/exporter/beaconjsonexporter/exporter.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter.go
@@ -142,7 +142,7 @@ func (e *beaconExporter) eventFromLog(resourceAttrs map[string]interface{}, reco
 	if action == "" {
 		action = inferAction(attrs, record.Body().AsString())
 	}
-	message := firstNonEmpty(record.Body().AsString(), firstString(attrs, "message", "log.message"))
+	message := firstNonEmpty(record.Body().AsString(), firstString(attrs, "message", "log.message", "event.name"))
 	event := newBeaconEvent(action, eventCategory(action, firstString(attrs, "beacon.event.category", "event.category", "category")), severity(record.SeverityText(), record.SeverityNumber().String()), harnessName(attrs, message), ts)
 	event.Message = message
 	e.populateCommon(&event, attrs)
@@ -257,17 +257,17 @@ func (e *beaconExporter) populateCommon(event *beaconEvent, attrs map[string]int
 	event.Model = firstString(attrs, "gen_ai.request.model", "gen_ai.response.model", "model", "ai.model")
 	event.Repository = firstString(attrs, "vcs.repository.url", "repository", "repo.path", "workspace.repository")
 	event.Branch = firstString(attrs, "vcs.branch.name", "git.branch", "branch")
-	if id := firstString(attrs, "session.id", "conversation.id", "conversation_id", "gen_ai.conversation.id"); id != "" || firstString(attrs, "cwd", "working_directory") != "" {
+	if id := firstString(attrs, "session.id", "conversation.id", "conversation_id", "gen_ai.conversation.id"); id != "" || firstString(attrs, "cwd", "working_directory", "workspace") != "" {
 		event.Session = &sessionInfo{
 			ID:               id,
-			WorkingDirectory: firstString(attrs, "cwd", "working_directory", "process.command_args.cwd"),
+			WorkingDirectory: firstString(attrs, "cwd", "working_directory", "process.command_args.cwd", "workspace"),
 		}
 	}
-	if name := firstString(attrs, "tool.name", "gen_ai.tool.name", "mcp.tool.name"); name != "" || firstString(attrs, "tool.command", "command") != "" {
+	if name := firstString(attrs, "tool.name", "gen_ai.tool.name", "mcp.tool.name", "function_name", "tool_name"); name != "" || firstString(attrs, "tool.command", "command", "function_args") != "" {
 		event.Tool = &toolInfo{
 			Name:    name,
-			Command: firstString(attrs, "tool.command", "command", "process.command_line"),
-			Path:    firstString(attrs, "tool.path", "file.path"),
+			Command: firstString(attrs, "tool.command", "command", "process.command_line", "function_args"),
+			Path:    firstString(attrs, "tool.path", "file.path", "file_path"),
 		}
 	}
 	if path := firstString(attrs, "file.path", "file_path", "code.filepath"); path != "" {
@@ -286,17 +286,17 @@ func (e *beaconExporter) populateCommon(event *beaconEvent, attrs map[string]int
 			event.Command.DurationMS = duration
 		}
 	}
-	if server := firstString(attrs, "mcp.server.name", "mcp.server", "gen_ai.mcp.server"); server != "" || firstString(attrs, "mcp.tool.name") != "" {
+	if server := firstString(attrs, "mcp.server.name", "mcp.server", "gen_ai.mcp.server", "mcp_server_name"); server != "" || firstString(attrs, "mcp.tool.name") != "" || firstString(attrs, "tool_type") == "mcp" {
 		event.MCP = &mcpInfo{
 			Server: server,
-			Tool:   firstString(attrs, "mcp.tool.name", "tool.name"),
+			Tool:   firstString(attrs, "mcp.tool.name", "tool.name", "function_name"),
 		}
 	}
-	if decision := firstString(attrs, "approval.decision", "policy.decision"); decision != "" {
+	if decision := firstString(attrs, "approval.decision", "policy.decision", "decision"); decision != "" {
 		event.Approval = &approvalInfo{
 			Required: true,
 			Decision: decision,
-			Reason:   firstString(attrs, "approval.reason", "policy.reason"),
+			Reason:   firstString(attrs, "approval.reason", "policy.reason", "approval_mode", "active_approval_mode"),
 		}
 	}
 	if e.cfg.ContentRetention != "metadata" && event.Event.Category == "prompt" {
@@ -437,6 +437,8 @@ func normalizeHarnessName(name string) string {
 		return "claude_code"
 	case strings.Contains(lower, "codex"):
 		return "codex_cli"
+	case strings.Contains(lower, "gemini"):
+		return "gemini_cli"
 	case name != "":
 		return name
 	default:
@@ -445,13 +447,21 @@ func normalizeHarnessName(name string) string {
 }
 
 func inferAction(attrs map[string]interface{}, fallback string) string {
-	tool := strings.ToLower(firstString(attrs, "tool.name", "gen_ai.tool.name", "mcp.tool.name"))
+	tool := strings.ToLower(firstString(attrs, "tool.name", "gen_ai.tool.name", "mcp.tool.name", "function_name", "tool_name"))
 	text := strings.ToLower(strings.Join([]string{
 		fallback,
 		tool,
 		firstString(attrs, "event.name", "codex.op", "rpc.method"),
 	}, " "))
 	switch {
+	case strings.Contains(text, "gemini_cli.user_prompt"):
+		return "prompt.submitted"
+	case strings.Contains(text, "gemini_cli.tool_call"):
+		return geminiToolAction(attrs)
+	case strings.Contains(text, "gemini_cli.file_operation"):
+		return geminiFileAction(attrs)
+	case strings.Contains(text, "approval_mode_switch") || strings.Contains(text, "approval_mode_duration") || strings.Contains(text, "plan_execution"):
+		return "approval.requested"
 	case strings.Contains(text, "prompt") || strings.Contains(text, "user_input"):
 		return "prompt.submitted"
 	case strings.Contains(text, "mcp"):
@@ -464,6 +474,24 @@ func inferAction(attrs map[string]interface{}, fallback string) string {
 		return "approval.requested"
 	default:
 		return "tool.invoked"
+	}
+}
+
+func geminiToolAction(attrs map[string]interface{}) string {
+	if firstString(attrs, "tool_type") == "mcp" || firstString(attrs, "mcp_server_name") != "" {
+		return "mcp.tool_invoked"
+	}
+	return "tool.invoked"
+}
+
+func geminiFileAction(attrs map[string]interface{}) string {
+	switch strings.ToLower(firstString(attrs, "operation")) {
+	case "read":
+		return "file.read"
+	case "create":
+		return "file.created"
+	default:
+		return "file.modified"
 	}
 }
 

--- a/collector-builder/exporter/beaconjsonexporter/exporter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter_test.go
@@ -375,6 +375,139 @@ func TestEventFromSpanMapsCodexUserInputToPrompt(t *testing.T) {
 	}
 }
 
+func TestConsumeLogsMapsGeminiPrompt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:             path,
+		MaxEventBytes:    defaultMaxEventBytes,
+		RotateBytes:      defaultRotateBytes,
+		RedactSecrets:    true,
+		ContentRetention: "full",
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "gemini-cli")
+	rec := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	rec.Attributes().PutStr("event.name", "gemini_cli.user_prompt")
+	rec.Attributes().PutStr("session.id", "gemini-session")
+	rec.Attributes().PutStr("prompt", "summarize token=gemini-secret")
+	rec.Attributes().PutStr("prompt_id", "prompt-1")
+
+	if err := exp.consumeLogs(context.Background(), logs); err != nil {
+		t.Fatalf("consumeLogs returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime log: %v", err)
+	}
+	var event beaconEvent
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &event); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	if event.Harness.Name != "gemini_cli" {
+		t.Fatalf("harness = %q, want gemini_cli", event.Harness.Name)
+	}
+	if event.Event.Action != "prompt.submitted" || event.Event.Category != "prompt" {
+		t.Fatalf("unexpected event action/category: %#v", event.Event)
+	}
+	if event.Session == nil || event.Session.ID != "gemini-session" {
+		t.Fatalf("session missing from event: %#v", event.Session)
+	}
+	if event.Prompt == nil || event.Prompt.Text != "summarize token=[REDACTED]" {
+		t.Fatalf("prompt = %#v, want redacted Gemini prompt", event.Prompt)
+	}
+}
+
+func TestConsumeLogsMapsGeminiMCPTool(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:             path,
+		MaxEventBytes:    defaultMaxEventBytes,
+		RotateBytes:      defaultRotateBytes,
+		RedactSecrets:    true,
+		ContentRetention: "metadata",
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "gemini")
+	rec := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	rec.Attributes().PutStr("event.name", "gemini_cli.tool_call")
+	rec.Attributes().PutStr("function_name", "search_docs")
+	rec.Attributes().PutStr("function_args", `{"query":"otel"}`)
+	rec.Attributes().PutStr("tool_type", "mcp")
+	rec.Attributes().PutStr("mcp_server_name", "docs")
+	rec.Attributes().PutStr("decision", "accept")
+	rec.Attributes().PutInt("duration_ms", 42)
+
+	if err := exp.consumeLogs(context.Background(), logs); err != nil {
+		t.Fatalf("consumeLogs returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime log: %v", err)
+	}
+	var event beaconEvent
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &event); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	if event.Event.Action != "mcp.tool_invoked" || event.Event.Category != "mcp" {
+		t.Fatalf("unexpected event action/category: %#v", event.Event)
+	}
+	if event.Tool == nil || event.Tool.Name != "search_docs" || event.Tool.Command != `{"query":"otel"}` {
+		t.Fatalf("tool mapping missing: %#v", event.Tool)
+	}
+	if event.MCP == nil || event.MCP.Server != "docs" || event.MCP.Tool != "search_docs" {
+		t.Fatalf("mcp mapping missing: %#v", event.MCP)
+	}
+	if event.Approval == nil || event.Approval.Decision != "accept" {
+		t.Fatalf("approval mapping missing: %#v", event.Approval)
+	}
+}
+
+func TestConsumeLogsMapsGeminiFileOperation(t *testing.T) {
+	exp, err := newExporter(&Config{
+		Path:             filepath.Join(t.TempDir(), "runtime.jsonl"),
+		MaxEventBytes:    defaultMaxEventBytes,
+		RotateBytes:      defaultRotateBytes,
+		RedactSecrets:    true,
+		ContentRetention: "metadata",
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+
+	logs := plog.NewLogs()
+	rec := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	rec.Attributes().PutStr("service.name", "gemini-cli")
+	rec.Attributes().PutStr("event.name", "gemini_cli.file_operation")
+	rec.Attributes().PutStr("file_path", "/tmp/main.go")
+	rec.Attributes().PutStr("operation", "create")
+
+	event := exp.eventFromLog(nil, rec)
+	if event.Event.Action != "file.created" || event.Event.Category != "file" {
+		t.Fatalf("unexpected event action/category: %#v", event.Event)
+	}
+	if event.File == nil || event.File.Path != "/tmp/main.go" || event.File.Operation != "create" {
+		t.Fatalf("file mapping missing: %#v", event.File)
+	}
+}
+
+func TestInferActionMapsGeminiApprovalEvents(t *testing.T) {
+	for _, name := range []string{"approval_mode_switch", "approval_mode_duration", "plan_execution"} {
+		if got := inferAction(map[string]interface{}{"service.name": "gemini-cli"}, name); got != "approval.requested" {
+			t.Fatalf("inferAction(%q) = %q, want approval.requested", name, got)
+		}
+	}
+}
+
 func TestMetadataRetentionDropsRawAttributes(t *testing.T) {
 	exp, err := newExporter(&Config{
 		Path:             filepath.Join(t.TempDir(), "runtime.jsonl"),

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -102,6 +102,10 @@ BEACON_SPLUNK_INSECURE_SKIP_VERIFY: accepts 1/true/yes
 BEACON_SPLUNK_CA_FILE: optional CA certificate path
 ```
 
+Gemini CLI is available as an opt-in local OpenTelemetry harness. Include it in
+the harness list, for example `BEACON_ENDPOINT_HARNESSES=claude,codex,gemini`,
+when you want the deployment to manage Gemini telemetry settings.
+
 Recommended rollout:
 
 1. Upload the signed/notarized package to a pilot group.
@@ -184,6 +188,9 @@ Parameter 14: Splunk sourcetype for install.sh only
 Parameter 15: Splunk insecure TLS skip verify for install.sh only
 Parameter 16: Splunk CA file for install.sh only
 ```
+
+To opt in Gemini CLI telemetry through Jamf, include `gemini` in parameter 4,
+for example `claude,codex,gemini`.
 
 For repair policies, prefer the `BEACON_SPLUNK_*` environment variables so
 tokens do not need to be entered as visible script parameters.
@@ -272,6 +279,9 @@ repair.sh argument 9: Splunk sourcetype
 repair.sh argument 10: Splunk insecure TLS skip verify
 repair.sh argument 11: Splunk CA file
 ```
+
+To opt in Gemini CLI telemetry through Fleet, include `gemini` in the harness
+argument, for example `claude,codex,gemini`.
 
 Add queries from `packaging/macos/fleet/queries` as Fleet policies or labels.
 They cover package/service/log/config presence and freshness; run

--- a/packaging/macos/pkgbuild.md
+++ b/packaging/macos/pkgbuild.md
@@ -114,6 +114,10 @@ Parameter 15: Splunk insecure TLS skip verify for install.sh only
 Parameter 16: Splunk CA file for install.sh only
 ```
 
+Gemini CLI telemetry is opt-in. Include `gemini` in the harness parameter, for
+example `claude,codex,gemini`, when the package deployment should manage Gemini
+local OpenTelemetry settings.
+
 For repair workflows, pass Splunk settings with `BEACON_SPLUNK_*` environment
 variables when possible so HEC tokens are not exposed as script parameters.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new endpoint harness that writes/modifies `~/.gemini/settings.json` and extends event normalization/inference logic, which could affect telemetry configuration and how events are categorized across runtimes.
> 
> **Overview**
> Adds **opt-in Gemini CLI support** as a first-class endpoint harness: discovery now includes `gemini_cli`, endpoint install/repair can configure it via `--harness gemini`, and a new `ConfigureGemini` implementation manages `~/.gemini/settings.json` (with backup) and respects content-retention by disabling prompt/traces for `metadata`.
> 
> Extends the JSONL exporter’s normalization to better map Gemini (and similar) OTLP logs: additional attribute fallbacks for message/session/tool/file/MCP/approval fields, `gemini_cli` harness name normalization, and Gemini-specific action inference for prompt/tool/MCP/file and approval-mode events, with new tests covering these mappings.
> 
> Updates docs/runbooks/packaging guidance to list Gemini CLI as supported and to describe how to opt in through MDM harness lists (Jamf/Fleet) and the release validation runbook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2e023f5091336d524f97dc9c629c92447a72fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->