### PR TITLE
Add devin CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Beacon is [Asymptote's open-source endpoint agent](https://justindsouza.substack
 need visibility into local AI agent activity.
 
 It runs locally, captures supported activity from local agent harnesses like
-Claude Code, Codex CLI, Gemini CLI, OpenCode, Factory Droid, Claude Cowork, and
-Cursor, then normalizes that activity into endpoint events your team can inspect
-and retain locally.
+Claude Code, Codex CLI, Gemini CLI, OpenCode, Devin, Factory Droid, Claude
+Cowork, and Cursor, then normalizes that activity into endpoint events your team
+can inspect and retain locally.
 
 Beacon is built to be easy to deploy for Security and IT teams through
 [MDM deployment](https://docs.asymptotelabs.ai/cli/security-it-teams) and to
@@ -57,6 +57,7 @@ security pipelines.
 | Codex CLI | Local OpenTelemetry configuration |
 | Gemini CLI | Opt-in local OpenTelemetry configuration |
 | OpenCode | Beacon hook adapter |
+| Devin | Beacon hook adapter |
 | Factory Droid | Local OpenTelemetry configuration and optional hook adapter |
 | Claude Cowork | Admin-configured OpenTelemetry setup |
 | Cursor | Beacon hook adapter |

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -132,6 +132,18 @@ func fileOperation(toolName string) string {
 
 func actionForTool(hookEvent, toolName string) string {
 	lower := strings.ToLower(toolName)
+	if platformFlag == "devin" {
+		switch {
+		case strings.HasPrefix(lower, "mcp__"):
+			return "mcp.tool_invoked"
+		case lower == "exec":
+			return "command.executed"
+		case lower == "read":
+			return "file.read"
+		case lower == "edit" || lower == "write":
+			return "file.modified"
+		}
+	}
 	switch {
 	case strings.Contains(lower, "mcp"):
 		return "mcp.tool_invoked"

--- a/cli/beacon-hooks/cmd/helpers.go
+++ b/cli/beacon-hooks/cmd/helpers.go
@@ -51,6 +51,8 @@ func resolveSessionID(input map[string]interface{}, platform string) string {
 		return getFirstStr(input, "sessionId", "session_id")
 	case "cursor":
 		return getFirstStr(input, "conversation_id")
+	case "devin":
+		return getFirstStr(input, "session_id", "sessionId", "conversation_id")
 	case "opencode":
 		return getFirstStr(input, "session_id", "sessionID")
 	default:
@@ -73,6 +75,10 @@ func resolveSessionIDWithTranscript(input map[string]interface{}, platform strin
 	case "cursor":
 		sessionID = getFirstStr(input, "conversation_id")
 		transcriptPath = getFirstStr(input, "transcript_path")
+		return
+	case "devin":
+		sessionID = getFirstStr(input, "session_id", "sessionId", "conversation_id")
+		transcriptPath = getFirstStr(input, "transcript_path", "transcriptPath")
 		return
 	case "opencode":
 		sessionID = getFirstStr(input, "session_id", "sessionID")
@@ -116,6 +122,12 @@ func resolveCwd(input map[string]interface{}, platform string) string {
 		if cwd := getFirstStr(input, "cwd", "directory", "worktree"); cwd != "" {
 			return cwd
 		}
+	}
+	if platform == "devin" {
+		if cwd := getFirstStr(input, "cwd", "project_dir", "projectDir"); cwd != "" {
+			return cwd
+		}
+		return os.Getenv("DEVIN_PROJECT_DIR")
 	}
 	cwd, _ := input["cwd"].(string)
 	return cwd

--- a/cli/beacon-hooks/cmd/permission_request.go
+++ b/cli/beacon-hooks/cmd/permission_request.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
+)
+
+var permissionRequestCmd = &cobra.Command{
+	Use:   "permission-request",
+	Short: "Observe Devin permission requests for local endpoint telemetry",
+	Long:  `PermissionRequest hook - triggered when Devin needs a permission decision.`,
+	Run:   runPermissionRequest,
+}
+
+func init() {
+	rootCmd.AddCommand(permissionRequestCmd)
+}
+
+var devinApproveResponse = map[string]interface{}{"decision": "approve"}
+
+func runPermissionRequest(cmd *cobra.Command, args []string) {
+	if platformFlag != "devin" {
+		outputJSON(emptyResponse)
+		return
+	}
+
+	input, err := readStdinJSON()
+	if err != nil {
+		outputJSON(devinApproveResponse)
+		return
+	}
+
+	sessionID := resolveSessionID(input, platformFlag)
+	var logger *logging.Logger
+	if sessionID != "" {
+		logger = logging.NewSessionLogger("permission-request", platformFlag, sessionID)
+	} else {
+		logger = logging.NewLoggerForPlatform("permission-request", platformFlag)
+	}
+
+	emitPreToolDecision(logger, input, sessionID, "approval.allowed", "approve", "Permission request approved")
+	outputJSON(devinApproveResponse)
+}

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -114,12 +114,12 @@ func parseCursorInput(input map[string]interface{}, logger *logging.Logger) *eva
 	}
 }
 
-// parseClaudeCopilotInput extracts evaluation params from Claude/Copilot PostToolUse format.
+// parseClaudeCopilotInput extracts evaluation params from Claude/Copilot-compatible PostToolUse format.
 func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logger) *evaluationParams {
 	var sessionID, toolName string
 	var toolInput, toolResponse map[string]interface{}
 
-	if platformFlag == "copilot" {
+	if platformFlag == "copilot" || platformFlag == "devin" {
 		sessionID = resolveSessionID(input, platformFlag)
 		toolName = getFirstStr(input, "toolName", "tool_name")
 		toolInput = resolveToolInput(input)
@@ -140,7 +140,7 @@ func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logge
 		filePath = diff.GetStringFromMaps("filePath", toolInput, toolResponse)
 	}
 
-	if sessionID == "" || toolName == "" || filePath == "" {
+	if (sessionID == "" && platformFlag != "devin") || toolName == "" || filePath == "" {
 		return nil
 	}
 
@@ -174,7 +174,9 @@ func recordLocalEdit(params *evaluationParams, logger *logging.Logger) {
 		fields[key] = value
 	}
 	fields["tool"] = map[string]interface{}{"name": params.toolName, "path": params.filePath}
-	fields["session"] = map[string]interface{}{"id": params.sessionID}
+	if params.sessionID != "" {
+		fields["session"] = map[string]interface{}{"id": params.sessionID}
+	}
 	logger.EndpointEvent("file.modified", "file", "info", "File edit observed", fields)
 }
 
@@ -256,6 +258,10 @@ func isFileEditTool(platform, toolName string) bool {
 	}
 	if platform == "factory" {
 		return toolName == "Write" || toolName == "Edit" || toolName == "MultiEdit" || toolName == "Create"
+	}
+	if platform == "devin" {
+		lower := strings.ToLower(toolName)
+		return lower == "edit" || lower == "write"
 	}
 	return toolName == "Write" || toolName == "Edit" || toolName == "MultiEdit"
 }

--- a/cli/beacon-hooks/cmd/post_tool_test.go
+++ b/cli/beacon-hooks/cmd/post_tool_test.go
@@ -30,6 +30,11 @@ func TestIsFileEditTool(t *testing.T) {
 		{"factory MultiEdit", "factory", "MultiEdit", true},
 		{"factory Create", "factory", "Create", true},
 		{"factory Read (not edit)", "factory", "Read", false},
+
+		// Devin tools
+		{"devin edit", "devin", "edit", true},
+		{"devin write", "devin", "write", true},
+		{"devin exec (not edit)", "devin", "exec", false},
 	}
 
 	for _, tt := range tests {
@@ -39,6 +44,47 @@ func TestIsFileEditTool(t *testing.T) {
 				t.Errorf("isFileEditTool(%q, %q) = %v, want %v", tt.platform, tt.toolName, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRunPostToolEmitsDevinFileModifiedEvent(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "devin"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPostTool, map[string]interface{}{
+		"cwd":       "/repo",
+		"tool_name": "edit",
+		"tool_input": map[string]interface{}{
+			"file_path": "/repo/main.go",
+			"old_str":   "old",
+			"new_str":   "new token=devin-secret",
+		},
+		"tool_response": map[string]interface{}{"success": true},
+	})
+	if len(out) != 0 {
+		t.Fatalf("post-tool response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "file.modified" {
+		t.Fatalf("event.action = %q, want file.modified", action)
+	}
+	if harness := event["harness"].(map[string]interface{})["name"]; harness != "devin" {
+		t.Fatalf("harness = %q, want devin", harness)
+	}
+	if session, ok := event["session"].(map[string]interface{}); ok {
+		if _, hasID := session["id"]; hasID {
+			t.Fatalf("devin file event should not include empty session id: %#v", session)
+		}
+	}
+	file := event["file"].(map[string]interface{})
+	if file["path"] != "/repo/main.go" {
+		t.Fatalf("file = %#v, want /repo/main.go", file)
+	}
+	if _, ok := file["diff_hash"]; !ok {
+		t.Fatalf("file diff_hash missing: %#v", file)
 	}
 }
 

--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
@@ -24,7 +26,7 @@ var allowResponse = map[string]interface{}{"permission": "allow"}
 func runPreTool(cmd *cobra.Command, args []string) {
 	input, err := readStdinJSON()
 	if err != nil {
-		outputJSON(allowResponse)
+		outputJSON(preToolResponse())
 		return
 	}
 
@@ -36,9 +38,13 @@ func runPreTool(cmd *cobra.Command, args []string) {
 		logger = logging.NewLoggerForPlatform("pre-tool", platformFlag)
 	}
 
-	logger.Debug("Pre-tool observed, allowing")
-	emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "Pre-tool observed")
-	outputJSON(allowResponse)
+	logger.Debug("Pre-tool observed")
+	if platformFlag == "devin" {
+		emitPreToolObserved(logger, input, sessionID)
+	} else {
+		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "Pre-tool observed")
+	}
+	outputJSON(preToolResponse())
 }
 
 func emitPreToolDecision(logger *logging.Logger, input map[string]interface{}, sessionID, action, decision, reason string) {
@@ -54,4 +60,34 @@ func emitPreToolDecision(logger *logging.Logger, input map[string]interface{}, s
 		"reason":   reason,
 	}
 	emitHookEvent(logger, action, "approval", "info", reason, input, fields)
+}
+
+func preToolResponse() map[string]interface{} {
+	if platformFlag == "devin" {
+		return emptyResponse
+	}
+	return allowResponse
+}
+
+func emitPreToolObserved(logger *logging.Logger, input map[string]interface{}, sessionID string) {
+	toolName := getFirstStr(input, "tool_name", "toolName")
+	toolInput := resolveToolInput(input)
+	fields := sessionFields(sessionID, input)
+	for key, value := range toolFields(toolName, toolInput) {
+		fields[key] = value
+	}
+	action := "tool.invoked"
+	category := "tool"
+	if platformFlag != "devin" {
+		action = actionForTool(getFirstStr(input, "hook_event_name"), toolName)
+		switch {
+		case strings.HasPrefix(action, "command."):
+			category = "command"
+		case strings.HasPrefix(action, "file."):
+			category = "file"
+		case strings.HasPrefix(action, "mcp."):
+			category = "mcp"
+		}
+	}
+	emitHookEvent(logger, action, category, "info", "Tool invocation observed", input, fields)
 }

--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
@@ -76,18 +74,5 @@ func emitPreToolObserved(logger *logging.Logger, input map[string]interface{}, s
 	for key, value := range toolFields(toolName, toolInput) {
 		fields[key] = value
 	}
-	action := "tool.invoked"
-	category := "tool"
-	if platformFlag != "devin" {
-		action = actionForTool(getFirstStr(input, "hook_event_name"), toolName)
-		switch {
-		case strings.HasPrefix(action, "command."):
-			category = "command"
-		case strings.HasPrefix(action, "file."):
-			category = "file"
-		case strings.HasPrefix(action, "mcp."):
-			category = "mcp"
-		}
-	}
-	emitHookEvent(logger, action, category, "info", "Tool invocation observed", input, fields)
+	emitHookEvent(logger, "tool.invoked", "tool", "info", "Tool invocation observed", input, fields)
 }

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -91,6 +91,138 @@ func TestRunPromptSubmitEmitsFactoryPromptEvent(t *testing.T) {
 	}
 }
 
+func TestRunPromptSubmitEmitsDevinPromptWithoutSession(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "devin"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "full")
+	t.Setenv("DEVIN_PROJECT_DIR", "/repo")
+
+	out := runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"hook_event_name": "UserPromptSubmit",
+		"prompt":          "summarize token=devin-secret",
+	})
+	if len(out) != 0 {
+		t.Fatalf("devin prompt response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "prompt.submitted" {
+		t.Fatalf("event.action = %q, want prompt.submitted", action)
+	}
+	if _, ok := event["session"].(map[string]interface{})["id"]; ok {
+		t.Fatalf("devin event should not invent session id: %#v", event["session"])
+	}
+	if got := event["repository"]; got != "/repo" {
+		t.Fatalf("repository = %q, want DEVIN_PROJECT_DIR", got)
+	}
+}
+
+func TestRunPreToolEmitsDevinToolTelemetryWithoutApproval(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "devin"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPreTool, map[string]interface{}{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       "exec",
+		"tool_input": map[string]interface{}{
+			"command": "git status",
+		},
+	})
+	if len(out) != 0 {
+		t.Fatalf("devin pre-tool response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "tool.invoked" {
+		t.Fatalf("event.action = %q, want tool.invoked", action)
+	}
+	if _, ok := event["approval"]; ok {
+		t.Fatalf("PreToolUse should not emit approval telemetry: %#v", event["approval"])
+	}
+	if command := event["command"].(map[string]interface{})["command"]; command != "git status" {
+		t.Fatalf("command = %q, want git status", command)
+	}
+}
+
+func TestRunPermissionRequestEmitsDevinApproval(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "devin"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPermissionRequest, map[string]interface{}{
+		"hook_event_name": "PermissionRequest",
+		"tool_name":       "exec",
+		"tool_input": map[string]interface{}{
+			"command": "git status",
+		},
+	})
+	if out["decision"] != "approve" {
+		t.Fatalf("devin permission response = %#v, want decision=approve", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "approval.allowed" {
+		t.Fatalf("event.action = %q, want approval.allowed", action)
+	}
+	approval := event["approval"].(map[string]interface{})
+	if approval["decision"] != "approve" {
+		t.Fatalf("approval = %#v, want approve", approval)
+	}
+}
+
+func TestRunPermissionRequestNoopsForNonDevinPlatform(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPermissionRequest, map[string]interface{}{
+		"hook_event_name": "PermissionRequest",
+		"tool_name":       "Shell",
+	})
+	if len(out) != 0 {
+		t.Fatalf("non-Devin permission response = %#v, want empty response", out)
+	}
+	if _, err := os.Stat(logPath); err == nil {
+		t.Fatalf("non-Devin permission request should not write endpoint log")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected endpoint log stat error: %v", err)
+	}
+}
+
+func TestRunSessionLifecycleEmitsDevinEventsWithoutSession(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "devin"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("DEVIN_PROJECT_DIR", "/repo")
+
+	runHookWithInput(t, runSessionStart, map[string]interface{}{"source": "startup"})
+	runHookWithInput(t, runStop, map[string]interface{}{"stop_hook_active": false})
+	runHookWithInput(t, runSessionEnd, map[string]interface{}{"reason": "exit"})
+
+	events := endpointEvents(t, logPath)
+	if len(events) != 3 {
+		t.Fatalf("event count = %d, want 3: %#v", len(events), events)
+	}
+	want := []string{"session.started", "tool.completed", "session.ended"}
+	for i, action := range want {
+		if got := events[i]["event"].(map[string]interface{})["action"]; got != action {
+			t.Fatalf("event[%d].action = %q, want %q", i, got, action)
+		}
+		if session, ok := events[i]["session"].(map[string]interface{}); ok {
+			if _, hasID := session["id"]; hasID {
+				t.Fatalf("event[%d] should not invent session id: %#v", i, session)
+			}
+		}
+	}
+}
+
 func TestRunPromptSubmitEmitsTypedPromptForFullRetention(t *testing.T) {
 	setupHookConfigDirs(t)
 	platformFlag = "cursor"
@@ -186,6 +318,7 @@ func setupHookConfigDirs(t *testing.T) {
 	origClaudeDir := hookconfig.ClaudeDir
 	origCopilotDir := hookconfig.CopilotDir
 	origCursorDir := hookconfig.CursorDir
+	origDevinDir := hookconfig.DevinDir
 	origFactoryDir := hookconfig.FactoryDir
 	origOpenCodeDir := hookconfig.OpenCodeDir
 	origPlatform := platformFlag
@@ -193,6 +326,7 @@ func setupHookConfigDirs(t *testing.T) {
 	hookconfig.ClaudeDir = filepath.Join(tmp, "claude")
 	hookconfig.CopilotDir = filepath.Join(tmp, "copilot")
 	hookconfig.CursorDir = filepath.Join(tmp, "cursor")
+	hookconfig.DevinDir = filepath.Join(tmp, "devin")
 	hookconfig.FactoryDir = filepath.Join(tmp, "factory")
 	hookconfig.OpenCodeDir = filepath.Join(tmp, "opencode")
 	t.Cleanup(func() {
@@ -200,6 +334,7 @@ func setupHookConfigDirs(t *testing.T) {
 		hookconfig.ClaudeDir = origClaudeDir
 		hookconfig.CopilotDir = origCopilotDir
 		hookconfig.CursorDir = origCursorDir
+		hookconfig.DevinDir = origDevinDir
 		hookconfig.FactoryDir = origFactoryDir
 		hookconfig.OpenCodeDir = origOpenCodeDir
 		platformFlag = origPlatform

--- a/cli/beacon-hooks/cmd/root.go
+++ b/cli/beacon-hooks/cmd/root.go
@@ -11,8 +11,8 @@ var platformFlag string
 
 var rootCmd = &cobra.Command{
 	Use:   "beacon-hooks",
-	Short: "Beacon hooks for Claude Code, GitHub Copilot, Cursor, Factory, and opencode",
-	Long: `Beacon hooks binary for Claude Code, GitHub Copilot, Cursor, Factory, and opencode integration.
+	Short: "Beacon hooks for Claude Code, GitHub Copilot, Cursor, Devin, Factory, and opencode",
+	Long: `Beacon hooks binary for Claude Code, GitHub Copilot, Cursor, Devin, Factory, and opencode integration.
 
 This binary provides hook commands that are called by IDE plugin systems
 to evaluate code changes for security violations.
@@ -21,7 +21,7 @@ Use --platform to specify the calling platform (default: claude).`,
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, copilot, cursor, factory, or opencode")
+	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, copilot, cursor, devin, factory, or opencode")
 }
 
 // Execute runs the root command

--- a/cli/beacon-hooks/cmd/session_end.go
+++ b/cli/beacon-hooks/cmd/session_end.go
@@ -41,6 +41,9 @@ func runSessionEnd(cmd *cobra.Command, args []string) {
 		if err := os.Remove(logFile); err != nil && !os.IsNotExist(err) {
 			platformLogger.Warn("Failed to remove session log", "session_id", sessionID, "error", err.Error())
 		}
+	} else if platformFlag == "devin" {
+		platformLogger.Info("Session ended", "platform", platformFlag)
+		emitHookEvent(platformLogger, "session.ended", "session", "info", "Agent session ended", input, sessionFields("", input))
 	}
 
 	cleaned := state.CleanupStaleForPlatform(platformFlag)

--- a/cli/beacon-hooks/cmd/session_start.go
+++ b/cli/beacon-hooks/cmd/session_start.go
@@ -32,6 +32,11 @@ func runSessionStart(cmd *cobra.Command, args []string) {
 
 	sessionID := resolveSessionID(input, platformFlag)
 	if sessionID == "" {
+		if platformFlag == "devin" {
+			logger := logging.NewLoggerForPlatform("session-start", platformFlag)
+			logger.Info("Session initialized", "platform", platformFlag)
+			emitHookEvent(logger, "session.started", "session", "info", "Agent session started", input, sessionFields("", input))
+		}
 		outputJSON(emptyResponse)
 		return
 	}

--- a/cli/beacon-hooks/cmd/stop.go
+++ b/cli/beacon-hooks/cmd/stop.go
@@ -47,6 +47,12 @@ func runStop(cmd *cobra.Command, args []string) {
 
 	logger.Debug("Stop hook called", "session_id", sessionID, "has_transcript", transcriptPath != "", "platform", platformFlag)
 	if sessionID == "" {
+		if platformFlag == "devin" {
+			logger.Info("stop completed")
+			emitHookEvent(logger, "tool.completed", "tool", "info", "Agent response completed", input, sessionFields("", input))
+			outputJSON(emptyResponse)
+			return
+		}
 		outputJSONAndExit(emptyResponse)
 		return
 	}
@@ -77,6 +83,8 @@ func platformToTranscriptName(platform string) string {
 		return "cursor"
 	case "factory":
 		return "factory"
+	case "devin":
+		return "devin"
 	default:
 		return "claude_code"
 	}
@@ -91,6 +99,8 @@ func extractMessages(transcriptPath, platform string) []map[string]interface{} {
 		return extractMessagesFromCursorTranscript(transcriptPath)
 	case "factory":
 		return extractMessagesFromFactoryTranscript(transcriptPath)
+	case "devin":
+		return extractMessagesFromClaudeTranscript(transcriptPath)
 	default:
 		return extractMessagesFromClaudeTranscript(transcriptPath)
 	}

--- a/cli/beacon-hooks/internal/config/config.go
+++ b/cli/beacon-hooks/internal/config/config.go
@@ -13,6 +13,7 @@ var (
 	ClaudeDir   = filepath.Join(BeaconDir, "claude")
 	CopilotDir  = filepath.Join(BeaconDir, "copilot")
 	CursorDir   = filepath.Join(BeaconDir, "cursor")
+	DevinDir    = filepath.Join(BeaconDir, "devin")
 	FactoryDir  = filepath.Join(BeaconDir, "factory")
 	OpenCodeDir = filepath.Join(BeaconDir, "opencode")
 )
@@ -88,6 +89,8 @@ func GetStateDir(platform string) string {
 		return CopilotDir
 	case "cursor":
 		return CursorDir
+	case "devin":
+		return DevinDir
 	case "factory":
 		return FactoryDir
 	case "opencode":

--- a/cli/beacon-hooks/internal/diff/diff.go
+++ b/cli/beacon-hooks/internal/diff/diff.go
@@ -23,7 +23,7 @@ func FromToolResponse(toolName string, toolInput, toolResponse map[string]interf
 
 	// Fall back to tool-specific construction
 	switch toolName {
-	case "Edit":
+	case "Edit", "edit":
 		oldString := resolveEditString("old_string", "oldString", "old_str", toolInput, toolResponse)
 		newString := resolveEditString("new_string", "newString", "new_str", toolInput, toolResponse)
 		return fromEditTool(filePath, oldString, newString)
@@ -33,7 +33,7 @@ func FromToolResponse(toolName string, toolInput, toolResponse map[string]interf
 		content := GetStringFromMaps("code", toolInput, toolResponse)
 		return fromWriteTool(filePath, content, "")
 
-	case "Write", "Create":
+	case "Write", "Create", "write":
 		content := GetStringFromMaps("content", toolInput, toolResponse)
 		originalFile := GetStringFromMaps("originalFile", toolInput, toolResponse)
 		return fromWriteTool(filePath, content, originalFile)

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -69,6 +69,9 @@ that may need review.
 ./beacon endpoint hooks install --harness opencode
 ./beacon endpoint hooks status --harness opencode
 
+./beacon endpoint hooks install --harness devin --level project
+./beacon endpoint hooks status --harness devin --level project
+
 ./beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --open
 ./beacon endpoint integrations claude-cowork setup --ngrok --open
 ./beacon endpoint integrations claude-cowork validate --since 10m
@@ -80,6 +83,12 @@ raw opencode hook payloads to Beacon's Go hook binary; Beacon handles
 normalization, retention, redaction, and JSONL output locally. For local
 troubleshooting, set `BEACON_OPENCODE_DEBUG=1` in the environment that launches
 opencode to emit best-effort plugin debug logs.
+
+The Devin integration writes Claude-compatible command hooks for Devin for
+Terminal. Project-level installs use `.devin/hooks.v1.json`; user-level installs
+use `~/.config/devin/config.json` under the `hooks` key. The hooks invoke
+Beacon's local Go hook binary and write normalized prompt, tool, command, file,
+approval, and session events to the configured runtime JSONL log.
 
 Claude Cowork monitoring is configured in the Claude admin console at
 `https://claude.ai/admin-settings/cowork`. The OTLP endpoint must be reachable

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -416,6 +416,16 @@ func runEndpointHooksInstall(cmd *cobra.Command, args []string) error {
 				return err
 			}
 			fmt.Printf("opencode plugin installed: %s\n", status.PluginPath)
+		case "devin":
+			status, err := endpointhooks.InstallDevin(endpointhooks.DevinOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Devin hooks installed: %s\n", status.ConfigPath)
 		case "":
 		default:
 			return fmt.Errorf("unsupported hook harness %q", name)
@@ -458,6 +468,16 @@ func runEndpointHooksUninstall(cmd *cobra.Command, args []string) error {
 				return err
 			}
 			fmt.Println(status.Message)
+		case "devin":
+			status, err := endpointhooks.UninstallDevin(endpointhooks.DevinOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Println(status.Message)
 		case "":
 		default:
 			return fmt.Errorf("unsupported hook harness %q", name)
@@ -489,6 +509,12 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
+		case "devin":
+			statuses["devin"] = endpointhooks.DevinHookStatus(endpointhooks.DevinOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
 		case "":
 		default:
 			return fmt.Errorf("unsupported hook harness %q", name)
@@ -510,6 +536,10 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 		case "opencode":
 			status := statuses["opencode"].(endpointhooks.OpenCodeStatus)
 			fmt.Printf("opencode plugin: installed=%t path=%s\n", status.Installed, status.PluginPath)
+			fmt.Println(status.Message)
+		case "devin":
+			status := statuses["devin"].(endpointhooks.DevinStatus)
+			fmt.Printf("Devin hooks: installed=%t path=%s\n", status.Installed, status.ConfigPath)
 			fmt.Println(status.Message)
 		}
 	}

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -51,6 +51,7 @@ func DiscoverAll() []Harness {
 		DiscoverOpenCode(),
 		DiscoverFactory(),
 		DiscoverCursor(),
+		DiscoverDevin(),
 		DiscoverClaudeCowork(),
 	}
 }
@@ -184,6 +185,35 @@ func DiscoverCursor() Harness {
 	} else {
 		h.TelemetryStatus = TelemetryMissing
 		h.Message = "Cursor hooks.json was not found"
+	}
+	return h
+}
+
+func DiscoverDevin() Harness {
+	h := Harness{Name: "devin", DisplayName: "Devin", Capability: "hooks"}
+	path, err := exec.LookPath("devin")
+	if err == nil {
+		h.Detected = true
+		h.ExecutablePath = path
+		h.Version = commandVersion(path)
+	}
+	home, _ := os.UserHomeDir()
+	userConfig := filepath.Join(home, ".config", "devin", "config.json")
+	projectConfig := filepath.Join(".devin", "hooks.v1.json")
+	h.ConfigPath = userConfig
+	if fileExists(projectConfig) {
+		h.ConfigPath = projectConfig
+	}
+	if !h.Detected && (dirExists(filepath.Join(home, ".config", "devin")) || dirExists(".devin")) {
+		h.Detected = true
+	}
+	if fileExists(h.ConfigPath) {
+		status, msg := devinStatus(h.ConfigPath)
+		h.TelemetryStatus = status
+		h.Message = msg
+	} else {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = "Devin endpoint hooks were not found"
 	}
 	return h
 }
@@ -403,6 +433,48 @@ func factoryStatus(path string) (TelemetryStatus, string) {
 		return TelemetryMisconfigured, "Factory Droid OTEL endpoint does not point to localhost"
 	}
 	return TelemetryEnabled, "Factory Droid telemetry is configured for local OTLP HTTP"
+}
+
+func devinStatus(path string) (TelemetryStatus, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return TelemetryMissing, err.Error()
+	}
+	if hasBeaconDevinHooks, err := hasBeaconDevinHooks(data); err != nil {
+		return TelemetryMisconfigured, "Devin hooks JSON is invalid"
+	} else if hasBeaconDevinHooks {
+		return TelemetryEnabled, "Devin endpoint hooks are configured"
+	}
+	return TelemetryDisabled, "Devin hooks exist but endpoint hooks were not found"
+}
+
+func hasBeaconDevinHooks(data []byte) (bool, error) {
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false, err
+	}
+	rawHooks := data
+	if raw, ok := root["hooks"]; ok {
+		rawHooks = raw
+	}
+	var hooks map[string][]struct {
+		Hooks []struct {
+			Command string `json:"command"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(rawHooks, &hooks); err != nil {
+		return false, nil
+	}
+	for _, groups := range hooks {
+		for _, group := range groups {
+			for _, hook := range group.Hooks {
+				if strings.Contains(hook.Command, "BEACON_ENDPOINT_MODE=1") && strings.Contains(hook.Command, "--platform devin") {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
 }
 
 func shellExportValue(text, key string) string {

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -473,6 +473,59 @@ func TestDiscoverFactoryDetectsExecutableOnPath(t *testing.T) {
 	}
 }
 
+func TestDiscoverDevinDetectsExecutableOnPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	devinPath := filepath.Join(binDir, "devin")
+	if err := os.WriteFile(devinPath, []byte("#!/bin/sh\necho devin 1.2.3\n"), 0755); err != nil {
+		t.Fatalf("write fake devin executable: %v", err)
+	}
+
+	h := DiscoverDevin()
+	if !h.Detected {
+		t.Fatalf("DiscoverDevin did not detect executable on PATH: %#v", h)
+	}
+	if h.ExecutablePath != devinPath {
+		t.Fatalf("ExecutablePath = %q, want %q", h.ExecutablePath, devinPath)
+	}
+	if h.Version != "devin 1.2.3" {
+		t.Fatalf("Version = %q, want fake executable version", h.Version)
+	}
+	if h.ConfigPath != filepath.Join(home, ".config", "devin", "config.json") {
+		t.Fatalf("ConfigPath = %q, want user config path", h.ConfigPath)
+	}
+}
+
+func TestDevinStatusVariants(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name   string
+		body   string
+		status TelemetryStatus
+	}{
+		{name: "invalid json", body: `{`, status: TelemetryMisconfigured},
+		{name: "no beacon hooks", body: `{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"echo keep"}]}]}}`, status: TelemetryDisabled},
+		{name: "enabled", body: `{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin pre-tool"}]}]}}`, status: TelemetryEnabled},
+		{name: "standalone enabled", body: `{"PreToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin pre-tool"}]}]}`, status: TelemetryEnabled},
+		{name: "beacon string outside hooks", body: `{"note":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin pre-tool"}`, status: TelemetryDisabled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, strings.ReplaceAll(tt.name, " ", "_")+".json")
+			if err := os.WriteFile(path, []byte(tt.body), 0600); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+			status, _ := devinStatus(path)
+			if status != tt.status {
+				t.Fatalf("devinStatus = %q, want %q", status, tt.status)
+			}
+		})
+	}
+}
+
 func TestFactoryStatusVariants(t *testing.T) {
 	dir := t.TempDir()
 	tests := []struct {

--- a/cli/beacon/internal/endpoint/hooks/devin.go
+++ b/cli/beacon/internal/endpoint/hooks/devin.go
@@ -1,0 +1,269 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type DevinOptions struct {
+	Level    Level
+	LogPath  string
+	UserMode bool
+}
+
+type DevinStatus struct {
+	Installed  bool   `json:"installed"`
+	BinaryPath string `json:"binary_path,omitempty"`
+	ConfigPath string `json:"config_path,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+type devinHookGroup struct {
+	Matcher string         `json:"matcher,omitempty"`
+	Hooks   []devinHookRef `json:"hooks"`
+}
+
+type devinHookRef struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+}
+
+type devinConfig struct {
+	values     map[string]json.RawMessage
+	hooks      map[string][]devinHookGroup
+	standalone bool
+}
+
+var devinRuntime = hookRuntime{
+	displayName: "Devin",
+	configPath:  devinConfigPath,
+	install:     installDevinHooks,
+	uninstall:   removeDevinEndpointHooks,
+	isInstalled: isDevinInstalledAt,
+}
+
+func InstallDevin(opts DevinOptions) (DevinStatus, error) {
+	status, err := installRuntimeHooks(devinRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return DevinStatus{}, err
+	}
+	return devinStatusFromRuntime(status), nil
+}
+
+func UninstallDevin(opts DevinOptions) (DevinStatus, error) {
+	status, err := uninstallRuntimeHooks(devinRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return DevinStatus{}, err
+	}
+	return devinStatusFromRuntime(status), nil
+}
+
+func DevinHookStatus(opts DevinOptions) DevinStatus {
+	return devinStatusFromRuntime(runtimeHookStatus(devinRuntime, RuntimeOptions(opts)))
+}
+
+func IsDevinInstalled(opts DevinOptions) bool {
+	return isRuntimeInstalled(devinRuntime, RuntimeOptions(opts))
+}
+
+func devinStatusFromRuntime(status runtimeStatus) DevinStatus {
+	return DevinStatus{
+		Installed:  status.Installed,
+		BinaryPath: status.BinaryPath,
+		ConfigPath: status.ConfigPath,
+		Message:    status.Message,
+	}
+}
+
+func installDevinHooks(path, binaryPath, logPath, configPath string) error {
+	config, err := readDevinConfig(path)
+	if err != nil {
+		return err
+	}
+	prefix := endpointCommandPrefix("devin", binaryPath, logPath, configPath)
+	endpointHooks := map[string]devinHookGroup{
+		"SessionStart":      {Hooks: []devinHookRef{{Type: "command", Command: prefix + " session-start"}}},
+		"UserPromptSubmit":  {Hooks: []devinHookRef{{Type: "command", Command: prefix + " prompt-submit", Timeout: 30}}},
+		"PreToolUse":        {Matcher: "", Hooks: []devinHookRef{{Type: "command", Command: prefix + " pre-tool"}}},
+		"PermissionRequest": {Matcher: "", Hooks: []devinHookRef{{Type: "command", Command: prefix + " permission-request"}}},
+		"PostToolUse":       {Matcher: "", Hooks: []devinHookRef{{Type: "command", Command: prefix + " post-tool"}}},
+		"Stop":              {Hooks: []devinHookRef{{Type: "command", Command: prefix + " stop", Timeout: 45}}},
+		"SessionEnd":        {Hooks: []devinHookRef{{Type: "command", Command: prefix + " session-end"}}},
+	}
+	for eventName, group := range endpointHooks {
+		config.hooks[eventName] = mergeDevinEndpointHook(config.hooks[eventName], group)
+	}
+	data, err := config.marshal()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+func readDevinConfig(path string) (devinConfig, error) {
+	config := devinConfig{
+		values:     map[string]json.RawMessage{},
+		hooks:      map[string][]devinHookGroup{},
+		standalone: filepath.Base(path) == "hooks.v1.json",
+	}
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if config.standalone {
+			if err := json.Unmarshal(data, &config.hooks); err != nil {
+				return devinConfig{}, err
+			}
+		} else {
+			if err := json.Unmarshal(data, &config.values); err != nil {
+				return devinConfig{}, err
+			}
+			if rawHooks, ok := config.values["hooks"]; ok {
+				if err := json.Unmarshal(rawHooks, &config.hooks); err != nil {
+					return devinConfig{}, err
+				}
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return devinConfig{}, err
+	}
+	if config.hooks == nil {
+		config.hooks = map[string][]devinHookGroup{}
+	}
+	return config, nil
+}
+
+func (config devinConfig) marshal() ([]byte, error) {
+	if config.standalone {
+		if len(config.hooks) == 0 {
+			return []byte("{}"), nil
+		}
+		return json.MarshalIndent(config.hooks, "", "  ")
+	}
+	out := make(map[string]json.RawMessage, len(config.values)+1)
+	for key, value := range config.values {
+		if key != "hooks" {
+			out[key] = value
+		}
+	}
+	if len(config.hooks) > 0 {
+		data, err := json.Marshal(config.hooks)
+		if err != nil {
+			return nil, err
+		}
+		out["hooks"] = data
+	}
+	return json.MarshalIndent(out, "", "  ")
+}
+
+func mergeDevinEndpointHook(existing []devinHookGroup, group devinHookGroup) []devinHookGroup {
+	out := make([]devinHookGroup, 0, len(existing)+1)
+	for _, item := range existing {
+		filtered, changed := filterDevinEndpointHooks(item)
+		if !changed || len(filtered.Hooks) > 0 {
+			out = append(out, item)
+			if changed {
+				out[len(out)-1] = filtered
+			}
+		}
+	}
+	return append(out, group)
+}
+
+func removeDevinEndpointHooks(path string) (bool, error) {
+	config, err := readDevinConfig(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	changed := false
+	for eventName, groups := range config.hooks {
+		filtered := groups[:0]
+		for _, group := range groups {
+			withoutEndpointHooks, groupChanged := filterDevinEndpointHooks(group)
+			if groupChanged {
+				changed = true
+			}
+			if len(withoutEndpointHooks.Hooks) == 0 {
+				continue
+			}
+			filtered = append(filtered, withoutEndpointHooks)
+		}
+		if len(filtered) == 0 {
+			delete(config.hooks, eventName)
+		} else {
+			config.hooks[eventName] = filtered
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+	if config.standalone && len(config.hooks) == 0 {
+		return true, os.Remove(path)
+	}
+	out, err := config.marshal()
+	if err != nil {
+		return false, err
+	}
+	return true, os.WriteFile(path, out, 0600)
+}
+
+func isDevinEndpointHookGroup(group devinHookGroup) bool {
+	for _, hook := range group.Hooks {
+		if isEndpointHookCommand(hook.Command, "devin") {
+			return true
+		}
+	}
+	return false
+}
+
+func filterDevinEndpointHooks(group devinHookGroup) (devinHookGroup, bool) {
+	filtered := group
+	filtered.Hooks = group.Hooks[:0]
+	changed := false
+	for _, hook := range group.Hooks {
+		if isEndpointHookCommand(hook.Command, "devin") {
+			changed = true
+			continue
+		}
+		filtered.Hooks = append(filtered.Hooks, hook)
+	}
+	return filtered, changed
+}
+
+func isDevinInstalledAt(path string) bool {
+	config, err := readDevinConfig(path)
+	if err != nil {
+		return false
+	}
+	for _, groups := range config.hooks {
+		for _, group := range groups {
+			if isDevinEndpointHookGroup(group) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func devinConfigPath(level Level) (string, error) {
+	switch level {
+	case LevelProject:
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cwd, ".devin", "hooks.v1.json"), nil
+	case "", LevelUser:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".config", "devin", "config.json"), nil
+	default:
+		return "", fmt.Errorf("unknown hook level %q", level)
+	}
+}

--- a/cli/beacon/internal/endpoint/hooks/devin_test.go
+++ b/cli/beacon/internal/endpoint/hooks/devin_test.go
@@ -1,0 +1,156 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallDevinProjectHooksPreservesNonBeaconHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hooks.v1.json")
+	existing := `{"PreToolUse":[{"matcher":"exec","hooks":[{"type":"command","command":"echo keep"}]}]}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installDevinHooks(path, "/tmp/beacon hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installDevinHooks returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"echo keep",
+		"BEACON_ENDPOINT_MODE=1",
+		"BEACON_ENDPOINT_LOG='/tmp/runtime.jsonl'",
+		"BEACON_ENDPOINT_CONFIG='/tmp/config.json'",
+		"'/tmp/beacon hooks' --platform devin",
+		"PermissionRequest",
+		"permission-request",
+		"PreToolUse",
+		"PostToolUse",
+		"SessionStart",
+		"SessionEnd",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("Devin hooks missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestInstallDevinUserConfigPreservesUnrelatedKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	existing := `{"theme":"dark","hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo keep"}]}]}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installDevinHooks(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installDevinHooks returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `"theme"`) || !strings.Contains(text, "echo keep") || !strings.Contains(text, "--platform devin") {
+		t.Fatalf("user config was not preserved and updated:\n%s", text)
+	}
+}
+
+func TestInstallDevinHooksReplacesOldBeaconHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hooks.v1.json")
+	existing := `{"PostToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 old-beacon-hooks --platform devin post-tool"}]},{"hooks":[{"type":"command","command":"echo keep"}]}]}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installDevinHooks(path, "/tmp/new-beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installDevinHooks returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "old-beacon-hooks") {
+		t.Fatalf("old endpoint hook was not replaced:\n%s", text)
+	}
+	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "/tmp/new-beacon-hooks") {
+		t.Fatalf("expected preserved hook and new hook:\n%s", text)
+	}
+}
+
+func TestRemoveDevinEndpointHooksPreservesOtherHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hooks.v1.json")
+	existing := `{"SessionStart":[{"hooks":[{"type":"command","command":"echo keep"}]},{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin session-start"}]}]}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := removeDevinEndpointHooks(path)
+	if err != nil {
+		t.Fatalf("removeDevinEndpointHooks returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected endpoint hook removal")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "echo keep") {
+		t.Fatalf("non-Beacon hook was not preserved:\n%s", text)
+	}
+	if strings.Contains(text, "BEACON_ENDPOINT_MODE=1") {
+		t.Fatalf("endpoint hook was not removed:\n%s", text)
+	}
+}
+
+func TestReadDevinConfigReturnsCorruptJSONError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0600); err != nil {
+		t.Fatalf("write corrupt config: %v", err)
+	}
+
+	if _, err := readDevinConfig(path); err == nil {
+		t.Fatal("expected corrupt config error")
+	}
+}
+
+func TestDevinConfigPathProjectLevel(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	target, err := devinConfigPath(LevelProject)
+	if err != nil {
+		t.Fatalf("devinConfigPath returned error: %v", err)
+	}
+	if got, want := target, filepath.Join(dir, ".devin", "hooks.v1.json"); got != want {
+		t.Fatalf("project config path = %q, want %q", got, want)
+	}
+}
+
+func TestDevinHookStatusDetectsInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".config", "devin", "config.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin stop"}]}]}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	status := DevinHookStatus(DevinOptions{Level: LevelUser, UserMode: true})
+	if !status.Installed {
+		t.Fatalf("DevinHookStatus installed = false, status=%#v", status)
+	}
+	if status.ConfigPath != path {
+		t.Fatalf("ConfigPath = %q, want %q", status.ConfigPath, path)
+	}
+}

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -116,14 +116,16 @@ Recommended rollout:
 4. Scope repair/remediation to unhealthy devices.
 5. Broaden deployment in stages after inventory and validation stay healthy.
 
-Cursor, Factory, and opencode hook installation is separate from the base system
-package because these integrations write per-user or per-project runtime
+Cursor, Devin, Factory, and opencode hook installation is separate from the base
+system package because these integrations write per-user or per-project runtime
 settings. Run hook helpers only when an interactive console user is present.
-Cursor hooks use `.cursor/hooks.json`; Factory hooks use `.factory/settings.json`;
-opencode uses Beacon's owned plugin at `~/.config/opencode/plugins/beacon.ts`.
-Restart the runtime after installation so new sessions pick up the settings.
-Install hooks with the same endpoint log path as the collector when you want hook
-telemetry and OTLP telemetry to appear in one dashboard.
+Cursor hooks use `.cursor/hooks.json`; Devin hooks use `.devin/hooks.v1.json`
+for project installs or `~/.config/devin/config.json` for user installs; Factory
+hooks use `.factory/settings.json`; opencode uses Beacon's owned plugin at
+`~/.config/opencode/plugins/beacon.ts`. Restart the runtime after installation
+so new sessions pick up the settings. Install hooks with the same endpoint log
+path as the collector when you want hook telemetry and OTLP telemetry to appear
+in one dashboard.
 
 Factory Droid OTLP metrics are also managed outside the base system package.
 Droid reads OTLP settings from its launch environment, so deploy the environment
@@ -150,6 +152,14 @@ the logged-in user's context:
 
 ```bash
 beacon endpoint hooks install --harness opencode --level user --log-path /var/log/beacon-agent/runtime.jsonl
+```
+
+For Devin prompt/session/tool/approval/file telemetry, install Beacon's Devin
+hooks in the logged-in user's context or project context:
+
+```bash
+beacon endpoint hooks install --harness devin --level user --log-path /var/log/beacon-agent/runtime.jsonl
+beacon endpoint hooks install --harness devin --level project --log-path /var/log/beacon-agent/runtime.jsonl
 ```
 
 The opencode plugin is a small Beacon-owned TypeScript adapter that calls the
@@ -198,8 +208,9 @@ tokens do not need to be entered as visible script parameters.
 Use `/opt/beacon/jamf/scripts/repair.sh` as a remediation policy for Macs where
 Extension Attributes report a stale or unhealthy install. Use
 `/opt/beacon/jamf/scripts/install-cursor-hooks.sh` as a separate user-context
-policy for hook telemetry. Set `BEACON_HOOK_HARNESSES=cursor,factory,opencode`
-to install supported hook integrations; the helper writes hook events to
+policy for hook telemetry. Set
+`BEACON_HOOK_HARNESSES=cursor,devin,factory,opencode` to install supported hook
+integrations; the helper writes hook events to
 `/var/log/beacon-agent/runtime.jsonl` by default.
 
 ### Jamf Extension Attributes
@@ -327,7 +338,7 @@ removal remains under the MDM/package receipt lifecycle.
   writable by the collector.
 - No recent runtime events: confirm supported harnesses are configured and the
   local OTLP ports are not in use by another process.
-- Cursor, Factory, or opencode hooks are missing: run the hook helper while a
-  non-root console user is logged in, and confirm the helper uses the same
-  runtime log path as the endpoint collector.
+- Cursor, Devin, Factory, or opencode hooks are missing: run the hook helper
+  while a non-root console user is logged in, and confirm the helper uses the
+  same runtime log path as the endpoint collector.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new hook harness with install/uninstall/config-mutation logic and expands hook event normalization paths; regressions could affect endpoint telemetry emission or users’ Devin hook configs.
> 
> **Overview**
> Adds **Devin** as a first-class endpoint harness and hook integration, including `beacon endpoint hooks install|uninstall|status --harness devin` with support for *user* (`~/.config/devin/config.json`) and *project* (`.devin/hooks.v1.json`) installs.
> 
> Extends the `beacon-hooks` binary to accept `--platform devin`, normalize Devin hook payloads (session/cwd/tool naming), emit Devin-specific tool/file/command actions, and handle Devin’s approval flow via a new `permission-request` command (auto-approves while recording `approval.allowed`). Session lifecycle and pre/post tool hooks are adjusted to tolerate missing Devin session IDs and avoid emitting empty `session.id` fields.
> 
> Updates discovery/status checks to detect Devin and validate whether Beacon-managed Devin hooks are present, and refreshes docs/packaging guidance to include Devin support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536fbcf3afe533c9a5b5de523c97caa5f65925bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->