### PR TITLE
Add OpenClaw support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ need visibility into local AI agent activity.
 
 It runs locally, captures supported activity from local agent harnesses like
 Claude Code, Codex CLI, Gemini CLI, OpenCode, Devin, Factory Droid, Claude
-Cowork, and Cursor, then normalizes that activity into endpoint events your team
-can inspect and retain locally.
+Cowork, OpenClaw Gateway, and Cursor, then normalizes that activity into endpoint
+events your team can inspect and retain locally.
 
 Beacon is built to be easy to deploy for Security and IT teams through
 [MDM deployment](https://docs.asymptotelabs.ai/cli/security-it-teams) and to
@@ -60,6 +60,7 @@ security pipelines.
 | Devin | Beacon hook adapter |
 | Factory Droid | Local OpenTelemetry configuration and optional hook adapter |
 | Claude Cowork | Admin-configured OpenTelemetry setup |
+| OpenClaw Gateway | Gateway-configured OTLP/HTTP export |
 | Cursor | Beacon hook adapter |
 
 ### SIEM / Output Destinations

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -75,6 +75,10 @@ that may need review.
 ./beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --open
 ./beacon endpoint integrations claude-cowork setup --ngrok --open
 ./beacon endpoint integrations claude-cowork validate --since 10m
+
+./beacon endpoint integrations openclaw print-config
+./beacon endpoint integrations openclaw status
+./beacon endpoint integrations openclaw validate --since 10m
 ```
 
 The opencode integration installs Beacon's owned local plugin at
@@ -95,6 +99,12 @@ Claude Cowork monitoring is configured in the Claude admin console at
 by Claude Cowork, so use a durable public HTTPS Collector endpoint for ongoing
 monitoring. The `--ngrok` mode is for short-lived local testing and prints an
 authenticated tunnel URL plus the matching `Authorization` header.
+
+OpenClaw Gateway monitoring is configured in OpenClaw's local Gateway config
+with the `diagnostics-otel` plugin enabled. Beacon prints a local OTLP/HTTP
+configuration that points OpenClaw at the endpoint collector. OpenClaw does not
+export raw prompt, response, tool, or system-prompt content unless
+`diagnostics.otel.captureContent.*` is explicitly enabled.
 
 ## Test
 

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/harness"
 	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations/cowork"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations/openclaw"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/wazuh"
@@ -46,6 +48,8 @@ var endpointOpts struct {
 	coworkNgrok              bool
 	coworkOpen               bool
 	coworkSince              string
+	openClawEndpoint         string
+	openClawSince            string
 	elasticPackDir           string
 	hookLevel                string
 	contentRetention         string
@@ -208,6 +212,54 @@ var endpointCoworkValidateCmd = &cobra.Command{
 	RunE:         func(cmd *cobra.Command, args []string) error { return runEndpointCoworkValidate() },
 }
 
+var endpointOpenClawCmd = &cobra.Command{
+	Use:   "openclaw",
+	Short: "Manage OpenClaw Gateway OpenTelemetry integration",
+}
+
+var endpointOpenClawPrintConfigCmd = &cobra.Command{
+	Use:   "print-config",
+	Short: "Print OpenClaw Gateway OTLP setup guidance",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := loadOrDefaultConfig()
+		endpoint := endpointOpts.openClawEndpoint
+		if endpoint == "" {
+			endpoint = fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort)
+		}
+		fmt.Print(openclaw.PrintConfig(openclaw.Config{
+			Endpoint:    endpoint,
+			Protocol:    "http/protobuf",
+			ServiceName: "openclaw-gateway",
+		}))
+	},
+}
+
+var endpointOpenClawStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show OpenClaw Gateway endpoint integration status",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := loadOrDefaultConfig()
+		status := openclaw.GetStatus(cfg.LogPath)
+		if endpointOpts.jsonOutput {
+			_ = json.NewEncoder(os.Stdout).Encode(status)
+			return
+		}
+		fmt.Printf("%s: observed=%t", status.DisplayName, status.LastEventObserved)
+		if status.LastEventObservedAt != "" {
+			fmt.Printf(" last=%s", status.LastEventObservedAt)
+		}
+		fmt.Println()
+		fmt.Println(status.Message)
+	},
+}
+
+var endpointOpenClawValidateCmd = &cobra.Command{
+	Use:          "validate",
+	Short:        "Validate whether OpenClaw OTLP-derived events are arriving",
+	SilenceUsage: true,
+	RunE:         func(cmd *cobra.Command, args []string) error { return runEndpointOpenClawValidate() },
+}
+
 var endpointWazuhPrintConfigCmd = &cobra.Command{
 	Use:   "print-config",
 	Short: "Print a Wazuh localfile snippet",
@@ -296,6 +348,7 @@ func init() {
 	endpointElasticCmd.AddCommand(endpointElasticUpCmd)
 	endpointElasticCmd.AddCommand(endpointElasticDownCmd)
 	endpointIntegrationsCmd.AddCommand(endpointCoworkCmd)
+	endpointIntegrationsCmd.AddCommand(endpointOpenClawCmd)
 	endpointHooksCmd.AddCommand(endpointHooksInstallCmd)
 	endpointHooksCmd.AddCommand(endpointHooksUninstallCmd)
 	endpointHooksCmd.AddCommand(endpointHooksStatusCmd)
@@ -303,6 +356,9 @@ func init() {
 	endpointCoworkCmd.AddCommand(endpointCoworkSetupCmd)
 	endpointCoworkCmd.AddCommand(endpointCoworkStatusCmd)
 	endpointCoworkCmd.AddCommand(endpointCoworkValidateCmd)
+	endpointOpenClawCmd.AddCommand(endpointOpenClawPrintConfigCmd)
+	endpointOpenClawCmd.AddCommand(endpointOpenClawStatusCmd)
+	endpointOpenClawCmd.AddCommand(endpointOpenClawValidateCmd)
 
 	for _, c := range []*cobra.Command{endpointInstallCmd, endpointStatusCmd, endpointDiscoverCmd, endpointUninstallCmd, endpointRepairCmd} {
 		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
@@ -370,6 +426,15 @@ func init() {
 	endpointCoworkValidateCmd.Flags().StringVar(&endpointOpts.coworkResourceAttributes, "resource-attributes", "", "Optional Claude Cowork resource attributes")
 	endpointCoworkValidateCmd.Flags().StringVar(&endpointOpts.coworkSince, "since", "", "Require a Claude Cowork event within this duration, such as 10m")
 	endpointCoworkStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
+	for _, c := range []*cobra.Command{endpointOpenClawPrintConfigCmd, endpointOpenClawStatusCmd, endpointOpenClawValidateCmd} {
+		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
+		c.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
+		c.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
+	}
+	endpointOpenClawPrintConfigCmd.Flags().StringVar(&endpointOpts.openClawEndpoint, "endpoint", "", "OTLP HTTP endpoint to show in setup guidance")
+	endpointOpenClawValidateCmd.Flags().StringVar(&endpointOpts.openClawEndpoint, "endpoint", "", "OTLP HTTP endpoint to show when validation fails")
+	endpointOpenClawValidateCmd.Flags().StringVar(&endpointOpts.openClawSince, "since", "", "Require an OpenClaw event within this duration, such as 10m")
+	endpointOpenClawStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
 	for _, c := range []*cobra.Command{endpointHooksInstallCmd, endpointHooksUninstallCmd, endpointHooksStatusCmd} {
 		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
 		c.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
@@ -557,6 +622,47 @@ func runEndpointWazuhValidate(cmd *cobra.Command, args []string) error {
 	fmt.Println("Wazuh localfile snippet:")
 	fmt.Print(wazuh.LocalfileSnippet(cfg.LogPath))
 	fmt.Println("Expected base rule: 100500")
+	return nil
+}
+
+func runEndpointOpenClawValidate() error {
+	cfg := loadOrDefaultConfig()
+	setup := func() {
+		endpoint := endpointOpts.openClawEndpoint
+		if endpoint == "" {
+			endpoint = fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort)
+		}
+		fmt.Print(openclaw.PrintConfig(openclaw.Config{
+			Endpoint:    endpoint,
+			Protocol:    "http/protobuf",
+			ServiceName: "openclaw-gateway",
+		}))
+	}
+	if endpointOpts.openClawSince != "" {
+		duration, err := time.ParseDuration(endpointOpts.openClawSince)
+		if err != nil {
+			return fmt.Errorf("--since must be a duration such as 10m: %w", err)
+		}
+		since := time.Now().Add(-duration)
+		if !openclaw.HasOpenClawEventSince(cfg.LogPath, since) {
+			setup()
+			return fmt.Errorf("no OpenClaw OTLP-derived events observed in %s since %s", cfg.LogPath, since.UTC().Format(time.RFC3339))
+		}
+		fmt.Printf("OpenClaw OTLP-derived events observed in endpoint runtime log since %s.\n", since.UTC().Format(time.RFC3339))
+		fmt.Println("Validation confirms at least one OpenClaw event reached Beacon; it does not prove logs, traces, and metrics are each flowing.")
+		return nil
+	}
+	status := openclaw.GetStatus(cfg.LogPath)
+	if !status.LastEventObserved {
+		setup()
+		return fmt.Errorf("no OpenClaw OTLP-derived events observed in %s", cfg.LogPath)
+	}
+	if status.LastEventObservedAt != "" {
+		fmt.Printf("OpenClaw OTLP-derived events observed in endpoint runtime log. Last observed: %s.\n", status.LastEventObservedAt)
+	} else {
+		fmt.Println("OpenClaw OTLP-derived events observed in endpoint runtime log.")
+	}
+	fmt.Println("Validation confirms at least one OpenClaw event reached Beacon; it does not prove logs, traces, and metrics are each flowing.")
 	return nil
 }
 

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -53,6 +53,31 @@ func TestEndpointCoworkSetupCommandRegistered(t *testing.T) {
 	}
 }
 
+func TestEndpointOpenClawCommandsRegistered(t *testing.T) {
+	for _, path := range [][]string{
+		{"integrations", "openclaw", "print-config"},
+		{"integrations", "openclaw", "status"},
+		{"integrations", "openclaw", "validate"},
+	} {
+		cmd, _, err := endpointCmd.Find(path)
+		if err != nil {
+			t.Fatalf("Find %v returned error: %v", path, err)
+		}
+		if cmd == nil || cmd.Use != path[len(path)-1] {
+			t.Fatalf("openclaw command %v not registered: %#v", path, cmd)
+		}
+	}
+	if endpointOpenClawPrintConfigCmd.Flags().Lookup("endpoint") == nil {
+		t.Fatal("openclaw print-config command missing --endpoint flag")
+	}
+	if endpointOpenClawStatusCmd.Flags().Lookup("json") == nil {
+		t.Fatal("openclaw status command missing --json flag")
+	}
+	if endpointOpenClawValidateCmd.Flags().Lookup("since") == nil {
+		t.Fatal("openclaw validate command missing --since flag")
+	}
+}
+
 func TestEndpointElasticCommandsRegistered(t *testing.T) {
 	for _, path := range [][]string{
 		{"elastic", "print-config"},

--- a/cli/beacon/internal/endpoint/integrations/cowork/cowork.go
+++ b/cli/beacon/internal/endpoint/integrations/cowork/cowork.go
@@ -1,14 +1,14 @@
 package cowork
 
 import (
-	"bufio"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations"
 )
 
 const (
@@ -111,48 +111,15 @@ func GetStatus(logPath string) Status {
 }
 
 func HasRecentCoworkEvent(logPath string) bool {
-	_, ok := LastCoworkEvent(logPath)
-	return ok
+	return integrations.HasRecentHarnessEvent(logPath, Name)
 }
 
 func HasCoworkEventSince(logPath string, since time.Time) bool {
-	last, ok := LastCoworkEvent(logPath)
-	if !ok || last.IsZero() {
-		return false
-	}
-	return !last.Before(since)
+	return integrations.HasHarnessEventSince(logPath, Name, since)
 }
 
 func LastCoworkEvent(logPath string) (time.Time, bool) {
-	if logPath == "" {
-		return time.Time{}, false
-	}
-	file, err := os.Open(logPath)
-	if err != nil {
-		return time.Time{}, false
-	}
-	defer file.Close()
-	var last time.Time
-	found := false
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		var event map[string]interface{}
-		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
-			continue
-		}
-		if harness, ok := event["harness"].(map[string]interface{}); ok {
-			if name, _ := harness["name"].(string); strings.EqualFold(name, Name) {
-				found = true
-				if ts, ok := event["timestamp"].(string); ok {
-					if parsed, err := time.Parse(time.RFC3339Nano, ts); err == nil && parsed.After(last) {
-						last = parsed
-					}
-				}
-			}
-		}
-	}
-	return last, found
+	return integrations.LastHarnessEvent(logPath, Name)
 }
 
 func headerText(headers string) string {

--- a/cli/beacon/internal/endpoint/integrations/logscan.go
+++ b/cli/beacon/internal/endpoint/integrations/logscan.go
@@ -1,0 +1,56 @@
+package integrations
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+)
+
+func HasRecentHarnessEvent(logPath, harnessName string) bool {
+	_, ok := LastHarnessEvent(logPath, harnessName)
+	return ok
+}
+
+func HasHarnessEventSince(logPath, harnessName string, since time.Time) bool {
+	last, ok := LastHarnessEvent(logPath, harnessName)
+	if !ok || last.IsZero() {
+		return false
+	}
+	return !last.Before(since)
+}
+
+func LastHarnessEvent(logPath, harnessName string) (time.Time, bool) {
+	if logPath == "" || strings.TrimSpace(harnessName) == "" {
+		return time.Time{}, false
+	}
+	file, err := os.Open(logPath)
+	if err != nil {
+		return time.Time{}, false
+	}
+	defer file.Close()
+
+	want := strings.ToLower(strings.TrimSpace(harnessName))
+	var last time.Time
+	found := false
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var event map[string]interface{}
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			continue
+		}
+		if harness, ok := event["harness"].(map[string]interface{}); ok {
+			if name, _ := harness["name"].(string); strings.ToLower(strings.TrimSpace(name)) == want {
+				found = true
+				if ts, ok := event["timestamp"].(string); ok {
+					if parsed, err := time.Parse(time.RFC3339Nano, ts); err == nil && parsed.After(last) {
+						last = parsed
+					}
+				}
+			}
+		}
+	}
+	return last, found
+}

--- a/cli/beacon/internal/endpoint/integrations/logscan_test.go
+++ b/cli/beacon/internal/endpoint/integrations/logscan_test.go
@@ -1,0 +1,62 @@
+package integrations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLastHarnessEventSkipsMalformedLinesAndUsesLatestTimestamp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	data := strings.Join([]string{
+		`not json`,
+		`{"timestamp":"2026-05-13T16:18:40Z","harness":{"name":"openclaw_gateway"}}`,
+		`{"harness":{"name":"openclaw_gateway"}}`,
+		`{"timestamp":"2026-05-13T16:19:40Z","harness":{"name":"cursor"}}`,
+		`{"timestamp":"2026-05-13T16:20:40Z","harness":{"name":"OpenClaw_Gateway"}}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	last, ok := LastHarnessEvent(path, "openclaw_gateway")
+	if !ok {
+		t.Fatal("expected openclaw event")
+	}
+	if got, want := last.UTC().Format(time.RFC3339), "2026-05-13T16:20:40Z"; got != want {
+		t.Fatalf("LastHarnessEvent = %s, want %s", got, want)
+	}
+}
+
+func TestHasHarnessEventSinceRequiresTimestampAfterSince(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	data := `{"timestamp":"2026-05-13T16:20:40Z","harness":{"name":"openclaw_gateway"}}` + "\n"
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !HasHarnessEventSince(path, "openclaw_gateway", time.Date(2026, 5, 13, 16, 20, 0, 0, time.UTC)) {
+		t.Fatal("expected event after since timestamp")
+	}
+	if HasHarnessEventSince(path, "openclaw_gateway", time.Date(2026, 5, 13, 16, 21, 0, 0, time.UTC)) {
+		t.Fatal("did not expect event after later since timestamp")
+	}
+}
+
+func TestHasHarnessEventSinceFalseWithoutParsedTimestamp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	data := `{"harness":{"name":"openclaw_gateway"}}` + "\n"
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !HasRecentHarnessEvent(path, "openclaw_gateway") {
+		t.Fatal("expected untimestamped event to count as observed")
+	}
+	if HasHarnessEventSince(path, "openclaw_gateway", time.Now()) {
+		t.Fatal("untimestamped event should not satisfy since filter")
+	}
+}

--- a/cli/beacon/internal/endpoint/integrations/openclaw/openclaw.go
+++ b/cli/beacon/internal/endpoint/integrations/openclaw/openclaw.go
@@ -1,0 +1,144 @@
+package openclaw
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations"
+)
+
+const (
+	Name        = "openclaw_gateway"
+	DisplayName = "OpenClaw Gateway"
+	DocsURL     = "https://docs.openclaw.ai/gateway/opentelemetry"
+)
+
+type Config struct {
+	Endpoint       string `json:"endpoint"`
+	Protocol       string `json:"protocol"`
+	ServiceName    string `json:"service_name"`
+	SampleRate     string `json:"sample_rate,omitempty"`
+	FlushInterval  string `json:"flush_interval,omitempty"`
+	CaptureContent bool   `json:"capture_content,omitempty"`
+}
+
+type Status struct {
+	Name                string `json:"name"`
+	DisplayName         string `json:"display_name"`
+	Configuration       string `json:"configuration"`
+	LastEventObserved   bool   `json:"last_event_observed"`
+	LastEventObservedAt string `json:"last_event_observed_at,omitempty"`
+	Message             string `json:"message"`
+}
+
+func DefaultConfig(httpPort int) Config {
+	return Config{
+		Endpoint:    fmt.Sprintf("http://127.0.0.1:%d", httpPort),
+		Protocol:    "http/protobuf",
+		ServiceName: "openclaw-gateway",
+	}
+}
+
+func PrintConfig(cfg Config) string {
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = DefaultConfig(4318).Endpoint
+	}
+	if cfg.Protocol == "" {
+		cfg.Protocol = "http/protobuf"
+	}
+	if cfg.ServiceName == "" {
+		cfg.ServiceName = "openclaw-gateway"
+	}
+	sampleRate := strings.TrimSpace(cfg.SampleRate)
+	if sampleRate == "" {
+		sampleRate = "1.0"
+	}
+	flushInterval := strings.TrimSpace(cfg.FlushInterval)
+	if flushInterval == "" {
+		flushInterval = "60000"
+	}
+
+	captureContent := "false"
+	if cfg.CaptureContent {
+		captureContent = "true"
+	}
+
+	return fmt.Sprintf(`OpenClaw Gateway OpenTelemetry setup
+
+Install and enable the diagnostics plugin:
+
+  openclaw plugins install clawhub:@openclaw/diagnostics-otel
+  openclaw plugins enable diagnostics-otel
+
+Add this to your OpenClaw Gateway config:
+
+  {
+    plugins: {
+      allow: ["diagnostics-otel"],
+      entries: {
+        "diagnostics-otel": { enabled: true },
+      },
+    },
+    diagnostics: {
+      enabled: true,
+      otel: {
+        enabled: true,
+        endpoint: %q,
+        protocol: %q,
+        serviceName: %q,
+        traces: true,
+        metrics: true,
+        logs: true,
+        sampleRate: %s,
+        flushIntervalMs: %s,
+        captureContent: {
+          enabled: %s,
+          inputMessages: false,
+          outputMessages: false,
+          toolInputs: false,
+          toolOutputs: false,
+          systemPrompt: false,
+        },
+      },
+    },
+  }
+
+Notes:
+- Beacon listens for OTLP/HTTP on the local endpoint collector and writes normalized events to the runtime JSONL log.
+- OpenClaw does not export raw prompt, response, tool, or system-prompt content unless captureContent is explicitly enabled.
+- Validation only confirms that Beacon observed at least one OpenClaw OTLP-derived event; it does not prove every signal type is flowing.
+- OpenClaw OTEL reference: %s
+`, cfg.Endpoint, cfg.Protocol, cfg.ServiceName, sampleRate, flushInterval, captureContent, DocsURL)
+}
+
+func GetStatus(logPath string) Status {
+	status := Status{
+		Name:          Name,
+		DisplayName:   DisplayName,
+		Configuration: "gateway_configured",
+		Message:       "Configure OpenClaw Gateway diagnostics-otel to export OTLP/HTTP to Beacon's local collector",
+	}
+	if last, ok := LastOpenClawEvent(logPath); ok {
+		status.LastEventObserved = true
+		if !last.IsZero() {
+			status.LastEventObservedAt = last.UTC().Format(time.RFC3339)
+		}
+	}
+	if status.LastEventObserved {
+		status.Message = "OpenClaw OTLP-derived events have been observed in the endpoint runtime log"
+	}
+	return status
+}
+
+func HasRecentOpenClawEvent(logPath string) bool {
+	return integrations.HasRecentHarnessEvent(logPath, Name)
+}
+
+func HasOpenClawEventSince(logPath string, since time.Time) bool {
+	return integrations.HasHarnessEventSince(logPath, Name, since)
+}
+
+func LastOpenClawEvent(logPath string) (time.Time, bool) {
+	return integrations.LastHarnessEvent(logPath, Name)
+}

--- a/cli/beacon/internal/endpoint/integrations/openclaw/openclaw_test.go
+++ b/cli/beacon/internal/endpoint/integrations/openclaw/openclaw_test.go
@@ -1,0 +1,60 @@
+package openclaw
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPrintConfigIncludesPluginConfigEndpointAndPrivacyNote(t *testing.T) {
+	out := PrintConfig(Config{
+		Endpoint:    "http://127.0.0.1:4318",
+		Protocol:    "http/protobuf",
+		ServiceName: "openclaw-gateway",
+	})
+	for _, want := range []string{
+		"openclaw plugins install clawhub:@openclaw/diagnostics-otel",
+		"openclaw plugins enable diagnostics-otel",
+		`endpoint: "http://127.0.0.1:4318"`,
+		`protocol: "http/protobuf"`,
+		`serviceName: "openclaw-gateway"`,
+		"does not export raw prompt",
+		DocsURL,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("PrintConfig missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestOpenClawEventStatusAndSince(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	data := strings.Join([]string{
+		`{"timestamp":"2026-05-13T16:18:40Z","harness":{"name":"cursor"}}`,
+		`{"timestamp":"2026-05-13T16:20:40Z","harness":{"name":"openclaw_gateway"}}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !HasRecentOpenClawEvent(path) {
+		t.Fatal("expected OpenClaw event to be detected")
+	}
+	if !HasOpenClawEventSince(path, time.Date(2026, 5, 13, 16, 20, 0, 0, time.UTC)) {
+		t.Fatal("expected OpenClaw event after since timestamp")
+	}
+	if HasOpenClawEventSince(path, time.Date(2026, 5, 13, 16, 21, 0, 0, time.UTC)) {
+		t.Fatal("did not expect OpenClaw event after later since timestamp")
+	}
+
+	status := GetStatus(path)
+	if !status.LastEventObserved {
+		t.Fatal("expected status to observe OpenClaw event")
+	}
+	if got, want := status.LastEventObservedAt, "2026-05-13T16:20:40Z"; got != want {
+		t.Fatalf("LastEventObservedAt = %q, want %q", got, want)
+	}
+}

--- a/collector-builder/exporter/beaconjsonexporter/exporter.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter.go
@@ -435,6 +435,8 @@ func normalizeHarnessName(name string) string {
 		return "claude_code"
 	case lower == "claude" || strings.Contains(lower, "claude"):
 		return "claude_code"
+	case strings.Contains(lower, "openclaw") || strings.Contains(lower, "open-claw"):
+		return "openclaw_gateway"
 	case strings.Contains(lower, "codex"):
 		return "codex_cli"
 	case strings.Contains(lower, "gemini"):

--- a/collector-builder/exporter/beaconjsonexporter/exporter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter_test.go
@@ -615,6 +615,11 @@ func TestHarnessNameSeparatesClaudeCodeAndCowork(t *testing.T) {
 			attrs: map[string]interface{}{"service.name": "codex-cli"},
 			want:  "codex_cli",
 		},
+		{
+			name:  "openclaw gateway service",
+			attrs: map[string]interface{}{"service.name": "openclaw-gateway"},
+			want:  "openclaw_gateway",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new OpenClaw integration surface and updates harness name normalization, which can affect how incoming OTLP data is classified and validated. Risk is moderate due to new CLI paths and shared JSONL log-scanning logic that could impact integration status checks.
> 
> **Overview**
> Adds **OpenClaw Gateway** as a supported endpoint integration, including new `beacon endpoint integrations openclaw` commands to `print-config`, report `status` (optionally `--json`), and `validate` event arrival with an optional `--since` duration.
> 
> Introduces a shared JSONL log-scanning helper (`integrations/logscan.go`) and refactors Claude Cowork event detection to use it, while also teaching the collector JSON exporter to normalize `service.name` values containing *OpenClaw* to the `openclaw_gateway` harness name. Documentation and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e9a9ef57cb39797397fde13f52080fc65d8f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->