### PR TITLE
Grok Build clean up, test strengthening

### DIFF
--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -140,7 +140,7 @@ func actionForTool(hookEvent, toolName string) string {
 			return "tool.failed"
 		}
 		switch lower {
-		case "run_terminal_cmd":
+		case "run_terminal_command":
 			return "command.executed"
 		case "read_file":
 			return "file.read"

--- a/cli/beacon-hooks/cmd/grok_hooks_test.go
+++ b/cli/beacon-hooks/cmd/grok_hooks_test.go
@@ -74,7 +74,7 @@ func TestGrokPreToolRecordsToolAndAllows(t *testing.T) {
 		"hookEventName": "pre_tool_use",
 		"sessionId":     "grok-session-1",
 		"workspaceRoot": "/tmp/grok-project",
-		"toolName":      "run_terminal_cmd",
+		"toolName":      "run_terminal_command",
 		"toolInput": map[string]interface{}{
 			"command": "npm test",
 		},
@@ -87,7 +87,7 @@ func TestGrokPreToolRecordsToolAndAllows(t *testing.T) {
 		t.Fatalf("event.action = %q, want tool.invoked", action)
 	}
 	tool := event["tool"].(map[string]interface{})
-	if tool["name"] != "run_terminal_cmd" || tool["command"] != "npm test" {
+	if tool["name"] != "run_terminal_command" || tool["command"] != "npm test" {
 		t.Fatalf("tool fields = %#v, want name and command", tool)
 	}
 	if command := event["command"].(map[string]interface{})["command"]; command != "npm test" {
@@ -105,7 +105,7 @@ func TestGrokPostToolMapsCommandAndFailure(t *testing.T) {
 	runHookWithInput(t, runPostTool, map[string]interface{}{
 		"hookEventName": "post_tool_use",
 		"sessionId":     "grok-session-1",
-		"toolName":      "run_terminal_cmd",
+		"toolName":      "run_terminal_command",
 		"toolInput": map[string]interface{}{
 			"command": "go test ./...",
 		},
@@ -132,7 +132,7 @@ func TestGrokPostToolMapsCommandAndFailure(t *testing.T) {
 	runHookWithInput(t, runPostTool, map[string]interface{}{
 		"hookEventName": "post_tool_use_failure",
 		"sessionId":     "grok-session-1",
-		"toolName":      "run_terminal_cmd",
+		"toolName":      "run_terminal_command",
 		"toolInput": map[string]interface{}{
 			"command": "exit 1",
 		},

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -92,7 +92,7 @@ troubleshooting, set `BEACON_OPENCODE_DEBUG=1` in the environment that launches
 opencode to emit best-effort plugin debug logs.
 
 The Grok Build integration writes Beacon's owned local hook file at
-`~/.grok/hooks/beacon.json` for user-level installs or `.grok/hooks/beacon.json`
+`~/.grok/hooks/beacon-endpoint.json` for user-level installs or `.grok/hooks/beacon-endpoint.json`
 for project-level installs. Project hooks require trusting the project in Grok
 with `/hooks-trust` before they execute.
 

--- a/cli/beacon/internal/endpoint/hooks/grok.go
+++ b/cli/beacon/internal/endpoint/hooks/grok.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 )
 
-const grokManagedHookFileName = "beacon.json"
+const (
+	grokManagedHookFileName = "beacon-endpoint.json"
+	grokManagedHookMarker   = "beacon-managed-grok-hooks:v1"
+)
 
 type GrokOptions struct {
 	Level    Level
@@ -25,6 +28,7 @@ type GrokStatus struct {
 
 type grokHooksFile struct {
 	Description string                     `json:"description,omitempty"`
+	Beacon      string                     `json:"beacon,omitempty"`
 	Hooks       map[string][]grokHookGroup `json:"hooks"`
 }
 
@@ -85,6 +89,7 @@ func installGrokHooks(path, binaryPath, logPath, configPath string) error {
 	prefix := endpointCommandPrefix("grok", binaryPath, logPath, configPath)
 	hooks := grokHooksFile{
 		Description: "Beacon managed Grok endpoint telemetry hooks.",
+		Beacon:      grokManagedHookMarker,
 		Hooks: map[string][]grokHookGroup{
 			"SessionStart":     {{Hooks: []grokHookRef{{Type: "command", Command: prefix + " session-start"}}}},
 			"UserPromptSubmit": {{Hooks: []grokHookRef{{Type: "command", Command: prefix + " prompt-submit", Timeout: 30}}}},
@@ -129,6 +134,9 @@ func isGrokInstalledAt(path string) bool {
 func isGrokManagedHookFile(data []byte) bool {
 	var hooks grokHooksFile
 	if err := json.Unmarshal(data, &hooks); err != nil {
+		return false
+	}
+	if hooks.Beacon != grokManagedHookMarker {
 		return false
 	}
 	for _, groups := range hooks.Hooks {

--- a/cli/beacon/internal/endpoint/hooks/grok_test.go
+++ b/cli/beacon/internal/endpoint/hooks/grok_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,7 +9,7 @@ import (
 )
 
 func TestInstallGrokHooksWritesManagedHookFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "beacon.json")
+	path := filepath.Join(t.TempDir(), "beacon-endpoint.json")
 	if err := installGrokHooks(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
 		t.Fatalf("installGrokHooks returned error: %v", err)
 	}
@@ -16,20 +17,38 @@ func TestInstallGrokHooksWritesManagedHookFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read Grok hooks: %v", err)
 	}
-	text := string(data)
-	for _, want := range []string{
-		"Beacon managed Grok endpoint telemetry hooks",
-		"SessionStart",
-		"UserPromptSubmit",
-		"PreToolUse",
-		"PostToolUseFailure",
-		"BEACON_ENDPOINT_MODE=1",
-		"--platform grok",
-		"BEACON_ENDPOINT_LOG='/tmp/runtime.jsonl'",
-		"BEACON_ENDPOINT_CONFIG='/tmp/config.json'",
-	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("Grok hook file missing %q:\n%s", want, text)
+	var hooks grokHooksFile
+	if err := json.Unmarshal(data, &hooks); err != nil {
+		t.Fatalf("decode Grok hooks: %v", err)
+	}
+	if hooks.Beacon != grokManagedHookMarker {
+		t.Fatalf("managed marker = %q, want %q", hooks.Beacon, grokManagedHookMarker)
+	}
+	wantCommands := map[string]string{
+		"SessionStart":       "session-start",
+		"UserPromptSubmit":   "prompt-submit",
+		"PreToolUse":         "pre-tool",
+		"PostToolUse":        "post-tool",
+		"PostToolUseFailure": "post-tool",
+		"Stop":               "stop",
+		"SessionEnd":         "session-end",
+	}
+	for eventName, commandName := range wantCommands {
+		groups := hooks.Hooks[eventName]
+		if len(groups) != 1 || len(groups[0].Hooks) != 1 {
+			t.Fatalf("%s hook shape = %#v, want one command hook", eventName, groups)
+		}
+		command := groups[0].Hooks[0].Command
+		for _, want := range []string{
+			"BEACON_ENDPOINT_MODE=1",
+			"--platform grok",
+			"BEACON_ENDPOINT_LOG='/tmp/runtime.jsonl'",
+			"BEACON_ENDPOINT_CONFIG='/tmp/config.json'",
+			commandName,
+		} {
+			if !strings.Contains(command, want) {
+				t.Fatalf("%s command missing %q:\n%s", eventName, want, command)
+			}
 		}
 	}
 }
@@ -51,7 +70,7 @@ func TestRemoveGrokHooksOnlyRemovesManagedHookFile(t *testing.T) {
 		t.Fatalf("user hook was removed: %v", err)
 	}
 
-	managed := filepath.Join(dir, "beacon.json")
+	managed := filepath.Join(dir, "beacon-endpoint.json")
 	if err := installGrokHooks(managed, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
 		t.Fatalf("installGrokHooks returned error: %v", err)
 	}
@@ -70,13 +89,13 @@ func TestRemoveGrokHooksOnlyRemovesManagedHookFile(t *testing.T) {
 func TestGrokHookPathLevels(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	if got, want := mustGrokHooksPath(t, LevelUser), filepath.Join(home, ".grok", "hooks", "beacon.json"); got != want {
+	if got, want := mustGrokHooksPath(t, LevelUser), filepath.Join(home, ".grok", "hooks", "beacon-endpoint.json"); got != want {
 		t.Fatalf("user Grok hook path = %q, want %q", got, want)
 	}
 
 	project := t.TempDir()
 	t.Chdir(project)
-	if got, want := mustGrokHooksPath(t, LevelProject), filepath.Join(project, ".grok", "hooks", "beacon.json"); got != want {
+	if got, want := mustGrokHooksPath(t, LevelProject), filepath.Join(project, ".grok", "hooks", "beacon-endpoint.json"); got != want {
 		t.Fatalf("project Grok hook path = %q, want %q", got, want)
 	}
 }
@@ -89,7 +108,7 @@ func TestGrokProjectStatusMentionsTrust(t *testing.T) {
 }
 
 func TestGrokInstalledUsesManagedEndpointCommand(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "beacon.json")
+	path := filepath.Join(t.TempDir(), "beacon-endpoint.json")
 	if err := os.WriteFile(path, []byte(`{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 echo keep"}]}]}}`), 0644); err != nil {
 		t.Fatalf("write unmarked hook: %v", err)
 	}
@@ -101,6 +120,26 @@ func TestGrokInstalledUsesManagedEndpointCommand(t *testing.T) {
 	}
 	if !isGrokInstalledAt(path) {
 		t.Fatal("managed Grok hook should be detected")
+	}
+}
+
+func TestGrokManagedDetectionRequiresMarker(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beacon-endpoint.json")
+	if err := os.WriteFile(path, []byte(`{"description":"user copied Beacon command","hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform grok session-start"}]}]}}`), 0644); err != nil {
+		t.Fatalf("write unmarked copied command hook: %v", err)
+	}
+	if isGrokInstalledAt(path) {
+		t.Fatal("unmarked copied Beacon command should not be detected as managed")
+	}
+	changed, err := removeGrokHooks(path)
+	if err != nil {
+		t.Fatalf("removeGrokHooks returned error: %v", err)
+	}
+	if changed {
+		t.Fatal("unmarked copied Beacon command should not be removed")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("unmarked hook was removed: %v", err)
 	}
 }
 

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -121,8 +121,8 @@ system package because these integrations write per-user or per-project runtime
 settings. Run hook helpers only when an interactive console user is present.
 Cursor hooks use `.cursor/hooks.json`; Devin hooks use `.devin/hooks.v1.json`
 for project installs or `~/.config/devin/config.json` for user installs; Factory
-hooks use `.factory/settings.json`; Grok Build uses `.grok/hooks/beacon.json`
-or `~/.grok/hooks/beacon.json`; opencode uses Beacon's owned plugin at
+hooks use `.factory/settings.json`; Grok Build uses `.grok/hooks/beacon-endpoint.json`
+or `~/.grok/hooks/beacon-endpoint.json`; opencode uses Beacon's owned plugin at
 `~/.config/opencode/plugins/beacon.ts`. Restart the runtime after installation
 so new sessions pick up the settings. Install hooks with the same endpoint log
 path as the collector when you want hook telemetry and OTLP telemetry to appear

--- a/packaging/macos/pkgbuild.md
+++ b/packaging/macos/pkgbuild.md
@@ -96,8 +96,8 @@ Grok Build support is also installed separately in the target user's context:
 beacon endpoint hooks install --harness grok --level user --log-path /var/log/beacon-agent/runtime.jsonl
 ```
 
-This writes Beacon's owned hook file to `~/.grok/hooks/beacon.json`. Project
-installs write `.grok/hooks/beacon.json` and require `/hooks-trust` in Grok before
+This writes Beacon's owned hook file to `~/.grok/hooks/beacon-endpoint.json`. Project
+installs write `.grok/hooks/beacon-endpoint.json` and require `/hooks-trust` in Grok before
 hooks execute.
 
 ## Jamf Deployment


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Grok hook installation paths and the logic used to detect/remove managed hook files, which could leave older installs undiscovered or not uninstalled until migrated.
> 
> **Overview**
> **Cleans up Grok Build hook management** by renaming Beacon’s managed Grok hook file to `beacon-endpoint.json` and updating docs/packaging guidance accordingly.
> 
> Adds an explicit `beacon-managed-grok-hooks:v1` marker field to the generated Grok hook JSON and tightens install/uninstall detection to require this marker (avoiding treating user-copied Beacon commands as managed). Updates Grok tool action mapping/tests to use `run_terminal_command` instead of `run_terminal_cmd`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c25a9597658d507f199ba5226dd879967075a09b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->