### PR TITLE
Fix broken subheading link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Beacon is [Asymptote's open-source endpoint agent](https://justindsouza.substack
 need visibility into local AI agent activity.
 
 It runs locally, captures all agent activity (e.g. prompts, tool use, file edits, etc.) from
-[all the major local agent harnesses](#coding-agents--runtimes), then
+all the [major local agent harnesses](#agent-runtimes), then
 normalizes that activity into endpoint events your team can inspect and retain
 locally.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates an internal README anchor link; no code or runtime behavior is affected.
> 
> **Overview**
> Fixes a broken internal README link by updating the “major local agent harnesses” anchor target to `#agent-runtimes`, matching the renamed “Agent Runtimes” section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acdd5d4b1a8761d3e12626156d583e9aae7ce369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->