### PR TITLE
Add CLI improvements (doctor, status, inventory)

### DIFF
--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -1284,6 +1284,19 @@ func loadOrDefaultConfig() endpointconfig.Config {
 	return endpointconfig.Default(userMode, logPath)
 }
 
+func loadConfigForMode(userMode bool, logPath string) endpointconfig.Config {
+	if cfg, err := endpointconfig.Load(userMode); err == nil {
+		if logPath != "" {
+			cfg.LogPath = logPath
+		}
+		return cfg
+	}
+	if logPath == "" {
+		logPath = writer.DefaultPath(userMode)
+	}
+	return endpointconfig.Default(userMode, logPath)
+}
+
 func endpointUserMode() bool {
 	return endpointOpts.userMode && !endpointOpts.systemMode
 }

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -527,7 +527,7 @@ func init() {
 	endpointOpenClawCmd.AddCommand(endpointOpenClawStatusCmd)
 	endpointOpenClawCmd.AddCommand(endpointOpenClawValidateCmd)
 
-	for _, c := range []*cobra.Command{endpointInstallCmd, endpointStatusCmd, endpointDoctorCmd, endpointInventoryCmd, endpointDiscoverCmd, endpointTestEventCmd, endpointBundleDiagnosticsCmd, endpointUninstallCmd, endpointRepairCmd, endpointConfigShowCmd, endpointConfigValidateCmd, endpointConfigSetRetentionCmd, topLevelDoctorCmd, topLevelStatusCmd, topLevelInventoryCmd} {
+	for _, c := range []*cobra.Command{endpointInstallCmd, endpointStatusCmd, endpointDoctorCmd, endpointInventoryCmd, endpointDiscoverCmd, endpointTestEventCmd, endpointBundleDiagnosticsCmd, endpointUninstallCmd, endpointRepairCmd, endpointConfigShowCmd, endpointConfigValidateCmd, endpointConfigSetRetentionCmd, endpointIntegrationsValidateCmd, topLevelDoctorCmd, topLevelStatusCmd, topLevelInventoryCmd} {
 		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
 		c.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 		c.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -45,6 +45,8 @@ var endpointOpts struct {
 	keepLogs                 bool
 	keepConfig               bool
 	noStart                  bool
+	dryRun                   bool
+	allTargets               bool
 	coworkHeaders            string
 	coworkEndpoint           string
 	coworkResourceAttributes string
@@ -65,6 +67,8 @@ var endpointOpts struct {
 	splunkCAFile             string
 	dashboardAddr            string
 	dashboardOpen            bool
+	includeEventSummaries    bool
+	includeRawEvents         bool
 }
 
 var endpointCmd = &cobra.Command{
@@ -88,11 +92,40 @@ var endpointStatusCmd = &cobra.Command{
 	RunE:         runEndpointStatus,
 }
 
+var endpointDoctorCmd = &cobra.Command{
+	Use:          "doctor",
+	Short:        "Run local endpoint health checks",
+	SilenceUsage: true,
+	RunE:         runEndpointDoctor,
+}
+
+var endpointInventoryCmd = &cobra.Command{
+	Use:          "inventory",
+	Short:        "Show installed, configured, and observed endpoint inventory",
+	SilenceUsage: true,
+	RunE:         runEndpointInventory,
+}
+
 var endpointDiscoverCmd = &cobra.Command{
 	Use:          "discover",
 	Short:        "Discover supported local AI agent runtimes",
 	SilenceUsage: true,
 	RunE:         runEndpointDiscover,
+}
+
+var endpointTestEventCmd = &cobra.Command{
+	Use:          "test-event",
+	Aliases:      []string{"validate-pipeline"},
+	Short:        "Write a synthetic endpoint validation event",
+	SilenceUsage: true,
+	RunE:         runEndpointTestEvent,
+}
+
+var endpointBundleDiagnosticsCmd = &cobra.Command{
+	Use:          "bundle-diagnostics",
+	Short:        "Write a redacted local diagnostics bundle",
+	SilenceUsage: true,
+	RunE:         runEndpointBundleDiagnostics,
 }
 
 var endpointUninstallCmd = &cobra.Command{
@@ -141,9 +174,43 @@ var endpointIntegrationsCmd = &cobra.Command{
 	Short: "Manage admin-configured endpoint integrations",
 }
 
+var endpointIntegrationsValidateCmd = &cobra.Command{
+	Use:          "validate",
+	Short:        "Validate admin-configured endpoint integrations",
+	SilenceUsage: true,
+	RunE:         runEndpointIntegrationsValidate,
+}
+
 var endpointHooksCmd = &cobra.Command{
 	Use:   "hooks",
 	Short: "Manage endpoint hook integrations",
+}
+
+var endpointConfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Inspect and safely update endpoint configuration",
+}
+
+var endpointConfigShowCmd = &cobra.Command{
+	Use:          "show",
+	Short:        "Print endpoint configuration with secrets redacted",
+	SilenceUsage: true,
+	RunE:         runEndpointConfigShow,
+}
+
+var endpointConfigValidateCmd = &cobra.Command{
+	Use:          "validate",
+	Short:        "Validate endpoint configuration",
+	SilenceUsage: true,
+	RunE:         runEndpointConfigValidate,
+}
+
+var endpointConfigSetRetentionCmd = &cobra.Command{
+	Use:          "set-retention <metadata|redacted|full>",
+	Short:        "Set endpoint content retention mode",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE:         runEndpointConfigSetRetention,
 }
 
 var endpointHooksInstallCmd = &cobra.Command{
@@ -151,6 +218,27 @@ var endpointHooksInstallCmd = &cobra.Command{
 	Short:        "Install endpoint hooks for supported harnesses",
 	SilenceUsage: true,
 	RunE:         runEndpointHooksInstall,
+}
+
+var topLevelDoctorCmd = &cobra.Command{
+	Use:          "doctor",
+	Short:        "Alias for beacon endpoint doctor",
+	SilenceUsage: true,
+	RunE:         runEndpointDoctor,
+}
+
+var topLevelStatusCmd = &cobra.Command{
+	Use:          "status",
+	Short:        "Alias for beacon endpoint status",
+	SilenceUsage: true,
+	RunE:         runEndpointStatus,
+}
+
+var topLevelInventoryCmd = &cobra.Command{
+	Use:          "inventory",
+	Short:        "Alias for beacon endpoint inventory",
+	SilenceUsage: true,
+	RunE:         runEndpointInventory,
 }
 
 var endpointHooksUninstallCmd = &cobra.Command{
@@ -388,10 +476,17 @@ var endpointSumoValidateCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(endpointCmd)
+	rootCmd.AddCommand(topLevelDoctorCmd)
+	rootCmd.AddCommand(topLevelStatusCmd)
+	rootCmd.AddCommand(topLevelInventoryCmd)
 
 	endpointCmd.AddCommand(endpointInstallCmd)
 	endpointCmd.AddCommand(endpointStatusCmd)
+	endpointCmd.AddCommand(endpointDoctorCmd)
+	endpointCmd.AddCommand(endpointInventoryCmd)
 	endpointCmd.AddCommand(endpointDiscoverCmd)
+	endpointCmd.AddCommand(endpointTestEventCmd)
+	endpointCmd.AddCommand(endpointBundleDiagnosticsCmd)
 	endpointCmd.AddCommand(endpointUninstallCmd)
 	endpointCmd.AddCommand(endpointRepairCmd)
 	endpointCmd.AddCommand(endpointDashboardCmd)
@@ -401,6 +496,10 @@ func init() {
 	endpointCmd.AddCommand(endpointSumoCmd)
 	endpointCmd.AddCommand(endpointIntegrationsCmd)
 	endpointCmd.AddCommand(endpointHooksCmd)
+	endpointCmd.AddCommand(endpointConfigCmd)
+	endpointConfigCmd.AddCommand(endpointConfigShowCmd)
+	endpointConfigCmd.AddCommand(endpointConfigValidateCmd)
+	endpointConfigCmd.AddCommand(endpointConfigSetRetentionCmd)
 	endpointWazuhCmd.AddCommand(endpointWazuhPrintConfigCmd)
 	endpointWazuhCmd.AddCommand(endpointWazuhInstallPackCmd)
 	endpointWazuhCmd.AddCommand(endpointWazuhValidateCmd)
@@ -414,6 +513,7 @@ func init() {
 	endpointSumoCmd.AddCommand(endpointSumoPrintConfigCmd)
 	endpointSumoCmd.AddCommand(endpointSumoInstallPackCmd)
 	endpointSumoCmd.AddCommand(endpointSumoValidateCmd)
+	endpointIntegrationsCmd.AddCommand(endpointIntegrationsValidateCmd)
 	endpointIntegrationsCmd.AddCommand(endpointCoworkCmd)
 	endpointIntegrationsCmd.AddCommand(endpointOpenClawCmd)
 	endpointHooksCmd.AddCommand(endpointHooksInstallCmd)
@@ -427,7 +527,7 @@ func init() {
 	endpointOpenClawCmd.AddCommand(endpointOpenClawStatusCmd)
 	endpointOpenClawCmd.AddCommand(endpointOpenClawValidateCmd)
 
-	for _, c := range []*cobra.Command{endpointInstallCmd, endpointStatusCmd, endpointDiscoverCmd, endpointUninstallCmd, endpointRepairCmd} {
+	for _, c := range []*cobra.Command{endpointInstallCmd, endpointStatusCmd, endpointDoctorCmd, endpointInventoryCmd, endpointDiscoverCmd, endpointTestEventCmd, endpointBundleDiagnosticsCmd, endpointUninstallCmd, endpointRepairCmd, endpointConfigShowCmd, endpointConfigValidateCmd, endpointConfigSetRetentionCmd, topLevelDoctorCmd, topLevelStatusCmd, topLevelInventoryCmd} {
 		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
 		c.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 		c.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
@@ -440,6 +540,7 @@ func init() {
 	endpointInstallCmd.Flags().BoolVar(&endpointOpts.includeRuntimeMetrics, "include-runtime-metrics", false, "Include generic process/runtime OTLP metrics and OpenClaw operational metrics in the runtime JSONL log")
 	endpointInstallCmd.Flags().BoolVar(&endpointOpts.includeCodexSpans, "include-codex-spans", false, "Include high-volume Codex OTLP spans for troubleshooting")
 	endpointInstallCmd.Flags().BoolVar(&endpointOpts.noStart, "no-start", false, "Write files without starting the launchd service")
+	endpointInstallCmd.Flags().BoolVar(&endpointOpts.dryRun, "dry-run", false, "Print planned actions without changing endpoint files or services")
 	endpointInstallCmd.Flags().StringVar(&endpointOpts.contentRetention, "content-retention", "full", "Content retention mode: metadata, redacted, or full")
 	registerSplunkFlags(endpointInstallCmd)
 	endpointRepairCmd.Flags().StringVar(&endpointOpts.harnesses, "harness", "claude,codex", "Comma-separated harnesses to configure")
@@ -449,6 +550,7 @@ func init() {
 	endpointRepairCmd.Flags().BoolVar(&endpointOpts.includeRuntimeMetrics, "include-runtime-metrics", false, "Include generic process/runtime OTLP metrics and OpenClaw operational metrics in the runtime JSONL log")
 	endpointRepairCmd.Flags().BoolVar(&endpointOpts.includeCodexSpans, "include-codex-spans", false, "Include high-volume Codex OTLP spans for troubleshooting")
 	endpointRepairCmd.Flags().BoolVar(&endpointOpts.noStart, "no-start", false, "Write files without starting the launchd service")
+	endpointRepairCmd.Flags().BoolVar(&endpointOpts.dryRun, "dry-run", false, "Print planned actions without changing endpoint files or services")
 	endpointRepairCmd.Flags().StringVar(&endpointOpts.contentRetention, "content-retention", "full", "Content retention mode: metadata, redacted, or full")
 	registerSplunkFlags(endpointRepairCmd)
 	endpointDashboardCmd.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
@@ -458,7 +560,21 @@ func init() {
 	endpointDashboardCmd.Flags().BoolVar(&endpointOpts.dashboardOpen, "open", false, "Open the dashboard in a browser")
 
 	endpointDiscoverCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print discovery as JSON")
+	endpointDiscoverCmd.Flags().BoolVar(&endpointOpts.allTargets, "all", false, "Discover all supported runtime targets")
 	endpointStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
+	endpointDoctorCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print doctor results as JSON")
+	endpointInventoryCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print inventory as JSON")
+	endpointInventoryCmd.Flags().BoolVar(&endpointOpts.allTargets, "all", false, "Include all supported targets")
+	topLevelDoctorCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print doctor results as JSON")
+	topLevelStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
+	topLevelInventoryCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print inventory as JSON")
+	topLevelInventoryCmd.Flags().BoolVar(&endpointOpts.allTargets, "all", false, "Include all supported targets")
+	endpointTestEventCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print validation stages as JSON")
+	endpointBundleDiagnosticsCmd.Flags().StringVar(&endpointOpts.outputDir, "output", "", "Output directory for diagnostics bundle")
+	endpointBundleDiagnosticsCmd.Flags().BoolVar(&endpointOpts.includeEventSummaries, "include-event-summaries", false, "Include redacted event summaries")
+	endpointBundleDiagnosticsCmd.Flags().BoolVar(&endpointOpts.includeRawEvents, "include-raw-events", false, "Include raw runtime JSONL events")
+	endpointIntegrationsValidateCmd.Flags().BoolVar(&endpointOpts.allTargets, "all", false, "Validate all supported admin integrations")
+	endpointIntegrationsValidateCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print validation as JSON")
 	endpointWazuhPrintConfigCmd.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
 	endpointWazuhPrintConfigCmd.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 	endpointWazuhPrintConfigCmd.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
@@ -523,14 +639,27 @@ func init() {
 		c.Flags().StringVar(&endpointOpts.hookHarnesses, "harness", "cursor", "Comma-separated hook harnesses")
 		c.Flags().StringVar(&endpointOpts.hookLevel, "level", "user", "Hook install level: user or project")
 	}
+	endpointHooksInstallCmd.Flags().BoolVar(&endpointOpts.allTargets, "all", false, "Target all supported hook harnesses")
+	endpointHooksInstallCmd.Flags().BoolVar(&endpointOpts.dryRun, "dry-run", false, "Print planned hook actions without changing files")
+	endpointHooksUninstallCmd.Flags().BoolVar(&endpointOpts.allTargets, "all", false, "Target all supported hook harnesses")
+	endpointHooksUninstallCmd.Flags().BoolVar(&endpointOpts.dryRun, "dry-run", false, "Print planned hook actions without changing files")
 	endpointHooksStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
+	endpointHooksStatusCmd.Flags().BoolVar(&endpointOpts.allTargets, "all", false, "Show all supported hook harnesses")
 	endpointUninstallCmd.Flags().BoolVar(&endpointOpts.keepLogs, "keep-logs", false, "Keep runtime logs during uninstall")
 	endpointUninstallCmd.Flags().BoolVar(&endpointOpts.keepConfig, "keep-config", false, "Keep harness telemetry configuration during uninstall")
+	endpointUninstallCmd.Flags().BoolVar(&endpointOpts.dryRun, "dry-run", false, "Print planned actions without changing endpoint files or services")
 }
 
 func runEndpointHooksInstall(cmd *cobra.Command, args []string) error {
+	if endpointOpts.dryRun {
+		actions := []plannedAction{}
+		for _, name := range hookTargets() {
+			actions = append(actions, plannedAction{Action: "configure_harness", Target: name, Message: "install endpoint hook integration"})
+		}
+		return printPlannedActions(actions)
+	}
 	cfg := loadOrDefaultConfig()
-	for _, name := range splitCSV(endpointOpts.hookHarnesses) {
+	for _, name := range hookTargets() {
 		switch strings.TrimSpace(name) {
 		case "cursor":
 			status, err := endpointhooks.InstallCursor(endpointhooks.CursorOptions{
@@ -594,8 +723,15 @@ func runEndpointHooksInstall(cmd *cobra.Command, args []string) error {
 }
 
 func runEndpointHooksUninstall(cmd *cobra.Command, args []string) error {
+	if endpointOpts.dryRun {
+		actions := []plannedAction{}
+		for _, name := range hookTargets() {
+			actions = append(actions, plannedAction{Action: "remove_hook", Target: name, Message: "uninstall endpoint hook integration"})
+		}
+		return printPlannedActions(actions)
+	}
 	cfg := loadOrDefaultConfig()
-	for _, name := range splitCSV(endpointOpts.hookHarnesses) {
+	for _, name := range hookTargets() {
 		switch strings.TrimSpace(name) {
 		case "cursor":
 			status, err := endpointhooks.UninstallCursor(endpointhooks.CursorOptions{
@@ -658,7 +794,7 @@ func runEndpointHooksUninstall(cmd *cobra.Command, args []string) error {
 func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 	cfg := loadOrDefaultConfig()
 	statuses := map[string]interface{}{}
-	for _, name := range splitCSV(endpointOpts.hookHarnesses) {
+	for _, name := range hookTargets() {
 		switch strings.TrimSpace(name) {
 		case "cursor":
 			statuses["cursor"] = endpointhooks.CursorHookStatus(endpointhooks.CursorOptions{
@@ -698,7 +834,7 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 	if endpointOpts.jsonOutput {
 		return json.NewEncoder(os.Stdout).Encode(statuses)
 	}
-	for _, name := range splitCSV(endpointOpts.hookHarnesses) {
+	for _, name := range hookTargets() {
 		switch strings.TrimSpace(name) {
 		case "cursor":
 			status := statuses["cursor"].(endpointhooks.CursorStatus)
@@ -978,6 +1114,9 @@ func runEndpointDashboard(cmd *cobra.Command, args []string) error {
 }
 
 func runEndpointInstall(cmd *cobra.Command, args []string) error {
+	if endpointOpts.dryRun {
+		return printPlannedActions(plannedInstallActions(false))
+	}
 	result, err := lifecycle.Install(lifecycle.InstallOptions{
 		UserMode:              endpointUserMode(),
 		LogPath:               endpointOpts.logPath,
@@ -1080,28 +1219,13 @@ func runEndpointDiscover(cmd *cobra.Command, args []string) error {
 }
 
 func writeValidationEvent(cfg endpointconfig.Config, destination string) (string, error) {
-	message := "Beacon endpoint Wazuh validation event"
-	mode := "localfile"
-	if destination == "datadog" {
-		message = "Beacon endpoint datadog validation event"
-		mode = "agent_file"
-	} else if destination == "sumo" {
-		message = "Beacon endpoint Sumo validation event"
-		mode = "http_source_jsonl"
-	}
-	event := schema.NewEvent(schema.NewEventOptions{
-		Action:       "agent.detected",
-		Category:     "validation",
-		Severity:     schema.SeverityInfo,
-		AgentVersion: version.GetVersion(),
-		Harness:      schema.HarnessInfo{Name: "test_harness", Version: "test"},
-		Message:      message,
-	})
-	event.Destination = &schema.DestinationInfo{Type: destination, Mode: mode, Status: "configured"}
-	return writer.AppendEvent(event, writer.Options{Path: cfg.LogPath, UserMode: cfg.UserMode})
+	return writer.AppendEvent(syntheticEvent(destination), writer.Options{Path: cfg.LogPath, UserMode: cfg.UserMode})
 }
 
 func runEndpointUninstall(cmd *cobra.Command, args []string) error {
+	if endpointOpts.dryRun {
+		return printPlannedActions(plannedUninstallActions())
+	}
 	if err := lifecycle.Uninstall(lifecycle.UninstallOptions{UserMode: endpointUserMode(), LogPath: endpointOpts.logPath, KeepLogs: endpointOpts.keepLogs, KeepConfig: endpointOpts.keepConfig}); err != nil {
 		return err
 	}
@@ -1110,6 +1234,9 @@ func runEndpointUninstall(cmd *cobra.Command, args []string) error {
 }
 
 func runEndpointRepair(cmd *cobra.Command, args []string) error {
+	if endpointOpts.dryRun {
+		return printPlannedActions(plannedInstallActions(true))
+	}
 	result, err := lifecycle.Repair(lifecycle.InstallOptions{
 		UserMode:              endpointUserMode(),
 		LogPath:               endpointOpts.logPath,

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -1183,9 +1183,21 @@ func runEndpointStatus(cmd *cobra.Command, args []string) error {
 func runEndpointDiscover(cmd *cobra.Command, args []string) error {
 	discovered := harness.DiscoverAll()
 	if endpointOpts.jsonOutput {
+		if !endpointOpts.allTargets {
+			filtered := []harness.Harness{}
+			for _, h := range discovered {
+				if h.Detected {
+					filtered = append(filtered, h)
+				}
+			}
+			return json.NewEncoder(os.Stdout).Encode(filtered)
+		}
 		return json.NewEncoder(os.Stdout).Encode(discovered)
 	}
 	for _, h := range discovered {
+		if !endpointOpts.allTargets && !h.Detected {
+			continue
+		}
 		state := "not detected"
 		if h.Detected {
 			state = "detected"

--- a/cli/beacon/cmd/endpoint_robust.go
+++ b/cli/beacon/cmd/endpoint_robust.go
@@ -117,6 +117,15 @@ func runEndpointInventory(cmd *cobra.Command, args []string) error {
 		LastEventObserved: status.LastEvent != "",
 	}
 	if endpointOpts.jsonOutput {
+		if !endpointOpts.allTargets {
+			filtered := []harness.Harness{}
+			for _, h := range result.Harnesses {
+				if h.Detected {
+					filtered = append(filtered, h)
+				}
+			}
+			result.Harnesses = filtered
+		}
 		return json.NewEncoder(os.Stdout).Encode(result)
 	}
 	fmt.Printf("Config: %s\n", result.ConfigPath)

--- a/cli/beacon/cmd/endpoint_robust.go
+++ b/cli/beacon/cmd/endpoint_robust.go
@@ -138,8 +138,22 @@ func runEndpointInventory(cmd *cobra.Command, args []string) error {
 
 func runEndpointTestEvent(cmd *cobra.Command, args []string) error {
 	cfg := loadOrDefaultConfig()
-	stages := []validationStage{
-		stageFromCheck(checkLogWritable(cfg)),
+	writableStage := stageFromCheck(checkLogWritable(cfg))
+	stages := []validationStage{writableStage}
+	if writableStage.Status != "ok" {
+		if endpointOpts.jsonOutput {
+			_ = json.NewEncoder(os.Stdout).Encode(stages)
+		} else {
+			fmt.Printf("%s: %s", writableStage.Name, writableStage.Status)
+			if writableStage.Target != "" {
+				fmt.Printf(" target=%s", writableStage.Target)
+			}
+			if writableStage.Message != "" {
+				fmt.Printf(" (%s)", writableStage.Message)
+			}
+			fmt.Println()
+		}
+		return fmt.Errorf("runtime log is not writable: %s", writableStage.Evidence)
 	}
 	path, err := writeValidationEvent(cfg, "pipeline")
 	if err != nil {
@@ -176,6 +190,7 @@ func runEndpointBundleDiagnostics(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	status := lifecycle.GetStatus(endpointUserMode(), endpointOpts.logPath)
+	status.LastEvent = redactLastEvent(status.LastEvent)
 	if err := writeJSONFile(filepath.Join(out, "status.json"), status); err != nil {
 		return err
 	}
@@ -422,6 +437,13 @@ func checkLogWritable(cfg endpointconfig.Config) diagnostics.Check {
 
 func stageFromCheck(check diagnostics.Check) validationStage {
 	return validationStage{Name: check.Name, Target: check.Target, Status: check.Status, Severity: check.Severity, Message: check.Message, Evidence: check.Evidence}
+}
+
+func redactLastEvent(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	return "[present]"
 }
 
 func redactConfig(cfg endpointconfig.Config) endpointconfig.Config {

--- a/cli/beacon/cmd/endpoint_robust.go
+++ b/cli/beacon/cmd/endpoint_robust.go
@@ -353,7 +353,7 @@ func hookStatuses(targets []string) map[string]hookTargetResult {
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksJSONPath, Raw: status}
 		case "factory", "droid":
 			status := endpointhooks.FactoryHookStatus(endpointhooks.FactoryOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
-			statuses["factory"] = hookTargetResult{Target: "factory", Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.SettingsPath, Raw: status}
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.SettingsPath, Raw: status}
 		case "opencode":
 			status := endpointhooks.OpenCodeHookStatus(endpointhooks.OpenCodeOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.PluginPath, Raw: status}
@@ -469,7 +469,7 @@ func writeEventBundleFiles(out, logPath string, includeRaw bool) error {
 	data, err := os.ReadFile(logPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return writeJSONFile(filepath.Join(out, "event-summaries.json"), []map[string]interface{}{})
 		}
 		return err
 	}

--- a/cli/beacon/cmd/endpoint_robust.go
+++ b/cli/beacon/cmd/endpoint_robust.go
@@ -100,19 +100,23 @@ func runEndpointDoctor(cmd *cobra.Command, args []string) error {
 	if result.Status == "ok" {
 		fmt.Println("All endpoint health checks passed.")
 	}
+	if result.Status == "fail" {
+		return fmt.Errorf("endpoint health checks failed")
+	}
 	return nil
 }
 
 func runEndpointInventory(cmd *cobra.Command, args []string) error {
 	status := lifecycle.GetStatus(endpointUserMode(), endpointOpts.logPath)
+	effectiveCfg := loadConfigForMode(status.RuntimeLog.EffectiveUserMode, status.LogPath)
 	result := inventoryResult{
 		GeneratedAt:       time.Now().UTC().Format(time.RFC3339),
 		RuntimeLog:        status.RuntimeLog,
 		ConfigPath:        status.ConfigPath,
 		LogPath:           status.LogPath,
-		ContentRetention:  loadOrDefaultConfig().ContentRetention,
+		ContentRetention:  effectiveCfg.ContentRetention,
 		Harnesses:         status.Harnesses,
-		Hooks:             hookStatuses(hookTargets()),
+		Hooks:             hookStatusesWithConfig(hookTargets(), effectiveCfg),
 		Destinations:      status.Destinations,
 		LastEventObserved: status.LastEvent != "",
 	}
@@ -354,6 +358,10 @@ func hookTargets() []string {
 
 func hookStatuses(targets []string) map[string]hookTargetResult {
 	cfg := loadOrDefaultConfig()
+	return hookStatusesWithConfig(targets, cfg)
+}
+
+func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[string]hookTargetResult {
 	statuses := map[string]hookTargetResult{}
 	for _, name := range targets {
 		switch strings.TrimSpace(name) {

--- a/cli/beacon/cmd/endpoint_robust.go
+++ b/cli/beacon/cmd/endpoint_robust.go
@@ -1,0 +1,507 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/diagnostics"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/harness"
+	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations/cowork"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations/openclaw"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/version"
+)
+
+type doctorResult struct {
+	Status      string              `json:"status"`
+	Checks      []diagnostics.Check `json:"checks"`
+	GeneratedAt string              `json:"generated_at"`
+}
+
+type inventoryResult struct {
+	GeneratedAt       string                          `json:"generated_at"`
+	RuntimeLog        lifecycle.RuntimeLogSource      `json:"runtime_log"`
+	ConfigPath        string                          `json:"config_path"`
+	LogPath           string                          `json:"log_path"`
+	ContentRetention  endpointconfig.ContentRetention `json:"content_retention"`
+	Harnesses         []harness.Harness               `json:"harnesses"`
+	Hooks             map[string]hookTargetResult     `json:"hooks,omitempty"`
+	Destinations      lifecycle.DestinationStatus     `json:"destinations"`
+	LastEventObserved bool                            `json:"last_event_observed"`
+}
+
+type hookTargetResult struct {
+	Target    string      `json:"target"`
+	Status    string      `json:"status"`
+	Installed bool        `json:"installed,omitempty"`
+	Message   string      `json:"message,omitempty"`
+	Path      string      `json:"path,omitempty"`
+	Raw       interface{} `json:"raw,omitempty"`
+}
+
+type validationStage struct {
+	Name     string `json:"name"`
+	Target   string `json:"target,omitempty"`
+	Status   string `json:"status"`
+	Severity string `json:"severity"`
+	Message  string `json:"message,omitempty"`
+	Evidence string `json:"evidence,omitempty"`
+}
+
+type plannedAction struct {
+	Action  string `json:"action"`
+	Target  string `json:"target,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func runEndpointDoctor(cmd *cobra.Command, args []string) error {
+	status := lifecycle.GetStatus(endpointUserMode(), endpointOpts.logPath)
+	checks := append([]diagnostics.Check{}, status.Diagnostics...)
+	checks = append(checks,
+		collectorCheck(status),
+		serviceCheck(status),
+		lastEventCheck(status),
+	)
+	for _, h := range status.Harnesses {
+		checks = append(checks, harnessCheck(h))
+	}
+	result := doctorResult{
+		Status:      aggregateCheckStatus(checks),
+		Checks:      checks,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if endpointOpts.jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(result)
+	}
+	fmt.Printf("Beacon endpoint doctor: %s\n", result.Status)
+	for _, check := range checks {
+		if check.Status == "ok" {
+			continue
+		}
+		fmt.Printf("%s: %s", check.Name, check.Status)
+		if check.Target != "" {
+			fmt.Printf(" target=%s", check.Target)
+		}
+		if check.Message != "" {
+			fmt.Printf(" (%s)", check.Message)
+		}
+		fmt.Println()
+	}
+	if result.Status == "ok" {
+		fmt.Println("All endpoint health checks passed.")
+	}
+	return nil
+}
+
+func runEndpointInventory(cmd *cobra.Command, args []string) error {
+	status := lifecycle.GetStatus(endpointUserMode(), endpointOpts.logPath)
+	result := inventoryResult{
+		GeneratedAt:       time.Now().UTC().Format(time.RFC3339),
+		RuntimeLog:        status.RuntimeLog,
+		ConfigPath:        status.ConfigPath,
+		LogPath:           status.LogPath,
+		ContentRetention:  loadOrDefaultConfig().ContentRetention,
+		Harnesses:         status.Harnesses,
+		Hooks:             hookStatuses(hookTargets()),
+		Destinations:      status.Destinations,
+		LastEventObserved: status.LastEvent != "",
+	}
+	if endpointOpts.jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(result)
+	}
+	fmt.Printf("Config: %s\n", result.ConfigPath)
+	fmt.Printf("Runtime log: %s\n", result.LogPath)
+	fmt.Printf("Content retention: %s\n", result.ContentRetention)
+	for _, h := range result.Harnesses {
+		if !endpointOpts.allTargets && !h.Detected {
+			continue
+		}
+		fmt.Printf("Harness: %s detected=%t telemetry=%s\n", h.DisplayName, h.Detected, h.TelemetryStatus)
+	}
+	for _, name := range hookTargets() {
+		if hook, ok := result.Hooks[name]; ok {
+			fmt.Printf("Hook: %s status=%s installed=%t\n", name, hook.Status, hook.Installed)
+		}
+	}
+	return nil
+}
+
+func runEndpointTestEvent(cmd *cobra.Command, args []string) error {
+	cfg := loadOrDefaultConfig()
+	stages := []validationStage{
+		stageFromCheck(checkLogWritable(cfg)),
+	}
+	path, err := writeValidationEvent(cfg, "pipeline")
+	if err != nil {
+		stages = append(stages, validationStage{Name: "write_test_event", Target: cfg.LogPath, Status: "fail", Severity: "high", Message: err.Error(), Evidence: "append_failed"})
+		if endpointOpts.jsonOutput {
+			_ = json.NewEncoder(os.Stdout).Encode(stages)
+		}
+		return err
+	}
+	stages = append(stages, validationStage{Name: "write_test_event", Target: path, Status: "ok", Severity: "info", Message: "synthetic validation event written", Evidence: "append_succeeded"})
+	if endpointOpts.jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(stages)
+	}
+	for _, stage := range stages {
+		fmt.Printf("%s: %s", stage.Name, stage.Status)
+		if stage.Target != "" {
+			fmt.Printf(" target=%s", stage.Target)
+		}
+		if stage.Message != "" {
+			fmt.Printf(" (%s)", stage.Message)
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+func runEndpointBundleDiagnostics(cmd *cobra.Command, args []string) error {
+	cfg := loadOrDefaultConfig()
+	out := endpointOpts.outputDir
+	if out == "" {
+		out = filepath.Join(endpointconfig.BaseDir(endpointUserMode()), "diagnostics-"+time.Now().UTC().Format("20060102T150405Z"))
+	}
+	if err := os.MkdirAll(out, 0755); err != nil {
+		return err
+	}
+	status := lifecycle.GetStatus(endpointUserMode(), endpointOpts.logPath)
+	if err := writeJSONFile(filepath.Join(out, "status.json"), status); err != nil {
+		return err
+	}
+	if err := writeJSONFile(filepath.Join(out, "config.redacted.json"), redactConfig(cfg)); err != nil {
+		return err
+	}
+	if endpointOpts.includeEventSummaries || endpointOpts.includeRawEvents {
+		if err := writeEventBundleFiles(out, cfg.LogPath, endpointOpts.includeRawEvents); err != nil {
+			return err
+		}
+	}
+	fmt.Printf("Diagnostics bundle written to %s\n", out)
+	if !endpointOpts.includeRawEvents {
+		fmt.Println("Raw runtime events were not included.")
+	}
+	return nil
+}
+
+func runEndpointConfigShow(cmd *cobra.Command, args []string) error {
+	return json.NewEncoder(os.Stdout).Encode(redactConfig(loadOrDefaultConfig()))
+}
+
+func runEndpointConfigValidate(cmd *cobra.Command, args []string) error {
+	cfg := loadOrDefaultConfig()
+	if err := endpointconfig.ValidateContentRetention(cfg.ContentRetention); err != nil {
+		return err
+	}
+	if err := endpointconfig.ValidateDestinations(cfg.Destinations); err != nil {
+		return err
+	}
+	fmt.Printf("Endpoint config is valid: %s\n", endpointconfig.ConfigPath(cfg.UserMode))
+	return nil
+}
+
+func runEndpointConfigSetRetention(cmd *cobra.Command, args []string) error {
+	mode := endpointconfig.ContentRetention(args[0])
+	if err := endpointconfig.ValidateContentRetention(mode); err != nil {
+		return err
+	}
+	cfg := loadOrDefaultConfig()
+	cfg.ContentRetention = mode
+	path, err := endpointconfig.Save(cfg)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Content retention set to %s in %s\n", mode, path)
+	return nil
+}
+
+func runEndpointIntegrationsValidate(cmd *cobra.Command, args []string) error {
+	targets := []string{"claude-cowork", "openclaw"}
+	if !endpointOpts.allTargets {
+		return fmt.Errorf("specify --all to validate all admin integrations, or use a specific integration validate command")
+	}
+	cfg := loadOrDefaultConfig()
+	results := map[string]validationStage{}
+	for _, target := range targets {
+		switch target {
+		case "claude-cowork":
+			status := cowork.GetStatus(cfg.LogPath)
+			stage := validationStage{Name: "integration_validate", Target: target, Status: "broken", Severity: "medium", Message: status.Message, Evidence: "not_observed"}
+			if status.LastEventObserved {
+				stage.Status = "configured"
+				stage.Severity = "info"
+				stage.Evidence = "last_event_observed"
+			}
+			results[target] = stage
+		case "openclaw":
+			status := openclaw.GetStatus(cfg.LogPath)
+			stage := validationStage{Name: "integration_validate", Target: target, Status: "broken", Severity: "medium", Message: status.Message, Evidence: "not_observed"}
+			if status.LastEventObserved {
+				stage.Status = "configured"
+				stage.Severity = "info"
+				stage.Evidence = "last_event_observed"
+			}
+			results[target] = stage
+		}
+	}
+	if endpointOpts.jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(results)
+	}
+	for _, target := range targets {
+		stage := results[target]
+		fmt.Printf("%s: %s", target, stage.Status)
+		if stage.Message != "" {
+			fmt.Printf(" (%s)", stage.Message)
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+func plannedInstallActions(repair bool) []plannedAction {
+	cfg := endpointconfig.Default(endpointUserMode(), endpointOpts.logPath)
+	if endpointOpts.logPath != "" {
+		cfg.LogPath = endpointOpts.logPath
+	}
+	actions := []plannedAction{}
+	if repair {
+		actions = append(actions, plannedAction{Action: "unload_service", Message: "repair unloads existing endpoint service if present"})
+	}
+	actions = append(actions,
+		plannedAction{Action: "write_file", Target: cfg.Collector.ConfigPath, Message: "collector configuration"},
+		plannedAction{Action: "write_plist", Message: "launchd service definition"},
+		plannedAction{Action: "write_file", Target: endpointconfig.ConfigPath(cfg.UserMode), Message: "endpoint configuration"},
+	)
+	for _, h := range splitCSV(endpointOpts.harnesses) {
+		actions = append(actions, plannedAction{Action: "configure_harness", Target: h})
+	}
+	if !endpointOpts.noStart {
+		actions = append(actions, plannedAction{Action: "load_service", Message: "start endpoint collector service"})
+	}
+	return actions
+}
+
+func plannedUninstallActions() []plannedAction {
+	cfg := loadOrDefaultConfig()
+	actions := []plannedAction{{Action: "unload_service", Message: "stop endpoint collector service if present"}}
+	if !endpointOpts.keepConfig {
+		actions = append(actions, plannedAction{Action: "restore_backup", Message: "restore backed up harness configs when available"})
+	}
+	actions = append(actions, plannedAction{Action: "remove_file", Target: endpointconfig.ConfigPath(cfg.UserMode), Message: "endpoint config"})
+	if !endpointOpts.keepLogs {
+		actions = append(actions, plannedAction{Action: "remove_file", Target: cfg.LogPath, Message: "runtime log"})
+	}
+	return actions
+}
+
+func printPlannedActions(actions []plannedAction) error {
+	if endpointOpts.jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(actions)
+	}
+	for _, action := range actions {
+		fmt.Printf("%s", action.Action)
+		if action.Target != "" {
+			fmt.Printf(" %s", action.Target)
+		}
+		if action.Message != "" {
+			fmt.Printf(" (%s)", action.Message)
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+func hookTargets() []string {
+	if endpointOpts.allTargets {
+		return []string{"cursor", "factory", "opencode", "grok", "devin"}
+	}
+	return splitCSV(endpointOpts.hookHarnesses)
+}
+
+func hookStatuses(targets []string) map[string]hookTargetResult {
+	cfg := loadOrDefaultConfig()
+	statuses := map[string]hookTargetResult{}
+	for _, name := range targets {
+		switch strings.TrimSpace(name) {
+		case "cursor":
+			status := endpointhooks.CursorHookStatus(endpointhooks.CursorOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksJSONPath, Raw: status}
+		case "factory", "droid":
+			status := endpointhooks.FactoryHookStatus(endpointhooks.FactoryOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses["factory"] = hookTargetResult{Target: "factory", Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.SettingsPath, Raw: status}
+		case "opencode":
+			status := endpointhooks.OpenCodeHookStatus(endpointhooks.OpenCodeOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.PluginPath, Raw: status}
+		case "grok":
+			status := endpointhooks.GrokHookStatus(endpointhooks.GrokOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
+		case "devin":
+			status := endpointhooks.DevinHookStatus(endpointhooks.DevinOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ConfigPath, Raw: status}
+		}
+	}
+	return statuses
+}
+
+func targetStatus(installed bool) string {
+	if installed {
+		return "configured"
+	}
+	return "not_installed"
+}
+
+func aggregateCheckStatus(checks []diagnostics.Check) string {
+	out := "ok"
+	for _, check := range checks {
+		if check.Status == "fail" {
+			return "fail"
+		}
+		if check.Status == "warn" {
+			out = "warn"
+		}
+	}
+	return out
+}
+
+func collectorCheck(status lifecycle.Status) diagnostics.Check {
+	if status.Collector.GRPCReady || status.Collector.HTTPReady {
+		return diagnostics.Check{Name: "collector_reachability", Target: status.ConfigPath, Status: "ok", Severity: "info", Message: status.Collector.Message, Evidence: "collector_ready"}
+	}
+	return diagnostics.Check{Name: "collector_reachability", Target: status.ConfigPath, Status: "fail", Severity: "high", Message: status.Collector.Message, Evidence: "collector_not_ready"}
+}
+
+func serviceCheck(status lifecycle.Status) diagnostics.Check {
+	if status.Service.Running {
+		return diagnostics.Check{Name: "service", Status: "ok", Severity: "info", Message: status.Service.Message, Evidence: "service_running"}
+	}
+	if status.Service.Loaded {
+		return diagnostics.Check{Name: "service", Status: "warn", Severity: "medium", Message: status.Service.Message, Evidence: "service_loaded_not_running"}
+	}
+	return diagnostics.Check{Name: "service", Status: "warn", Severity: "medium", Message: status.Service.Message, Evidence: "service_not_loaded"}
+}
+
+func lastEventCheck(status lifecycle.Status) diagnostics.Check {
+	if status.LastEvent != "" {
+		return diagnostics.Check{Name: "last_event", Target: status.LogPath, Status: "ok", Severity: "info", Message: "runtime log has events", Evidence: "last_event_present"}
+	}
+	return diagnostics.Check{Name: "last_event", Target: status.LogPath, Status: "warn", Severity: "low", Message: "runtime log has no events yet", Evidence: "last_event_missing"}
+}
+
+func harnessCheck(h harness.Harness) diagnostics.Check {
+	if !h.Detected {
+		return diagnostics.Check{Name: "harness", Target: h.Name, Status: "ok", Severity: "info", Message: "not installed", Evidence: "not_installed"}
+	}
+	if h.TelemetryStatus == harness.TelemetryEnabled {
+		return diagnostics.Check{Name: "harness", Target: h.Name, Status: "ok", Severity: "info", Message: h.Message, Evidence: "configured"}
+	}
+	return diagnostics.Check{Name: "harness", Target: h.Name, Status: "warn", Severity: "medium", Message: h.Message, Evidence: string(h.TelemetryStatus)}
+}
+
+func checkLogWritable(cfg endpointconfig.Config) diagnostics.Check {
+	dir := filepath.Dir(cfg.LogPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return diagnostics.Check{Name: "runtime_log_writable", Target: cfg.LogPath, Status: "fail", Severity: "high", Message: err.Error(), Evidence: "mkdir_failed"}
+	}
+	file, err := os.OpenFile(cfg.LogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return diagnostics.Check{Name: "runtime_log_writable", Target: cfg.LogPath, Status: "fail", Severity: "high", Message: err.Error(), Evidence: "open_failed"}
+	}
+	_ = file.Close()
+	return diagnostics.Check{Name: "runtime_log_writable", Target: cfg.LogPath, Status: "ok", Severity: "info", Message: "runtime log is writable", Evidence: "open_succeeded"}
+}
+
+func stageFromCheck(check diagnostics.Check) validationStage {
+	return validationStage{Name: check.Name, Target: check.Target, Status: check.Status, Severity: check.Severity, Message: check.Message, Evidence: check.Evidence}
+}
+
+func redactConfig(cfg endpointconfig.Config) endpointconfig.Config {
+	if cfg.Destinations != nil && cfg.Destinations.SplunkHEC != nil && cfg.Destinations.SplunkHEC.Token != "" {
+		destinations := *cfg.Destinations
+		splunk := *cfg.Destinations.SplunkHEC
+		splunk.Token = "[REDACTED]"
+		destinations.SplunkHEC = &splunk
+		cfg.Destinations = &destinations
+	}
+	return cfg
+}
+
+func writeJSONFile(path string, value interface{}) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0644)
+}
+
+func writeEventBundleFiles(out, logPath string, includeRaw bool) error {
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	summaries := []map[string]interface{}{}
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var event schema.Event
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+		hash := fmt.Sprintf("%x", sha256.Sum256([]byte(line)))
+		summaries = append(summaries, map[string]interface{}{
+			"timestamp": event.Timestamp,
+			"category":  event.Event.Category,
+			"action":    event.Event.Action,
+			"severity":  event.Severity,
+			"harness":   event.Harness.Name,
+			"hash":      hash,
+		})
+	}
+	if err := writeJSONFile(filepath.Join(out, "event-summaries.json"), summaries); err != nil {
+		return err
+	}
+	if includeRaw {
+		return os.WriteFile(filepath.Join(out, "runtime.raw.jsonl"), data, 0600)
+	}
+	return nil
+}
+
+func syntheticEvent(destination string) schema.Event {
+	mode := "local_jsonl"
+	message := "Beacon endpoint pipeline validation event"
+	switch destination {
+	case "wazuh":
+		mode = "localfile"
+		message = "Beacon endpoint Wazuh validation event"
+	case "datadog":
+		mode = "agent_file"
+		message = "Beacon endpoint datadog validation event"
+	case "sumo":
+		mode = "http_source_jsonl"
+		message = "Beacon endpoint Sumo validation event"
+	}
+	event := schema.NewEvent(schema.NewEventOptions{
+		Action:       "agent.detected",
+		Category:     "validation",
+		Severity:     schema.SeverityInfo,
+		AgentVersion: version.GetVersion(),
+		Harness:      schema.HarnessInfo{Name: "test_harness", Version: "test"},
+		Message:      message,
+	})
+	event.Destination = &schema.DestinationInfo{Type: destination, Mode: mode, Status: "configured"}
+	return event
+}

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/diagnostics"
 
 	"github.com/spf13/cobra"
 )
@@ -289,5 +293,113 @@ func TestEndpointCommandsDefaultToUserMode(t *testing.T) {
 		if cmd.Flags().Lookup("system") == nil {
 			t.Fatalf("%s missing --system flag", cmd.Use)
 		}
+	}
+}
+
+func TestRobustEndpointCommandsRegistered(t *testing.T) {
+	for _, path := range [][]string{
+		{"doctor"},
+		{"inventory"},
+		{"test-event"},
+		{"bundle-diagnostics"},
+		{"config", "show"},
+		{"config", "validate"},
+		{"config", "set-retention"},
+		{"integrations", "validate"},
+	} {
+		cmd, _, err := endpointCmd.Find(path)
+		if err != nil {
+			t.Fatalf("Find %v returned error: %v", path, err)
+		}
+		if cmd == nil {
+			t.Fatalf("command %v not registered", path)
+		}
+	}
+}
+
+func TestTopLevelAliasesRegistered(t *testing.T) {
+	for _, name := range []string{"doctor", "status", "inventory"} {
+		cmd, _, err := rootCmd.Find([]string{name})
+		if err != nil {
+			t.Fatalf("Find %s returned error: %v", name, err)
+		}
+		if cmd == nil || cmd.Use != name {
+			t.Fatalf("top-level %s alias not registered: %#v", name, cmd)
+		}
+		if cmd.Flags().Lookup("user") == nil || cmd.Flags().Lookup("log-path") == nil {
+			t.Fatalf("top-level %s alias missing endpoint flags", name)
+		}
+	}
+}
+
+func TestRobustCLIFlagsRegistered(t *testing.T) {
+	for _, cmd := range []*cobra.Command{endpointInstallCmd, endpointRepairCmd, endpointUninstallCmd, endpointHooksInstallCmd, endpointHooksUninstallCmd} {
+		if cmd.Flags().Lookup("dry-run") == nil {
+			t.Fatalf("%s missing --dry-run", cmd.Use)
+		}
+	}
+	for _, cmd := range []*cobra.Command{endpointDiscoverCmd, endpointInventoryCmd, endpointHooksStatusCmd, endpointHooksInstallCmd, endpointHooksUninstallCmd, endpointIntegrationsValidateCmd} {
+		if cmd.Flags().Lookup("all") == nil {
+			t.Fatalf("%s missing --all", cmd.Use)
+		}
+	}
+	if endpointBundleDiagnosticsCmd.Flags().Lookup("include-event-summaries") == nil {
+		t.Fatal("bundle-diagnostics missing --include-event-summaries")
+	}
+	if endpointBundleDiagnosticsCmd.Flags().Lookup("include-raw-events") == nil {
+		t.Fatal("bundle-diagnostics missing --include-raw-events")
+	}
+}
+
+func TestCompletionAndDocsCommandsRegistered(t *testing.T) {
+	for _, name := range []string{"completion", "docs"} {
+		cmd, _, err := rootCmd.Find([]string{name})
+		if err != nil {
+			t.Fatalf("Find %s returned error: %v", name, err)
+		}
+		if cmd == nil || cmd.Use == "" {
+			t.Fatalf("%s command not registered: %#v", name, cmd)
+		}
+	}
+	if docsCmd.Flags().Lookup("output") == nil {
+		t.Fatal("docs command missing --output")
+	}
+}
+
+func TestRedactConfigScrubsSplunkToken(t *testing.T) {
+	cfg := endpointconfig.Default(true, "/tmp/runtime.jsonl")
+	cfg.Destinations = &endpointconfig.Destinations{SplunkHEC: &endpointconfig.SplunkHEC{
+		Endpoint: "https://splunk.example/services/collector",
+		Token:    "secret-token",
+	}}
+	redacted := redactConfig(cfg)
+	if redacted.Destinations.SplunkHEC.Token != "[REDACTED]" {
+		t.Fatalf("token was not redacted: %#v", redacted.Destinations.SplunkHEC)
+	}
+	if cfg.Destinations.SplunkHEC.Token != "secret-token" {
+		t.Fatal("redactConfig mutated input config")
+	}
+}
+
+func TestAggregateCheckStatus(t *testing.T) {
+	if got := aggregateCheckStatus([]diagnostics.Check{{Status: "ok"}}); got != "ok" {
+		t.Fatalf("ok aggregate = %q", got)
+	}
+	if got := aggregateCheckStatus([]diagnostics.Check{{Status: "ok"}, {Status: "warn"}}); got != "warn" {
+		t.Fatalf("warn aggregate = %q", got)
+	}
+	if got := aggregateCheckStatus([]diagnostics.Check{{Status: "warn"}, {Status: "fail"}}); got != "fail" {
+		t.Fatalf("fail aggregate = %q", got)
+	}
+}
+
+func TestSyntheticEventDestinations(t *testing.T) {
+	event := syntheticEvent("pipeline")
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Destination.Type != "pipeline" || event.Destination.Mode != "local_jsonl" {
+		t.Fatalf("pipeline destination = %#v json=%s", event.Destination, data)
 	}
 }

--- a/cli/beacon/cmd/root.go
+++ b/cli/beacon/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/version"
 )
@@ -28,6 +29,45 @@ Beacon-hosted backend.`,
 	},
 }
 
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion scripts",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return rootCmd.GenBashCompletion(os.Stdout)
+		case "zsh":
+			return rootCmd.GenZshCompletion(os.Stdout)
+		case "fish":
+			return rootCmd.GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return rootCmd.GenPowerShellCompletion(os.Stdout)
+		default:
+			return fmt.Errorf("unsupported shell %q", args[0])
+		}
+	},
+}
+
+var docsCmd = &cobra.Command{
+	Use:          "docs --output <dir>",
+	Short:        "Generate command reference markdown",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		output, err := cmd.Flags().GetString("output")
+		if err != nil {
+			return err
+		}
+		if output == "" {
+			return fmt.Errorf("--output is required")
+		}
+		if err := os.MkdirAll(output, 0755); err != nil {
+			return err
+		}
+		return doc.GenMarkdownTree(rootCmd, output)
+	},
+}
+
 // Execute runs the root command
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
@@ -41,4 +81,7 @@ func init() {
 
 	// Add version flag shorthand
 	rootCmd.Flags().BoolP("version", "v", false, "Print the version number")
+	docsCmd.Flags().String("output", "", "Output directory for markdown command docs")
+	rootCmd.AddCommand(completionCmd)
+	rootCmd.AddCommand(docsCmd)
 }

--- a/cli/beacon/go.mod
+++ b/cli/beacon/go.mod
@@ -5,6 +5,9 @@ go 1.24
 require github.com/spf13/cobra v1.8.1
 
 require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/cli/beacon/go.sum
+++ b/cli/beacon/go.sum
@@ -1,10 +1,13 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cli/beacon/internal/endpoint/diagnostics/diagnostics.go
+++ b/cli/beacon/internal/endpoint/diagnostics/diagnostics.go
@@ -12,9 +12,11 @@ import (
 
 type Check struct {
 	Name     string `json:"name"`
+	Target   string `json:"target,omitempty"`
 	Status   string `json:"status"`
 	Severity string `json:"severity"`
 	Message  string `json:"message,omitempty"`
+	Evidence string `json:"evidence,omitempty"`
 }
 
 func Run(cfg endpointconfig.Config) []Check {
@@ -43,29 +45,29 @@ func checkFile(name, path string, required bool) Check {
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) && !required {
-			return Check{Name: name, Status: "warn", Severity: "low", Message: fmt.Sprintf("%s does not exist yet", path)}
+			return Check{Name: name, Target: path, Status: "warn", Severity: "low", Message: fmt.Sprintf("%s does not exist yet", path), Evidence: "missing_optional_file"}
 		}
-		return Check{Name: name, Status: "fail", Severity: "medium", Message: err.Error()}
+		return Check{Name: name, Target: path, Status: "fail", Severity: "medium", Message: err.Error(), Evidence: "stat_failed"}
 	}
 	if info.IsDir() {
-		return Check{Name: name, Status: "fail", Severity: "medium", Message: path + " is a directory"}
+		return Check{Name: name, Target: path, Status: "fail", Severity: "medium", Message: path + " is a directory", Evidence: "target_is_directory"}
 	}
-	return Check{Name: name, Status: "ok", Severity: "info", Message: path}
+	return Check{Name: name, Target: path, Status: "ok", Severity: "info", Message: path, Evidence: "file_exists"}
 }
 
 func checkLogPermissions(path string) Check {
 	info, err := os.Stat(path)
 	if err != nil {
-		return Check{Name: "runtime_log_permissions", Status: "warn", Severity: "low", Message: "runtime log not created yet"}
+		return Check{Name: "runtime_log_permissions", Target: path, Status: "warn", Severity: "low", Message: "runtime log not created yet", Evidence: "runtime_log_missing"}
 	}
 	mode := info.Mode().Perm()
 	if mode&0022 != 0 {
-		return Check{Name: "runtime_log_permissions", Status: "fail", Severity: "high", Message: fmt.Sprintf("runtime log is group/world writable: %o", mode)}
+		return Check{Name: "runtime_log_permissions", Target: path, Status: "fail", Severity: "high", Message: fmt.Sprintf("runtime log is group/world writable: %o", mode), Evidence: "group_or_world_writable"}
 	}
 	if mode&0044 == 0 {
-		return Check{Name: "runtime_log_permissions", Status: "warn", Severity: "low", Message: fmt.Sprintf("runtime log may not be readable by Wazuh: %o", mode)}
+		return Check{Name: "runtime_log_permissions", Target: path, Status: "warn", Severity: "low", Message: fmt.Sprintf("runtime log may not be readable by Wazuh: %o", mode), Evidence: "not_group_or_world_readable"}
 	}
-	return Check{Name: "runtime_log_permissions", Status: "ok", Severity: "info", Message: fmt.Sprintf("mode %o", mode)}
+	return Check{Name: "runtime_log_permissions", Target: path, Status: "ok", Severity: "info", Message: fmt.Sprintf("mode %o", mode), Evidence: fmt.Sprintf("mode_%o", mode)}
 }
 
 func launchPlistPath(userMode bool) string {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds multiple new CLI commands and flags that change operational behavior (including new file writes for diagnostics and config updates) and introduces dry-run paths that must match real lifecycle actions. Risk is moderate due to expanded surface area around local filesystem/service management, though changes are largely additive and guarded by explicit commands/flags.
> 
> **Overview**
> Adds a set of **robust endpoint CLI utilities**: `endpoint doctor` (health checks with aggregated status), `endpoint inventory` (installed/configured/observed summary), `endpoint test-event` (synthetic pipeline event), `endpoint bundle-diagnostics` (redacted diagnostics bundle), and `endpoint config` subcommands to show/validate config and set content retention; also adds `endpoint integrations validate --all`.
> 
> Extends existing commands with **safety and targeting flags**: `--dry-run` for install/repair/uninstall and hook install/uninstall (printing planned actions instead of mutating files/services), and `--all` to include non-detected targets in discover/inventory and to target all hook harnesses.
> 
> Improves diagnostics signal by enriching `diagnostics.Check` with `Target` and `Evidence`, adds top-level aliases for `doctor`/`status`/`inventory`, and introduces root-level `completion` and `docs --output` commands (adding cobra doc-related indirect deps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6dfae930f34f255238c85ace0f70a49ed21ff11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->