### PR TITLE
Validate exists, rename file

### DIFF
--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -260,6 +260,7 @@ func runEndpointIntegrationsValidate(cmd *cobra.Command, args []string) error {
 	}
 	cfg := loadOrDefaultConfig()
 	results := map[string]validationStage{}
+	broken := []string{}
 	for _, target := range targets {
 		switch target {
 		case "claude-cowork":
@@ -270,6 +271,9 @@ func runEndpointIntegrationsValidate(cmd *cobra.Command, args []string) error {
 				stage.Severity = "info"
 				stage.Evidence = "last_event_observed"
 			}
+			if stage.Status == "broken" {
+				broken = append(broken, target)
+			}
 			results[target] = stage
 		case "openclaw":
 			status := openclaw.GetStatus(cfg.LogPath)
@@ -279,11 +283,20 @@ func runEndpointIntegrationsValidate(cmd *cobra.Command, args []string) error {
 				stage.Severity = "info"
 				stage.Evidence = "last_event_observed"
 			}
+			if stage.Status == "broken" {
+				broken = append(broken, target)
+			}
 			results[target] = stage
 		}
 	}
 	if endpointOpts.jsonOutput {
-		return json.NewEncoder(os.Stdout).Encode(results)
+		if err := json.NewEncoder(os.Stdout).Encode(results); err != nil {
+			return err
+		}
+		if len(broken) > 0 {
+			return fmt.Errorf("integration validation failed for %s", strings.Join(broken, ", "))
+		}
+		return nil
 	}
 	for _, target := range targets {
 		stage := results[target]
@@ -292,6 +305,9 @@ func runEndpointIntegrationsValidate(cmd *cobra.Command, args []string) error {
 			fmt.Printf(" (%s)", stage.Message)
 		}
 		fmt.Println()
+	}
+	if len(broken) > 0 {
+		return fmt.Errorf("integration validation failed for %s", strings.Join(broken, ", "))
 	}
 	return nil
 }

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
@@ -393,6 +395,63 @@ func TestAggregateCheckStatus(t *testing.T) {
 	}
 }
 
+func TestEndpointIntegrationsValidateAllReturnsErrorForBrokenText(t *testing.T) {
+	oldAllTargets := endpointOpts.allTargets
+	oldJSONOutput := endpointOpts.jsonOutput
+	oldLogPath := endpointOpts.logPath
+	endpointOpts.allTargets = true
+	endpointOpts.jsonOutput = false
+	endpointOpts.logPath = filepath.Join(t.TempDir(), "missing.jsonl")
+	t.Cleanup(func() {
+		endpointOpts.allTargets = oldAllTargets
+		endpointOpts.jsonOutput = oldJSONOutput
+		endpointOpts.logPath = oldLogPath
+	})
+
+	output, err := captureStdout(t, func() error {
+		return runEndpointIntegrationsValidate(endpointIntegrationsValidateCmd, nil)
+	})
+	if err == nil {
+		t.Fatal("runEndpointIntegrationsValidate returned nil for broken integrations")
+	}
+	if !strings.Contains(output, "claude-cowork: broken") {
+		t.Fatalf("text output missing claude-cowork broken status: %s", output)
+	}
+	if !strings.Contains(output, "openclaw: broken") {
+		t.Fatalf("text output missing openclaw broken status: %s", output)
+	}
+}
+
+func TestEndpointIntegrationsValidateAllReturnsErrorForBrokenJSON(t *testing.T) {
+	oldAllTargets := endpointOpts.allTargets
+	oldJSONOutput := endpointOpts.jsonOutput
+	oldLogPath := endpointOpts.logPath
+	endpointOpts.allTargets = true
+	endpointOpts.jsonOutput = true
+	endpointOpts.logPath = filepath.Join(t.TempDir(), "missing.jsonl")
+	t.Cleanup(func() {
+		endpointOpts.allTargets = oldAllTargets
+		endpointOpts.jsonOutput = oldJSONOutput
+		endpointOpts.logPath = oldLogPath
+	})
+
+	output, err := captureStdout(t, func() error {
+		return runEndpointIntegrationsValidate(endpointIntegrationsValidateCmd, nil)
+	})
+	if err == nil {
+		t.Fatal("runEndpointIntegrationsValidate returned nil for broken integrations")
+	}
+	var results map[string]validationStage
+	if err := json.Unmarshal([]byte(output), &results); err != nil {
+		t.Fatalf("json output did not decode: %v output=%s", err, output)
+	}
+	for _, target := range []string{"claude-cowork", "openclaw"} {
+		if got := results[target].Status; got != "broken" {
+			t.Fatalf("%s status = %q, want broken", target, got)
+		}
+	}
+}
+
 func TestSyntheticEventDestinations(t *testing.T) {
 	event := syntheticEvent("pipeline")
 	data, err := json.Marshal(event)
@@ -402,4 +461,27 @@ func TestSyntheticEventDestinations(t *testing.T) {
 	if event.Destination.Type != "pipeline" || event.Destination.Mode != "local_jsonl" {
 		t.Fatalf("pipeline destination = %#v json=%s", event.Destination, data)
 	}
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	oldStdout := os.Stdout
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writeEnd
+	runErr := fn()
+	if err := writeEnd.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = oldStdout
+	output, err := io.ReadAll(readEnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := readEnd.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(output), runErr
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the CLI exit behavior for `endpoint integrations validate --all` to return a non-zero error when integrations are reported as broken, which may impact automation that previously relied on a zero exit code. Logic is straightforward and covered by new tests, but it affects command semantics.
> 
> **Overview**
> `endpoint integrations validate --all` now **fails the command** when any integration validates as `broken`, while still printing/encoding the per-integration results (both text and `--json`).
> 
> Adds unit tests to assert the new non-zero error behavior and to validate emitted output for both text and JSON modes, plus a small `captureStdout` helper for CLI-output tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2511758f6ab55720bd86cfcab37553afee0a58a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->