### PR TITLE
Add GitHub copilot CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Claude Cowork, OpenClaw).
 | Claude Code | Local OpenTelemetry configuration |
 | Codex CLI | Local OpenTelemetry configuration |
 | Gemini CLI | Opt-in local OpenTelemetry configuration |
+| GitHub Copilot CLI | MDM-managed OpenTelemetry (OTLP HTTP) |
 | Grok Build | Beacon hook adapter |
 | OpenCode | Beacon hook adapter |
 | Devin | Beacon hook adapter |

--- a/cli/beacon/internal/endpoint/dashboard/static/app.js
+++ b/cli/beacon/internal/endpoint/dashboard/static/app.js
@@ -567,6 +567,7 @@ function harnessLabel(value) {
     cursor: "Cursor",
     claude_code: "Claude Code",
     codex_cli: "Codex CLI",
+    copilot_cli: "GitHub Copilot CLI",
     grok: "Grok Build",
     cli: "Beacon CLI",
   };

--- a/cli/beacon/internal/endpoint/harness/copilot.go
+++ b/cli/beacon/internal/endpoint/harness/copilot.go
@@ -87,11 +87,10 @@ func copilotStatusFromEnv(env copilotEnv, expectedEndpoint string) (TelemetrySta
 	if env.fileExporter != "" {
 		return TelemetryMisconfigured, "GitHub Copilot CLI file exporter is configured and will bypass local OTLP"
 	}
-	enabled := truthySetting(env.enabled)
-	endpoint := env.endpoint
-	if !enabled && endpoint == "" {
+	if !truthySetting(env.enabled) {
 		return TelemetryDisabled, "GitHub Copilot CLI OTel env is not configured"
 	}
+	endpoint := env.endpoint
 	if endpoint == "" {
 		endpoint = "http://localhost:4318"
 	}

--- a/cli/beacon/internal/endpoint/harness/copilot.go
+++ b/cli/beacon/internal/endpoint/harness/copilot.go
@@ -1,0 +1,130 @@
+package harness
+
+import (
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func DiscoverCopilotCLI() Harness {
+	return discoverCopilotCLI("")
+}
+
+func discoverCopilotCLI(expectedEndpoint string) Harness {
+	h := Harness{Name: "copilot_cli", DisplayName: "GitHub Copilot CLI", Capability: "otel_env"}
+	path, err := exec.LookPath("copilot")
+	if err == nil {
+		h.Detected = true
+		h.ExecutablePath = path
+		h.Version = commandVersion(path)
+	}
+	home, _ := os.UserHomeDir()
+	if !h.Detected && fileExists(filepath.Join(home, ".copilot", "config.json")) {
+		h.Detected = true
+	}
+	h.ConfigPath = factoryProfilePath(home)
+	if fileExists(h.ConfigPath) {
+		status, msg := copilotStatus(h.ConfigPath, expectedEndpoint)
+		h.TelemetryStatus = status
+		h.Message = msg
+	} else {
+		status, msg := copilotStatusFromEnv(copilotEnvFromProcess(), expectedEndpoint)
+		h.TelemetryStatus = status
+		h.Message = msg
+		if status == TelemetryDisabled {
+			h.TelemetryStatus = TelemetryMissing
+			h.Message = "GitHub Copilot CLI telemetry is MDM-managed; set COPILOT_OTEL_ENABLED=true and OTEL_EXPORTER_OTLP_ENDPOINT to the local OTLP HTTP receiver"
+		}
+	}
+	return h
+}
+
+func copilotStatus(path string, expectedEndpoint ...string) (TelemetryStatus, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		status, msg := copilotStatusFromEnv(copilotEnvFromProcess(), firstNonEmptyString(expectedEndpoint...))
+		if status != TelemetryDisabled {
+			return status, msg
+		}
+		return TelemetryMissing, err.Error()
+	}
+	env := copilotEnvFromProcess()
+	if !env.configured() {
+		env = copilotEnvFromProfile(string(data))
+	}
+	return copilotStatusFromEnv(env, firstNonEmptyString(expectedEndpoint...))
+}
+
+type copilotEnv struct {
+	enabled      string
+	endpoint     string
+	fileExporter string
+}
+
+func (env copilotEnv) configured() bool {
+	return env.enabled != "" || env.endpoint != "" || env.fileExporter != ""
+}
+
+func copilotEnvFromProcess() copilotEnv {
+	return copilotEnv{
+		enabled:      os.Getenv("COPILOT_OTEL_ENABLED"),
+		endpoint:     firstNonEmptyString(os.Getenv("COPILOT_OTEL_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")),
+		fileExporter: os.Getenv("COPILOT_OTEL_FILE_EXPORTER_PATH"),
+	}
+}
+
+func copilotEnvFromProfile(text string) copilotEnv {
+	return copilotEnv{
+		enabled:      shellExportValue(text, "COPILOT_OTEL_ENABLED"),
+		endpoint:     firstNonEmptyString(shellExportValue(text, "COPILOT_OTEL_ENDPOINT"), shellExportValue(text, "OTEL_EXPORTER_OTLP_ENDPOINT")),
+		fileExporter: shellExportValue(text, "COPILOT_OTEL_FILE_EXPORTER_PATH"),
+	}
+}
+
+func copilotStatusFromEnv(env copilotEnv, expectedEndpoint string) (TelemetryStatus, string) {
+	if env.fileExporter != "" {
+		return TelemetryMisconfigured, "GitHub Copilot CLI file exporter is configured and will bypass local OTLP"
+	}
+	enabled := truthySetting(env.enabled)
+	endpoint := env.endpoint
+	if !enabled && endpoint == "" {
+		return TelemetryDisabled, "GitHub Copilot CLI OTel env is not configured"
+	}
+	if endpoint == "" {
+		endpoint = "http://localhost:4318"
+	}
+	if !localOTLPEndpointMatches(endpoint, expectedEndpoint) {
+		return TelemetryMisconfigured, "GitHub Copilot CLI OTLP endpoint does not point to localhost"
+	}
+	return TelemetryEnabled, "GitHub Copilot CLI telemetry is configured for local OTLP HTTP"
+}
+
+func localOTLPEndpointMatches(endpoint, expectedEndpoint string) bool {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host != "127.0.0.1" && host != "localhost" {
+		return false
+	}
+	if expectedEndpoint == "" {
+		return true
+	}
+	expected, err := url.Parse(expectedEndpoint)
+	if err != nil || expected.Port() == "" {
+		return true
+	}
+	return parsed.Port() == expected.Port()
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/cli/beacon/internal/endpoint/harness/copilot.go
+++ b/cli/beacon/internal/endpoint/harness/copilot.go
@@ -50,9 +50,16 @@ func copilotStatus(path string, expectedEndpoint ...string) (TelemetryStatus, st
 		}
 		return TelemetryMissing, err.Error()
 	}
-	env := copilotEnvFromProcess()
-	if !env.configured() {
-		env = copilotEnvFromProfile(string(data))
+	env := copilotEnvFromProfile(string(data))
+	procEnv := copilotEnvFromProcess()
+	if procEnv.enabled != "" {
+		env.enabled = procEnv.enabled
+	}
+	if procEnv.endpoint != "" {
+		env.endpoint = procEnv.endpoint
+	}
+	if procEnv.fileExporter != "" {
+		env.fileExporter = procEnv.fileExporter
 	}
 	return copilotStatusFromEnv(env, firstNonEmptyString(expectedEndpoint...))
 }

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -48,6 +48,7 @@ func DiscoverAll() []Harness {
 		DiscoverClaude(),
 		DiscoverCodex(),
 		DiscoverGemini(),
+		DiscoverCopilotCLI(),
 		DiscoverOpenCode(),
 		DiscoverFactory(),
 		DiscoverCursor(),
@@ -291,6 +292,7 @@ func ValidateConfigured(endpoint string) []ValidationResult {
 	claude := DiscoverClaude()
 	codex := DiscoverCodex()
 	gemini := DiscoverGemini()
+	copilot := discoverCopilotCLI(endpoint)
 	factory := DiscoverFactory()
 	return []ValidationResult{
 		{
@@ -307,6 +309,11 @@ func ValidateConfigured(endpoint string) []ValidationResult {
 			Harness: gemini.Name,
 			Status:  gemini.TelemetryStatus,
 			Message: validateEndpointMessage(gemini.TelemetryStatus, gemini.Message, endpoint),
+		},
+		{
+			Harness: copilot.Name,
+			Status:  copilot.TelemetryStatus,
+			Message: validateEndpointMessage(copilot.TelemetryStatus, copilot.Message, endpoint),
 		},
 		{
 			Harness: factory.Name,

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -612,9 +612,12 @@ func TestCopilotStatusVariants(t *testing.T) {
 	}{
 		{name: "missing export", body: `export OTHER=1`, status: TelemetryDisabled},
 		{name: "enabled default endpoint", body: `export COPILOT_OTEL_ENABLED=true`, status: TelemetryEnabled},
-		{name: "remote endpoint", body: `export OTEL_EXPORTER_OTLP_ENDPOINT="https://example.com:4318"`, status: TelemetryMisconfigured},
-		{name: "copilot endpoint enabled", body: `export COPILOT_OTEL_ENDPOINT="http://localhost:4318"`, status: TelemetryEnabled},
-		{name: "standard endpoint enabled", body: `export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318`, status: TelemetryEnabled},
+		{name: "endpoint without enable flag", body: `export OTEL_EXPORTER_OTLP_ENDPOINT="https://example.com:4318"`, status: TelemetryDisabled},
+		{name: "copilot endpoint without enable flag", body: `export COPILOT_OTEL_ENDPOINT="http://localhost:4318"`, status: TelemetryDisabled},
+		{name: "standard endpoint without enable flag", body: `export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318`, status: TelemetryDisabled},
+		{name: "enabled remote endpoint", body: "export COPILOT_OTEL_ENABLED=true\nexport OTEL_EXPORTER_OTLP_ENDPOINT=\"https://example.com:4318\"", status: TelemetryMisconfigured},
+		{name: "enabled copilot endpoint", body: "export COPILOT_OTEL_ENABLED=true\nexport COPILOT_OTEL_ENDPOINT=\"http://localhost:4318\"", status: TelemetryEnabled},
+		{name: "enabled standard endpoint", body: "export COPILOT_OTEL_ENABLED=true\nexport OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318", status: TelemetryEnabled},
 		{name: "file exporter bypass", body: "export COPILOT_OTEL_ENABLED=true\nexport COPILOT_OTEL_FILE_EXPORTER_PATH=/tmp/copilot.jsonl", status: TelemetryMisconfigured},
 	}
 

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -660,6 +660,21 @@ func TestCopilotStatusValidatesExpectedHTTPPort(t *testing.T) {
 	}
 }
 
+func TestCopilotStatusMergesProfileWithGenericProcessEndpoint(t *testing.T) {
+	clearCopilotEnv(t)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
+
+	path := filepath.Join(t.TempDir(), "profile")
+	if err := os.WriteFile(path, []byte("export COPILOT_OTEL_ENABLED=true\n"), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	status, msg := copilotStatus(path)
+	if status != TelemetryEnabled {
+		t.Fatalf("copilotStatus = %q (%s), want %q; generic OTEL_EXPORTER_OTLP_ENDPOINT should not suppress profile COPILOT_OTEL_ENABLED", status, msg, TelemetryEnabled)
+	}
+}
+
 func clearCopilotEnv(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -479,6 +479,50 @@ func TestDiscoverFactoryDetectsExecutableOnPath(t *testing.T) {
 	}
 }
 
+func TestDiscoverCopilotCLIDetectsExecutableOnPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "/bin/bash")
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	copilotPath := filepath.Join(binDir, "copilot")
+	if err := os.WriteFile(copilotPath, []byte("#!/bin/sh\necho copilot 1.0.4\n"), 0755); err != nil {
+		t.Fatalf("write fake copilot executable: %v", err)
+	}
+
+	h := DiscoverCopilotCLI()
+	if !h.Detected {
+		t.Fatalf("DiscoverCopilotCLI did not detect executable on PATH: %#v", h)
+	}
+	if h.ExecutablePath != copilotPath {
+		t.Fatalf("ExecutablePath = %q, want %q", h.ExecutablePath, copilotPath)
+	}
+	if h.Version != "copilot 1.0.4" {
+		t.Fatalf("Version = %q, want fake executable version", h.Version)
+	}
+	if h.ConfigPath != filepath.Join(home, ".bash_profile") {
+		t.Fatalf("ConfigPath = %q, want bash profile", h.ConfigPath)
+	}
+}
+
+func TestDiscoverCopilotCLIDetectsConfigFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	configPath := filepath.Join(home, ".copilot", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatalf("mkdir copilot config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{}`), 0600); err != nil {
+		t.Fatalf("write copilot config: %v", err)
+	}
+
+	h := DiscoverCopilotCLI()
+	if !h.Detected {
+		t.Fatalf("DiscoverCopilotCLI did not detect config file: %#v", h)
+	}
+}
+
 func TestDiscoverDevinDetectsExecutableOnPath(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -556,5 +600,71 @@ func TestFactoryStatusVariants(t *testing.T) {
 				t.Fatalf("factoryStatus = %q, want %q", status, tt.status)
 			}
 		})
+	}
+}
+
+func TestCopilotStatusVariants(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name   string
+		body   string
+		status TelemetryStatus
+	}{
+		{name: "missing export", body: `export OTHER=1`, status: TelemetryDisabled},
+		{name: "enabled default endpoint", body: `export COPILOT_OTEL_ENABLED=true`, status: TelemetryEnabled},
+		{name: "remote endpoint", body: `export OTEL_EXPORTER_OTLP_ENDPOINT="https://example.com:4318"`, status: TelemetryMisconfigured},
+		{name: "copilot endpoint enabled", body: `export COPILOT_OTEL_ENDPOINT="http://localhost:4318"`, status: TelemetryEnabled},
+		{name: "standard endpoint enabled", body: `export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318`, status: TelemetryEnabled},
+		{name: "file exporter bypass", body: "export COPILOT_OTEL_ENABLED=true\nexport COPILOT_OTEL_FILE_EXPORTER_PATH=/tmp/copilot.jsonl", status: TelemetryMisconfigured},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearCopilotEnv(t)
+			path := filepath.Join(dir, strings.ReplaceAll(tt.name, " ", "_")+".profile")
+			if err := os.WriteFile(path, []byte(tt.body), 0600); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+			status, _ := copilotStatus(path)
+			if status != tt.status {
+				t.Fatalf("copilotStatus = %q, want %q", status, tt.status)
+			}
+		})
+	}
+}
+
+func TestCopilotStatusReadsProcessEnvironment(t *testing.T) {
+	clearCopilotEnv(t)
+	t.Setenv("COPILOT_OTEL_ENABLED", "true")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:54318")
+
+	status, msg := copilotStatus(filepath.Join(t.TempDir(), "missing.profile"), "http://127.0.0.1:54318")
+	if status != TelemetryEnabled {
+		t.Fatalf("copilotStatus = %q (%s), want %q", status, msg, TelemetryEnabled)
+	}
+}
+
+func TestCopilotStatusValidatesExpectedHTTPPort(t *testing.T) {
+	clearCopilotEnv(t)
+	path := filepath.Join(t.TempDir(), "profile")
+	if err := os.WriteFile(path, []byte(`export COPILOT_OTEL_ENABLED=true`), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	status, _ := copilotStatus(path, "http://127.0.0.1:54318")
+	if status != TelemetryMisconfigured {
+		t.Fatalf("copilotStatus = %q, want %q for default 4318 endpoint with expected custom port", status, TelemetryMisconfigured)
+	}
+}
+
+func clearCopilotEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"COPILOT_OTEL_ENABLED",
+		"COPILOT_OTEL_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"COPILOT_OTEL_FILE_EXPORTER_PATH",
+	} {
+		t.Setenv(key, "")
 	}
 }

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -381,6 +381,8 @@ func configureHarnesses(cfg endpointconfig.Config) ([]string, error) {
 			paths = append(paths, path)
 		case "opencode":
 			return paths, fmt.Errorf("opencode telemetry is installed with `beacon endpoint hooks install --harness opencode`, not endpoint install")
+		case "copilot", "copilot_cli", "github_copilot":
+			return paths, fmt.Errorf("Copilot CLI telemetry is MDM-managed; set COPILOT_OTEL_ENABLED=true and OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:%d in the Copilot CLI launch environment instead of using --harness %s", cfg.Collector.HTTPPort, name)
 		case "factory", "droid":
 			return paths, fmt.Errorf("Factory Droid telemetry is MDM-managed; set OTEL_TELEMETRY_ENDPOINT=http://127.0.0.1:%d in the Droid launch environment instead of using --harness %s", cfg.Collector.HTTPPort, name)
 		case "":

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -148,6 +148,21 @@ func TestConfigureHarnessesRejectsFactoryAsMDMManaged(t *testing.T) {
 	}
 }
 
+func TestConfigureHarnessesRejectsCopilotCLIAsMDMManaged(t *testing.T) {
+	cfg := endpointconfig.Config{
+		Harnesses: []string{"copilot"},
+		Collector: endpointconfig.Collector{
+			GRPCPort: 54317,
+			HTTPPort: 54318,
+		},
+	}
+
+	_, err := configureHarnesses(cfg)
+	if err == nil || !strings.Contains(err.Error(), "Copilot CLI telemetry is MDM-managed") || !strings.Contains(err.Error(), "54318") {
+		t.Fatalf("configureHarnesses error = %v, want MDM-managed Copilot CLI error with HTTP port", err)
+	}
+}
+
 func TestConfigureHarnessesRejectsOpenCodeAsHookManaged(t *testing.T) {
 	cfg := endpointconfig.Config{Harnesses: []string{"opencode"}}
 	_, err := configureHarnesses(cfg)

--- a/collector-builder/exporter/beaconjsonexporter/exporter.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter.go
@@ -178,6 +178,9 @@ func shouldDropMetric(resourceAttrs map[string]interface{}, name string, include
 	if shouldDropOpenClawMetric(resourceAttrs, name, includeRuntimeMetrics) {
 		return true
 	}
+	if shouldDropCopilotMetric(resourceAttrs, name, includeRuntimeMetrics) {
+		return true
+	}
 	if !includeRuntimeMetrics && shouldDropRuntimeMetric(name) {
 		return true
 	}
@@ -234,6 +237,25 @@ func shouldDropOpenClawMetric(resourceAttrs map[string]interface{}, name string,
 		}
 	}
 	return false
+}
+
+func shouldDropCopilotMetric(resourceAttrs map[string]interface{}, name string, includeRuntimeMetrics bool) bool {
+	if includeRuntimeMetrics {
+		return false
+	}
+	if harnessName(resourceAttrs, name) != "copilot_cli" {
+		return false
+	}
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if slices.Contains(copilotKeptMetricNames, normalized) {
+		return false
+	}
+	return strings.HasPrefix(normalized, "copilot_chat.")
+}
+
+var copilotKeptMetricNames = []string{
+	"gen_ai.client.operation.duration",
+	"gen_ai.client.token.usage",
 }
 
 var openClawKeptMetricNames = []string{
@@ -587,6 +609,8 @@ func normalizeHarnessName(name string) string {
 		return "codex_cli"
 	case strings.Contains(lower, "gemini"):
 		return "gemini_cli"
+	case strings.Contains(lower, "github-copilot") || strings.Contains(lower, "copilot-chat") || strings.Contains(lower, "copilot_cli") || strings.Contains(lower, "copilot"):
+		return "copilot_cli"
 	case name != "":
 		return name
 	default:
@@ -596,12 +620,17 @@ func normalizeHarnessName(name string) string {
 
 func inferAction(attrs map[string]interface{}, fallback string) string {
 	tool := strings.ToLower(firstString(attrs, "tool.name", "gen_ai.tool.name", "mcp.tool.name", "function_name", "tool_name"))
+	operation := strings.ToLower(firstString(attrs, "gen_ai.operation.name"))
+	harness := harnessName(attrs, fallback)
 	text := strings.ToLower(strings.Join([]string{
 		fallback,
 		tool,
+		operation,
 		firstString(attrs, "event.name", "codex.op", "rpc.method"),
 	}, " "))
 	switch {
+	case harness == "copilot_cli":
+		return copilotAction(operation, text)
 	case strings.Contains(text, "gemini_cli.user_prompt"):
 		return "prompt.submitted"
 	case strings.Contains(text, "gemini_cli.tool_call"):
@@ -619,6 +648,21 @@ func inferAction(attrs map[string]interface{}, fallback string) string {
 	case strings.Contains(text, "file") || strings.Contains(text, "write") || strings.Contains(text, "edit"):
 		return "file.modified"
 	case strings.Contains(text, "approval"):
+		return "approval.requested"
+	default:
+		return "tool.invoked"
+	}
+}
+
+func copilotAction(operation, text string) string {
+	switch {
+	case operation == "invoke_agent":
+		return "session.activity"
+	case operation == "chat":
+		return "prompt.submitted"
+	case operation == "execute_tool":
+		return "tool.invoked"
+	case strings.Contains(text, "permission"):
 		return "approval.requested"
 	default:
 		return "tool.invoked"
@@ -658,6 +702,8 @@ func eventCategory(action, explicit string) string {
 		return "mcp"
 	case strings.HasPrefix(action, "approval.") || strings.HasPrefix(action, "policy."):
 		return "approval"
+	case strings.HasPrefix(action, "session."):
+		return "session"
 	case strings.HasPrefix(action, "metric."):
 		return "metric"
 	case strings.HasPrefix(action, "tool."):

--- a/collector-builder/exporter/beaconjsonexporter/exporter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter_test.go
@@ -485,6 +485,84 @@ func TestConsumeMetricsDropsCodexMetricsByDefault(t *testing.T) {
 	}
 }
 
+func TestConsumeMetricsDropsCopilotOperationalMetricsByDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:             path,
+		MaxEventBytes:    defaultMaxEventBytes,
+		RotateBytes:      defaultRotateBytes,
+		RedactSecrets:    true,
+		ContentRetention: "metadata",
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "github-copilot")
+	sm := rm.ScopeMetrics().AppendEmpty()
+	for _, name := range []string{
+		"gen_ai.client.operation.duration",
+		"gen_ai.client.token.usage",
+		"copilot_chat.tool.call.count",
+		"copilot_chat.agent.invocation.duration",
+	} {
+		sm.Metrics().AppendEmpty().SetName(name)
+	}
+
+	if err := exp.consumeMetrics(context.Background(), metrics); err != nil {
+		t.Fatalf("consumeMetrics returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime log: %v", err)
+	}
+	text := strings.TrimSpace(string(data))
+	for _, dropped := range []string{"copilot_chat.tool.call.count", "copilot_chat.agent.invocation.duration"} {
+		if strings.Contains(text, dropped) {
+			t.Fatalf("Copilot operational metric %q should have been dropped, wrote: %s", dropped, text)
+		}
+	}
+	for _, kept := range []string{"gen_ai.client.operation.duration", "gen_ai.client.token.usage"} {
+		if !strings.Contains(text, kept) {
+			t.Fatalf("Copilot GenAI metric %q should have been kept, wrote: %s", kept, text)
+		}
+	}
+}
+
+func TestConsumeMetricsIncludesCopilotOperationalMetricsWhenConfigured(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:                  path,
+		MaxEventBytes:         defaultMaxEventBytes,
+		RotateBytes:           defaultRotateBytes,
+		RedactSecrets:         true,
+		ContentRetention:      "metadata",
+		IncludeRuntimeMetrics: true,
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "github-copilot")
+	metric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("copilot_chat.tool.call.count")
+
+	if err := exp.consumeMetrics(context.Background(), metrics); err != nil {
+		t.Fatalf("consumeMetrics returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime log: %v", err)
+	}
+	if !strings.Contains(string(data), "copilot_chat.tool.call.count") {
+		t.Fatalf("Copilot operational metric should have been kept: %s", string(data))
+	}
+}
+
 func TestInferActionMapsCodexUserInputToPrompt(t *testing.T) {
 	attrs := map[string]interface{}{"service.name": "codex_cli_rs"}
 	if got := inferAction(attrs, "op.dispatch.user_input_with_turn_context"); got != "prompt.submitted" {
@@ -953,6 +1031,16 @@ func TestHarnessNameSeparatesClaudeCodeAndCowork(t *testing.T) {
 			want:  "codex_cli",
 		},
 		{
+			name:  "copilot service",
+			attrs: map[string]interface{}{"service.name": "github-copilot"},
+			want:  "copilot_cli",
+		},
+		{
+			name:  "copilot chat wrapper",
+			attrs: map[string]interface{}{"service.name": "copilot-chat"},
+			want:  "copilot_cli",
+		},
+		{
 			name:  "openclaw gateway service",
 			attrs: map[string]interface{}{"service.name": "openclaw-gateway"},
 			want:  "openclaw_gateway",
@@ -963,6 +1051,44 @@ func TestHarnessNameSeparatesClaudeCodeAndCowork(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := harnessName(tt.attrs, tt.hints...); got != tt.want {
 				t.Fatalf("harnessName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCopilotSpanActions(t *testing.T) {
+	exp := &beaconExporter{cfg: &Config{ContentRetention: "metadata"}}
+	tests := []struct {
+		name      string
+		spanName  string
+		operation string
+		want      string
+		category  string
+	}{
+		{name: "agent invocation", spanName: "invoke_agent", operation: "invoke_agent", want: "session.activity", category: "session"},
+		{name: "chat", spanName: "chat gpt-4o", operation: "chat", want: "prompt.submitted", category: "prompt"},
+		{name: "tool", spanName: "execute_tool readFile", operation: "execute_tool", want: "tool.invoked", category: "tool"},
+		{name: "permission", spanName: "permission", operation: "", want: "approval.requested", category: "approval"},
+		{name: "hook", spanName: "hook postToolUse", operation: "", want: "tool.invoked", category: "tool"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			traces := ptrace.NewTraces()
+			span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+			span.SetName(tt.spanName)
+			if tt.operation != "" {
+				span.Attributes().PutStr("gen_ai.operation.name", tt.operation)
+			}
+			event := exp.eventFromSpan(map[string]interface{}{"service.name": "github-copilot"}, span)
+			if event.Harness.Name != "copilot_cli" {
+				t.Fatalf("harness = %q, want copilot_cli", event.Harness.Name)
+			}
+			if event.Event.Action != tt.want {
+				t.Fatalf("action = %q, want %q", event.Event.Action, tt.want)
+			}
+			if event.Event.Category != tt.category {
+				t.Fatalf("category = %q, want %q", event.Event.Category, tt.category)
 			}
 		})
 	}

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -122,6 +122,22 @@ Gemini CLI is available as an opt-in local OpenTelemetry harness. Include it in
 the harness list, for example `BEACON_ENDPOINT_HARNESSES=claude,codex,gemini`,
 when you want the deployment to manage Gemini telemetry settings.
 
+GitHub Copilot CLI is opt-in and MDM-managed. Do not add it to the default
+Beacon harness list; instead, deploy Copilot's OTel environment in the Copilot
+CLI launch environment so it exports to Beacon's local OTLP HTTP receiver:
+
+```sh
+export COPILOT_OTEL_ENABLED="true"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4318"
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="true"
+```
+
+`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is optional and should
+match deployments that intentionally use Beacon's `full` content retention.
+Beacon validates Copilot CLI through endpoint discovery/status and normalizes
+events when the MDM-managed environment sends OTLP. Copilot CLI currently
+exports OTLP over HTTP, not gRPC.
+
 Recommended rollout:
 
 1. Upload the signed/notarized package to a pilot group.
@@ -228,6 +244,16 @@ Parameter 16: Splunk CA file for install.sh only
 To opt in Gemini CLI telemetry through Jamf, include `gemini` in parameter 4,
 for example `claude,codex,gemini`.
 
+For GitHub Copilot CLI, keep parameter 4 at the normal default unless you want
+install or repair output to call out that Copilot is MDM-managed. Configure the
+Copilot launch environment separately:
+
+```sh
+export COPILOT_OTEL_ENABLED="true"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4318"
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="true"
+```
+
 For repair policies, prefer the `BEACON_SPLUNK_*` environment variables so
 tokens do not need to be entered as visible script parameters.
 
@@ -319,6 +345,11 @@ repair.sh argument 11: Splunk CA file
 
 To opt in Gemini CLI telemetry through Fleet, include `gemini` in the harness
 argument, for example `claude,codex,gemini`.
+
+For GitHub Copilot CLI, deploy the same `COPILOT_OTEL_ENABLED=true` and
+`OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318` environment outside the
+Beacon package. Copilot is not part of the default Fleet harness argument and
+Beacon does not write Copilot shell profiles or `~/.copilot/config.json`.
 
 Add queries from `packaging/macos/fleet/queries` as Fleet policies or labels.
 They cover package/service/log/config presence and freshness; run


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes telemetry ingestion and harness validation for a new OTLP source; misconfigured MDM env could miss or misroute events, but scope is additive with no auth or data-store changes.
> 
> **Overview**
> Adds **GitHub Copilot CLI** as an opt-in, **MDM-managed** harness: Beacon discovers it and validates local OTLP HTTP (`COPILOT_OTEL_ENABLED`, localhost endpoints, optional port match) but **does not** auto-configure it via `endpoint install`—that path returns an explicit MDM error like Factory Droid.
> 
> The **dashboard** labels `copilot_cli`, and **docs** (root README + macOS packaging) describe setting Copilot’s OTel env to Beacon’s HTTP receiver (4318), outside the default harness list.
> 
> The **JSONL exporter** maps Copilot OTLP to `copilot_cli`, infers span actions (chat → prompt, tools, permissions, agent invoke → session), adds a **session** event category, and by default **drops** noisy `copilot_chat.*` metrics while keeping selected `gen_ai.client.*` metrics (opt-in via runtime metrics).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d565d4dfdd0e3bad92d522cf72564f7218bbb9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->