### PR TITLE
Add CrowdStrike hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ enterprise-grade SIEMs.
 | [Sumo Logic](https://docs.asymptotelabs.ai/cli/siem-forwarding-sumo) | HTTP Logs & Metrics Source content pack over local JSONL |
 | [Rapid7 InsightIDR](https://docs.asymptotelabs.ai/cli/siem-forwarding-rapid7) | Custom Logs webhook content pack over local JSONL |
 | [Splunk HEC](https://docs.asymptotelabs.ai/cli/siem-forwarding-splunk) | Optional endpoint forwarding during install or repair |
-| CrowdStrike Falcon LogScale HEC | Optional endpoint forwarding with LogScale ingest tokens during install or repair |
+| [CrowdStrike Falcon LogScale HEC](https://docs.asymptotelabs.ai/cli/siem-forwarding-falcon) | Optional endpoint forwarding with LogScale ingest tokens during install or repair |
 | [Customer-managed SIEM pipelines](https://docs.asymptotelabs.ai/cli/siem-forwarding) | Forwarding from local Beacon JSONL under customer control |
 
 ### MDM Deployment


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single README documentation link; no code, configuration, or security behavior changes.
> 
> **Overview**
> The **SIEM / Output Destinations** table in `README.md` now links **CrowdStrike Falcon LogScale HEC** to the same docs pattern as the other SIEM rows (`https://docs.asymptotelabs.ai/cli/siem-forwarding-falcon`), instead of plain text with no hyperlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2819b791d1b18ba0c77ed1df71113b85b0ec0603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->