### PR TITLE
Add Wazuh dashboard column helper

### DIFF
--- a/cli/beacon/internal/endpoint/wazuh/pack/README.md
+++ b/cli/beacon/internal/endpoint/wazuh/pack/README.md
@@ -11,3 +11,17 @@ Validate locally with:
 ```bash
 beacon endpoint wazuh validate
 ```
+
+For local Wazuh Dashboard testing, apply Beacon-oriented Discover columns with:
+
+```bash
+WAZUH_DASHBOARD_URL=https://localhost \
+WAZUH_DASHBOARD_USER=admin \
+WAZUH_DASHBOARD_PASSWORD=SecretPassword \
+sh apply-dashboard-default-columns.sh
+```
+
+The script sets `defaultColumns` so prompt text, event action, harness, model,
+repository, command, file, and session fields appear by default. Wazuh's
+default alert index maps Beacon command and file details as `data.command` and
+`data.file`.

--- a/cli/beacon/internal/endpoint/wazuh/pack/apply-dashboard-default-columns.sh
+++ b/cli/beacon/internal/endpoint/wazuh/pack/apply-dashboard-default-columns.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+DASHBOARD_URL="${WAZUH_DASHBOARD_URL:-https://localhost}"
+DASHBOARD_USER="${WAZUH_DASHBOARD_USER:-admin}"
+DASHBOARD_PASSWORD="${WAZUH_DASHBOARD_PASSWORD:-SecretPassword}"
+
+curl -sk \
+  -u "${DASHBOARD_USER}:${DASHBOARD_PASSWORD}" \
+  -X POST \
+  -H 'osd-xsrf: beacon' \
+  -H 'Content-Type: application/json' \
+  "${DASHBOARD_URL}/api/opensearch-dashboards/settings/defaultColumns" \
+  -d '{"value":["timestamp","agent.name","rule.description","rule.level","rule.id","data.event.action","data.prompt.text","data.message","data.harness.name","data.model","data.repository","data.command","data.file","data.session.id","data.session.working_directory"]}'
+
+printf '\nBeacon Wazuh default columns applied to %s\n' "${DASHBOARD_URL}"

--- a/cli/beacon/internal/endpoint/wazuh/wazuh.go
+++ b/cli/beacon/internal/endpoint/wazuh/wazuh.go
@@ -22,10 +22,12 @@ func Files() []File {
 	rules := mustRead("pack/beacon-rules.xml")
 	sample := mustRead("pack/sample-event.jsonl")
 	readme := mustRead("pack/README.md")
+	dashboardColumns := mustRead("pack/apply-dashboard-default-columns.sh")
 	return []File{
 		{Name: "ossec-localfile.xml", Content: localfile},
 		{Name: "beacon-rules.xml", Content: rules},
 		{Name: "sample-event.jsonl", Content: sample},
+		{Name: "apply-dashboard-default-columns.sh", Content: dashboardColumns},
 		{Name: "README.md", Content: readme},
 	}
 }

--- a/cli/beacon/internal/endpoint/wazuh/wazuh_test.go
+++ b/cli/beacon/internal/endpoint/wazuh/wazuh_test.go
@@ -22,7 +22,7 @@ func TestInstallPackWritesExpectedFiles(t *testing.T) {
 	if err := InstallPack(dir, "/tmp/beacon/runtime.jsonl"); err != nil {
 		t.Fatalf("InstallPack returned error: %v", err)
 	}
-	for _, name := range []string{"ossec-localfile.xml", "beacon-rules.xml", "sample-event.jsonl", "README.md"} {
+	for _, name := range []string{"ossec-localfile.xml", "beacon-rules.xml", "sample-event.jsonl", "apply-dashboard-default-columns.sh", "README.md"} {
 		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
 			t.Fatalf("expected %s: %v", name, err)
 		}
@@ -39,5 +39,19 @@ func TestRulesCoverAgentWorkflowActions(t *testing.T) {
 	sample := mustRead("pack/sample-event.jsonl")
 	if !strings.Contains(sample, `"content":{"retention":"full","included":true}`) {
 		t.Fatalf("sample event missing full retention: %s", sample)
+	}
+}
+
+func TestDashboardColumnsScriptIncludesBeaconFields(t *testing.T) {
+	script := mustRead("pack/apply-dashboard-default-columns.sh")
+	for _, field := range []string{"data.event.action", "data.prompt.text", "data.command", "data.file", "data.session.id"} {
+		if !strings.Contains(script, field) {
+			t.Fatalf("dashboard columns script missing %s", field)
+		}
+	}
+	for _, field := range []string{"data.command.command", "data.file.path", "data.tool.name"} {
+		if strings.Contains(script, field) {
+			t.Fatalf("dashboard columns script includes unmapped Wazuh field %s", field)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add a Wazuh pack helper that applies Beacon-friendly dashboard default columns.
- Include the helper in generated Wazuh packs and document how to use it.
- Cover the helper with focused Wazuh pack tests.

## Test plan
- go test ./internal/endpoint/wazuh


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pack-only tooling and documentation for optional local Dashboard configuration; no changes to agent logging, rules ingestion, or production auth paths.
> 
> **Overview**
> Adds **`apply-dashboard-default-columns.sh`** to the Wazuh pack so local Dashboard testing can POST Beacon-oriented **`defaultColumns`** (event action, prompt, harness, model, repo, command, file, session, etc.) via the OpenSearch Dashboards settings API.
> 
> The script is **embedded and shipped** with generated packs (`Files()` / `InstallPack`), and the pack **README** documents env vars and how Wazuh maps command/file fields.
> 
> **Tests** assert the new file is written on install and that the script lists mapped fields while excluding unmapped nested names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35f4091edeb08438721d60479fbb6d40e4b0c2b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->