### PR TITLE
Add antigravity CLI support

### DIFF
--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -52,11 +52,11 @@ func toolFields(toolName string, toolInput map[string]interface{}) map[string]in
 	if toolName != "" {
 		fields["tool"] = map[string]interface{}{"name": toolName}
 	}
-	if command := firstToolString(toolInput, "command", "cmd", "shell_command"); command != "" {
+	if command := firstToolString(toolInput, "command", "cmd", "shell_command", "CommandLine", "commandLine"); command != "" {
 		fields["command"] = map[string]interface{}{"command": command}
 		fields["tool"] = mergeNested(fields["tool"], map[string]interface{}{"name": toolName, "command": command})
 	}
-	if path := firstToolString(toolInput, "file_path", "filePath", "path"); path != "" {
+	if path := firstToolString(toolInput, "file_path", "filePath", "path", "Path", "AbsolutePath", "DirectoryPath", "SearchPath", "searchPath"); path != "" {
 		fields["file"] = map[string]interface{}{
 			"path":      path,
 			"operation": fileOperation(toolName),
@@ -111,7 +111,7 @@ func mergeNested(existing interface{}, values map[string]interface{}) map[string
 func firstToolString(input map[string]interface{}, keys ...string) string {
 	for _, key := range keys {
 		if value, ok := input[key]; ok {
-			if str := strings.TrimSpace(fmt.Sprint(value)); str != "" && str != "<nil>" {
+			if str := normalizeToolString(value); str != "" {
 				return str
 			}
 		}
@@ -119,10 +119,18 @@ func firstToolString(input map[string]interface{}, keys ...string) string {
 	return ""
 }
 
+func normalizeToolString(value interface{}) string {
+	str := strings.TrimSpace(fmt.Sprint(value))
+	if str == "" || str == "<nil>" {
+		return ""
+	}
+	return strings.Trim(strings.TrimSpace(str), `"`)
+}
+
 func fileOperation(toolName string) string {
 	lower := strings.ToLower(toolName)
 	switch {
-	case strings.Contains(lower, "read"):
+	case strings.Contains(lower, "read") || strings.Contains(lower, "view") || strings.Contains(lower, "list") || strings.Contains(lower, "grep") || strings.Contains(lower, "search"):
 		return "read"
 	case strings.Contains(lower, "write") || strings.Contains(lower, "create"):
 		return "create"
@@ -157,6 +165,16 @@ func actionForTool(hookEvent, toolName string) string {
 		case lower == "read":
 			return "file.read"
 		case lower == "edit" || lower == "write":
+			return "file.modified"
+		}
+	}
+	if platformFlag == "antigravity" {
+		switch lower {
+		case "run_command":
+			return "command.executed"
+		case "view_file", "list_dir", "grep_search", "find_by_name":
+			return "file.read"
+		case "edit_file", "write_file", "apply_patch":
 			return "file.modified"
 		}
 	}

--- a/cli/beacon-hooks/cmd/helpers.go
+++ b/cli/beacon-hooks/cmd/helpers.go
@@ -43,6 +43,8 @@ func getFirstStr(input map[string]interface{}, keys ...string) string {
 // For Claude, it reads session_id directly.
 func resolveSessionID(input map[string]interface{}, platform string) string {
 	switch platform {
+	case "antigravity":
+		return getFirstStr(input, "conversationId", "conversation_id", "session_id", "sessionId")
 	case "copilot":
 		transcriptPath := getFirstStr(input, "transcriptPath", "transcript_path")
 		if id := sessionIDFromTranscriptPath(transcriptPath); id != "" {
@@ -67,6 +69,10 @@ func resolveSessionID(input map[string]interface{}, platform string) string {
 // Used by commands that need the transcript path for upload.
 func resolveSessionIDWithTranscript(input map[string]interface{}, platform string) (sessionID, transcriptPath string) {
 	switch platform {
+	case "antigravity":
+		sessionID = getFirstStr(input, "conversationId", "conversation_id", "session_id", "sessionId")
+		transcriptPath = getFirstStr(input, "transcriptPath", "transcript_path")
+		return
 	case "copilot":
 		transcriptPath = getFirstStr(input, "transcriptPath", "transcript_path")
 		sessionID = sessionIDFromTranscriptPath(transcriptPath)
@@ -109,6 +115,27 @@ func sessionIDFromTranscriptPath(transcriptPath string) string {
 // For Cursor: tries input["cwd"], then workspace_roots[0], then CURSOR_PROJECT_DIR env var.
 // For other platforms: reads input["cwd"] directly.
 func resolveCwd(input map[string]interface{}, platform string) string {
+	if platform == "antigravity" {
+		if cwd := getFirstStr(input, "cwd", "workingDirectoryPath"); cwd != "" {
+			return cwd
+		}
+		if toolInput := resolveToolInput(input); toolInput != nil {
+			if cwd := firstToolString(toolInput, "Cwd", "cwd", "workingDirectoryPath"); cwd != "" {
+				return cwd
+			}
+		}
+		if roots, ok := input["workspacePaths"].([]interface{}); ok && len(roots) > 0 {
+			if cwd, ok := roots[0].(string); ok && cwd != "" {
+				return cwd
+			}
+		}
+		if roots, ok := input["workspace_paths"].([]interface{}); ok && len(roots) > 0 {
+			if cwd, ok := roots[0].(string); ok && cwd != "" {
+				return cwd
+			}
+		}
+		return ""
+	}
 	if platform == "cursor" {
 		if cwd := getFirstStr(input, "cwd"); cwd != "" {
 			return cwd

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -119,9 +119,12 @@ func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logge
 	var sessionID, toolName string
 	var toolInput, toolResponse map[string]interface{}
 
-	if platformFlag == "copilot" || platformFlag == "devin" || platformFlag == "grok" {
+	if platformFlag == "antigravity" || platformFlag == "copilot" || platformFlag == "devin" || platformFlag == "grok" {
 		sessionID = resolveSessionID(input, platformFlag)
 		toolName = getFirstStr(input, "toolName", "tool_name")
+		if platformFlag == "antigravity" {
+			toolName = antigravityToolName(input)
+		}
 		toolInput = resolveToolInput(input)
 		toolResponse = resolveToolResponse(input)
 	} else {
@@ -138,6 +141,15 @@ func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logge
 	filePath := diff.GetStringFromMaps("file_path", toolInput, toolResponse)
 	if filePath == "" {
 		filePath = diff.GetStringFromMaps("filePath", toolInput, toolResponse)
+	}
+	if filePath == "" {
+		filePath = diff.GetStringFromMaps("path", toolInput, toolResponse)
+	}
+	if filePath == "" {
+		filePath = diff.GetStringFromMaps("Path", toolInput, toolResponse)
+	}
+	if filePath == "" {
+		filePath = diff.GetStringFromMaps("AbsolutePath", toolInput, toolResponse)
 	}
 
 	if (sessionID == "" && platformFlag != "devin") || toolName == "" || filePath == "" {
@@ -182,6 +194,11 @@ func recordLocalEdit(params *evaluationParams, logger *logging.Logger) {
 
 // resolveToolInput extracts tool input from Copilot's various formats.
 func resolveToolInput(input map[string]interface{}) map[string]interface{} {
+	if toolCall, ok := input["toolCall"].(map[string]interface{}); ok {
+		if args, ok := toolCall["args"].(map[string]interface{}); ok {
+			return args
+		}
+	}
 	if m, ok := input["tool_input"].(map[string]interface{}); ok {
 		return m
 	}
@@ -203,6 +220,23 @@ func resolveToolInput(input map[string]interface{}) map[string]interface{} {
 
 // resolveToolResponse extracts tool response from Copilot's various formats.
 func resolveToolResponse(input map[string]interface{}) map[string]interface{} {
+	if platformFlag == "antigravity" {
+		response := map[string]interface{}{}
+		if errMsg := getFirstStr(input, "error"); errMsg != "" {
+			response["error"] = errMsg
+		}
+		if result, ok := input["toolResult"]; ok {
+			response["result"] = result
+		}
+		if result, ok := input["toolResult"].(map[string]interface{}); ok {
+			for key, value := range result {
+				response[key] = value
+			}
+		}
+		if len(response) > 0 {
+			return response
+		}
+	}
 	if m, ok := input["tool_response"].(map[string]interface{}); ok {
 		return m
 	}
@@ -221,6 +255,9 @@ func resolveToolResponse(input map[string]interface{}) map[string]interface{} {
 
 func emitPostToolObserved(logger *logging.Logger, input map[string]interface{}) {
 	toolName := getFirstStr(input, "tool_name", "toolName")
+	if platformFlag == "antigravity" {
+		toolName = antigravityToolName(input)
+	}
 	hookEvent := getFirstStr(input, "hook_event_name", "hookEventName")
 	toolInput := resolveToolInput(input)
 	if toolInput == nil {
@@ -233,7 +270,7 @@ func emitPostToolObserved(logger *logging.Logger, input map[string]interface{}) 
 	for key, value := range toolFields(toolName, toolInput) {
 		fields[key] = value
 	}
-	if hookEvent == "postToolUseFailure" || hookEvent == "post_tool_use_failure" {
+	if hookEvent == "postToolUseFailure" || hookEvent == "post_tool_use_failure" || getFirstStr(input, "error") != "" {
 		emitHookEvent(logger, "tool.failed", "tool", "high", "Tool execution failed", input, fields)
 		return
 	}
@@ -273,5 +310,21 @@ func isFileEditTool(platform, toolName string) bool {
 		lower := strings.ToLower(toolName)
 		return lower == "search_replace" || lower == "write_file" || strings.Contains(lower, "edit") || strings.Contains(lower, "write")
 	}
+	if platform == "antigravity" {
+		lower := strings.ToLower(toolName)
+		return strings.Contains(lower, "edit") ||
+			strings.Contains(lower, "write") ||
+			strings.Contains(lower, "create") ||
+			strings.Contains(lower, "patch")
+	}
 	return toolName == "Write" || toolName == "Edit" || toolName == "MultiEdit"
+}
+
+func antigravityToolName(input map[string]interface{}) string {
+	if toolCall, ok := input["toolCall"].(map[string]interface{}); ok {
+		if name, ok := toolCall["name"].(string); ok {
+			return name
+		}
+	}
+	return getFirstStr(input, "tool_name", "toolName")
 }

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -138,6 +138,10 @@ func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logge
 		return nil
 	}
 
+	if platformFlag == "antigravity" && getFirstStr(input, "error") != "" {
+		return nil
+	}
+
 	filePath := diff.GetStringFromMaps("file_path", toolInput, toolResponse)
 	if filePath == "" {
 		filePath = diff.GetStringFromMaps("filePath", toolInput, toolResponse)
@@ -151,6 +155,7 @@ func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logge
 	if filePath == "" {
 		filePath = diff.GetStringFromMaps("AbsolutePath", toolInput, toolResponse)
 	}
+	filePath = diff.NormalizePath(filePath)
 
 	if (sessionID == "" && platformFlag != "devin") || toolName == "" || filePath == "" {
 		return nil

--- a/cli/beacon-hooks/cmd/post_tool_test.go
+++ b/cli/beacon-hooks/cmd/post_tool_test.go
@@ -35,6 +35,11 @@ func TestIsFileEditTool(t *testing.T) {
 		{"devin edit", "devin", "edit", true},
 		{"devin write", "devin", "write", true},
 		{"devin exec (not edit)", "devin", "exec", false},
+
+		// Antigravity tools
+		{"antigravity write", "antigravity", "write_file", true},
+		{"antigravity patch", "antigravity", "apply_patch", true},
+		{"antigravity command (not edit)", "antigravity", "run_command", false},
 	}
 
 	for _, tt := range tests {
@@ -44,6 +49,107 @@ func TestIsFileEditTool(t *testing.T) {
 				t.Errorf("isFileEditTool(%q, %q) = %v, want %v", tt.platform, tt.toolName, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRunPostToolEmitsAntigravityToolFailed(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "antigravity"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPostTool, map[string]interface{}{
+		"conversationId": "ag-session",
+		"workspacePaths": []interface{}{"/repo"},
+		"toolCall": map[string]interface{}{
+			"name": "run_command",
+			"args": map[string]interface{}{
+				"CommandLine": "npm test",
+				"Cwd":         "/repo",
+			},
+		},
+		"error": "exit status 1",
+	})
+	if len(out) != 0 {
+		t.Fatalf("post-tool response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "tool.failed" {
+		t.Fatalf("event.action = %q, want tool.failed", action)
+	}
+	if severity := event["severity"]; severity != "high" {
+		t.Fatalf("severity = %q, want high", severity)
+	}
+	if command := event["command"].(map[string]interface{})["command"]; command != "npm test" {
+		t.Fatalf("command = %q, want npm test", command)
+	}
+}
+
+func TestRunPostToolEmitsAntigravityFileModifiedEvent(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "antigravity"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPostTool, map[string]interface{}{
+		"conversationId": "ag-session",
+		"toolCall": map[string]interface{}{
+			"name": "write_file",
+			"args": map[string]interface{}{
+				"Path":    "/repo/main.go",
+				"content": "package main\n// token=ag-secret",
+			},
+		},
+	})
+	if len(out) != 0 {
+		t.Fatalf("post-tool response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "file.modified" {
+		t.Fatalf("event.action = %q, want file.modified", action)
+	}
+	file := event["file"].(map[string]interface{})
+	if file["path"] != "/repo/main.go" {
+		t.Fatalf("file = %#v, want /repo/main.go", file)
+	}
+	if _, ok := file["diff_hash"]; !ok {
+		t.Fatalf("file diff_hash missing: %#v", file)
+	}
+}
+
+func TestRunPostToolEmitsAntigravityFileReadPathFields(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "antigravity"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPostTool, map[string]interface{}{
+		"conversationId": "ag-session",
+		"workspacePaths": []interface{}{"/repo"},
+		"toolCall": map[string]interface{}{
+			"name": "list_dir",
+			"args": map[string]interface{}{
+				"DirectoryPath": "/repo/docs",
+			},
+		},
+	})
+	if len(out) != 0 {
+		t.Fatalf("post-tool response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "file.read" {
+		t.Fatalf("event.action = %q, want file.read", action)
+	}
+	file := event["file"].(map[string]interface{})
+	if file["path"] != "/repo/docs" || file["operation"] != "read" {
+		t.Fatalf("file = %#v, want /repo/docs read", file)
+	}
+	tool := event["tool"].(map[string]interface{})
+	if tool["path"] != "/repo/docs" {
+		t.Fatalf("tool = %#v, want path /repo/docs", tool)
 	}
 }
 

--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -1,9 +1,17 @@
 package cmd
 
 import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/spf13/cobra"
 
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/state"
 )
 
 var preToolCmd = &cobra.Command{
@@ -37,7 +45,10 @@ func runPreTool(cmd *cobra.Command, args []string) {
 	}
 
 	logger.Debug("Pre-tool observed")
-	if platformFlag == "devin" || platformFlag == "grok" {
+	if platformFlag == "antigravity" {
+		emitAntigravityPromptFromTranscript(logger, input, sessionID)
+		emitPreToolObserved(logger, input, sessionID)
+	} else if platformFlag == "devin" || platformFlag == "grok" {
 		emitPreToolObserved(logger, input, sessionID)
 	} else {
 		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "Pre-tool observed")
@@ -61,7 +72,7 @@ func emitPreToolDecision(logger *logging.Logger, input map[string]interface{}, s
 }
 
 func preToolResponse() map[string]interface{} {
-	if platformFlag == "grok" {
+	if platformFlag == "antigravity" || platformFlag == "grok" {
 		return map[string]interface{}{"decision": "allow"}
 	}
 	if platformFlag == "devin" {
@@ -72,10 +83,79 @@ func preToolResponse() map[string]interface{} {
 
 func emitPreToolObserved(logger *logging.Logger, input map[string]interface{}, sessionID string) {
 	toolName := getFirstStr(input, "tool_name", "toolName")
+	if platformFlag == "antigravity" {
+		toolName = antigravityToolName(input)
+	}
 	toolInput := resolveToolInput(input)
 	fields := sessionFields(sessionID, input)
 	for key, value := range toolFields(toolName, toolInput) {
 		fields[key] = value
 	}
 	emitHookEvent(logger, "tool.invoked", "tool", "info", "Tool invocation observed", input, fields)
+}
+
+func emitAntigravityPromptFromTranscript(logger *logging.Logger, input map[string]interface{}, sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	st := state.NewSessionState(sessionID, "antigravity")
+	if !st.MarkPromptEmittedIfNeeded() {
+		return
+	}
+	prompt := antigravityPromptFromTranscript(input, sessionID)
+	if prompt == "" {
+		return
+	}
+	fields := sessionFields(sessionID, input)
+	if config.ContentRetentionMode() != config.ContentRetentionMetadata {
+		fields["prompt"] = map[string]interface{}{"text": prompt}
+	}
+	emitHookEvent(logger, "prompt.submitted", "prompt", "info", "Prompt submitted to agent", input, fields)
+}
+
+func antigravityPromptFromTranscript(input map[string]interface{}, sessionID string) string {
+	path := getFirstStr(input, "transcriptPath", "transcript_path")
+	if path == "" {
+		path = defaultAntigravityTranscriptPath(sessionID)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		var entry map[string]interface{}
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		source := strings.ToUpper(getFirstStr(entry, "source"))
+		entryType := strings.ToUpper(getFirstStr(entry, "type"))
+		if source != "USER_EXPLICIT" && entryType != "USER_INPUT" {
+			continue
+		}
+		if content := getFirstStr(entry, "content"); content != "" {
+			return stripAntigravityPromptWrappers(content)
+		}
+	}
+	return ""
+}
+
+func defaultAntigravityTranscriptPath(sessionID string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".gemini", "antigravity-cli", "brain", sessionID, ".system_generated", "logs", "transcript.jsonl")
+}
+
+func stripAntigravityPromptWrappers(content string) string {
+	if start := strings.Index(content, "<USER_REQUEST>"); start >= 0 {
+		content = content[start+len("<USER_REQUEST>"):]
+		if end := strings.Index(content, "</USER_REQUEST>"); end >= 0 {
+			content = content[:end]
+		}
+	}
+	return strings.TrimSpace(content)
 }

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -91,6 +91,110 @@ func TestRunPromptSubmitEmitsFactoryPromptEvent(t *testing.T) {
 	}
 }
 
+func TestRunPromptSubmitEmitsAntigravityPromptEvent(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "antigravity"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "full")
+
+	out := runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"conversationId": "ag-session",
+		"workspacePaths": []interface{}{"/repo"},
+		"prompt":         "summarize token=ag-secret",
+	})
+	if len(out) != 0 {
+		t.Fatalf("antigravity prompt response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "prompt.submitted" {
+		t.Fatalf("event.action = %q, want prompt.submitted", action)
+	}
+	if harness := event["harness"].(map[string]interface{})["name"]; harness != "antigravity" {
+		t.Fatalf("harness = %q, want antigravity", harness)
+	}
+	if got := event["prompt"].(map[string]interface{})["text"]; got != "summarize token=[REDACTED]" {
+		t.Fatalf("prompt.text = %q, want redacted prompt", got)
+	}
+	if got := event["repository"]; got != "/repo" {
+		t.Fatalf("repository = %q, want /repo", got)
+	}
+}
+
+func TestRunPromptSubmitEmitsAntigravityUserPromptEvent(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "antigravity"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "full")
+
+	out := runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"conversationId": "ag-session",
+		"userPrompt":     "explain this repo token=ag-secret",
+	})
+	if len(out) != 0 {
+		t.Fatalf("antigravity prompt response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "prompt.submitted" {
+		t.Fatalf("event.action = %q, want prompt.submitted", action)
+	}
+	if got := event["prompt"].(map[string]interface{})["text"]; got != "explain this repo token=[REDACTED]" {
+		t.Fatalf("prompt.text = %q, want redacted prompt", got)
+	}
+}
+
+func TestRunPromptSubmitOmitsAntigravityPromptForMetadataRetention(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "antigravity"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "metadata")
+
+	out := runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"conversationId": "ag-session",
+		"prompt":         "summarize this file",
+	})
+	if len(out) != 0 {
+		t.Fatalf("antigravity prompt response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if _, ok := event["prompt"]; ok {
+		t.Fatalf("metadata retention should omit prompt field: %#v", event["prompt"])
+	}
+}
+
+func TestRunSessionLifecycleEmitsAntigravityEvents(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "antigravity"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	input := map[string]interface{}{
+		"conversationId": "ag-session",
+		"workspacePaths": []interface{}{"/repo"},
+	}
+	runHookWithInput(t, runSessionStart, input)
+	runHookWithInput(t, runSessionEnd, input)
+
+	events := endpointEvents(t, logPath)
+	if len(events) != 2 {
+		t.Fatalf("event count = %d, want 2: %#v", len(events), events)
+	}
+	want := []string{"session.started", "session.ended"}
+	for i, action := range want {
+		if got := events[i]["event"].(map[string]interface{})["action"]; got != action {
+			t.Fatalf("event[%d].action = %q, want %q", i, got, action)
+		}
+		if session := events[i]["session"].(map[string]interface{}); session["id"] != "ag-session" {
+			t.Fatalf("event[%d] session = %#v, want ag-session", i, session)
+		}
+	}
+}
+
 func TestRunPromptSubmitEmitsDevinPromptWithoutSession(t *testing.T) {
 	setupHookConfigDirs(t)
 	platformFlag = "devin"
@@ -145,6 +249,91 @@ func TestRunPreToolEmitsDevinToolTelemetryWithoutApproval(t *testing.T) {
 	}
 	if command := event["command"].(map[string]interface{})["command"]; command != "git status" {
 		t.Fatalf("command = %q, want git status", command)
+	}
+}
+
+func TestRunPreToolEmitsAntigravityCommandTelemetry(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "antigravity"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPreTool, map[string]interface{}{
+		"conversationId": "ag-session",
+		"workspacePaths": []interface{}{
+			"/repo",
+		},
+		"toolCall": map[string]interface{}{
+			"name": "run_command",
+			"args": map[string]interface{}{
+				"CommandLine": "npm test",
+				"Cwd":         "/repo",
+			},
+		},
+		"stepIdx": 19,
+	})
+	if out["decision"] != "allow" {
+		t.Fatalf("antigravity pre-tool response = %#v, want decision=allow", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if harness := event["harness"].(map[string]interface{})["name"]; harness != "antigravity" {
+		t.Fatalf("harness = %q, want antigravity", harness)
+	}
+	if action := event["event"].(map[string]interface{})["action"]; action != "tool.invoked" {
+		t.Fatalf("event.action = %q, want tool.invoked", action)
+	}
+	if _, ok := event["approval"]; ok {
+		t.Fatalf("Antigravity PreToolUse should not emit approval telemetry: %#v", event["approval"])
+	}
+	if command := event["command"].(map[string]interface{})["command"]; command != "npm test" {
+		t.Fatalf("command = %q, want npm test", command)
+	}
+	session := event["session"].(map[string]interface{})
+	if session["id"] != "ag-session" || session["working_directory"] != "/repo" {
+		t.Fatalf("session = %#v, want id and working_directory", session)
+	}
+}
+
+func TestRunPreToolSynthesizesAntigravityPromptFromTranscript(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "antigravity"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "full")
+	transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
+	if err := os.WriteFile(transcriptPath, []byte(`{"source":"USER_EXPLICIT","type":"USER_INPUT","content":"<USER_REQUEST>\ntell me about token=ag-secret\n</USER_REQUEST>\n<ADDITIONAL_METADATA>\nignored\n</ADDITIONAL_METADATA>"}`+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	input := map[string]interface{}{
+		"conversationId":  "ag-session",
+		"transcriptPath":  transcriptPath,
+		"workspacePaths":  []interface{}{"/repo"},
+		"toolCall":        map[string]interface{}{"name": "list_dir", "args": map[string]interface{}{"DirectoryPath": `"/repo"`}},
+		"artifactDirPath": "/tmp/artifacts",
+	}
+	out := runHookWithInput(t, runPreTool, input)
+	if out["decision"] != "allow" {
+		t.Fatalf("antigravity pre-tool response = %#v, want decision=allow", out)
+	}
+	out = runHookWithInput(t, runPreTool, input)
+	if out["decision"] != "allow" {
+		t.Fatalf("second antigravity pre-tool response = %#v, want decision=allow", out)
+	}
+
+	events := endpointEvents(t, logPath)
+	if len(events) != 3 {
+		t.Fatalf("event count = %d, want prompt plus two tool events: %#v", len(events), events)
+	}
+	if action := events[0]["event"].(map[string]interface{})["action"]; action != "prompt.submitted" {
+		t.Fatalf("first event.action = %q, want prompt.submitted", action)
+	}
+	if got := events[0]["prompt"].(map[string]interface{})["text"]; got != "tell me about token=[REDACTED]" {
+		t.Fatalf("prompt.text = %q, want redacted transcript prompt", got)
+	}
+	if got := events[1]["file"].(map[string]interface{})["path"]; got != "/repo" {
+		t.Fatalf("file.path = %q, want normalized /repo", got)
 	}
 }
 
@@ -316,6 +505,7 @@ func setupHookConfigDirs(t *testing.T) {
 	tmp := t.TempDir()
 	origBeaconDir := hookconfig.BeaconDir
 	origClaudeDir := hookconfig.ClaudeDir
+	origAntigravityDir := hookconfig.AntigravityDir
 	origCopilotDir := hookconfig.CopilotDir
 	origCursorDir := hookconfig.CursorDir
 	origDevinDir := hookconfig.DevinDir
@@ -325,6 +515,7 @@ func setupHookConfigDirs(t *testing.T) {
 	origPlatform := platformFlag
 	hookconfig.BeaconDir = tmp
 	hookconfig.ClaudeDir = filepath.Join(tmp, "claude")
+	hookconfig.AntigravityDir = filepath.Join(tmp, "antigravity")
 	hookconfig.CopilotDir = filepath.Join(tmp, "copilot")
 	hookconfig.CursorDir = filepath.Join(tmp, "cursor")
 	hookconfig.DevinDir = filepath.Join(tmp, "devin")
@@ -334,6 +525,7 @@ func setupHookConfigDirs(t *testing.T) {
 	t.Cleanup(func() {
 		hookconfig.BeaconDir = origBeaconDir
 		hookconfig.ClaudeDir = origClaudeDir
+		hookconfig.AntigravityDir = origAntigravityDir
 		hookconfig.CopilotDir = origCopilotDir
 		hookconfig.CursorDir = origCursorDir
 		hookconfig.DevinDir = origDevinDir

--- a/cli/beacon-hooks/cmd/prompt_submit.go
+++ b/cli/beacon-hooks/cmd/prompt_submit.go
@@ -42,12 +42,10 @@ func runPromptSubmit(cmd *cobra.Command, args []string) {
 
 	logger.Debug("Prompt submit observed")
 	fields := sessionFields(sessionID, input)
-	hasPrompt := false
-	if config.ContentRetentionMode() != config.ContentRetentionMetadata {
-		if prompt := getFirstStr(input, "prompt", "user_prompt", "userPrompt", "text", "promptText", "input"); prompt != "" {
-			fields["prompt"] = map[string]interface{}{"text": prompt}
-			hasPrompt = true
-		}
+	prompt := getFirstStr(input, "prompt", "user_prompt", "userPrompt", "text", "promptText", "input")
+	hasPrompt := prompt != ""
+	if hasPrompt && config.ContentRetentionMode() != config.ContentRetentionMetadata {
+		fields["prompt"] = map[string]interface{}{"text": prompt}
 	}
 	emitHookEvent(logger, "prompt.submitted", "prompt", "info", "Prompt submitted to agent", input, fields)
 

--- a/cli/beacon-hooks/cmd/prompt_submit.go
+++ b/cli/beacon-hooks/cmd/prompt_submit.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/state"
 )
 
 var promptSubmitCmd = &cobra.Command{
@@ -47,6 +48,11 @@ func runPromptSubmit(cmd *cobra.Command, args []string) {
 		}
 	}
 	emitHookEvent(logger, "prompt.submitted", "prompt", "info", "Prompt submitted to agent", input, fields)
+
+	if platformFlag == "antigravity" && sessionID != "" {
+		st := state.NewSessionState(sessionID, "antigravity")
+		st.SetPromptEmitted()
+	}
 
 	outputJSON(noopResponse)
 }

--- a/cli/beacon-hooks/cmd/prompt_submit.go
+++ b/cli/beacon-hooks/cmd/prompt_submit.go
@@ -42,7 +42,7 @@ func runPromptSubmit(cmd *cobra.Command, args []string) {
 	logger.Debug("Prompt submit observed")
 	fields := sessionFields(sessionID, input)
 	if config.ContentRetentionMode() != config.ContentRetentionMetadata {
-		if prompt := getFirstStr(input, "prompt", "user_prompt", "text", "promptText"); prompt != "" {
+		if prompt := getFirstStr(input, "prompt", "user_prompt", "userPrompt", "text", "promptText", "input"); prompt != "" {
 			fields["prompt"] = map[string]interface{}{"text": prompt}
 		}
 	}

--- a/cli/beacon-hooks/cmd/prompt_submit.go
+++ b/cli/beacon-hooks/cmd/prompt_submit.go
@@ -42,14 +42,16 @@ func runPromptSubmit(cmd *cobra.Command, args []string) {
 
 	logger.Debug("Prompt submit observed")
 	fields := sessionFields(sessionID, input)
+	hasPrompt := false
 	if config.ContentRetentionMode() != config.ContentRetentionMetadata {
 		if prompt := getFirstStr(input, "prompt", "user_prompt", "userPrompt", "text", "promptText", "input"); prompt != "" {
 			fields["prompt"] = map[string]interface{}{"text": prompt}
+			hasPrompt = true
 		}
 	}
 	emitHookEvent(logger, "prompt.submitted", "prompt", "info", "Prompt submitted to agent", input, fields)
 
-	if platformFlag == "antigravity" && sessionID != "" {
+	if platformFlag == "antigravity" && sessionID != "" && hasPrompt {
 		st := state.NewSessionState(sessionID, "antigravity")
 		st.SetPromptEmitted()
 	}

--- a/cli/beacon-hooks/cmd/root.go
+++ b/cli/beacon-hooks/cmd/root.go
@@ -11,8 +11,8 @@ var platformFlag string
 
 var rootCmd = &cobra.Command{
 	Use:   "beacon-hooks",
-	Short: "Beacon hooks for Claude Code, GitHub Copilot, Cursor, Devin, Factory, Grok, and opencode",
-	Long: `Beacon hooks binary for Claude Code, GitHub Copilot, Cursor, Devin, Factory, Grok, and opencode integration.
+	Short: "Beacon hooks for Claude Code, GitHub Copilot, Cursor, Devin, Factory, Grok, Antigravity, and opencode",
+	Long: `Beacon hooks binary for Claude Code, GitHub Copilot, Cursor, Devin, Factory, Grok, Antigravity, and opencode integration.
 
 This binary provides hook commands that are called by IDE plugin systems
 to evaluate code changes for security violations.
@@ -21,7 +21,7 @@ Use --platform to specify the calling platform (default: claude).`,
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, copilot, cursor, devin, factory, grok, or opencode")
+	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, antigravity, copilot, cursor, devin, factory, grok, or opencode")
 }
 
 // Execute runs the root command

--- a/cli/beacon-hooks/internal/config/config.go
+++ b/cli/beacon-hooks/internal/config/config.go
@@ -9,14 +9,15 @@ import (
 
 // Directories
 var (
-	BeaconDir   = getBeaconDir()
-	ClaudeDir   = filepath.Join(BeaconDir, "claude")
-	CopilotDir  = filepath.Join(BeaconDir, "copilot")
-	CursorDir   = filepath.Join(BeaconDir, "cursor")
-	DevinDir    = filepath.Join(BeaconDir, "devin")
-	FactoryDir  = filepath.Join(BeaconDir, "factory")
-	GrokDir     = filepath.Join(BeaconDir, "grok")
-	OpenCodeDir = filepath.Join(BeaconDir, "opencode")
+	BeaconDir      = getBeaconDir()
+	ClaudeDir      = filepath.Join(BeaconDir, "claude")
+	AntigravityDir = filepath.Join(BeaconDir, "antigravity")
+	CopilotDir     = filepath.Join(BeaconDir, "copilot")
+	CursorDir      = filepath.Join(BeaconDir, "cursor")
+	DevinDir       = filepath.Join(BeaconDir, "devin")
+	FactoryDir     = filepath.Join(BeaconDir, "factory")
+	GrokDir        = filepath.Join(BeaconDir, "grok")
+	OpenCodeDir    = filepath.Join(BeaconDir, "opencode")
 )
 
 // Log rotation
@@ -86,6 +87,8 @@ func IsScannableFile(filePath string) bool {
 // GetStateDir returns the state directory for the given platform
 func GetStateDir(platform string) string {
 	switch platform {
+	case "antigravity":
+		return AntigravityDir
 	case "copilot":
 		return CopilotDir
 	case "cursor":

--- a/cli/beacon-hooks/internal/diff/diff.go
+++ b/cli/beacon-hooks/internal/diff/diff.go
@@ -21,6 +21,7 @@ func FromToolResponse(toolName string, toolInput, toolResponse map[string]interf
 	if filePath == "" {
 		filePath = GetStringFromMaps("AbsolutePath", toolInput, toolResponse)
 	}
+	filePath = NormalizePath(filePath)
 	if filePath == "" {
 		return ""
 	}
@@ -32,7 +33,7 @@ func FromToolResponse(toolName string, toolInput, toolResponse map[string]interf
 
 	// Fall back to tool-specific construction
 	switch toolName {
-	case "Edit", "edit":
+	case "Edit", "edit", "edit_file":
 		oldString := resolveEditString("old_string", "oldString", "old_str", toolInput, toolResponse)
 		newString := resolveEditString("new_string", "newString", "new_str", toolInput, toolResponse)
 		return fromEditTool(filePath, oldString, newString)
@@ -301,6 +302,12 @@ func splitLines(s string) []string {
 		return []string{}
 	}
 	return strings.Split(s, "\n")
+}
+
+// NormalizePath strips surrounding double quotes and whitespace from a path string.
+func NormalizePath(s string) string {
+	s = strings.TrimSpace(s)
+	return strings.Trim(s, `"`)
 }
 
 // GetStringFromMaps returns the first non-empty string value for key across the given maps.

--- a/cli/beacon-hooks/internal/diff/diff.go
+++ b/cli/beacon-hooks/internal/diff/diff.go
@@ -13,6 +13,15 @@ func FromToolResponse(toolName string, toolInput, toolResponse map[string]interf
 		filePath = GetStringFromMaps("filePath", toolInput, toolResponse)
 	}
 	if filePath == "" {
+		filePath = GetStringFromMaps("path", toolInput, toolResponse)
+	}
+	if filePath == "" {
+		filePath = GetStringFromMaps("Path", toolInput, toolResponse)
+	}
+	if filePath == "" {
+		filePath = GetStringFromMaps("AbsolutePath", toolInput, toolResponse)
+	}
+	if filePath == "" {
 		return ""
 	}
 
@@ -33,7 +42,7 @@ func FromToolResponse(toolName string, toolInput, toolResponse map[string]interf
 		content := GetStringFromMaps("code", toolInput, toolResponse)
 		return fromWriteTool(filePath, content, "")
 
-	case "Write", "Create", "write":
+	case "Write", "Create", "write", "write_file":
 		content := GetStringFromMaps("content", toolInput, toolResponse)
 		originalFile := GetStringFromMaps("originalFile", toolInput, toolResponse)
 		return fromWriteTool(filePath, content, originalFile)

--- a/cli/beacon-hooks/internal/state/state.go
+++ b/cli/beacon-hooks/internal/state/state.go
@@ -28,6 +28,7 @@ type SessionData struct {
 	Evaluations   []Evaluation `json:"evaluations"`
 	RepromptCount int          `json:"reprompt_count"`
 	Model         string       `json:"model,omitempty"`
+	PromptEmitted bool         `json:"prompt_emitted,omitempty"`
 	CreatedAt     string       `json:"created_at,omitempty"`
 }
 
@@ -109,6 +110,41 @@ func (s *SessionState) GetModel() string {
 		return sessionData.Model
 	}
 	return ""
+}
+
+func (s *SessionState) HasPromptEmitted() bool {
+	stateMutex.Lock()
+	defer stateMutex.Unlock()
+
+	state := s.loadStateFile()
+	if sessionData, ok := state[s.sessionID]; ok {
+		return sessionData.PromptEmitted
+	}
+	return false
+}
+
+func (s *SessionState) SetPromptEmitted() {
+	stateMutex.Lock()
+	defer stateMutex.Unlock()
+
+	state := s.loadStateFile()
+	s.ensureSession(state)
+	state[s.sessionID].PromptEmitted = true
+	s.saveStateFile(state)
+}
+
+func (s *SessionState) MarkPromptEmittedIfNeeded() bool {
+	stateMutex.Lock()
+	defer stateMutex.Unlock()
+
+	state := s.loadStateFile()
+	s.ensureSession(state)
+	if state[s.sessionID].PromptEmitted {
+		return false
+	}
+	state[s.sessionID].PromptEmitted = true
+	s.saveStateFile(state)
+	return true
 }
 
 // AddEvaluation adds a new pending evaluation

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -709,6 +709,16 @@ func runEndpointHooksInstall(cmd *cobra.Command, args []string) error {
 	cfg := loadOrDefaultConfig()
 	for _, name := range hookTargets() {
 		switch strings.TrimSpace(name) {
+		case "antigravity", "antigravity_cli":
+			status, err := endpointhooks.InstallAntigravity(endpointhooks.AntigravityOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Antigravity hooks installed: %s\n", status.ConfigPath)
 		case "cursor":
 			status, err := endpointhooks.InstallCursor(endpointhooks.CursorOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -781,6 +791,16 @@ func runEndpointHooksUninstall(cmd *cobra.Command, args []string) error {
 	cfg := loadOrDefaultConfig()
 	for _, name := range hookTargets() {
 		switch strings.TrimSpace(name) {
+		case "antigravity", "antigravity_cli":
+			status, err := endpointhooks.UninstallAntigravity(endpointhooks.AntigravityOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Println(status.Message)
 		case "cursor":
 			status, err := endpointhooks.UninstallCursor(endpointhooks.CursorOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -844,6 +864,12 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 	statuses := map[string]interface{}{}
 	for _, name := range hookTargets() {
 		switch strings.TrimSpace(name) {
+		case "antigravity", "antigravity_cli":
+			statuses["antigravity"] = endpointhooks.AntigravityHookStatus(endpointhooks.AntigravityOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
 		case "cursor":
 			statuses["cursor"] = endpointhooks.CursorHookStatus(endpointhooks.CursorOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -884,6 +910,10 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 	}
 	for _, name := range hookTargets() {
 		switch strings.TrimSpace(name) {
+		case "antigravity", "antigravity_cli":
+			status := statuses["antigravity"].(endpointhooks.AntigravityStatus)
+			fmt.Printf("Antigravity hooks: installed=%t path=%s\n", status.Installed, status.ConfigPath)
+			fmt.Println(status.Message)
 		case "cursor":
 			status := statuses["cursor"].(endpointhooks.CursorStatus)
 			fmt.Printf("Cursor hooks: installed=%t path=%s\n", status.Installed, status.HooksJSONPath)

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -367,7 +367,7 @@ func printPlannedActions(actions []plannedAction) error {
 
 func hookTargets() []string {
 	if endpointOpts.allTargets {
-		return []string{"cursor", "factory", "opencode", "grok", "devin"}
+		return []string{"cursor", "factory", "opencode", "grok", "devin", "antigravity"}
 	}
 	return splitCSV(endpointOpts.hookHarnesses)
 }
@@ -381,6 +381,9 @@ func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[str
 	statuses := map[string]hookTargetResult{}
 	for _, name := range targets {
 		switch strings.TrimSpace(name) {
+		case "antigravity", "antigravity_cli":
+			status := endpointhooks.AntigravityHookStatus(endpointhooks.AntigravityOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ConfigPath, Raw: status}
 		case "cursor":
 			status := endpointhooks.CursorHookStatus(endpointhooks.CursorOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksJSONPath, Raw: status}

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -48,6 +48,7 @@ func DiscoverAll() []Harness {
 		DiscoverClaude(),
 		DiscoverCodex(),
 		DiscoverGemini(),
+		DiscoverAntigravity(),
 		DiscoverCopilotCLI(),
 		DiscoverOpenCode(),
 		DiscoverFactory(),
@@ -55,6 +56,38 @@ func DiscoverAll() []Harness {
 		DiscoverDevin(),
 		DiscoverClaudeCowork(),
 	}
+}
+
+func DiscoverAntigravity() Harness {
+	h := Harness{Name: "antigravity_cli", DisplayName: "Antigravity CLI", Capability: "hooks"}
+	for _, name := range []string{"antigravity", "antigravity-cli"} {
+		path, err := exec.LookPath(name)
+		if err == nil {
+			h.Detected = true
+			h.ExecutablePath = path
+			h.Version = commandVersion(path)
+			break
+		}
+	}
+	home, _ := os.UserHomeDir()
+	userConfig := filepath.Join(home, ".gemini", "config", "hooks.json")
+	projectConfig := filepath.Join(".agents", "hooks.json")
+	h.ConfigPath = userConfig
+	if fileExists(projectConfig) {
+		h.ConfigPath = projectConfig
+	}
+	if !h.Detected && (dirExists(filepath.Join(home, ".gemini", "config")) || dirExists(".agents")) {
+		h.Detected = true
+	}
+	if fileExists(h.ConfigPath) {
+		status, msg := antigravityStatus(h.ConfigPath)
+		h.TelemetryStatus = status
+		h.Message = msg
+	} else {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = "Antigravity hooks.json was not found"
+	}
+	return h
 }
 
 func DiscoverClaude() Harness {
@@ -473,6 +506,34 @@ func hasBeaconDevinHooks(data []byte) (bool, error) {
 					return true, nil
 				}
 			}
+		}
+	}
+	return false, nil
+}
+
+func antigravityStatus(path string) (TelemetryStatus, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return TelemetryMissing, err.Error()
+	}
+	hasHooks, err := hasBeaconAntigravityHooks(data)
+	if err != nil {
+		return TelemetryMisconfigured, "Antigravity hooks JSON is invalid"
+	}
+	if hasHooks {
+		return TelemetryEnabled, "Antigravity endpoint hooks are configured"
+	}
+	return TelemetryDisabled, "Antigravity hooks exist but endpoint hooks were not found"
+}
+
+func hasBeaconAntigravityHooks(data []byte) (bool, error) {
+	var blocks map[string]json.RawMessage
+	if err := json.Unmarshal(data, &blocks); err != nil {
+		return false, err
+	}
+	for _, raw := range blocks {
+		if strings.Contains(string(raw), "BEACON_ENDPOINT_MODE=1") && strings.Contains(string(raw), "--platform antigravity") {
+			return true, nil
 		}
 	}
 	return false, nil

--- a/cli/beacon/internal/endpoint/hooks/antigravity.go
+++ b/cli/beacon/internal/endpoint/hooks/antigravity.go
@@ -1,0 +1,226 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const antigravityBeaconHookName = "beacon-endpoint"
+
+type AntigravityOptions struct {
+	Level    Level
+	LogPath  string
+	UserMode bool
+}
+
+type AntigravityStatus struct {
+	Installed  bool   `json:"installed"`
+	BinaryPath string `json:"binary_path,omitempty"`
+	ConfigPath string `json:"config_path,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+type antigravityHookGroup struct {
+	Matcher string               `json:"matcher,omitempty"`
+	Hooks   []antigravityHookRef `json:"hooks"`
+}
+
+type antigravityHookRef struct {
+	Type    string `json:"type,omitempty"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+}
+
+type antigravityHookBlock struct {
+	PreInvocation    []antigravityHookGroup `json:"PreInvocation,omitempty"`
+	UserPromptSubmit []antigravityHookGroup `json:"UserPromptSubmit,omitempty"`
+	PostInvocation   []antigravityHookGroup `json:"PostInvocation,omitempty"`
+	PreToolUse       []antigravityHookGroup `json:"PreToolUse,omitempty"`
+	PostToolUse      []antigravityHookGroup `json:"PostToolUse,omitempty"`
+	Stop             []antigravityHookGroup `json:"Stop,omitempty"`
+}
+
+type antigravityConfig struct {
+	values map[string]json.RawMessage
+}
+
+var antigravityRuntime = hookRuntime{
+	displayName: "Antigravity CLI",
+	configPath:  antigravityConfigPath,
+	install:     installAntigravityHooks,
+	uninstall:   removeAntigravityEndpointHooks,
+	isInstalled: isAntigravityInstalledAt,
+}
+
+func InstallAntigravity(opts AntigravityOptions) (AntigravityStatus, error) {
+	status, err := installRuntimeHooks(antigravityRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return AntigravityStatus{}, err
+	}
+	return antigravityStatusFromRuntime(status), nil
+}
+
+func UninstallAntigravity(opts AntigravityOptions) (AntigravityStatus, error) {
+	status, err := uninstallRuntimeHooks(antigravityRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return AntigravityStatus{}, err
+	}
+	return antigravityStatusFromRuntime(status), nil
+}
+
+func AntigravityHookStatus(opts AntigravityOptions) AntigravityStatus {
+	return antigravityStatusFromRuntime(runtimeHookStatus(antigravityRuntime, RuntimeOptions(opts)))
+}
+
+func IsAntigravityInstalled(opts AntigravityOptions) bool {
+	return isRuntimeInstalled(antigravityRuntime, RuntimeOptions(opts))
+}
+
+func antigravityStatusFromRuntime(status runtimeStatus) AntigravityStatus {
+	return AntigravityStatus{
+		Installed:  status.Installed,
+		BinaryPath: status.BinaryPath,
+		ConfigPath: status.ConfigPath,
+		Message:    status.Message,
+	}
+}
+
+func installAntigravityHooks(path, binaryPath, logPath, configPath string) error {
+	config, err := readAntigravityConfig(path)
+	if err != nil {
+		return err
+	}
+	prefix := endpointCommandPrefix("antigravity", binaryPath, logPath, configPath)
+	block := antigravityHookBlock{
+		PreInvocation: []antigravityHookGroup{{
+			Hooks: []antigravityHookRef{{Type: "command", Command: prefix + " prompt-submit", Timeout: 30}},
+		}},
+		UserPromptSubmit: []antigravityHookGroup{{
+			Hooks: []antigravityHookRef{{Type: "command", Command: prefix + " prompt-submit", Timeout: 30}},
+		}},
+		PreToolUse: []antigravityHookGroup{{
+			Hooks: []antigravityHookRef{{Type: "command", Command: prefix + " pre-tool"}},
+		}},
+		PostToolUse: []antigravityHookGroup{{
+			Hooks: []antigravityHookRef{{Type: "command", Command: prefix + " post-tool"}},
+		}},
+		PostInvocation: []antigravityHookGroup{{
+			Hooks: []antigravityHookRef{{Type: "command", Command: prefix + " stop", Timeout: 45}},
+		}},
+		Stop: []antigravityHookGroup{{
+			Hooks: []antigravityHookRef{{Type: "command", Command: prefix + " stop", Timeout: 45}},
+		}},
+	}
+	data, err := json.Marshal(block)
+	if err != nil {
+		return err
+	}
+	config.values[antigravityBeaconHookName] = data
+	out, err := config.marshal()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0600)
+}
+
+func readAntigravityConfig(path string) (antigravityConfig, error) {
+	config := antigravityConfig{values: map[string]json.RawMessage{}}
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if err := json.Unmarshal(data, &config.values); err != nil {
+			return antigravityConfig{}, err
+		}
+	} else if !os.IsNotExist(err) {
+		return antigravityConfig{}, err
+	}
+	if config.values == nil {
+		config.values = map[string]json.RawMessage{}
+	}
+	return config, nil
+}
+
+func (config antigravityConfig) marshal() ([]byte, error) {
+	if len(config.values) == 0 {
+		return []byte("{}"), nil
+	}
+	return json.MarshalIndent(config.values, "", "  ")
+}
+
+func removeAntigravityEndpointHooks(path string) (bool, error) {
+	config, err := readAntigravityConfig(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if _, ok := config.values[antigravityBeaconHookName]; !ok {
+		return false, nil
+	}
+	delete(config.values, antigravityBeaconHookName)
+	if len(config.values) == 0 {
+		return true, os.Remove(path)
+	}
+	out, err := config.marshal()
+	if err != nil {
+		return false, err
+	}
+	return true, os.WriteFile(path, out, 0600)
+}
+
+func isAntigravityInstalledAt(path string) bool {
+	config, err := readAntigravityConfig(path)
+	if err != nil {
+		return false
+	}
+	raw, ok := config.values[antigravityBeaconHookName]
+	if !ok {
+		return false
+	}
+	return hasAntigravityEndpointHook(raw)
+}
+
+func hasAntigravityEndpointHook(raw json.RawMessage) bool {
+	var block antigravityHookBlock
+	if err := json.Unmarshal(raw, &block); err != nil {
+		return false
+	}
+	for _, groups := range [][]antigravityHookGroup{
+		block.PreInvocation,
+		block.UserPromptSubmit,
+		block.PostInvocation,
+		block.PreToolUse,
+		block.PostToolUse,
+		block.Stop,
+	} {
+		for _, group := range groups {
+			for _, hook := range group.Hooks {
+				if isEndpointHookCommand(hook.Command, "antigravity") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func antigravityConfigPath(level Level) (string, error) {
+	switch level {
+	case LevelProject:
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cwd, ".agents", "hooks.json"), nil
+	case "", LevelUser:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".gemini", "config", "hooks.json"), nil
+	default:
+		return "", fmt.Errorf("unknown hook level %q", level)
+	}
+}

--- a/cli/beacon/internal/endpoint/hooks/antigravity_test.go
+++ b/cli/beacon/internal/endpoint/hooks/antigravity_test.go
@@ -1,0 +1,147 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallAntigravityHooksPreservesNonBeaconBlocks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hooks.json")
+	existing := `{"my-linter-hook":{"PostToolUse":[{"matcher":"run_command","hooks":[{"type":"command","command":"echo keep"}]}]}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installAntigravityHooks(path, "/tmp/beacon hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installAntigravityHooks returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"my-linter-hook",
+		"echo keep",
+		"beacon-endpoint",
+		"BEACON_ENDPOINT_MODE=1",
+		"BEACON_ENDPOINT_LOG='/tmp/runtime.jsonl'",
+		"BEACON_ENDPOINT_CONFIG='/tmp/config.json'",
+		"'/tmp/beacon hooks' --platform antigravity",
+		"PreInvocation",
+		"UserPromptSubmit",
+		"PreToolUse",
+		"PostToolUse",
+		"PostInvocation",
+		"Stop",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("Antigravity hooks missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestInstallAntigravityHooksReplacesManagedBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hooks.json")
+	existing := `{"beacon-endpoint":{"Stop":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 old-beacon-hooks --platform antigravity stop"}]}]},"other":{"Stop":[{"hooks":[{"command":"echo keep"}]}]}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installAntigravityHooks(path, "/tmp/new-beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installAntigravityHooks returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "old-beacon-hooks") {
+		t.Fatalf("old endpoint hook was not replaced:\n%s", text)
+	}
+	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "/tmp/new-beacon-hooks") {
+		t.Fatalf("expected preserved block and new hook:\n%s", text)
+	}
+}
+
+func TestRemoveAntigravityEndpointHooksPreservesOtherBlocks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hooks.json")
+	existing := `{"beacon-endpoint":{"Stop":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform antigravity stop"}]}]},"other":{"Stop":[{"hooks":[{"command":"echo keep"}]}]}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := removeAntigravityEndpointHooks(path)
+	if err != nil {
+		t.Fatalf("removeAntigravityEndpointHooks returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected endpoint hook removal")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "echo keep") {
+		t.Fatalf("non-Beacon block was not preserved:\n%s", text)
+	}
+	if strings.Contains(text, "beacon-endpoint") || strings.Contains(text, "BEACON_ENDPOINT_MODE=1") {
+		t.Fatalf("endpoint hook was not removed:\n%s", text)
+	}
+}
+
+func TestReadAntigravityConfigReturnsCorruptJSONError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hooks.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0600); err != nil {
+		t.Fatalf("write corrupt config: %v", err)
+	}
+
+	if _, err := readAntigravityConfig(path); err == nil {
+		t.Fatal("expected corrupt config error")
+	}
+}
+
+func TestAntigravityConfigPathLevels(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	userPath, err := antigravityConfigPath(LevelUser)
+	if err != nil {
+		t.Fatalf("user antigravityConfigPath returned error: %v", err)
+	}
+	if got, want := userPath, filepath.Join(home, ".gemini", "config", "hooks.json"); got != want {
+		t.Fatalf("user config path = %q, want %q", got, want)
+	}
+	projectPath, err := antigravityConfigPath(LevelProject)
+	if err != nil {
+		t.Fatalf("project antigravityConfigPath returned error: %v", err)
+	}
+	if got, want := projectPath, filepath.Join(dir, ".agents", "hooks.json"); got != want {
+		t.Fatalf("project config path = %q, want %q", got, want)
+	}
+}
+
+func TestAntigravityHookStatusDetectsInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".gemini", "config", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"beacon-endpoint":{"Stop":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform antigravity stop"}]}]}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	status := AntigravityHookStatus(AntigravityOptions{Level: LevelUser, UserMode: true})
+	if !status.Installed {
+		t.Fatalf("AntigravityHookStatus installed = false, status=%#v", status)
+	}
+	if status.ConfigPath != path {
+		t.Fatalf("ConfigPath = %q, want %q", status.ConfigPath, path)
+	}
+}

--- a/collector-builder/exporter/beaconjsonexporter/exporter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter_test.go
@@ -1086,6 +1086,11 @@ func TestHarnessNameSeparatesClaudeCodeAndCowork(t *testing.T) {
 			attrs: map[string]interface{}{"service.name": "openclaw-gateway"},
 			want:  "openclaw_gateway",
 		},
+		{
+			name:  "antigravity service",
+			attrs: map[string]interface{}{"service.name": "antigravity-cli"},
+			want:  "antigravity_cli",
+		},
 	}
 
 	for _, tt := range tests {

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -519,6 +519,8 @@ func NormalizeHarnessName(name string) string {
 		return "claude_code"
 	case strings.Contains(lower, "openclaw") || strings.Contains(lower, "open-claw"):
 		return "openclaw_gateway"
+	case strings.Contains(lower, "antigravity") || strings.Contains(lower, "anti-gravity"):
+		return "antigravity_cli"
 	case strings.Contains(lower, "codex"):
 		return "codex_cli"
 	case strings.Contains(lower, "gemini"):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small telemetry hook change; improves session-state correctness without altering auth or data paths beyond existing retention rules.
> 
> **Overview**
> In **`prompt-submit`**, prompt detection is split from content retention: **`hasPrompt`** is now true whenever stdin includes prompt text, while **`BEACON_CONTENT_RETENTION`** metadata-only mode still only omits **`prompt.text`** from the emitted event.
> 
> For **antigravity**, **`SetPromptEmitted()`** now runs whenever there is a session and prompt text, including under metadata-only retention—so session deduplication (e.g. vs transcript fallback in **`pre-tool`**) no longer skips prompts that were withheld from telemetry payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a561a6f4ee3bcbcf8f58b43f4b2cd371c1575d04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->