### PR TITLE
Fix prompt submission event handling for Antigravity CLI

### DIFF
--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -99,7 +99,7 @@ func emitAntigravityPromptFromTranscript(logger *logging.Logger, input map[strin
 		return
 	}
 	st := state.NewSessionState(sessionID, "antigravity")
-	if !st.MarkPromptEmittedIfNeeded() {
+	if st.HasPromptEmitted() {
 		return
 	}
 	prompt := antigravityPromptFromTranscript(input, sessionID)
@@ -111,6 +111,7 @@ func emitAntigravityPromptFromTranscript(logger *logging.Logger, input map[strin
 		fields["prompt"] = map[string]interface{}{"text": prompt}
 	}
 	emitHookEvent(logger, "prompt.submitted", "prompt", "info", "Prompt submitted to agent", input, fields)
+	st.SetPromptEmitted()
 }
 
 func antigravityPromptFromTranscript(input map[string]interface{}, sessionID string) string {

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -337,6 +337,42 @@ func TestRunPreToolSynthesizesAntigravityPromptFromTranscript(t *testing.T) {
 	}
 }
 
+func TestRunPreToolRetriesAntigravityPromptUntilTranscriptExists(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "antigravity"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "full")
+	transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
+	input := map[string]interface{}{
+		"conversationId": "ag-session",
+		"transcriptPath": transcriptPath,
+		"workspacePaths": []interface{}{"/repo"},
+		"toolCall":       map[string]interface{}{"name": "list_dir", "args": map[string]interface{}{"DirectoryPath": `"/repo"`}},
+	}
+
+	if out := runHookWithInput(t, runPreTool, input); out["decision"] != "allow" {
+		t.Fatalf("first antigravity pre-tool response = %#v, want decision=allow", out)
+	}
+	if err := os.WriteFile(transcriptPath, []byte(`{"source":"USER_EXPLICIT","type":"USER_INPUT","content":"<USER_REQUEST>\nshow me the full prompt\n</USER_REQUEST>"}`+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if out := runHookWithInput(t, runPreTool, input); out["decision"] != "allow" {
+		t.Fatalf("second antigravity pre-tool response = %#v, want decision=allow", out)
+	}
+
+	events := endpointEvents(t, logPath)
+	if len(events) != 3 {
+		t.Fatalf("event count = %d, want first tool, prompt, second tool: %#v", len(events), events)
+	}
+	if action := events[1]["event"].(map[string]interface{})["action"]; action != "prompt.submitted" {
+		t.Fatalf("second event.action = %q, want prompt.submitted", action)
+	}
+	if got := events[1]["prompt"].(map[string]interface{})["text"]; got != "show me the full prompt" {
+		t.Fatalf("prompt.text = %q, want full transcript prompt", got)
+	}
+}
+
 func TestRunPermissionRequestEmitsDevinApproval(t *testing.T) {
 	setupHookConfigDirs(t)
 	platformFlag = "devin"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized Antigravity hook telemetry ordering; no auth, security, or data-path changes beyond when prompt events are recorded.
> 
> **Overview**
> Fixes Antigravity **pre-tool** handling so `prompt.submitted` is emitted from the transcript only after readable prompt text exists, instead of locking out retries on the first hook when the transcript is still missing.
> 
> `emitAntigravityPromptFromTranscript` now checks `HasPromptEmitted` before returning early and calls `SetPromptEmitted` only after a successful `prompt.submitted` event (replacing the eager `MarkPromptEmittedIfNeeded` path). A new test covers the first pre-tool firing with no transcript file, then a second pre-tool after the transcript is written, expecting the prompt event between the two tool invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b7516fb500a9bdc578e905e271835522133c82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->