### PR TITLE
fix: replace panic() with error returns in pack asset loading

### DIFF
--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -408,11 +408,17 @@ var endpointWazuhValidateCmd = &cobra.Command{
 }
 
 var endpointElasticPrintConfigCmd = &cobra.Command{
-	Use:   "print-config",
-	Short: "Print a Filebeat input for Beacon endpoint events",
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:          "print-config",
+	Short:        "Print a Filebeat input for Beacon endpoint events",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := loadOrDefaultConfig()
-		fmt.Print(elastic.InputSnippet(cfg.LogPath))
+		snippet, err := elastic.InputSnippet(cfg.LogPath)
+		if err != nil {
+			return err
+		}
+		fmt.Print(snippet)
+		return nil
 	},
 }
 
@@ -442,11 +448,17 @@ var endpointElasticDownCmd = &cobra.Command{
 }
 
 var endpointDatadogPrintConfigCmd = &cobra.Command{
-	Use:   "print-config",
-	Short: "Print a Datadog Agent custom log config for Beacon endpoint events",
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:          "print-config",
+	Short:        "Print a Datadog Agent custom log config for Beacon endpoint events",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := loadOrDefaultConfig()
-		fmt.Print(datadog.ConfigSnippet(cfg.LogPath))
+		snippet, err := datadog.ConfigSnippet(cfg.LogPath)
+		if err != nil {
+			return err
+		}
+		fmt.Print(snippet)
+		return nil
 	},
 }
 
@@ -465,11 +477,17 @@ var endpointDatadogValidateCmd = &cobra.Command{
 }
 
 var endpointSumoPrintConfigCmd = &cobra.Command{
-	Use:   "print-config",
-	Short: "Print a Sumo HTTP Source smoke-test uploader for Beacon endpoint events",
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:          "print-config",
+	Short:        "Print a Sumo HTTP Source smoke-test uploader for Beacon endpoint events",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := loadOrDefaultConfig()
-		fmt.Print(sumo.UploadSmokeTest(cfg.LogPath))
+		snippet, err := sumo.UploadSmokeTest(cfg.LogPath)
+		if err != nil {
+			return err
+		}
+		fmt.Print(snippet)
+		return nil
 	},
 }
 
@@ -488,11 +506,17 @@ var endpointSumoValidateCmd = &cobra.Command{
 }
 
 var endpointRapid7PrintConfigCmd = &cobra.Command{
-	Use:   "print-config",
-	Short: "Print a Rapid7 Custom Logs webhook smoke-test uploader for Beacon endpoint events",
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:          "print-config",
+	Short:        "Print a Rapid7 Custom Logs webhook smoke-test uploader for Beacon endpoint events",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := loadOrDefaultConfig()
-		fmt.Print(rapid7.UploadSmokeTest(cfg.LogPath))
+		snippet, err := rapid7.UploadSmokeTest(cfg.LogPath)
+		if err != nil {
+			return err
+		}
+		fmt.Print(snippet)
+		return nil
 	},
 }
 

--- a/cli/beacon/internal/endpoint/datadog/datadog.go
+++ b/cli/beacon/internal/endpoint/datadog/datadog.go
@@ -3,9 +3,12 @@ package datadog
 import (
 	"embed"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
 )
 
 //go:embed pack/*
@@ -21,21 +24,71 @@ type File struct {
 	Content string
 }
 
-func Files() []File {
-	return []File{
-		{Name: "README.md", Content: mustRead("pack/README.md")},
-		{Name: "conf.yaml", Content: ConfigSnippet(DefaultLogPath)},
-		{Name: "sample-event.jsonl", Content: mustRead("pack/sample-event.jsonl")},
+// readAsset reads an embedded asset by path and returns its contents or an error.
+func readAsset(path string) (string, error) {
+	data, err := packFS.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("datadog pack asset %q: %w", path, err)
 	}
+	return string(data), nil
 }
 
-func ConfigSnippet(logPath string) string {
+// mustRead returns the embedded asset at path or panics. Retained for test use
+// where the embedded FS is always present; all production code uses readAsset.
+func mustRead(path string) string {
+	s, err := readAsset(path)
+	if err != nil {
+		panic(err.Error())
+	}
+	return s
+}
+
+// configSnippetFromFS renders the Datadog Agent conf.yaml snippet using the supplied FS.
+func configSnippetFromFS(fsys fs.FS, logPath string) (string, error) {
 	if logPath == "" {
 		logPath = DefaultLogPath
 	}
-	return strings.ReplaceAll(mustRead("pack/conf.yaml.tmpl"), "{{LOG_PATH}}", logPath)
+	content, err := siempack.ReadFile(fsys, "pack/conf.yaml.tmpl")
+	if err != nil {
+		return "", fmt.Errorf("datadog pack asset %q: %w", "pack/conf.yaml.tmpl", err)
+	}
+	return strings.ReplaceAll(content, "{{LOG_PATH}}", logPath), nil
 }
 
+// filesFromFS builds the full file list from the supplied FS, propagating any
+// read errors instead of panicking.
+func filesFromFS(fsys fs.FS, logPath string) ([]File, error) {
+	readme, err := siempack.ReadFile(fsys, "pack/README.md")
+	if err != nil {
+		return nil, fmt.Errorf("datadog pack asset %q: %w", "pack/README.md", err)
+	}
+	conf, err := configSnippetFromFS(fsys, logPath)
+	if err != nil {
+		return nil, err
+	}
+	sample, err := siempack.ReadFile(fsys, "pack/sample-event.jsonl")
+	if err != nil {
+		return nil, fmt.Errorf("datadog pack asset %q: %w", "pack/sample-event.jsonl", err)
+	}
+	return []File{
+		{Name: "README.md", Content: readme},
+		{Name: "conf.yaml", Content: conf},
+		{Name: "sample-event.jsonl", Content: sample},
+	}, nil
+}
+
+// Files returns all pack files rendered with DefaultLogPath, propagating any
+// embedded asset read error.
+func Files() ([]File, error) {
+	return filesFromFS(packFS, DefaultLogPath)
+}
+
+// ConfigSnippet returns the Datadog Agent conf.yaml snippet with logPath substituted.
+func ConfigSnippet(logPath string) (string, error) {
+	return configSnippetFromFS(packFS, logPath)
+}
+
+// InstallPack writes the pack files to outputDir with logPath substituted.
 func InstallPack(outputDir, logPath string) error {
 	if outputDir == "" {
 		outputDir = DefaultOutputDir
@@ -43,22 +96,22 @@ func InstallPack(outputDir, logPath string) error {
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return err
 	}
-	for _, file := range Files() {
+	files, err := filesFromFS(packFS, logPath)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
 		content := file.Content
 		if file.Name == "conf.yaml" {
-			content = ConfigSnippet(logPath)
+			s, err := ConfigSnippet(logPath)
+			if err != nil {
+				return err
+			}
+			content = s
 		}
 		if err := os.WriteFile(filepath.Join(outputDir, file.Name), []byte(content), 0644); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func mustRead(path string) string {
-	data, err := packFS.ReadFile(path)
-	if err != nil {
-		panic(fmt.Sprintf("datadog pack asset %s: %v", path, err))
-	}
-	return string(data)
 }

--- a/cli/beacon/internal/endpoint/datadog/datadog.go
+++ b/cli/beacon/internal/endpoint/datadog/datadog.go
@@ -101,15 +101,7 @@ func InstallPack(outputDir, logPath string) error {
 		return err
 	}
 	for _, file := range files {
-		content := file.Content
-		if file.Name == "conf.yaml" {
-			s, err := ConfigSnippet(logPath)
-			if err != nil {
-				return err
-			}
-			content = s
-		}
-		if err := os.WriteFile(filepath.Join(outputDir, file.Name), []byte(content), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(outputDir, file.Name), []byte(file.Content), 0644); err != nil {
 			return err
 		}
 	}

--- a/cli/beacon/internal/endpoint/datadog/datadog_test.go
+++ b/cli/beacon/internal/endpoint/datadog/datadog_test.go
@@ -7,10 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 )
 
 func TestConfigSnippetUsesConfiguredPath(t *testing.T) {
-	got := ConfigSnippet("/tmp/beacon/runtime.jsonl")
+	got, err := ConfigSnippet("/tmp/beacon/runtime.jsonl")
+	if err != nil {
+		t.Fatalf("ConfigSnippet returned unexpected error: %v", err)
+	}
 	if !strings.Contains(got, "/tmp/beacon/runtime.jsonl") {
 		t.Fatalf("snippet did not include configured path: %s", got)
 	}
@@ -89,5 +93,82 @@ func TestPackREADMEMentionsValidationRetentionAndMacOSPermissions(t *testing.T) 
 		if !strings.Contains(readme, want) {
 			t.Fatalf("pack README missing %q", want)
 		}
+	}
+}
+
+func TestFiles_NoError(t *testing.T) {
+	files, err := Files()
+	if err != nil {
+		t.Fatalf("Files() returned unexpected error: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("Files() returned no files")
+	}
+}
+
+func TestFiles_ContainsAllRequiredNames(t *testing.T) {
+	files, err := Files()
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make(map[string]bool)
+	for _, f := range files {
+		names[f.Name] = true
+	}
+	for _, required := range []string{
+		"README.md", "conf.yaml", "sample-event.jsonl",
+	} {
+		if !names[required] {
+			t.Errorf("Files() missing required file %q", required)
+		}
+	}
+}
+
+func TestFilesFromFS_PropagatesReadError(t *testing.T) {
+	emptyFS := fstest.MapFS{}
+	_, err := filesFromFS(emptyFS, DefaultLogPath)
+	if err == nil {
+		t.Fatal("filesFromFS with empty FS should return an error")
+	}
+	if !strings.Contains(err.Error(), "datadog pack asset") {
+		t.Fatalf("error should identify the pack source, got: %v", err)
+	}
+}
+
+func TestConfigSnippetFromFS_ErrorOnMissingAsset(t *testing.T) {
+	emptyFS := fstest.MapFS{}
+	_, err := configSnippetFromFS(emptyFS, "/some/path.jsonl")
+	if err == nil {
+		t.Fatal("configSnippetFromFS with empty FS should return error")
+	}
+	if !strings.Contains(err.Error(), "datadog pack asset") {
+		t.Fatalf("error should identify the pack source, got: %v", err)
+	}
+}
+
+func TestInstallPack_ErrorOnWriteFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: filesystem permission restrictions do not apply")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Skip("cannot set directory permissions:", err)
+	}
+	defer os.Chmod(dir, 0755)
+
+	subdir := filepath.Join(dir, "output")
+	err := InstallPack(subdir, DefaultLogPath)
+	if err == nil {
+		t.Fatal("InstallPack into read-only directory should return error")
+	}
+}
+
+func TestConfigSnippet_DefaultLogPath(t *testing.T) {
+	got, err := ConfigSnippet("")
+	if err != nil {
+		t.Fatalf("ConfigSnippet with empty path returned error: %v", err)
+	}
+	if !strings.Contains(got, DefaultLogPath) {
+		t.Fatalf("ConfigSnippet with empty logPath should use DefaultLogPath %q, got: %s", DefaultLogPath, got)
 	}
 }

--- a/cli/beacon/internal/endpoint/elastic/elastic.go
+++ b/cli/beacon/internal/endpoint/elastic/elastic.go
@@ -140,11 +140,6 @@ func InputSnippet(logPath string) (string, error) {
 	return inputSnippetFromFS(packFS, logPath)
 }
 
-// standaloneAgentConfig returns the elastic-agent standalone config with logPath substituted.
-func standaloneAgentConfig(logPath string) (string, error) {
-	return standaloneAgentConfigFromFS(packFS, logPath)
-}
-
 // InstallPack writes the pack files to outputDir with logPath substituted.
 func InstallPack(outputDir, logPath string) error {
 	if outputDir == "" {

--- a/cli/beacon/internal/endpoint/elastic/elastic.go
+++ b/cli/beacon/internal/endpoint/elastic/elastic.go
@@ -158,22 +158,7 @@ func InstallPack(outputDir, logPath string) error {
 		return err
 	}
 	for _, file := range files {
-		content := file.Content
-		switch file.Name {
-		case "filebeat.yml":
-			s, err := InputSnippet(logPath)
-			if err != nil {
-				return err
-			}
-			content = s
-		case "elastic-agent-standalone.yml":
-			s, err := standaloneAgentConfig(logPath)
-			if err != nil {
-				return err
-			}
-			content = s
-		}
-		if err := os.WriteFile(filepath.Join(outputDir, file.Name), []byte(content), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(outputDir, file.Name), []byte(file.Content), 0644); err != nil {
 			return err
 		}
 	}

--- a/cli/beacon/internal/endpoint/elastic/elastic.go
+++ b/cli/beacon/internal/endpoint/elastic/elastic.go
@@ -3,9 +3,12 @@ package elastic
 import (
 	"embed"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
 )
 
 //go:embed pack/*
@@ -21,29 +24,128 @@ type File struct {
 	Content string
 }
 
-func Files() []File {
-	return []File{
-		{Name: "README.md", Content: mustRead("pack/README.md")},
-		{Name: "filebeat.yml", Content: InputSnippet(DefaultLogPath)},
-		{Name: "elastic-agent-standalone.yml", Content: standaloneAgentConfig(DefaultLogPath)},
-		{Name: "ilm-policy.json", Content: mustRead("pack/ilm-policy.json")},
-		{Name: "component-template-mappings.json", Content: mustRead("pack/component-template-mappings.json")},
-		{Name: "component-template-settings.json", Content: mustRead("pack/component-template-settings.json")},
-		{Name: "index-template.json", Content: mustRead("pack/index-template.json")},
-		{Name: "ingest-pipeline.json", Content: mustRead("pack/ingest-pipeline.json")},
-		{Name: "kibana-assets.ndjson", Content: mustRead("pack/kibana-assets.ndjson")},
-		{Name: "docker-compose.yml", Content: mustRead("pack/docker-compose.yml")},
-		{Name: "sample-event.jsonl", Content: mustRead("pack/sample-event.jsonl")},
+// readAsset reads an embedded asset by path and returns its contents or an error.
+func readAsset(path string) (string, error) {
+	data, err := packFS.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("elastic pack asset %q: %w", path, err)
 	}
+	return string(data), nil
 }
 
-func InputSnippet(logPath string) string {
+// mustRead returns the embedded asset at path or panics. Retained for test use
+// where the embedded FS is always present; all production code uses readAsset.
+func mustRead(path string) string {
+	s, err := readAsset(path)
+	if err != nil {
+		panic(err.Error())
+	}
+	return s
+}
+
+// inputSnippetFromFS renders the filebeat input snippet using the supplied FS.
+func inputSnippetFromFS(fsys fs.FS, logPath string) (string, error) {
 	if logPath == "" {
 		logPath = DefaultLogPath
 	}
-	return strings.ReplaceAll(mustRead("pack/filebeat.yml.tmpl"), "{{LOG_PATH}}", logPath)
+	content, err := siempack.ReadFile(fsys, "pack/filebeat.yml.tmpl")
+	if err != nil {
+		return "", fmt.Errorf("elastic pack asset %q: %w", "pack/filebeat.yml.tmpl", err)
+	}
+	return strings.ReplaceAll(content, "{{LOG_PATH}}", logPath), nil
 }
 
+// standaloneAgentConfigFromFS renders the elastic-agent standalone config using the supplied FS.
+func standaloneAgentConfigFromFS(fsys fs.FS, logPath string) (string, error) {
+	if logPath == "" {
+		logPath = DefaultLogPath
+	}
+	content, err := siempack.ReadFile(fsys, "pack/elastic-agent-standalone.yml.tmpl")
+	if err != nil {
+		return "", fmt.Errorf("elastic pack asset %q: %w", "pack/elastic-agent-standalone.yml.tmpl", err)
+	}
+	return strings.ReplaceAll(content, "{{LOG_PATH}}", logPath), nil
+}
+
+// filesFromFS builds the full file list from the supplied FS, propagating any
+// read errors instead of panicking.
+func filesFromFS(fsys fs.FS, logPath string) ([]File, error) {
+	readme, err := siempack.ReadFile(fsys, "pack/README.md")
+	if err != nil {
+		return nil, fmt.Errorf("elastic pack asset %q: %w", "pack/README.md", err)
+	}
+	fbSnippet, err := inputSnippetFromFS(fsys, logPath)
+	if err != nil {
+		return nil, err
+	}
+	agentConfig, err := standaloneAgentConfigFromFS(fsys, logPath)
+	if err != nil {
+		return nil, err
+	}
+	ilm, err := siempack.ReadFile(fsys, "pack/ilm-policy.json")
+	if err != nil {
+		return nil, fmt.Errorf("elastic pack asset %q: %w", "pack/ilm-policy.json", err)
+	}
+	compMappings, err := siempack.ReadFile(fsys, "pack/component-template-mappings.json")
+	if err != nil {
+		return nil, fmt.Errorf("elastic pack asset %q: %w", "pack/component-template-mappings.json", err)
+	}
+	compSettings, err := siempack.ReadFile(fsys, "pack/component-template-settings.json")
+	if err != nil {
+		return nil, fmt.Errorf("elastic pack asset %q: %w", "pack/component-template-settings.json", err)
+	}
+	idxTemplate, err := siempack.ReadFile(fsys, "pack/index-template.json")
+	if err != nil {
+		return nil, fmt.Errorf("elastic pack asset %q: %w", "pack/index-template.json", err)
+	}
+	ingestPipeline, err := siempack.ReadFile(fsys, "pack/ingest-pipeline.json")
+	if err != nil {
+		return nil, fmt.Errorf("elastic pack asset %q: %w", "pack/ingest-pipeline.json", err)
+	}
+	kibana, err := siempack.ReadFile(fsys, "pack/kibana-assets.ndjson")
+	if err != nil {
+		return nil, fmt.Errorf("elastic pack asset %q: %w", "pack/kibana-assets.ndjson", err)
+	}
+	compose, err := siempack.ReadFile(fsys, "pack/docker-compose.yml")
+	if err != nil {
+		return nil, fmt.Errorf("elastic pack asset %q: %w", "pack/docker-compose.yml", err)
+	}
+	sample, err := siempack.ReadFile(fsys, "pack/sample-event.jsonl")
+	if err != nil {
+		return nil, fmt.Errorf("elastic pack asset %q: %w", "pack/sample-event.jsonl", err)
+	}
+	return []File{
+		{Name: "README.md", Content: readme},
+		{Name: "filebeat.yml", Content: fbSnippet},
+		{Name: "elastic-agent-standalone.yml", Content: agentConfig},
+		{Name: "ilm-policy.json", Content: ilm},
+		{Name: "component-template-mappings.json", Content: compMappings},
+		{Name: "component-template-settings.json", Content: compSettings},
+		{Name: "index-template.json", Content: idxTemplate},
+		{Name: "ingest-pipeline.json", Content: ingestPipeline},
+		{Name: "kibana-assets.ndjson", Content: kibana},
+		{Name: "docker-compose.yml", Content: compose},
+		{Name: "sample-event.jsonl", Content: sample},
+	}, nil
+}
+
+// Files returns all pack files rendered with DefaultLogPath, propagating any
+// embedded asset read error.
+func Files() ([]File, error) {
+	return filesFromFS(packFS, DefaultLogPath)
+}
+
+// InputSnippet returns the Filebeat input snippet with logPath substituted.
+func InputSnippet(logPath string) (string, error) {
+	return inputSnippetFromFS(packFS, logPath)
+}
+
+// standaloneAgentConfig returns the elastic-agent standalone config with logPath substituted.
+func standaloneAgentConfig(logPath string) (string, error) {
+	return standaloneAgentConfigFromFS(packFS, logPath)
+}
+
+// InstallPack writes the pack files to outputDir with logPath substituted.
 func InstallPack(outputDir, logPath string) error {
 	if outputDir == "" {
 		outputDir = DefaultOutputDir
@@ -51,32 +153,29 @@ func InstallPack(outputDir, logPath string) error {
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return err
 	}
-	for _, file := range Files() {
+	files, err := filesFromFS(packFS, logPath)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
 		content := file.Content
 		switch file.Name {
 		case "filebeat.yml":
-			content = InputSnippet(logPath)
+			s, err := InputSnippet(logPath)
+			if err != nil {
+				return err
+			}
+			content = s
 		case "elastic-agent-standalone.yml":
-			content = standaloneAgentConfig(logPath)
+			s, err := standaloneAgentConfig(logPath)
+			if err != nil {
+				return err
+			}
+			content = s
 		}
 		if err := os.WriteFile(filepath.Join(outputDir, file.Name), []byte(content), 0644); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func standaloneAgentConfig(logPath string) string {
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	return strings.ReplaceAll(mustRead("pack/elastic-agent-standalone.yml.tmpl"), "{{LOG_PATH}}", logPath)
-}
-
-func mustRead(path string) string {
-	data, err := packFS.ReadFile(path)
-	if err != nil {
-		panic(fmt.Sprintf("elastic pack asset %s: %v", path, err))
-	}
-	return string(data)
 }

--- a/cli/beacon/internal/endpoint/elastic/elastic_test.go
+++ b/cli/beacon/internal/endpoint/elastic/elastic_test.go
@@ -7,10 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 )
 
 func TestInputSnippetUsesConfiguredPath(t *testing.T) {
-	got := InputSnippet("/tmp/beacon/runtime.jsonl")
+	got, err := InputSnippet("/tmp/beacon/runtime.jsonl")
+	if err != nil {
+		t.Fatalf("InputSnippet returned unexpected error: %v", err)
+	}
 	if !strings.Contains(got, "/tmp/beacon/runtime.jsonl") {
 		t.Fatalf("snippet did not include configured path: %s", got)
 	}
@@ -180,5 +184,84 @@ func TestIngestPipelineMentionsKeyMappings(t *testing.T) {
 	}
 	if strings.Contains(pipeline, "event.action = 'file.' + ctx.file.operation") {
 		t.Fatal("ingest pipeline should preserve Beacon file actions instead of deriving lossy file operation actions")
+	}
+}
+
+func TestFiles_NoError(t *testing.T) {
+	files, err := Files()
+	if err != nil {
+		t.Fatalf("Files() returned unexpected error: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("Files() returned no files")
+	}
+}
+
+func TestFiles_ContainsAllRequiredNames(t *testing.T) {
+	files, err := Files()
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make(map[string]bool)
+	for _, f := range files {
+		names[f.Name] = true
+	}
+	for _, required := range []string{
+		"README.md", "filebeat.yml", "elastic-agent-standalone.yml",
+		"ilm-policy.json", "kibana-assets.ndjson", "docker-compose.yml",
+		"sample-event.jsonl",
+	} {
+		if !names[required] {
+			t.Errorf("Files() missing required file %q", required)
+		}
+	}
+}
+
+func TestFilesFromFS_PropagatesReadError(t *testing.T) {
+	emptyFS := fstest.MapFS{}
+	_, err := filesFromFS(emptyFS, DefaultLogPath)
+	if err == nil {
+		t.Fatal("filesFromFS with empty FS should return an error")
+	}
+	if !strings.Contains(err.Error(), "elastic pack asset") {
+		t.Fatalf("error should identify the pack source, got: %v", err)
+	}
+}
+
+func TestInputSnippetFromFS_ErrorOnMissingAsset(t *testing.T) {
+	emptyFS := fstest.MapFS{}
+	_, err := inputSnippetFromFS(emptyFS, "/some/path.jsonl")
+	if err == nil {
+		t.Fatal("inputSnippetFromFS with empty FS should return error")
+	}
+	if !strings.Contains(err.Error(), "elastic pack asset") {
+		t.Fatalf("error should identify the pack source, got: %v", err)
+	}
+}
+
+func TestInstallPack_ErrorOnWriteFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: filesystem permission restrictions do not apply")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Skip("cannot set directory permissions:", err)
+	}
+	defer os.Chmod(dir, 0755)
+
+	subdir := filepath.Join(dir, "output")
+	err := InstallPack(subdir, DefaultLogPath)
+	if err == nil {
+		t.Fatal("InstallPack into read-only directory should return error")
+	}
+}
+
+func TestInputSnippet_DefaultLogPath(t *testing.T) {
+	got, err := InputSnippet("")
+	if err != nil {
+		t.Fatalf("InputSnippet with empty path returned error: %v", err)
+	}
+	if !strings.Contains(got, DefaultLogPath) {
+		t.Fatalf("InputSnippet with empty logPath should use DefaultLogPath %q, got: %s", DefaultLogPath, got)
 	}
 }

--- a/cli/beacon/internal/endpoint/rapid7/rapid7.go
+++ b/cli/beacon/internal/endpoint/rapid7/rapid7.go
@@ -55,8 +55,9 @@ func uploadSmokeTestFromFS(fsys fs.FS, logPath string) (string, error) {
 }
 
 // filesFromFS builds the full file list from the supplied FS, propagating any
-// read errors instead of panicking.
-func filesFromFS(fsys fs.FS, logPath string) ([]File, error) {
+// read errors instead of panicking. Template substitution of LOG_PATH is
+// deferred to siempack.Install via the TemplateLogPath field.
+func filesFromFS(fsys fs.FS) ([]File, error) {
 	readme, err := siempack.ReadFile(fsys, "pack/README.md")
 	if err != nil {
 		return nil, fmt.Errorf("rapid7 pack asset %q: %w", "pack/README.md", err)
@@ -83,7 +84,7 @@ func filesFromFS(fsys fs.FS, logPath string) ([]File, error) {
 
 // Files returns all pack files, propagating any embedded asset read error.
 func Files() ([]File, error) {
-	return filesFromFS(packFS, DefaultLogPath)
+	return filesFromFS(packFS)
 }
 
 // UploadSmokeTest returns the Rapid7 upload smoke-test script with logPath substituted.
@@ -99,7 +100,7 @@ func InstallPack(outputDir, logPath string) error {
 	if logPath == "" {
 		logPath = DefaultLogPath
 	}
-	files, err := filesFromFS(packFS, logPath)
+	files, err := filesFromFS(packFS)
 	if err != nil {
 		return err
 	}

--- a/cli/beacon/internal/endpoint/rapid7/rapid7.go
+++ b/cli/beacon/internal/endpoint/rapid7/rapid7.go
@@ -3,6 +3,7 @@ package rapid7
 import (
 	"embed"
 	"fmt"
+	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
 )
@@ -21,22 +22,76 @@ type File struct {
 	TemplateLogPath bool
 }
 
-func Files() []File {
-	return []File{
-		{Name: "README.md", Content: mustRead("pack/README.md")},
-		{Name: "rapid7-upload-smoke-test.sh", Content: mustRead("pack/rapid7-upload-smoke-test.sh.tmpl"), TemplateLogPath: true},
-		{Name: "sample-event.jsonl", Content: mustRead("pack/sample-event.jsonl")},
-		{Name: "vector.toml", Content: mustRead("pack/vector.toml.tmpl"), TemplateLogPath: true},
+// readAsset reads an embedded asset using the module-level packFS and returns its
+// contents or an error.
+func readAsset(path string) (string, error) {
+	data, err := siempack.ReadFile(packFS, path)
+	if err != nil {
+		return "", fmt.Errorf("rapid7 pack asset %q: %w", path, err)
 	}
+	return data, nil
 }
 
-func UploadSmokeTest(logPath string) string {
+// mustRead returns the embedded asset at path or panics. Retained for test use
+// where the embedded FS is always present; all production code uses readAsset.
+func mustRead(path string) string {
+	s, err := readAsset(path)
+	if err != nil {
+		panic(err.Error())
+	}
+	return s
+}
+
+// uploadSmokeTestFromFS renders the Rapid7 upload smoke-test script using the supplied FS.
+func uploadSmokeTestFromFS(fsys fs.FS, logPath string) (string, error) {
 	if logPath == "" {
 		logPath = DefaultLogPath
 	}
-	return siempack.RenderLogPath(mustRead("pack/rapid7-upload-smoke-test.sh.tmpl"), logPath)
+	content, err := siempack.ReadFile(fsys, "pack/rapid7-upload-smoke-test.sh.tmpl")
+	if err != nil {
+		return "", fmt.Errorf("rapid7 pack asset %q: %w", "pack/rapid7-upload-smoke-test.sh.tmpl", err)
+	}
+	return siempack.RenderLogPath(content, logPath), nil
 }
 
+// filesFromFS builds the full file list from the supplied FS, propagating any
+// read errors instead of panicking.
+func filesFromFS(fsys fs.FS, logPath string) ([]File, error) {
+	readme, err := siempack.ReadFile(fsys, "pack/README.md")
+	if err != nil {
+		return nil, fmt.Errorf("rapid7 pack asset %q: %w", "pack/README.md", err)
+	}
+	smokeTest, err := siempack.ReadFile(fsys, "pack/rapid7-upload-smoke-test.sh.tmpl")
+	if err != nil {
+		return nil, fmt.Errorf("rapid7 pack asset %q: %w", "pack/rapid7-upload-smoke-test.sh.tmpl", err)
+	}
+	sample, err := siempack.ReadFile(fsys, "pack/sample-event.jsonl")
+	if err != nil {
+		return nil, fmt.Errorf("rapid7 pack asset %q: %w", "pack/sample-event.jsonl", err)
+	}
+	vector, err := siempack.ReadFile(fsys, "pack/vector.toml.tmpl")
+	if err != nil {
+		return nil, fmt.Errorf("rapid7 pack asset %q: %w", "pack/vector.toml.tmpl", err)
+	}
+	return []File{
+		{Name: "README.md", Content: readme},
+		{Name: "rapid7-upload-smoke-test.sh", Content: smokeTest, TemplateLogPath: true},
+		{Name: "sample-event.jsonl", Content: sample},
+		{Name: "vector.toml", Content: vector, TemplateLogPath: true},
+	}, nil
+}
+
+// Files returns all pack files, propagating any embedded asset read error.
+func Files() ([]File, error) {
+	return filesFromFS(packFS, DefaultLogPath)
+}
+
+// UploadSmokeTest returns the Rapid7 upload smoke-test script with logPath substituted.
+func UploadSmokeTest(logPath string) (string, error) {
+	return uploadSmokeTestFromFS(packFS, logPath)
+}
+
+// InstallPack writes the pack files to outputDir with logPath substituted.
 func InstallPack(outputDir, logPath string) error {
 	if outputDir == "" {
 		outputDir = DefaultOutputDir
@@ -44,17 +99,13 @@ func InstallPack(outputDir, logPath string) error {
 	if logPath == "" {
 		logPath = DefaultLogPath
 	}
-	files := make([]siempack.File, 0, len(Files()))
-	for _, file := range Files() {
-		files = append(files, siempack.File(file))
-	}
-	return siempack.Install(outputDir, files, logPath)
-}
-
-func mustRead(path string) string {
-	data, err := siempack.ReadFile(packFS, path)
+	files, err := filesFromFS(packFS, logPath)
 	if err != nil {
-		panic(fmt.Sprintf("rapid7 pack asset %s: %v", path, err))
+		return err
 	}
-	return data
+	sfiles := make([]siempack.File, 0, len(files))
+	for _, file := range files {
+		sfiles = append(sfiles, siempack.File(file))
+	}
+	return siempack.Install(outputDir, sfiles, logPath)
 }

--- a/cli/beacon/internal/endpoint/rapid7/rapid7_test.go
+++ b/cli/beacon/internal/endpoint/rapid7/rapid7_test.go
@@ -173,7 +173,7 @@ func TestFiles_ContainsAllRequiredNames(t *testing.T) {
 
 func TestFilesFromFS_PropagatesReadError(t *testing.T) {
 	emptyFS := fstest.MapFS{}
-	_, err := filesFromFS(emptyFS, DefaultLogPath)
+	_, err := filesFromFS(emptyFS)
 	if err == nil {
 		t.Fatal("filesFromFS with empty FS should return an error")
 	}

--- a/cli/beacon/internal/endpoint/rapid7/rapid7_test.go
+++ b/cli/beacon/internal/endpoint/rapid7/rapid7_test.go
@@ -7,10 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 )
 
 func TestUploadSmokeTestUsesConfiguredPath(t *testing.T) {
-	got := UploadSmokeTest("/tmp/beacon/runtime.jsonl")
+	got, err := UploadSmokeTest("/tmp/beacon/runtime.jsonl")
+	if err != nil {
+		t.Fatalf("UploadSmokeTest returned unexpected error: %v", err)
+	}
 	if !strings.Contains(got, "/tmp/beacon/runtime.jsonl") {
 		t.Fatalf("script did not include configured path: %s", got)
 	}
@@ -136,5 +140,82 @@ func TestPackREADMEMentionsRapid7SetupAndProductionForwarding(t *testing.T) {
 		if !strings.Contains(readme, want) {
 			t.Fatalf("pack README missing %q", want)
 		}
+	}
+}
+
+func TestFiles_NoError(t *testing.T) {
+	files, err := Files()
+	if err != nil {
+		t.Fatalf("Files() returned unexpected error: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("Files() returned no files")
+	}
+}
+
+func TestFiles_ContainsAllRequiredNames(t *testing.T) {
+	files, err := Files()
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make(map[string]bool)
+	for _, f := range files {
+		names[f.Name] = true
+	}
+	for _, required := range []string{
+		"README.md", "rapid7-upload-smoke-test.sh", "sample-event.jsonl", "vector.toml",
+	} {
+		if !names[required] {
+			t.Errorf("Files() missing required file %q", required)
+		}
+	}
+}
+
+func TestFilesFromFS_PropagatesReadError(t *testing.T) {
+	emptyFS := fstest.MapFS{}
+	_, err := filesFromFS(emptyFS, DefaultLogPath)
+	if err == nil {
+		t.Fatal("filesFromFS with empty FS should return an error")
+	}
+	if !strings.Contains(err.Error(), "rapid7 pack asset") {
+		t.Fatalf("error should identify the pack source, got: %v", err)
+	}
+}
+
+func TestUploadSmokeTestFromFS_ErrorOnMissingAsset(t *testing.T) {
+	emptyFS := fstest.MapFS{}
+	_, err := uploadSmokeTestFromFS(emptyFS, "/some/path.jsonl")
+	if err == nil {
+		t.Fatal("uploadSmokeTestFromFS with empty FS should return error")
+	}
+	if !strings.Contains(err.Error(), "rapid7 pack asset") {
+		t.Fatalf("error should identify the pack source, got: %v", err)
+	}
+}
+
+func TestInstallPack_ErrorOnWriteFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: filesystem permission restrictions do not apply")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Skip("cannot set directory permissions:", err)
+	}
+	defer os.Chmod(dir, 0755)
+
+	subdir := filepath.Join(dir, "output")
+	err := InstallPack(subdir, DefaultLogPath)
+	if err == nil {
+		t.Fatal("InstallPack into read-only directory should return error")
+	}
+}
+
+func TestUploadSmokeTest_DefaultLogPath(t *testing.T) {
+	got, err := UploadSmokeTest("")
+	if err != nil {
+		t.Fatalf("UploadSmokeTest with empty path returned error: %v", err)
+	}
+	if !strings.Contains(got, DefaultLogPath) {
+		t.Fatalf("UploadSmokeTest with empty logPath should use DefaultLogPath %q, got: %s", DefaultLogPath, got)
 	}
 }

--- a/cli/beacon/internal/endpoint/sumo/sumo.go
+++ b/cli/beacon/internal/endpoint/sumo/sumo.go
@@ -55,8 +55,9 @@ func uploadSmokeTestFromFS(fsys fs.FS, logPath string) (string, error) {
 }
 
 // filesFromFS builds the full file list from the supplied FS, propagating any
-// read errors instead of panicking.
-func filesFromFS(fsys fs.FS, logPath string) ([]File, error) {
+// read errors instead of panicking. Template substitution of LOG_PATH is
+// deferred to siempack.Install via the TemplateLogPath field.
+func filesFromFS(fsys fs.FS) ([]File, error) {
 	readme, err := siempack.ReadFile(fsys, "pack/README.md")
 	if err != nil {
 		return nil, fmt.Errorf("sumo pack asset %q: %w", "pack/README.md", err)
@@ -83,7 +84,7 @@ func filesFromFS(fsys fs.FS, logPath string) ([]File, error) {
 
 // Files returns all pack files, propagating any embedded asset read error.
 func Files() ([]File, error) {
-	return filesFromFS(packFS, DefaultLogPath)
+	return filesFromFS(packFS)
 }
 
 // UploadSmokeTest returns the Sumo upload smoke-test script with logPath substituted.
@@ -99,7 +100,7 @@ func InstallPack(outputDir, logPath string) error {
 	if logPath == "" {
 		logPath = DefaultLogPath
 	}
-	files, err := filesFromFS(packFS, logPath)
+	files, err := filesFromFS(packFS)
 	if err != nil {
 		return err
 	}

--- a/cli/beacon/internal/endpoint/sumo/sumo.go
+++ b/cli/beacon/internal/endpoint/sumo/sumo.go
@@ -3,6 +3,7 @@ package sumo
 import (
 	"embed"
 	"fmt"
+	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
 )
@@ -21,22 +22,76 @@ type File struct {
 	TemplateLogPath bool
 }
 
-func Files() []File {
-	return []File{
-		{Name: "README.md", Content: mustRead("pack/README.md")},
-		{Name: "sumo-upload-smoke-test.sh", Content: mustRead("pack/sumo-upload-smoke-test.sh.tmpl"), TemplateLogPath: true},
-		{Name: "sample-event.jsonl", Content: mustRead("pack/sample-event.jsonl")},
-		{Name: "vector.toml", Content: mustRead("pack/vector.toml.tmpl"), TemplateLogPath: true},
+// readAsset reads an embedded asset using the module-level packFS and returns its
+// contents or an error.
+func readAsset(path string) (string, error) {
+	data, err := siempack.ReadFile(packFS, path)
+	if err != nil {
+		return "", fmt.Errorf("sumo pack asset %q: %w", path, err)
 	}
+	return data, nil
 }
 
-func UploadSmokeTest(logPath string) string {
+// mustRead returns the embedded asset at path or panics. Retained for test use
+// where the embedded FS is always present; all production code uses readAsset.
+func mustRead(path string) string {
+	s, err := readAsset(path)
+	if err != nil {
+		panic(err.Error())
+	}
+	return s
+}
+
+// uploadSmokeTestFromFS renders the Sumo upload smoke-test script using the supplied FS.
+func uploadSmokeTestFromFS(fsys fs.FS, logPath string) (string, error) {
 	if logPath == "" {
 		logPath = DefaultLogPath
 	}
-	return siempack.RenderLogPath(mustRead("pack/sumo-upload-smoke-test.sh.tmpl"), logPath)
+	content, err := siempack.ReadFile(fsys, "pack/sumo-upload-smoke-test.sh.tmpl")
+	if err != nil {
+		return "", fmt.Errorf("sumo pack asset %q: %w", "pack/sumo-upload-smoke-test.sh.tmpl", err)
+	}
+	return siempack.RenderLogPath(content, logPath), nil
 }
 
+// filesFromFS builds the full file list from the supplied FS, propagating any
+// read errors instead of panicking.
+func filesFromFS(fsys fs.FS, logPath string) ([]File, error) {
+	readme, err := siempack.ReadFile(fsys, "pack/README.md")
+	if err != nil {
+		return nil, fmt.Errorf("sumo pack asset %q: %w", "pack/README.md", err)
+	}
+	smokeTest, err := siempack.ReadFile(fsys, "pack/sumo-upload-smoke-test.sh.tmpl")
+	if err != nil {
+		return nil, fmt.Errorf("sumo pack asset %q: %w", "pack/sumo-upload-smoke-test.sh.tmpl", err)
+	}
+	sample, err := siempack.ReadFile(fsys, "pack/sample-event.jsonl")
+	if err != nil {
+		return nil, fmt.Errorf("sumo pack asset %q: %w", "pack/sample-event.jsonl", err)
+	}
+	vector, err := siempack.ReadFile(fsys, "pack/vector.toml.tmpl")
+	if err != nil {
+		return nil, fmt.Errorf("sumo pack asset %q: %w", "pack/vector.toml.tmpl", err)
+	}
+	return []File{
+		{Name: "README.md", Content: readme},
+		{Name: "sumo-upload-smoke-test.sh", Content: smokeTest, TemplateLogPath: true},
+		{Name: "sample-event.jsonl", Content: sample},
+		{Name: "vector.toml", Content: vector, TemplateLogPath: true},
+	}, nil
+}
+
+// Files returns all pack files, propagating any embedded asset read error.
+func Files() ([]File, error) {
+	return filesFromFS(packFS, DefaultLogPath)
+}
+
+// UploadSmokeTest returns the Sumo upload smoke-test script with logPath substituted.
+func UploadSmokeTest(logPath string) (string, error) {
+	return uploadSmokeTestFromFS(packFS, logPath)
+}
+
+// InstallPack writes the pack files to outputDir with logPath substituted.
 func InstallPack(outputDir, logPath string) error {
 	if outputDir == "" {
 		outputDir = DefaultOutputDir
@@ -44,17 +99,13 @@ func InstallPack(outputDir, logPath string) error {
 	if logPath == "" {
 		logPath = DefaultLogPath
 	}
-	files := make([]siempack.File, 0, len(Files()))
-	for _, file := range Files() {
-		files = append(files, siempack.File(file))
-	}
-	return siempack.Install(outputDir, files, logPath)
-}
-
-func mustRead(path string) string {
-	data, err := siempack.ReadFile(packFS, path)
+	files, err := filesFromFS(packFS, logPath)
 	if err != nil {
-		panic(fmt.Sprintf("sumo pack asset %s: %v", path, err))
+		return err
 	}
-	return data
+	sfiles := make([]siempack.File, 0, len(files))
+	for _, file := range files {
+		sfiles = append(sfiles, siempack.File(file))
+	}
+	return siempack.Install(outputDir, sfiles, logPath)
 }

--- a/cli/beacon/internal/endpoint/sumo/sumo_test.go
+++ b/cli/beacon/internal/endpoint/sumo/sumo_test.go
@@ -179,7 +179,7 @@ func TestFiles_ContainsAllRequiredNames(t *testing.T) {
 
 func TestFilesFromFS_PropagatesReadError(t *testing.T) {
 	emptyFS := fstest.MapFS{}
-	_, err := filesFromFS(emptyFS, DefaultLogPath)
+	_, err := filesFromFS(emptyFS)
 	if err == nil {
 		t.Fatal("filesFromFS with empty FS should return an error")
 	}

--- a/cli/beacon/internal/endpoint/sumo/sumo_test.go
+++ b/cli/beacon/internal/endpoint/sumo/sumo_test.go
@@ -7,10 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 )
 
 func TestUploadSmokeTestUsesConfiguredPath(t *testing.T) {
-	got := UploadSmokeTest("/tmp/beacon/runtime.jsonl")
+	got, err := UploadSmokeTest("/tmp/beacon/runtime.jsonl")
+	if err != nil {
+		t.Fatalf("UploadSmokeTest returned unexpected error: %v", err)
+	}
 	if !strings.Contains(got, "/tmp/beacon/runtime.jsonl") {
 		t.Fatalf("script did not include configured path: %s", got)
 	}
@@ -142,5 +146,82 @@ func TestPackREADMEMentionsSumoSetupAndProductionForwarding(t *testing.T) {
 		if !strings.Contains(readme, want) {
 			t.Fatalf("pack README missing %q", want)
 		}
+	}
+}
+
+func TestFiles_NoError(t *testing.T) {
+	files, err := Files()
+	if err != nil {
+		t.Fatalf("Files() returned unexpected error: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("Files() returned no files")
+	}
+}
+
+func TestFiles_ContainsAllRequiredNames(t *testing.T) {
+	files, err := Files()
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make(map[string]bool)
+	for _, f := range files {
+		names[f.Name] = true
+	}
+	for _, required := range []string{
+		"README.md", "sumo-upload-smoke-test.sh", "sample-event.jsonl", "vector.toml",
+	} {
+		if !names[required] {
+			t.Errorf("Files() missing required file %q", required)
+		}
+	}
+}
+
+func TestFilesFromFS_PropagatesReadError(t *testing.T) {
+	emptyFS := fstest.MapFS{}
+	_, err := filesFromFS(emptyFS, DefaultLogPath)
+	if err == nil {
+		t.Fatal("filesFromFS with empty FS should return an error")
+	}
+	if !strings.Contains(err.Error(), "sumo pack asset") {
+		t.Fatalf("error should identify the pack source, got: %v", err)
+	}
+}
+
+func TestUploadSmokeTestFromFS_ErrorOnMissingAsset(t *testing.T) {
+	emptyFS := fstest.MapFS{}
+	_, err := uploadSmokeTestFromFS(emptyFS, "/some/path.jsonl")
+	if err == nil {
+		t.Fatal("uploadSmokeTestFromFS with empty FS should return error")
+	}
+	if !strings.Contains(err.Error(), "sumo pack asset") {
+		t.Fatalf("error should identify the pack source, got: %v", err)
+	}
+}
+
+func TestInstallPack_ErrorOnWriteFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: filesystem permission restrictions do not apply")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Skip("cannot set directory permissions:", err)
+	}
+	defer os.Chmod(dir, 0755)
+
+	subdir := filepath.Join(dir, "output")
+	err := InstallPack(subdir, DefaultLogPath)
+	if err == nil {
+		t.Fatal("InstallPack into read-only directory should return error")
+	}
+}
+
+func TestUploadSmokeTest_DefaultLogPath(t *testing.T) {
+	got, err := UploadSmokeTest("")
+	if err != nil {
+		t.Fatalf("UploadSmokeTest with empty path returned error: %v", err)
+	}
+	if !strings.Contains(got, DefaultLogPath) {
+		t.Fatalf("UploadSmokeTest with empty logPath should use DefaultLogPath %q, got: %s", DefaultLogPath, got)
 	}
 }


### PR DESCRIPTION
## Problem

Four packages (`elastic`, `datadog`, `sumo`, `rapid7`) each had a `mustRead()` function that called `panic()` if an embedded asset could not be read:

```go
func mustRead(path string) string {
    data, err := packFS.ReadFile(path)
    if err != nil {
        panic(fmt.Sprintf("... pack asset %s: %v", path, err))
    }
    return string(data)
}
```

This function was called directly from `Files()`, `InputSnippet()`, `ConfigSnippet()`, `UploadSmokeTest()`, and `standaloneAgentConfig()` — all of which would crash the entire process with an unrecoverable panic if any embedded asset was missing.

While `go:embed` makes asset absence impossible in a correctly-built binary, `panic` is still wrong for library code:

- It crashes the entire process; callers have no way to handle or report the failure gracefully
- It makes the functions untestable for error paths (no way to inject a failing FS)
- It conflates "build-time invariant" with "runtime error handling"

The four `print-config` commands in `cmd/endpoint.go` used `Run` (not `RunE`) and called these functions without any error handling, so any failure would crash the process silently rather than returning a proper exit code.

## Changes

**Source packages** (`elastic`, `datadog`, `sumo`, `rapid7`):
- Added `readAsset(path string) (string, error)` — the safe, error-returning helper
- Added `filesFromFS(fsys fs.FS, logPath string) ([]File, error)` — takes an injected `fs.FS` so tests can exercise error paths
- Added `inputSnippetFromFS` / `configSnippetFromFS` / `uploadSmokeTestFromFS` helpers for the same reason
- Changed `Files()` to return `([]File, error)` instead of `[]File`
- Changed `InputSnippet`, `ConfigSnippet`, `UploadSmokeTest` to return `(string, error)`
- Changed `InstallPack()` to propagate errors from all asset reads
- Retained `mustRead()` as a panic wrapper — it is only used in test code where the embedded FS is always present and a panic is caught by the test runner

**`cmd/endpoint.go`**:
- Changed the four `print-config` command handlers from `Run` to `RunE`
- Added `SilenceUsage: true` to all four (consistent with other commands)
- Each now checks the error returned by the snippet function and returns it

## Tests added

Each package gains six new tests:

| Test | What it verifies |
|------|-----------------|
| `TestFiles_NoError` | `Files()` returns no error with real embedded FS |
| `TestFiles_ContainsAllRequiredNames` | `Files()` includes all expected file names |
| `TestFilesFromFS_PropagatesReadError` | Empty `fstest.MapFS` causes an error with the right prefix |
| `TestInputSnippetFromFS_ErrorOnMissingAsset` (etc.) | Snippet helper propagates error from bad FS |
| `TestInstallPack_ErrorOnWriteFailure` | `InstallPack` returns error on unwritable directory (skipped when running as root) |
| `TestInputSnippet_DefaultLogPath` (etc.) | Empty log path falls back to `DefaultLogPath` |

## Testing

All tests pass:

```
ok  github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/elastic
ok  github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/datadog
ok  github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/sumo
ok  github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/rapid7
```

Pre-existing failures in `internal/embedded` and `internal/endpoint/hooks` are unrelated (macOS Mach-O binary embedded in a Linux test environment) and present on `main` before this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVJYLLritTma2nLPPPP96D)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to error handling and CLI exit codes for integration config generation; no auth, data, or runtime telemetry path changes.
> 
> **Overview**
> Replaces **panic-on-missing-embed** behavior in the **elastic**, **datadog**, **sumo**, and **rapid7** endpoint pack helpers with **returned errors**, and wires the CLI to surface them instead of crashing.
> 
> Pack APIs such as `Files()`, `InputSnippet` / `ConfigSnippet` / `UploadSmokeTest`, and `InstallPack` now propagate read/render failures. Production paths use `readAsset` and injectable `*FromFS` helpers via `siempack.ReadFile`; `mustRead` remains for tests only. The four `endpoint … print-config` commands switch to **`RunE`**, set **`SilenceUsage: true`**, and return errors from snippet generation.
> 
> Each integration package gains tests for successful `Files()`, required filenames, empty `fstest.MapFS` errors, default log path, and `InstallPack` write failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3c90ce5ea6975e3a11631980811491f2217dbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->