### PR TITLE
add VS Code endpoint telemetry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Claude Cowork, OpenClaw).
 | [Grok Build](https://docs.asymptotelabs.ai/cli/supported-runtimes-grok-build) | Beacon hook adapter |
 | [OpenClaw Gateway](https://docs.asymptotelabs.ai/cli/supported-runtimes-openclaw-gateway) | Gateway-configured OTLP/HTTP export |
 | [OpenCode](https://docs.asymptotelabs.ai/cli/supported-runtimes-opencode) | Beacon hook adapter |
+| VS Code | VS Code Copilot OpenTelemetry and optional Beacon hook adapter |
 
 ### SIEM / Output Destinations
 

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -18,6 +18,9 @@ func emitHookEvent(logger *logging.Logger, action, category, severity, message s
 	if platformFlag == "grok" {
 		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"grok": input})
 	}
+	if platformFlag == "vscode" {
+		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"vscode": input})
+	}
 	if model := getFirstStr(input, "model"); model != "" {
 		fields["model"] = model
 	}

--- a/cli/beacon-hooks/cmd/helpers.go
+++ b/cli/beacon-hooks/cmd/helpers.go
@@ -53,6 +53,8 @@ func resolveSessionID(input map[string]interface{}, platform string) string {
 		return getFirstStr(input, "sessionId", "session_id")
 	case "cursor":
 		return getFirstStr(input, "conversation_id")
+	case "vscode":
+		return getFirstStr(input, "sessionId", "session_id", "conversation_id", "gen_ai.conversation.id")
 	case "devin":
 		return getFirstStr(input, "session_id", "sessionId", "conversation_id")
 	case "grok":
@@ -83,6 +85,10 @@ func resolveSessionIDWithTranscript(input map[string]interface{}, platform strin
 	case "cursor":
 		sessionID = getFirstStr(input, "conversation_id")
 		transcriptPath = getFirstStr(input, "transcript_path")
+		return
+	case "vscode":
+		sessionID = getFirstStr(input, "sessionId", "session_id", "conversation_id", "gen_ai.conversation.id")
+		transcriptPath = getFirstStr(input, "transcript_path", "transcriptPath")
 		return
 	case "devin":
 		sessionID = getFirstStr(input, "session_id", "sessionId", "conversation_id")
@@ -136,7 +142,7 @@ func resolveCwd(input map[string]interface{}, platform string) string {
 		}
 		return ""
 	}
-	if platform == "cursor" {
+	if platform == "cursor" || platform == "vscode" {
 		if cwd := getFirstStr(input, "cwd"); cwd != "" {
 			return cwd
 		}
@@ -144,6 +150,14 @@ func resolveCwd(input map[string]interface{}, platform string) string {
 			if cwd, ok := roots[0].(string); ok && cwd != "" {
 				return cwd
 			}
+		}
+		if roots, ok := input["workspaceFolders"].([]interface{}); ok && len(roots) > 0 {
+			if cwd, ok := roots[0].(string); ok && cwd != "" {
+				return cwd
+			}
+		}
+		if platform == "vscode" {
+			return os.Getenv("VSCODE_CWD")
 		}
 		if cwd := os.Getenv("CURSOR_PROJECT_DIR"); cwd != "" {
 			return cwd

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -119,7 +119,7 @@ func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logge
 	var sessionID, toolName string
 	var toolInput, toolResponse map[string]interface{}
 
-	if platformFlag == "antigravity" || platformFlag == "copilot" || platformFlag == "devin" || platformFlag == "grok" {
+	if platformFlag == "antigravity" || platformFlag == "copilot" || platformFlag == "devin" || platformFlag == "grok" || platformFlag == "vscode" {
 		sessionID = resolveSessionID(input, platformFlag)
 		toolName = getFirstStr(input, "toolName", "tool_name")
 		if platformFlag == "antigravity" {
@@ -297,7 +297,7 @@ func emitPostToolObserved(logger *logging.Logger, input map[string]interface{}) 
 
 // isFileEditTool returns true if the tool name represents a file edit operation.
 func isFileEditTool(platform, toolName string) bool {
-	if platform == "copilot" {
+	if platform == "copilot" || platform == "vscode" {
 		lower := strings.ToLower(toolName)
 		return strings.Contains(lower, "edit") ||
 			strings.Contains(lower, "write") ||

--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -48,7 +48,7 @@ func runPreTool(cmd *cobra.Command, args []string) {
 	if platformFlag == "antigravity" {
 		emitAntigravityPromptFromTranscript(logger, input, sessionID)
 		emitPreToolObserved(logger, input, sessionID)
-	} else if platformFlag == "devin" || platformFlag == "grok" {
+	} else if platformFlag == "devin" || platformFlag == "grok" || platformFlag == "vscode" {
 		emitPreToolObserved(logger, input, sessionID)
 	} else {
 		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "Pre-tool observed")
@@ -75,7 +75,7 @@ func preToolResponse() map[string]interface{} {
 	if platformFlag == "antigravity" || platformFlag == "grok" {
 		return map[string]interface{}{"decision": "allow"}
 	}
-	if platformFlag == "devin" {
+	if platformFlag == "devin" || platformFlag == "vscode" {
 		return emptyResponse
 	}
 	return allowResponse

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -55,6 +55,67 @@ func TestRunPromptSubmitUsesCursorResponse(t *testing.T) {
 	}
 }
 
+func TestVSCodeHooksEmitLowNoiseTelemetry(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "vscode"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "full")
+
+	out := runHookWithInput(t, runPreTool, map[string]interface{}{
+		"sessionId":     "vscode-session",
+		"hookEventName": "PreToolUse",
+		"cwd":           "/repo",
+		"tool_name":     "runCommand",
+		"tool_input": map[string]interface{}{
+			"command": "go test ./...",
+		},
+	})
+	if len(out) != 0 {
+		t.Fatalf("vscode pre-tool output = %#v, want empty non-controlling response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "tool.invoked" {
+		t.Fatalf("event.action = %q, want tool.invoked", action)
+	}
+	if harness := event["harness"].(map[string]interface{})["name"]; harness != "vscode" {
+		t.Fatalf("harness = %q, want vscode", harness)
+	}
+	if _, ok := event["raw"].(map[string]interface{})["vscode"]; !ok {
+		t.Fatalf("raw.vscode missing: %#v", event["raw"])
+	}
+	if _, ok := event["prompt"]; ok {
+		t.Fatalf("metadata retention should omit prompt: %#v", event["prompt"])
+	}
+}
+
+func TestRunSubagentLifecycleEmitsVSCodeEvents(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "vscode"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	runHookWithInput(t, func(cmd *cobra.Command, args []string) {
+		runSubagentLifecycle("subagent.started", "Subagent started")
+	}, map[string]interface{}{
+		"sessionId":  "vscode-session",
+		"agent_id":   "agent-1",
+		"agent_type": "Plan",
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "subagent.started" {
+		t.Fatalf("event.action = %q, want subagent.started", action)
+	}
+	if harness := event["harness"].(map[string]interface{})["name"]; harness != "vscode" {
+		t.Fatalf("harness = %q, want vscode", harness)
+	}
+	if _, ok := event["tool"]; ok {
+		t.Fatalf("subagent event should not be encoded as tool: %#v", event["tool"])
+	}
+}
+
 func TestRunPromptSubmitEmitsFactoryPromptEvent(t *testing.T) {
 	setupHookConfigDirs(t)
 	platformFlag = "factory"
@@ -544,6 +605,7 @@ func setupHookConfigDirs(t *testing.T) {
 	origAntigravityDir := hookconfig.AntigravityDir
 	origCopilotDir := hookconfig.CopilotDir
 	origCursorDir := hookconfig.CursorDir
+	origVSCodeDir := hookconfig.VSCodeDir
 	origDevinDir := hookconfig.DevinDir
 	origFactoryDir := hookconfig.FactoryDir
 	origGrokDir := hookconfig.GrokDir
@@ -554,6 +616,7 @@ func setupHookConfigDirs(t *testing.T) {
 	hookconfig.AntigravityDir = filepath.Join(tmp, "antigravity")
 	hookconfig.CopilotDir = filepath.Join(tmp, "copilot")
 	hookconfig.CursorDir = filepath.Join(tmp, "cursor")
+	hookconfig.VSCodeDir = filepath.Join(tmp, "vscode")
 	hookconfig.DevinDir = filepath.Join(tmp, "devin")
 	hookconfig.FactoryDir = filepath.Join(tmp, "factory")
 	hookconfig.GrokDir = filepath.Join(tmp, "grok")
@@ -564,6 +627,7 @@ func setupHookConfigDirs(t *testing.T) {
 		hookconfig.AntigravityDir = origAntigravityDir
 		hookconfig.CopilotDir = origCopilotDir
 		hookconfig.CursorDir = origCursorDir
+		hookconfig.VSCodeDir = origVSCodeDir
 		hookconfig.DevinDir = origDevinDir
 		hookconfig.FactoryDir = origFactoryDir
 		hookconfig.GrokDir = origGrokDir

--- a/cli/beacon-hooks/cmd/root.go
+++ b/cli/beacon-hooks/cmd/root.go
@@ -11,8 +11,8 @@ var platformFlag string
 
 var rootCmd = &cobra.Command{
 	Use:   "beacon-hooks",
-	Short: "Beacon hooks for Claude Code, GitHub Copilot, Cursor, Devin, Factory, Grok, Antigravity, and opencode",
-	Long: `Beacon hooks binary for Claude Code, GitHub Copilot, Cursor, Devin, Factory, Grok, Antigravity, and opencode integration.
+	Short: "Beacon hooks for Claude Code, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Antigravity, and opencode",
+	Long: `Beacon hooks binary for Claude Code, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Antigravity, and opencode integration.
 
 This binary provides hook commands that are called by IDE plugin systems
 to evaluate code changes for security violations.
@@ -21,7 +21,7 @@ Use --platform to specify the calling platform (default: claude).`,
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, antigravity, copilot, cursor, devin, factory, grok, or opencode")
+	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, antigravity, copilot, cursor, vscode, devin, factory, grok, or opencode")
 }
 
 // Execute runs the root command

--- a/cli/beacon-hooks/cmd/stop.go
+++ b/cli/beacon-hooks/cmd/stop.go
@@ -81,6 +81,8 @@ func platformToTranscriptName(platform string) string {
 		return "copilot"
 	case "cursor":
 		return "cursor"
+	case "vscode":
+		return "vscode"
 	case "factory":
 		return "factory"
 	case "devin":
@@ -95,7 +97,7 @@ func extractMessages(transcriptPath, platform string) []map[string]interface{} {
 	switch platform {
 	case "copilot":
 		return extractMessagesFromCopilotTranscript(transcriptPath)
-	case "cursor":
+	case "cursor", "vscode":
 		return extractMessagesFromCursorTranscript(transcriptPath)
 	case "factory":
 		return extractMessagesFromFactoryTranscript(transcriptPath)

--- a/cli/beacon-hooks/cmd/subagent.go
+++ b/cli/beacon-hooks/cmd/subagent.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
+)
+
+var subagentStartCmd = &cobra.Command{
+	Use:   "subagent-start",
+	Short: "Record subagent start telemetry",
+	Run: func(cmd *cobra.Command, args []string) {
+		runSubagentLifecycle("subagent.started", "Subagent started")
+	},
+}
+
+var subagentStopCmd = &cobra.Command{
+	Use:   "subagent-stop",
+	Short: "Record subagent stop telemetry",
+	Run: func(cmd *cobra.Command, args []string) {
+		runSubagentLifecycle("subagent.stopped", "Subagent stopped")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(subagentStartCmd)
+	rootCmd.AddCommand(subagentStopCmd)
+}
+
+func runSubagentLifecycle(action, message string) {
+	input, err := readStdinJSON()
+	if err != nil {
+		outputJSON(emptyResponse)
+		return
+	}
+	sessionID := resolveSessionID(input, platformFlag)
+	var logger *logging.Logger
+	if sessionID != "" {
+		logger = logging.NewSessionLogger("subagent", platformFlag, sessionID)
+	} else {
+		logger = logging.NewLoggerForPlatform("subagent", platformFlag)
+	}
+	fields := sessionFields(sessionID, input)
+	fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"subagent": map[string]interface{}{
+		"id":   getFirstStr(input, "agent_id", "agentId"),
+		"type": getFirstStr(input, "agent_type", "agentType"),
+	}})
+	emitHookEvent(logger, action, "session", "info", message, input, fields)
+	outputJSON(emptyResponse)
+}

--- a/cli/beacon-hooks/internal/config/config.go
+++ b/cli/beacon-hooks/internal/config/config.go
@@ -14,6 +14,7 @@ var (
 	AntigravityDir = filepath.Join(BeaconDir, "antigravity")
 	CopilotDir     = filepath.Join(BeaconDir, "copilot")
 	CursorDir      = filepath.Join(BeaconDir, "cursor")
+	VSCodeDir      = filepath.Join(BeaconDir, "vscode")
 	DevinDir       = filepath.Join(BeaconDir, "devin")
 	FactoryDir     = filepath.Join(BeaconDir, "factory")
 	GrokDir        = filepath.Join(BeaconDir, "grok")
@@ -93,6 +94,8 @@ func GetStateDir(platform string) string {
 		return CopilotDir
 	case "cursor":
 		return CursorDir
+	case "vscode":
+		return VSCodeDir
 	case "devin":
 		return DevinDir
 	case "factory":

--- a/cli/beacon-hooks/internal/config/config_test.go
+++ b/cli/beacon-hooks/internal/config/config_test.go
@@ -14,6 +14,7 @@ func TestGetStateDir(t *testing.T) {
 		{"claude", ClaudeDir},
 		{"copilot", CopilotDir},
 		{"cursor", CursorDir},
+		{"vscode", VSCodeDir},
 		{"unknown", ClaudeDir}, // defaults to claude
 	}
 
@@ -35,6 +36,7 @@ func TestGetLogFile(t *testing.T) {
 		{"claude", "hooks.log"},
 		{"copilot", "hooks.log"},
 		{"cursor", "hooks.log"},
+		{"vscode", "hooks.log"},
 	}
 
 	for _, tt := range tests {
@@ -55,6 +57,7 @@ func TestGetSessionLogDir(t *testing.T) {
 		{"claude", "logs"},
 		{"copilot", "logs"},
 		{"cursor", "logs"},
+		{"vscode", "logs"},
 	}
 
 	for _, tt := range tests {
@@ -80,6 +83,7 @@ func TestGetSessionLogFile(t *testing.T) {
 		{"claude", "abc-123", "abc-123.log"},
 		{"copilot", "sess-456", "sess-456.log"},
 		{"cursor", "conv-789", "conv-789.log"},
+		{"vscode", "vscode-session", "vscode-session.log"},
 	}
 
 	for _, tt := range tests {

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -125,6 +125,11 @@ Beacon endpoint configuration.
 ./beacon endpoint integrations openclaw print-config
 ./beacon endpoint integrations openclaw status
 ./beacon endpoint integrations openclaw validate --since 10m
+
+./beacon endpoint integrations vscode setup
+./beacon endpoint integrations vscode status
+./beacon endpoint integrations vscode validate --since 10m
+./beacon endpoint hooks install --harness vscode --level project
 ```
 
 The opencode integration installs Beacon's owned local plugin at
@@ -156,6 +161,28 @@ with the `diagnostics-otel` plugin enabled. Beacon prints a local OTLP/HTTP
 configuration that points OpenClaw at the endpoint collector. OpenClaw does not
 export raw prompt, response, tool, or system-prompt content unless
 `diagnostics.otel.captureContent.*` is explicitly enabled.
+
+VS Code Copilot monitoring is configured in VS Code settings and exports
+OTLP/HTTP to Beacon's local collector. For a first-time local setup, install the
+endpoint collector with the VS Code harness, reload VS Code, and validate recent
+activity:
+
+```bash
+./beacon endpoint install --user --harness vscode
+./beacon endpoint integrations vscode validate --user --since 10m
+```
+
+VS Code hook support is optional and depends on the `Chat: Use Hooks` setting,
+which may be managed by the organization. When enabled, project-level hooks use
+`.github/hooks/beacon.json`:
+
+```bash
+cd /path/to/workspace
+beacon endpoint hooks install --harness vscode --level project --user
+```
+
+OTel-derived events use `harness.name=vscode_copilot`; hook-derived events use
+`harness.name=vscode`.
 
 ## Test
 

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -21,6 +21,7 @@ import (
 	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations/cowork"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations/openclaw"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations/vscode"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/rapid7"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
@@ -56,6 +57,10 @@ var endpointOpts struct {
 	coworkSince              string
 	openClawEndpoint         string
 	openClawSince            string
+	vscodeEndpoint           string
+	vscodeSince              string
+	vscodeWorkspace          string
+	vscodeCaptureContent     bool
 	elasticPackDir           string
 	hookLevel                string
 	contentRetention         string
@@ -374,6 +379,67 @@ var endpointOpenClawValidateCmd = &cobra.Command{
 	RunE:         func(cmd *cobra.Command, args []string) error { return runEndpointOpenClawValidate() },
 }
 
+var endpointVSCodeCmd = &cobra.Command{
+	Use:   "vscode",
+	Short: "Manage VS Code Copilot OpenTelemetry integration",
+}
+
+var endpointVSCodePrintConfigCmd = &cobra.Command{
+	Use:   "print-config",
+	Short: "Print VS Code Copilot OpenTelemetry setup guidance",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := loadOrDefaultConfig()
+		endpoint := endpointOpts.vscodeEndpoint
+		if endpoint == "" {
+			endpoint = fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort)
+		}
+		fmt.Print(vscode.PrintConfig(vscode.Config{
+			Endpoint:       endpoint,
+			CaptureContent: endpointOpts.vscodeCaptureContent,
+			WorkspacePath:  endpointOpts.vscodeWorkspace,
+		}))
+	},
+}
+
+var endpointVSCodeSetupCmd = &cobra.Command{
+	Use:          "setup",
+	Short:        "Configure VS Code Copilot OpenTelemetry for local Beacon collection",
+	SilenceUsage: true,
+	RunE:         func(cmd *cobra.Command, args []string) error { return runEndpointVSCodeSetup() },
+}
+
+var endpointVSCodeStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show VS Code endpoint integration status",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := loadOrDefaultConfig()
+		endpoint := endpointOpts.vscodeEndpoint
+		if endpoint == "" {
+			endpoint = fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort)
+		}
+		status := vscode.GetStatusForConfig(cfg.LogPath, endpoint, vscode.Config{
+			WorkspacePath: endpointOpts.vscodeWorkspace,
+		})
+		if endpointOpts.jsonOutput {
+			_ = json.NewEncoder(os.Stdout).Encode(status)
+			return
+		}
+		fmt.Printf("%s: detected=%t telemetry=%s", status.DisplayName, status.Detected, status.TelemetryStatus)
+		if status.LastEventObservedAt != "" {
+			fmt.Printf(" last=%s", status.LastEventObservedAt)
+		}
+		fmt.Println()
+		fmt.Println(status.Message)
+	},
+}
+
+var endpointVSCodeValidateCmd = &cobra.Command{
+	Use:          "validate",
+	Short:        "Validate whether VS Code events are arriving",
+	SilenceUsage: true,
+	RunE:         func(cmd *cobra.Command, args []string) error { return runEndpointVSCodeValidate() },
+}
+
 var endpointWazuhPrintConfigCmd = &cobra.Command{
 	Use:   "print-config",
 	Short: "Print a Wazuh localfile snippet",
@@ -556,6 +622,7 @@ func init() {
 	endpointIntegrationsCmd.AddCommand(endpointIntegrationsValidateCmd)
 	endpointIntegrationsCmd.AddCommand(endpointCoworkCmd)
 	endpointIntegrationsCmd.AddCommand(endpointOpenClawCmd)
+	endpointIntegrationsCmd.AddCommand(endpointVSCodeCmd)
 	endpointHooksCmd.AddCommand(endpointHooksInstallCmd)
 	endpointHooksCmd.AddCommand(endpointHooksUninstallCmd)
 	endpointHooksCmd.AddCommand(endpointHooksStatusCmd)
@@ -566,6 +633,10 @@ func init() {
 	endpointOpenClawCmd.AddCommand(endpointOpenClawPrintConfigCmd)
 	endpointOpenClawCmd.AddCommand(endpointOpenClawStatusCmd)
 	endpointOpenClawCmd.AddCommand(endpointOpenClawValidateCmd)
+	endpointVSCodeCmd.AddCommand(endpointVSCodePrintConfigCmd)
+	endpointVSCodeCmd.AddCommand(endpointVSCodeSetupCmd)
+	endpointVSCodeCmd.AddCommand(endpointVSCodeStatusCmd)
+	endpointVSCodeCmd.AddCommand(endpointVSCodeValidateCmd)
 
 	for _, c := range []*cobra.Command{endpointInstallCmd, endpointStatusCmd, endpointDoctorCmd, endpointInventoryCmd, endpointDiscoverCmd, endpointTestEventCmd, endpointBundleDiagnosticsCmd, endpointUninstallCmd, endpointRepairCmd, endpointConfigShowCmd, endpointConfigValidateCmd, endpointConfigSetRetentionCmd, endpointIntegrationsValidateCmd, topLevelDoctorCmd, topLevelStatusCmd, topLevelInventoryCmd} {
 		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
@@ -680,6 +751,17 @@ func init() {
 	endpointOpenClawValidateCmd.Flags().StringVar(&endpointOpts.openClawEndpoint, "endpoint", "", "OTLP HTTP endpoint to show when validation fails")
 	endpointOpenClawValidateCmd.Flags().StringVar(&endpointOpts.openClawSince, "since", "", "Require an OpenClaw event within this duration, such as 10m")
 	endpointOpenClawStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
+	for _, c := range []*cobra.Command{endpointVSCodePrintConfigCmd, endpointVSCodeSetupCmd, endpointVSCodeStatusCmd, endpointVSCodeValidateCmd} {
+		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
+		c.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
+		c.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
+		c.Flags().StringVar(&endpointOpts.vscodeEndpoint, "endpoint", "", "OTLP HTTP endpoint for VS Code Copilot")
+		c.Flags().StringVar(&endpointOpts.vscodeWorkspace, "workspace", "", "Workspace path for .vscode/settings.json")
+		c.Flags().BoolVar(&endpointOpts.vscodeCaptureContent, "capture-content", false, "Enable full Copilot prompt, response, tool argument, and tool result capture")
+	}
+	endpointVSCodeSetupCmd.Flags().BoolVar(&endpointOpts.dryRun, "dry-run", false, "Print VS Code setup guidance without changing settings")
+	endpointVSCodeValidateCmd.Flags().StringVar(&endpointOpts.vscodeSince, "since", "", "Require a VS Code event within this duration, such as 10m")
+	endpointVSCodeStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
 	for _, c := range []*cobra.Command{endpointHooksInstallCmd, endpointHooksUninstallCmd, endpointHooksStatusCmd} {
 		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
 		c.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
@@ -729,6 +811,16 @@ func runEndpointHooksInstall(cmd *cobra.Command, args []string) error {
 				return err
 			}
 			fmt.Printf("Cursor hooks installed: %s\n", status.HooksJSONPath)
+		case "vscode", "vs_code":
+			status, err := endpointhooks.InstallVSCode(endpointhooks.VSCodeOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("VS Code hooks installed: %s\n", status.HooksPath)
 		case "factory", "droid":
 			status, err := endpointhooks.InstallFactory(endpointhooks.FactoryOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -811,6 +903,16 @@ func runEndpointHooksUninstall(cmd *cobra.Command, args []string) error {
 				return err
 			}
 			fmt.Println(status.Message)
+		case "vscode", "vs_code":
+			status, err := endpointhooks.UninstallVSCode(endpointhooks.VSCodeOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Println(status.Message)
 		case "factory", "droid":
 			status, err := endpointhooks.UninstallFactory(endpointhooks.FactoryOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -876,6 +978,12 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
+		case "vscode", "vs_code":
+			statuses["vscode"] = endpointhooks.VSCodeHookStatus(endpointhooks.VSCodeOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
 		case "factory", "droid":
 			statuses["factory"] = endpointhooks.FactoryHookStatus(endpointhooks.FactoryOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -917,6 +1025,10 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 		case "cursor":
 			status := statuses["cursor"].(endpointhooks.CursorStatus)
 			fmt.Printf("Cursor hooks: installed=%t path=%s\n", status.Installed, status.HooksJSONPath)
+			fmt.Println(status.Message)
+		case "vscode", "vs_code":
+			status := statuses["vscode"].(endpointhooks.VSCodeStatus)
+			fmt.Printf("VS Code hooks: installed=%t path=%s\n", status.Installed, status.HooksPath)
 			fmt.Println(status.Message)
 		case "factory", "droid":
 			status := statuses["factory"].(endpointhooks.FactoryStatus)
@@ -1066,6 +1178,72 @@ func runEndpointOpenClawValidate() error {
 		fmt.Println("OpenClaw OTLP-derived events observed in endpoint runtime log.")
 	}
 	fmt.Println("Validation confirms at least one OpenClaw event reached Beacon; it does not prove logs, traces, and metrics are each flowing.")
+	return nil
+}
+
+func runEndpointVSCodeSetup() error {
+	cfg := loadOrDefaultConfig()
+	endpoint := endpointOpts.vscodeEndpoint
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort)
+	}
+	setup := vscode.Config{
+		Endpoint:       endpoint,
+		CaptureContent: endpointOpts.vscodeCaptureContent,
+		WorkspacePath:  endpointOpts.vscodeWorkspace,
+	}
+	if endpointOpts.dryRun {
+		fmt.Print(vscode.PrintConfig(setup))
+		return nil
+	}
+	path, err := vscode.Setup(setup)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("VS Code Copilot OTel settings written to %s\n", path)
+	return nil
+}
+
+func runEndpointVSCodeValidate() error {
+	cfg := loadOrDefaultConfig()
+	endpoint := endpointOpts.vscodeEndpoint
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort)
+	}
+	setup := func() {
+		fmt.Print(vscode.PrintConfig(vscode.Config{
+			Endpoint:       endpoint,
+			CaptureContent: endpointOpts.vscodeCaptureContent,
+			WorkspacePath:  endpointOpts.vscodeWorkspace,
+		}))
+	}
+	if endpointOpts.vscodeSince != "" {
+		duration, err := time.ParseDuration(endpointOpts.vscodeSince)
+		if err != nil {
+			return fmt.Errorf("--since must be a duration such as 10m: %w", err)
+		}
+		since := time.Now().Add(-duration)
+		if !vscode.HasVSCodeEventSince(cfg.LogPath, since) {
+			setup()
+			return fmt.Errorf("no VS Code events observed in %s since %s", cfg.LogPath, since.UTC().Format(time.RFC3339))
+		}
+		fmt.Printf("VS Code events observed in endpoint runtime log since %s.\n", since.UTC().Format(time.RFC3339))
+		fmt.Println("Validation confirms at least one low-noise VS Code event reached Beacon.")
+		return nil
+	}
+	status := vscode.GetStatusForConfig(cfg.LogPath, endpoint, vscode.Config{
+		WorkspacePath: endpointOpts.vscodeWorkspace,
+	})
+	if !status.LastEventObserved {
+		setup()
+		return fmt.Errorf("no VS Code events observed in %s", cfg.LogPath)
+	}
+	if status.LastEventObservedAt != "" {
+		fmt.Printf("VS Code events observed in endpoint runtime log. Last observed: %s.\n", status.LastEventObservedAt)
+	} else {
+		fmt.Println("VS Code events observed in endpoint runtime log.")
+	}
+	fmt.Println("Validation confirms at least one low-noise VS Code event reached Beacon.")
 	return nil
 }
 
@@ -1223,7 +1401,7 @@ func runEndpointInstall(cmd *cobra.Command, args []string) error {
 	result, err := lifecycle.Install(lifecycle.InstallOptions{
 		UserMode:              endpointUserMode(),
 		LogPath:               endpointOpts.logPath,
-		Harnesses:             splitCSV(endpointOpts.harnesses),
+		Harnesses:             splitHarnessCSV(endpointOpts.harnesses),
 		GRPCPort:              endpointOpts.grpcPort,
 		HTTPPort:              endpointOpts.httpPort,
 		CollectorPath:         endpointOpts.collectorPath,
@@ -1356,7 +1534,7 @@ func runEndpointRepair(cmd *cobra.Command, args []string) error {
 	result, err := lifecycle.Repair(lifecycle.InstallOptions{
 		UserMode:              endpointUserMode(),
 		LogPath:               endpointOpts.logPath,
-		Harnesses:             splitCSV(endpointOpts.harnesses),
+		Harnesses:             splitHarnessCSV(endpointOpts.harnesses),
 		GRPCPort:              endpointOpts.grpcPort,
 		HTTPPort:              endpointOpts.httpPort,
 		CollectorPath:         endpointOpts.collectorPath,
@@ -1416,6 +1594,13 @@ func splitCSV(value string) []string {
 		}
 	}
 	return out
+}
+
+func splitHarnessCSV(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return []string{}
+	}
+	return splitCSV(value)
 }
 
 func registerSplunkFlags(cmd *cobra.Command) {

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -326,7 +326,7 @@ func plannedInstallActions(repair bool) []plannedAction {
 		plannedAction{Action: "write_plist", Message: "launchd service definition"},
 		plannedAction{Action: "write_file", Target: endpointconfig.ConfigPath(cfg.UserMode), Message: "endpoint configuration"},
 	)
-	for _, h := range splitCSV(endpointOpts.harnesses) {
+	for _, h := range splitHarnessCSV(endpointOpts.harnesses) {
 		actions = append(actions, plannedAction{Action: "configure_harness", Target: h})
 	}
 	if !endpointOpts.noStart {
@@ -367,7 +367,7 @@ func printPlannedActions(actions []plannedAction) error {
 
 func hookTargets() []string {
 	if endpointOpts.allTargets {
-		return []string{"cursor", "factory", "opencode", "grok", "devin", "antigravity"}
+		return []string{"cursor", "vscode", "factory", "opencode", "grok", "devin", "antigravity"}
 	}
 	return splitCSV(endpointOpts.hookHarnesses)
 }
@@ -387,6 +387,9 @@ func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[str
 		case "cursor":
 			status := endpointhooks.CursorHookStatus(endpointhooks.CursorOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksJSONPath, Raw: status}
+		case "vscode", "vs_code":
+			status := endpointhooks.VSCodeHookStatus(endpointhooks.VSCodeOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
 		case "factory", "droid":
 			status := endpointhooks.FactoryHookStatus(endpointhooks.FactoryOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.SettingsPath, Raw: status}

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -28,6 +28,17 @@ func TestSplitCSV(t *testing.T) {
 	}
 }
 
+func TestSplitHarnessCSVAllowsCollectorOnly(t *testing.T) {
+	got := splitHarnessCSV("")
+	if len(got) != 0 {
+		t.Fatalf("splitHarnessCSV empty = %#v, want empty slice", got)
+	}
+	got = splitHarnessCSV("claude,codex")
+	if len(got) != 2 || got[0] != "claude" || got[1] != "codex" {
+		t.Fatalf("splitHarnessCSV populated = %#v, want claude/codex", got)
+	}
+}
+
 func TestEndpointDashboardCommandRegistered(t *testing.T) {
 	cmd, _, err := endpointCmd.Find([]string{"dashboard"})
 	if err != nil {
@@ -109,6 +120,37 @@ func TestEndpointOpenClawCommandsRegistered(t *testing.T) {
 	}
 	if endpointOpenClawValidateCmd.Flags().Lookup("since") == nil {
 		t.Fatal("openclaw validate command missing --since flag")
+	}
+}
+
+func TestEndpointVSCodeCommandsRegistered(t *testing.T) {
+	for _, path := range [][]string{
+		{"integrations", "vscode", "print-config"},
+		{"integrations", "vscode", "setup"},
+		{"integrations", "vscode", "status"},
+		{"integrations", "vscode", "validate"},
+	} {
+		cmd, _, err := endpointCmd.Find(path)
+		if err != nil {
+			t.Fatalf("Find %v returned error: %v", path, err)
+		}
+		if cmd == nil || cmd.Use != path[len(path)-1] {
+			t.Fatalf("vscode command %v not registered: %#v", path, cmd)
+		}
+	}
+	for _, name := range []string{"endpoint", "workspace", "capture-content"} {
+		if endpointVSCodeSetupCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("vscode setup command missing --%s flag", name)
+		}
+	}
+	if endpointVSCodeSetupCmd.Flags().Lookup("dry-run") == nil {
+		t.Fatal("vscode setup command missing --dry-run flag")
+	}
+	if endpointVSCodeStatusCmd.Flags().Lookup("json") == nil {
+		t.Fatal("vscode status command missing --json flag")
+	}
+	if endpointVSCodeValidateCmd.Flags().Lookup("since") == nil {
+		t.Fatal("vscode validate command missing --since flag")
 	}
 }
 

--- a/cli/beacon/internal/endpoint/dashboard/events_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/events_test.go
@@ -154,6 +154,51 @@ func TestBuildSummaryAggregatesSignals(t *testing.T) {
 	}
 }
 
+func TestDashboardAPIsSurfaceVSCodeEvents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	events := []schema.Event{
+		testSchemaEvent("2026-05-13T01:00:00Z", "vscode", "prompt.submitted", "prompt", "repo-a"),
+		testSchemaEvent("2026-05-13T01:01:00Z", "vscode_copilot", "tool.invoked", "tool", "repo-a"),
+		testSchemaEvent("2026-05-13T01:02:00Z", "vscode", "file.modified", "file", "repo-a"),
+	}
+	events[1].Tool = &schema.ToolInfo{Name: "runCommand"}
+	events[2].File = &schema.FileInfo{Path: "main.go", Operation: "modify", Language: "go"}
+	writeTestLog(t, path, marshalEvents(t, events...)...)
+
+	handler, err := Handler(Options{UserMode: true, LogPath: path})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/summary", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("summary status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var summary Summary
+	if err := json.Unmarshal(rec.Body.Bytes(), &summary); err != nil {
+		t.Fatalf("unmarshal summary: %v", err)
+	}
+	if summary.CountsByHarness["vscode"] != 2 || summary.CountsByHarness["vscode_copilot"] != 1 {
+		t.Fatalf("VS Code harness counts = %#v", summary.CountsByHarness)
+	}
+	if summary.PromptEvents != 1 || summary.ToolEvents != 1 || summary.FileEvents != 1 {
+		t.Fatalf("signal counts = prompt %d tool %d file %d", summary.PromptEvents, summary.ToolEvents, summary.FileEvents)
+	}
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/events?harness=vscode", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("events status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var result EventResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal events: %v", err)
+	}
+	if result.TotalMatched != 2 {
+		t.Fatalf("vscode filtered events = %d, want 2", result.TotalMatched)
+	}
+}
+
 func TestReadEventsFreeTextSearchMatchesStructuredFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "runtime.jsonl")
 	events := []schema.Event{

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -1,6 +1,7 @@
 package harness
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -52,6 +53,7 @@ func DiscoverAll() []Harness {
 		DiscoverCopilotCLI(),
 		DiscoverOpenCode(),
 		DiscoverFactory(),
+		DiscoverVSCode(),
 		DiscoverCursor(),
 		DiscoverDevin(),
 		DiscoverClaudeCowork(),
@@ -327,6 +329,7 @@ func ValidateConfigured(endpoint string) []ValidationResult {
 	gemini := DiscoverGemini()
 	copilot := discoverCopilotCLI(endpoint)
 	factory := DiscoverFactory()
+	vscode := discoverVSCode(endpoint)
 	return []ValidationResult{
 		{
 			Harness: claude.Name,
@@ -352,6 +355,11 @@ func ValidateConfigured(endpoint string) []ValidationResult {
 			Harness: factory.Name,
 			Status:  factory.TelemetryStatus,
 			Message: validateEndpointMessage(factory.TelemetryStatus, factory.Message, endpoint),
+		},
+		{
+			Harness: vscode.Name,
+			Status:  vscode.TelemetryStatus,
+			Message: validateEndpointMessage(vscode.TelemetryStatus, vscode.Message, endpoint),
 		},
 	}
 }
@@ -564,10 +572,10 @@ func factoryProfilePath(home string) string {
 }
 
 func commandVersion(path string) string {
-	cmd := exec.Command(path, "--version")
-	timer := time.AfterFunc(2*time.Second, func() { _ = cmd.Process.Kill() })
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, "--version")
 	out, err := cmd.CombinedOutput()
-	timer.Stop()
 	if err != nil {
 		return "unknown"
 	}

--- a/cli/beacon/internal/endpoint/harness/vscode.go
+++ b/cli/beacon/internal/endpoint/harness/vscode.go
@@ -1,0 +1,205 @@
+package harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	VSCodeName        = "vscode"
+	VSCodeCopilotName = "vscode_copilot"
+)
+
+type VSCodeConfigOptions struct {
+	Endpoint       string
+	CaptureContent bool
+	WorkspacePath  string
+}
+
+func DiscoverVSCode() Harness {
+	return discoverVSCode("")
+}
+
+func discoverVSCode(expectedEndpoint string) Harness {
+	h := Harness{Name: VSCodeName, DisplayName: "VS Code", Capability: "otel_hooks"}
+	if path, err := exec.LookPath("code"); err == nil {
+		h.Detected = true
+		h.ExecutablePath = path
+		h.Version = commandVersion(path)
+	}
+	settingsPath, err := VSCodeUserSettingsPath()
+	if err == nil {
+		h.ConfigPath = settingsPath
+	}
+	if !h.Detected {
+		for _, candidate := range vscodeUserDataDirs() {
+			if dirExists(candidate) {
+				h.Detected = true
+				break
+			}
+		}
+	}
+	status, msg := VSCodeOTelStatus(h.ConfigPath, expectedEndpoint)
+	h.TelemetryStatus = status
+	h.Message = msg
+	return h
+}
+
+func VSCodeUserSettingsPath() (string, error) {
+	return vscodeUserSettingsPath(runtime.GOOS)
+}
+
+func vscodeUserSettingsPath(goos string) (string, error) {
+	dirs := vscodeUserDataDirsForOS(goos)
+	if len(dirs) == 0 {
+		return "", fmt.Errorf("unsupported operating system %q", goos)
+	}
+	return filepath.Join(dirs[0], "User", "settings.json"), nil
+}
+
+func vscodeUserDataDirs() []string {
+	return vscodeUserDataDirsForOS(runtime.GOOS)
+}
+
+func vscodeUserDataDirsForOS(goos string) []string {
+	switch goos {
+	case "darwin":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		return []string{filepath.Join(home, "Library", "Application Support", "Code")}
+	case "linux":
+		base := os.Getenv("XDG_CONFIG_HOME")
+		if base == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return nil
+			}
+			base = filepath.Join(home, ".config")
+		}
+		return []string{filepath.Join(base, "Code")}
+	case "windows":
+		base := os.Getenv("APPDATA")
+		if base == "" {
+			return nil
+		}
+		return []string{filepath.Join(base, "Code")}
+	default:
+		return nil
+	}
+}
+
+func VSCodeWorkspaceSettingsPath(workspacePath string) (string, error) {
+	if workspacePath == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		workspacePath = cwd
+	}
+	return filepath.Join(workspacePath, ".vscode", "settings.json"), nil
+}
+
+func ConfigureVSCode(opts VSCodeConfigOptions) (string, error) {
+	if opts.Endpoint == "" {
+		opts.Endpoint = "http://127.0.0.1:4318"
+	}
+	path, err := VSCodeUserSettingsPath()
+	if opts.WorkspacePath != "" {
+		path, err = VSCodeWorkspaceSettingsPath(opts.WorkspacePath)
+	}
+	if err != nil {
+		return "", err
+	}
+	settings := map[string]interface{}{}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return "", fmt.Errorf("VS Code settings JSON is invalid: %w", err)
+		}
+		if err := backup(path, data); err != nil {
+			return "", err
+		}
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	settings["github.copilot.chat.otel.enabled"] = true
+	settings["github.copilot.chat.otel.exporterType"] = "otlp-http"
+	settings["github.copilot.chat.otel.otlpEndpoint"] = opts.Endpoint
+	settings["github.copilot.chat.otel.captureContent"] = opts.CaptureContent
+	settings["github.copilot.chat.otel.maxAttributeSizeChars"] = 8192
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return "", err
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return path, os.WriteFile(path, data, 0600)
+}
+
+func VSCodeOTelStatus(path, expectedEndpoint string) (TelemetryStatus, string) {
+	if path == "" {
+		return TelemetryMissing, "VS Code settings path could not be resolved"
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return TelemetryMissing, "VS Code settings.json was not found"
+		}
+		return TelemetryMissing, err.Error()
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return TelemetryMisconfigured, "VS Code settings JSON is invalid"
+	}
+	if vscodeSettingString(settings, "github.copilot.chat.otel.exporterType") == "file" ||
+		vscodeSettingString(settings, "github.copilot.chat.otel.outfile") != "" {
+		return TelemetryMisconfigured, "VS Code Copilot OTel file exporter is configured and will bypass local OTLP"
+	}
+	enabled := truthySetting(vscodeSettingString(settings, "github.copilot.chat.otel.enabled"))
+	endpoint := vscodeSettingString(settings, "github.copilot.chat.otel.otlpEndpoint")
+	if !enabled && endpoint == "" {
+		return TelemetryDisabled, "VS Code Copilot OTel is not enabled"
+	}
+	if endpoint == "" {
+		endpoint = "http://localhost:4318"
+	}
+	if !localVSCodeOTLPEndpointMatches(endpoint, expectedEndpoint) {
+		return TelemetryMisconfigured, "VS Code Copilot OTLP endpoint does not point to the local Beacon HTTP receiver"
+	}
+	return TelemetryEnabled, "VS Code Copilot OTel is configured for local OTLP HTTP"
+}
+
+func vscodeSettingString(settings map[string]interface{}, key string) string {
+	value, ok := settings[key]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func localVSCodeOTLPEndpointMatches(endpoint, expectedEndpoint string) bool {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host != "127.0.0.1" && host != "localhost" {
+		return false
+	}
+	if expectedEndpoint == "" {
+		return true
+	}
+	expected, err := url.Parse(expectedEndpoint)
+	if err != nil || expected.Port() == "" {
+		return true
+	}
+	return parsed.Port() == expected.Port()
+}

--- a/cli/beacon/internal/endpoint/harness/vscode_test.go
+++ b/cli/beacon/internal/endpoint/harness/vscode_test.go
@@ -1,0 +1,98 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVSCodeUserSettingsPathByOS(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+
+	tests := []struct {
+		goos string
+		want string
+	}{
+		{"darwin", filepath.Join(home, "Library", "Application Support", "Code", "User", "settings.json")},
+		{"linux", filepath.Join(home, "xdg", "Code", "User", "settings.json")},
+		{"windows", filepath.Join(home, "AppData", "Roaming", "Code", "User", "settings.json")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.goos, func(t *testing.T) {
+			got, err := vscodeUserSettingsPath(tt.goos)
+			if err != nil {
+				t.Fatalf("vscodeUserSettingsPath returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("settings path = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigureVSCodePreservesSettingsAndDisablesContentCaptureByDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, "Library", "Application Support", "Code", "User", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"editor.formatOnSave":true}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ConfigureVSCode(VSCodeConfigOptions{Endpoint: "http://127.0.0.1:54318"})
+	if err != nil {
+		t.Fatalf("ConfigureVSCode returned error: %v", err)
+	}
+	if got != path {
+		t.Fatalf("configured path = %q, want %q", got, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`"editor.formatOnSave": true`,
+		`"github.copilot.chat.otel.enabled": true`,
+		`"github.copilot.chat.otel.exporterType": "otlp-http"`,
+		`"github.copilot.chat.otel.otlpEndpoint": "http://127.0.0.1:54318"`,
+		`"github.copilot.chat.otel.captureContent": false`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("settings missing %q:\n%s", want, text)
+		}
+	}
+	backups, err := filepath.Glob(path + ".beacon.*.bak")
+	if err != nil {
+		t.Fatalf("glob backups: %v", err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("backups = %#v, want one timestamped backup", backups)
+	}
+}
+
+func TestVSCodeOTelStatus(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{"github.copilot.chat.otel.enabled":true,"github.copilot.chat.otel.otlpEndpoint":"http://127.0.0.1:4318"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	status, msg := VSCodeOTelStatus(path, "http://127.0.0.1:4318")
+	if status != TelemetryEnabled {
+		t.Fatalf("status = %s msg=%s, want enabled", status, msg)
+	}
+
+	if err := os.WriteFile(path, []byte(`{"github.copilot.chat.otel.enabled":true,"github.copilot.chat.otel.otlpEndpoint":"https://example.com"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	status, _ = VSCodeOTelStatus(path, "http://127.0.0.1:4318")
+	if status != TelemetryMisconfigured {
+		t.Fatalf("remote endpoint status = %s, want misconfigured", status)
+	}
+}

--- a/cli/beacon/internal/endpoint/hooks/vscode.go
+++ b/cli/beacon/internal/endpoint/hooks/vscode.go
@@ -1,0 +1,190 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type VSCodeOptions struct {
+	Level    Level
+	LogPath  string
+	UserMode bool
+}
+
+type VSCodeStatus struct {
+	Installed  bool   `json:"installed"`
+	BinaryPath string `json:"binary_path,omitempty"`
+	HooksPath  string `json:"hooks_path,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+type vscodeHookRef struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+}
+
+type vscodeHooksFile struct {
+	Hooks map[string][]vscodeHookRef `json:"hooks"`
+}
+
+var vscodeRuntime = hookRuntime{
+	displayName: "VS Code",
+	configPath:  vscodeHooksPath,
+	install:     installVSCodeHooks,
+	uninstall:   removeVSCodeEndpointHooks,
+	isInstalled: isVSCodeInstalledAt,
+}
+
+func InstallVSCode(opts VSCodeOptions) (VSCodeStatus, error) {
+	status, err := installRuntimeHooks(vscodeRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return VSCodeStatus{}, err
+	}
+	return vscodeStatusFromRuntime(status), nil
+}
+
+func UninstallVSCode(opts VSCodeOptions) (VSCodeStatus, error) {
+	status, err := uninstallRuntimeHooks(vscodeRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return VSCodeStatus{}, err
+	}
+	return vscodeStatusFromRuntime(status), nil
+}
+
+func VSCodeHookStatus(opts VSCodeOptions) VSCodeStatus {
+	return vscodeStatusFromRuntime(runtimeHookStatus(vscodeRuntime, RuntimeOptions(opts)))
+}
+
+func vscodeStatusFromRuntime(status runtimeStatus) VSCodeStatus {
+	return VSCodeStatus{
+		Installed:  status.Installed,
+		BinaryPath: status.BinaryPath,
+		HooksPath:  status.ConfigPath,
+		Message:    status.Message,
+	}
+}
+
+func installVSCodeHooks(path, binaryPath, logPath, configPath string) error {
+	hooksFile, err := readVSCodeHooks(path)
+	if err != nil {
+		return err
+	}
+	prefix := endpointCommandPrefix("vscode", binaryPath, logPath, configPath)
+	endpointHooks := map[string]vscodeHookRef{
+		"SessionStart":     {Type: "command", Command: prefix + " session-start"},
+		"UserPromptSubmit": {Type: "command", Command: prefix + " prompt-submit", Timeout: 30},
+		"PreToolUse":       {Type: "command", Command: prefix + " pre-tool"},
+		"PostToolUse":      {Type: "command", Command: prefix + " post-tool"},
+		"SubagentStart":    {Type: "command", Command: prefix + " subagent-start"},
+		"SubagentStop":     {Type: "command", Command: prefix + " subagent-stop"},
+		"Stop":             {Type: "command", Command: prefix + " stop", Timeout: 45},
+	}
+	for eventName, ref := range endpointHooks {
+		hooksFile.Hooks[eventName] = mergeVSCodeEndpointHook(hooksFile.Hooks[eventName], ref)
+	}
+	data, err := json.MarshalIndent(hooksFile, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+func readVSCodeHooks(path string) (vscodeHooksFile, error) {
+	hooksFile := vscodeHooksFile{Hooks: map[string][]vscodeHookRef{}}
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if err := json.Unmarshal(data, &hooksFile); err != nil {
+			return vscodeHooksFile{}, err
+		}
+	} else if !os.IsNotExist(err) {
+		return vscodeHooksFile{}, err
+	}
+	if hooksFile.Hooks == nil {
+		hooksFile.Hooks = map[string][]vscodeHookRef{}
+	}
+	return hooksFile, nil
+}
+
+func mergeVSCodeEndpointHook(existing []vscodeHookRef, ref vscodeHookRef) []vscodeHookRef {
+	out := make([]vscodeHookRef, 0, len(existing)+1)
+	for _, item := range existing {
+		if !isEndpointHookCommand(item.Command, "vscode") {
+			out = append(out, item)
+		}
+	}
+	return append(out, ref)
+}
+
+func removeVSCodeEndpointHooks(path string) (bool, error) {
+	hooksFile, err := readVSCodeHooks(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	changed := false
+	for eventName, refs := range hooksFile.Hooks {
+		filtered := refs[:0]
+		for _, ref := range refs {
+			if isEndpointHookCommand(ref.Command, "vscode") {
+				changed = true
+				continue
+			}
+			filtered = append(filtered, ref)
+		}
+		if len(filtered) == 0 {
+			delete(hooksFile.Hooks, eventName)
+		} else {
+			hooksFile.Hooks[eventName] = filtered
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+	if len(hooksFile.Hooks) == 0 {
+		return true, os.Remove(path)
+	}
+	data, err := json.MarshalIndent(hooksFile, "", "  ")
+	if err != nil {
+		return false, err
+	}
+	return true, os.WriteFile(path, data, 0600)
+}
+
+func isVSCodeInstalledAt(path string) bool {
+	hooksFile, err := readVSCodeHooks(path)
+	if err != nil {
+		return false
+	}
+	for _, refs := range hooksFile.Hooks {
+		for _, ref := range refs {
+			if isEndpointHookCommand(ref.Command, "vscode") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func vscodeHooksPath(level Level) (string, error) {
+	switch level {
+	case "", LevelUser:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".copilot", "hooks", "beacon.json"), nil
+	case LevelProject:
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cwd, ".github", "hooks", "beacon.json"), nil
+	default:
+		return "", fmt.Errorf("unknown hook level %q", level)
+	}
+}

--- a/cli/beacon/internal/endpoint/hooks/vscode_test.go
+++ b/cli/beacon/internal/endpoint/hooks/vscode_test.go
@@ -1,0 +1,92 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallVSCodeHooksPreservesNonBeaconHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beacon.json")
+	existing := `{"hooks":{"SessionStart":[{"type":"command","command":"echo keep"}]}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installVSCodeHooks(path, "/tmp/beacon hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installVSCodeHooks returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"echo keep",
+		"BEACON_ENDPOINT_MODE=1",
+		"BEACON_ENDPOINT_LOG='/tmp/runtime.jsonl'",
+		"BEACON_ENDPOINT_CONFIG='/tmp/config.json'",
+		"'/tmp/beacon hooks' --platform vscode",
+		"SessionStart",
+		"UserPromptSubmit",
+		"PreToolUse",
+		"PostToolUse",
+		"SubagentStart",
+		"SubagentStop",
+		"Stop",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("hooks missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRemoveVSCodeEndpointHooksPreservesOtherHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beacon.json")
+	existing := `{"hooks":{"PreToolUse":[{"type":"command","command":"echo keep"},{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform vscode pre-tool"}]}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := removeVSCodeEndpointHooks(path)
+	if err != nil {
+		t.Fatalf("removeVSCodeEndpointHooks returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected endpoint hook removal")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "echo keep") {
+		t.Fatalf("non-Beacon hook was not preserved:\n%s", text)
+	}
+	if strings.Contains(text, "BEACON_ENDPOINT_MODE=1") {
+		t.Fatalf("endpoint hook was not removed:\n%s", text)
+	}
+}
+
+func TestVSCodeHooksPathLevels(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	userPath, err := vscodeHooksPath(LevelUser)
+	if err != nil {
+		t.Fatalf("user path error: %v", err)
+	}
+	if want := filepath.Join(home, ".copilot", "hooks", "beacon.json"); userPath != want {
+		t.Fatalf("user path = %q, want %q", userPath, want)
+	}
+
+	project := t.TempDir()
+	t.Chdir(project)
+	projectPath, err := vscodeHooksPath(LevelProject)
+	if err != nil {
+		t.Fatalf("project path error: %v", err)
+	}
+	if want := filepath.Join(project, ".github", "hooks", "beacon.json"); projectPath != want {
+		t.Fatalf("project path = %q, want %q", projectPath, want)
+	}
+}

--- a/cli/beacon/internal/endpoint/integrations/vscode/vscode.go
+++ b/cli/beacon/internal/endpoint/integrations/vscode/vscode.go
@@ -1,0 +1,137 @@
+package vscode
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/harness"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations"
+)
+
+const (
+	Name        = harness.VSCodeName
+	CopilotName = harness.VSCodeCopilotName
+	DisplayName = "VS Code"
+)
+
+type Config struct {
+	Endpoint       string `json:"endpoint"`
+	CaptureContent bool   `json:"capture_content"`
+	WorkspacePath  string `json:"workspace_path,omitempty"`
+}
+
+type Status struct {
+	Name                string                  `json:"name"`
+	DisplayName         string                  `json:"display_name"`
+	Detected            bool                    `json:"detected"`
+	ExecutablePath      string                  `json:"executable_path,omitempty"`
+	Version             string                  `json:"version,omitempty"`
+	SettingsPath        string                  `json:"settings_path,omitempty"`
+	TelemetryStatus     harness.TelemetryStatus `json:"telemetry_status"`
+	LastEventObserved   bool                    `json:"last_event_observed"`
+	LastEventObservedAt string                  `json:"last_event_observed_at,omitempty"`
+	Message             string                  `json:"message"`
+}
+
+func DefaultConfig(httpPort int) Config {
+	return Config{
+		Endpoint: fmt.Sprintf("http://127.0.0.1:%d", httpPort),
+	}
+}
+
+func PrintConfig(cfg Config) string {
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = DefaultConfig(4318).Endpoint
+	}
+	captureContent := "false"
+	if cfg.CaptureContent {
+		captureContent = "true"
+	}
+	scope := "user settings"
+	if strings.TrimSpace(cfg.WorkspacePath) != "" {
+		scope = "workspace settings"
+	}
+	return fmt.Sprintf(`VS Code Copilot OpenTelemetry setup
+
+Add this to your VS Code %s:
+
+  {
+    "github.copilot.chat.otel.enabled": true,
+    "github.copilot.chat.otel.exporterType": "otlp-http",
+    "github.copilot.chat.otel.otlpEndpoint": %q,
+    "github.copilot.chat.otel.captureContent": %s,
+    "github.copilot.chat.otel.maxAttributeSizeChars": 8192
+  }
+
+Notes:
+- Beacon listens for OTLP/HTTP on the local endpoint collector and writes low-noise normalized events to the runtime JSONL log.
+- Beacon drops standalone chat spans, token/duration histograms, TTFT, HTTP instrumentation, and runtime/process metrics by default.
+- Full prompt, response, tool argument, and tool result capture is off unless captureContent is explicitly enabled.
+- Use VS Code hooks for Cursor-like lifecycle, prompt, tool, file, command, MCP, approval, and subagent telemetry.
+`, scope, cfg.Endpoint, captureContent)
+}
+
+func Setup(cfg Config) (string, error) {
+	return harness.ConfigureVSCode(harness.VSCodeConfigOptions{
+		Endpoint:       cfg.Endpoint,
+		CaptureContent: cfg.CaptureContent,
+		WorkspacePath:  cfg.WorkspacePath,
+	})
+}
+
+func GetStatus(logPath, expectedEndpoint string) Status {
+	return GetStatusForConfig(logPath, expectedEndpoint, Config{})
+}
+
+func GetStatusForConfig(logPath, expectedEndpoint string, cfg Config) Status {
+	discovered := harness.DiscoverVSCode()
+	settingsPath := discovered.ConfigPath
+	if strings.TrimSpace(cfg.WorkspacePath) != "" {
+		if path, err := harness.VSCodeWorkspaceSettingsPath(cfg.WorkspacePath); err == nil {
+			settingsPath = path
+		}
+	}
+	status := Status{
+		Name:            Name,
+		DisplayName:     DisplayName,
+		Detected:        discovered.Detected,
+		ExecutablePath:  discovered.ExecutablePath,
+		Version:         discovered.Version,
+		SettingsPath:    settingsPath,
+		TelemetryStatus: discovered.TelemetryStatus,
+		Message:         discovered.Message,
+	}
+	if settingsPath != "" {
+		status.TelemetryStatus, status.Message = harness.VSCodeOTelStatus(settingsPath, expectedEndpoint)
+	}
+	if last, ok := LastVSCodeEvent(logPath); ok {
+		status.LastEventObserved = true
+		if !last.IsZero() {
+			status.LastEventObservedAt = last.UTC().Format(time.RFC3339)
+		}
+	}
+	if status.LastEventObserved {
+		status.Message = "VS Code events have been observed in the endpoint runtime log"
+	}
+	return status
+}
+
+func HasVSCodeEventSince(logPath string, since time.Time) bool {
+	if integrations.HasHarnessEventSince(logPath, Name, since) {
+		return true
+	}
+	return integrations.HasHarnessEventSince(logPath, CopilotName, since)
+}
+
+func LastVSCodeEvent(logPath string) (time.Time, bool) {
+	hookLast, hookOK := integrations.LastHarnessEvent(logPath, Name)
+	copilotLast, copilotOK := integrations.LastHarnessEvent(logPath, CopilotName)
+	if !hookOK {
+		return copilotLast, copilotOK
+	}
+	if !copilotOK || hookLast.After(copilotLast) {
+		return hookLast, true
+	}
+	return copilotLast, true
+}

--- a/cli/beacon/internal/endpoint/integrations/vscode/vscode_test.go
+++ b/cli/beacon/internal/endpoint/integrations/vscode/vscode_test.go
@@ -1,0 +1,31 @@
+package vscode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/harness"
+)
+
+func TestGetStatusForConfigUsesWorkspaceSettings(t *testing.T) {
+	workspace := t.TempDir()
+	settingsPath, err := harness.VSCodeWorkspaceSettingsPath(workspace)
+	if err != nil {
+		t.Fatalf("workspace settings path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"github.copilot.chat.otel.enabled":true,"github.copilot.chat.otel.otlpEndpoint":"http://127.0.0.1:4318"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	status := GetStatusForConfig("", "http://127.0.0.1:4318", Config{WorkspacePath: workspace})
+	if status.SettingsPath != settingsPath {
+		t.Fatalf("SettingsPath = %q, want %q", status.SettingsPath, settingsPath)
+	}
+	if status.TelemetryStatus != harness.TelemetryEnabled {
+		t.Fatalf("TelemetryStatus = %q, want enabled; message=%s", status.TelemetryStatus, status.Message)
+	}
+}

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -273,7 +273,7 @@ func buildConfig(opts InstallOptions) endpointconfig.Config {
 		logPath = writer.DefaultPath(opts.UserMode)
 	}
 	cfg := endpointconfig.Default(opts.UserMode, logPath)
-	if len(opts.Harnesses) > 0 {
+	if opts.Harnesses != nil {
 		cfg.Harnesses = opts.Harnesses
 	}
 	if opts.GRPCPort != 0 {
@@ -387,6 +387,7 @@ func preflight(cfg endpointconfig.Config, startService bool) error {
 
 func configureHarnesses(cfg endpointconfig.Config) ([]string, error) {
 	grpcEndpoint := fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.GRPCPort)
+	httpEndpoint := fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort)
 	var paths []string
 	for _, name := range cfg.Harnesses {
 		switch name {
@@ -404,6 +405,12 @@ func configureHarnesses(cfg endpointconfig.Config) ([]string, error) {
 			paths = append(paths, path)
 		case "gemini", "gemini_cli":
 			path, err := harness.ConfigureGemini(harness.ConfigureOptions{Endpoint: grpcEndpoint, UserMode: cfg.UserMode, ContentRetention: string(cfg.ContentRetention)})
+			if err != nil {
+				return paths, err
+			}
+			paths = append(paths, path)
+		case "vscode", "vs_code", "vscode_copilot":
+			path, err := harness.ConfigureVSCode(harness.VSCodeConfigOptions{Endpoint: httpEndpoint})
 			if err != nil {
 				return paths, err
 			}

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -79,6 +79,17 @@ func TestBuildConfigAppliesInstallOptions(t *testing.T) {
 	}
 }
 
+func TestBuildConfigPreservesExplicitEmptyHarnesses(t *testing.T) {
+	cfg := buildConfig(InstallOptions{UserMode: true, Harnesses: []string{}})
+	if cfg.Harnesses == nil || len(cfg.Harnesses) != 0 {
+		t.Fatalf("Harnesses = %#v, want explicit empty slice", cfg.Harnesses)
+	}
+	defaultCfg := buildConfig(InstallOptions{UserMode: true})
+	if len(defaultCfg.Harnesses) == 0 {
+		t.Fatalf("default harnesses should be preserved when Harnesses is nil")
+	}
+}
+
 func TestSelectRuntimeLogWarnsWhenSystemCollectorConflictsWithUserMode(t *testing.T) {
 	userLog := filepath.Join(t.TempDir(), "user-runtime.jsonl")
 	systemLog := filepath.Join(t.TempDir(), "system-runtime.jsonl")
@@ -357,6 +368,37 @@ func TestUninstallFallbackRemovesKnownFiles(t *testing.T) {
 	}
 }
 
+func TestConfigureHarnessesAcceptsVSCode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := endpointconfig.Config{
+		UserMode:  true,
+		Harnesses: []string{"vscode"},
+		Collector: endpointconfig.Collector{
+			GRPCPort: 54317,
+			HTTPPort: 54318,
+		},
+	}
+
+	paths, err := configureHarnesses(cfg)
+	if err != nil {
+		t.Fatalf("configureHarnesses returned error: %v", err)
+	}
+	settingsPath := filepath.Join(home, "Library", "Application Support", "Code", "User", "settings.json")
+	if len(paths) != 1 || paths[0] != settingsPath {
+		t.Fatalf("paths = %#v, want VS Code settings path", paths)
+	}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read VS Code settings: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `"github.copilot.chat.otel.otlpEndpoint": "http://127.0.0.1:54318"`) ||
+		!strings.Contains(text, `"github.copilot.chat.otel.captureContent": false`) {
+		t.Fatalf("VS Code settings did not configure low-noise local OTLP: %s", text)
+	}
+}
+
 func TestInstallUserModeWithoutStartingService(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("install preflight is macOS-only")
@@ -375,7 +417,7 @@ func TestInstallUserModeWithoutStartingService(t *testing.T) {
 	result, err := Install(InstallOptions{
 		UserMode:      true,
 		LogPath:       logPath,
-		Harnesses:     []string{""},
+		Harnesses:     []string{},
 		GRPCPort:      freePort(t),
 		HTTPPort:      freePort(t),
 		CollectorPath: collectorPath,
@@ -413,7 +455,7 @@ func TestInstallFailsBeforeWritingArtifactsWhenCollectorMissing(t *testing.T) {
 	_, err := Install(InstallOptions{
 		UserMode:      true,
 		LogPath:       logPath,
-		Harnesses:     []string{""},
+		Harnesses:     []string{},
 		GRPCPort:      freePort(t),
 		HTTPPort:      freePort(t),
 		CollectorPath: missingCollector,

--- a/collector-builder/exporter/beaconjsonexporter/exporter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter_test.go
@@ -1079,7 +1079,7 @@ func TestHarnessNameSeparatesClaudeCodeAndCowork(t *testing.T) {
 		{
 			name:  "copilot chat wrapper",
 			attrs: map[string]interface{}{"service.name": "copilot-chat"},
-			want:  "copilot_cli",
+			want:  "vscode_copilot",
 		},
 		{
 			name:  "openclaw gateway service",
@@ -1144,6 +1144,196 @@ func TestCopilotSpanActions(t *testing.T) {
 				t.Fatalf("category = %q, want %q", event.Event.Category, tt.category)
 			}
 		})
+	}
+}
+
+func TestVSCodeCopilotDropsNoisySpansByDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:             path,
+		MaxEventBytes:    defaultMaxEventBytes,
+		RotateBytes:      defaultRotateBytes,
+		RedactSecrets:    true,
+		ContentRetention: "metadata",
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "copilot-chat")
+	spans := rs.ScopeSpans().AppendEmpty().Spans()
+	chat := spans.AppendEmpty()
+	chat.SetName("chat gpt-4o")
+	chat.Attributes().PutStr("gen_ai.operation.name", "chat")
+	tool := spans.AppendEmpty()
+	tool.SetName("execute_tool readFile")
+	tool.Attributes().PutStr("gen_ai.operation.name", "execute_tool")
+	tool.Attributes().PutStr("gen_ai.tool.name", "readFile")
+
+	if err := exp.consumeTraces(context.Background(), traces); err != nil {
+		t.Fatalf("consumeTraces returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime log: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "chat gpt-4o") {
+		t.Fatalf("chat span should be dropped by default: %s", text)
+	}
+	if !strings.Contains(text, "execute_tool readFile") || !strings.Contains(text, "vscode_copilot") {
+		t.Fatalf("normalized tool span missing: %s", text)
+	}
+}
+
+func TestVSCodeCopilotDropsNoisyMetricsByDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:             path,
+		MaxEventBytes:    defaultMaxEventBytes,
+		RotateBytes:      defaultRotateBytes,
+		RedactSecrets:    true,
+		ContentRetention: "metadata",
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "copilot-chat")
+	sm := rm.ScopeMetrics().AppendEmpty()
+	for _, name := range []string{"gen_ai.client.token.usage", "gen_ai.client.operation.duration", "copilot_chat.time_to_first_token"} {
+		sm.Metrics().AppendEmpty().SetName(name)
+	}
+	if err := exp.consumeMetrics(context.Background(), metrics); err != nil {
+		t.Fatalf("consumeMetrics returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read runtime log: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("VS Code Copilot metrics should be dropped by default, wrote: %s", string(data))
+	}
+}
+
+func TestVSCodeCopilotKeepsActivityLogs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:             path,
+		MaxEventBytes:    defaultMaxEventBytes,
+		RotateBytes:      defaultRotateBytes,
+		RedactSecrets:    true,
+		ContentRetention: "metadata",
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "copilot-chat")
+	rec := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	rec.Body().SetStr("copilot_chat.tool.call")
+	rec.Attributes().PutStr("event.name", "copilot_chat.tool.call")
+	rec.Attributes().PutStr("gen_ai.tool.name", "runCommand")
+	rec.Attributes().PutStr("success", "true")
+
+	if err := exp.consumeLogs(context.Background(), logs); err != nil {
+		t.Fatalf("consumeLogs returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime log: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "vscode_copilot") || !strings.Contains(text, "tool.invoked") {
+		t.Fatalf("activity log not normalized: %s", text)
+	}
+}
+
+func TestVSCodeCopilotDropsRepeatedSessionStartLogs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:             path,
+		MaxEventBytes:    defaultMaxEventBytes,
+		RotateBytes:      defaultRotateBytes,
+		RedactSecrets:    true,
+		ContentRetention: "metadata",
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "copilot-chat")
+	for i := 0; i < 3; i++ {
+		rec := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+		rec.Body().SetStr("copilot_chat.session.start")
+		rec.Attributes().PutStr("event.name", "copilot_chat.session.start")
+		rec.Attributes().PutStr("session.id", "same-session")
+	}
+
+	if err := exp.consumeLogs(context.Background(), logs); err != nil {
+		t.Fatalf("consumeLogs returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read runtime log: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("session start logs should be dropped, wrote: %s", string(data))
+	}
+}
+
+func TestVSCodeCopilotInvokeAgentUserRequestBecomesPrompt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:             path,
+		MaxEventBytes:    defaultMaxEventBytes,
+		RotateBytes:      defaultRotateBytes,
+		RedactSecrets:    true,
+		ContentRetention: "full",
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "copilot-chat")
+	span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName("invoke_agent GitHub Copilot Chat")
+	span.Attributes().PutStr("gen_ai.operation.name", "invoke_agent")
+	span.Attributes().PutStr("gen_ai.agent.name", "GitHub Copilot Chat")
+	span.Attributes().PutStr("gen_ai.request.model", "gpt-4.1")
+	span.Attributes().PutStr("copilot_chat.user_request", "please read CLAUDE.md for me")
+	span.Attributes().PutStr("copilot_chat.session_id", "chat-session")
+	span.Attributes().PutStr("session.id", "vscode-window")
+
+	if err := exp.consumeTraces(context.Background(), traces); err != nil {
+		t.Fatalf("consumeTraces returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime log: %v", err)
+	}
+	var event beaconEvent
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &event); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	if event.Harness.Name != "vscode_copilot" {
+		t.Fatalf("harness = %q, want vscode_copilot", event.Harness.Name)
+	}
+	if event.Event.Action != "prompt.submitted" || event.Event.Category != "prompt" {
+		t.Fatalf("event = %#v, want prompt.submitted/prompt", event.Event)
+	}
+	if event.Prompt == nil || event.Prompt.Text != "please read CLAUDE.md for me" {
+		t.Fatalf("prompt = %#v, want user request", event.Prompt)
+	}
+	if event.Session == nil || event.Session.ID != "chat-session" {
+		t.Fatalf("session = %#v, want Copilot chat session", event.Session)
 	}
 }
 

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -26,6 +26,14 @@ var allowedCodexLogEvents = map[string]struct{}{
 	CodexToolResult:         {},
 }
 
+var allowedVSCodeCopilotLogEvents = map[string]struct{}{
+	"copilot_chat.tool.call":            {},
+	"copilot_chat.edit.feedback":        {},
+	"copilot_chat.edit.hunk.action":     {},
+	"copilot_chat.inline.done":          {},
+	"copilot_chat.cloud.session.invoke": {},
+}
+
 var noisyCodexLogMessages = []string{
 	"runtime metrics reset skipped",
 	"flushing otel metrics",
@@ -107,10 +115,14 @@ func (c Converter) EventsFromMetrics(metrics pmetric.Metrics) []Event {
 
 func ShouldDropLog(resourceAttrs map[string]interface{}, record plog.LogRecord) bool {
 	attrs := MergeMaps(resourceAttrs, AttrsToMap(record.Attributes()))
-	if HarnessName(attrs, record.Body().AsString()) != "codex_cli" {
+	switch HarnessName(attrs, record.Body().AsString()) {
+	case "codex_cli":
+		return isNoisyCodexLog(attrs, record.Body().AsString())
+	case "vscode_copilot":
+		return isNoisyVSCodeCopilotLog(attrs, record.Body().AsString())
+	default:
 		return false
 	}
-	return isNoisyCodexLog(attrs, record.Body().AsString())
 }
 
 func isNoisyCodexLog(attrs map[string]interface{}, body string) bool {
@@ -130,8 +142,22 @@ func isNoisyCodexLog(attrs map[string]interface{}, body string) bool {
 	return strings.HasPrefix(eventName, "codex.")
 }
 
+func isNoisyVSCodeCopilotLog(attrs map[string]interface{}, body string) bool {
+	eventName := FirstString(attrs, "event.name", "name")
+	if eventName == "" {
+		eventName = strings.TrimSpace(body)
+	}
+	if _, ok := allowedVSCodeCopilotLogEvents[eventName]; ok {
+		return false
+	}
+	return true
+}
+
 func ShouldDropMetric(resourceAttrs map[string]interface{}, name string, includeRuntimeMetrics bool) bool {
 	if shouldDropCodexMetric(resourceAttrs, name) {
+		return true
+	}
+	if shouldDropVSCodeCopilotMetric(resourceAttrs, name, includeRuntimeMetrics) {
 		return true
 	}
 	if shouldDropOpenClawMetric(resourceAttrs, name, includeRuntimeMetrics) {
@@ -177,6 +203,34 @@ func shouldDropOpenClawMetric(resourceAttrs map[string]interface{}, name string,
 		return false
 	}
 	if HarnessName(resourceAttrs, name) != "openclaw_gateway" {
+		return false
+	}
+	return true
+}
+
+func shouldDropVSCodeCopilotMetric(resourceAttrs map[string]interface{}, name string, includeRuntimeMetrics bool) bool {
+	if includeRuntimeMetrics {
+		return false
+	}
+	if HarnessName(resourceAttrs, name) != "vscode_copilot" {
+		return false
+	}
+	return true
+}
+
+func shouldDropVSCodeCopilotSpan(attrs map[string]interface{}, spanName string, includeRuntimeMetrics bool) bool {
+	if includeRuntimeMetrics {
+		return false
+	}
+	operation := strings.ToLower(FirstString(attrs, "gen_ai.operation.name"))
+	name := strings.ToLower(spanName)
+	switch operation {
+	case "invoke_agent", "execute_tool", "execute_hook":
+		return false
+	case "chat", "embeddings":
+		return true
+	}
+	if strings.Contains(name, "invoke_agent") || strings.Contains(name, "execute_tool") || strings.Contains(name, "execute_hook") {
 		return false
 	}
 	return true
@@ -236,10 +290,14 @@ func (c Converter) EventFromSpan(resourceAttrs map[string]interface{}, span ptra
 
 func (c Converter) ShouldDropSpan(resourceAttrs map[string]interface{}, span ptrace.Span) bool {
 	attrs := MergeMaps(resourceAttrs, AttrsToMap(span.Attributes()))
-	if HarnessName(attrs, span.Name()) != "codex_cli" {
+	switch HarnessName(attrs, span.Name()) {
+	case "codex_cli":
+		return !c.opts.IncludeCodexSpans
+	case "vscode_copilot":
+		return shouldDropVSCodeCopilotSpan(attrs, span.Name(), c.opts.IncludeRuntimeMetrics)
+	default:
 		return false
 	}
-	return !c.opts.IncludeCodexSpans
 }
 
 func (c Converter) NormalizeCodexLogEvent(event *Event, attrs map[string]interface{}) {
@@ -339,7 +397,7 @@ func (c Converter) PopulateCommon(event *Event, attrs map[string]interface{}) {
 	event.Model = FirstString(attrs, "gen_ai.request.model", "gen_ai.response.model", "model", "ai.model")
 	event.Repository = FirstString(attrs, "vcs.repository.url", "repository", "repo.path", "workspace.repository")
 	event.Branch = FirstString(attrs, "vcs.branch.name", "git.branch", "branch")
-	if id := FirstString(attrs, "session.id", "conversation.id", "conversation_id", "gen_ai.conversation.id"); id != "" || FirstString(attrs, "cwd", "working_directory", "workspace") != "" {
+	if id := FirstString(attrs, "gen_ai.conversation.id", "copilot_chat.session_id", "copilot_chat.chat_session_id", "conversation.id", "conversation_id", "session.id"); id != "" || FirstString(attrs, "cwd", "working_directory", "workspace") != "" {
 		event.Session = &SessionInfo{
 			ID:               id,
 			WorkingDirectory: FirstString(attrs, "cwd", "working_directory", "process.command_args.cwd", "workspace"),
@@ -382,7 +440,7 @@ func (c Converter) PopulateCommon(event *Event, attrs map[string]interface{}) {
 		}
 	}
 	if c.opts.ContentRetention != "metadata" && event.Event.Category == "prompt" {
-		if text := FirstString(attrs, "gen_ai.prompt", "prompt", "user_prompt", "input.prompt"); text != "" {
+		if text := FirstString(attrs, "gen_ai.prompt", "prompt", "user_prompt", "input.prompt", "copilot_chat.user_request"); text != "" {
 			event.Prompt = &PromptInfo{Text: text}
 		}
 	}
@@ -525,7 +583,9 @@ func NormalizeHarnessName(name string) string {
 		return "codex_cli"
 	case strings.Contains(lower, "gemini"):
 		return "gemini_cli"
-	case strings.Contains(lower, "github-copilot") || strings.Contains(lower, "copilot-chat") || strings.Contains(lower, "copilot_cli") || strings.Contains(lower, "copilot"):
+	case strings.Contains(lower, "copilot-chat"):
+		return "vscode_copilot"
+	case strings.Contains(lower, "github-copilot") || strings.Contains(lower, "copilot_cli") || strings.Contains(lower, "copilot"):
 		return "copilot_cli"
 	case name != "":
 		return name
@@ -545,7 +605,7 @@ func InferAction(attrs map[string]interface{}, fallback string) string {
 		FirstString(attrs, "event.name", "codex.op", "rpc.method"),
 	}, " "))
 	switch {
-	case harness == "copilot_cli":
+	case harness == "copilot_cli" || harness == "vscode_copilot":
 		return CopilotAction(attrs, operation, text)
 	case strings.Contains(text, "gemini_cli.user_prompt"):
 		return "prompt.submitted"
@@ -571,9 +631,26 @@ func InferAction(attrs map[string]interface{}, fallback string) string {
 }
 
 func CopilotAction(attrs map[string]interface{}, operation, text string) string {
+	if eventName := FirstString(attrs, "event.name", "name"); eventName != "" {
+		switch eventName {
+		case "copilot_chat.session.start", "copilot_chat.cloud.session.invoke":
+			return "session.activity"
+		case "copilot_chat.tool.call":
+			if strings.EqualFold(FirstString(attrs, "success"), "false") || FirstString(attrs, "error.type") != "" {
+				return "tool.failed"
+			}
+			return "tool.invoked"
+		case "copilot_chat.edit.feedback", "copilot_chat.edit.hunk.action", "copilot_chat.inline.done":
+			return "file.modified"
+		}
+	}
 	switch {
+	case operation == "invoke_agent" && FirstString(attrs, "copilot_chat.user_request") != "":
+		return "prompt.submitted"
 	case operation == "invoke_agent":
 		return "session.activity"
+	case operation == "execute_hook":
+		return "approval.requested"
 	case operation == "chat":
 		initiator := strings.ToLower(FirstString(attrs, "github.copilot.initiator"))
 		turnID := FirstString(attrs, "github.copilot.turn_id")

--- a/packaging/macos/smoke-vscode-endpoint.sh
+++ b/packaging/macos/smoke-vscode-endpoint.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TMPDIR="${TMPDIR:-/tmp}/beacon-vscode-smoke.$$"
+LOG="$TMPDIR/runtime.jsonl"
+WORKSPACE="$TMPDIR/workspace"
+DASHBOARD_ADDR="127.0.0.1:18765"
+DASHBOARD_PID=""
+
+cleanup() {
+  if [ -n "$DASHBOARD_PID" ]; then
+    kill "$DASHBOARD_PID" 2>/dev/null || true
+    wait "$DASHBOARD_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$WORKSPACE"
+
+cd "$ROOT/cli/beacon"
+go build -o "$TMPDIR/beacon" .
+
+cd "$ROOT/cli/beacon-hooks"
+go build -o "$TMPDIR/beacon-hooks" .
+
+"$TMPDIR/beacon" endpoint integrations vscode print-config --log-path "$LOG" >/dev/null
+
+cat <<JSON | BEACON_ENDPOINT_MODE=1 BEACON_ENDPOINT_LOG="$LOG" BEACON_CONTENT_RETENTION=metadata "$TMPDIR/beacon-hooks" --platform vscode prompt-submit >/dev/null
+{"sessionId":"vscode-smoke","hookEventName":"UserPromptSubmit","cwd":"$WORKSPACE","prompt":"summarize this repository"}
+JSON
+
+cat <<JSON | BEACON_ENDPOINT_MODE=1 BEACON_ENDPOINT_LOG="$LOG" BEACON_CONTENT_RETENTION=metadata "$TMPDIR/beacon-hooks" --platform vscode pre-tool >/dev/null
+{"sessionId":"vscode-smoke","hookEventName":"PreToolUse","cwd":"$WORKSPACE","tool_name":"runCommand","tool_input":{"command":"go test ./..."}}
+JSON
+
+cat <<JSON | BEACON_ENDPOINT_MODE=1 BEACON_ENDPOINT_LOG="$LOG" BEACON_CONTENT_RETENTION=metadata "$TMPDIR/beacon-hooks" --platform vscode post-tool >/dev/null
+{"sessionId":"vscode-smoke","hookEventName":"PostToolUse","cwd":"$WORKSPACE","tool_name":"runCommand","tool_input":{"command":"go test ./..."},"tool_response":"ok"}
+JSON
+
+"$TMPDIR/beacon" endpoint integrations vscode validate --log-path "$LOG" >/dev/null
+
+"$TMPDIR/beacon" endpoint dashboard --log-path "$LOG" --addr "$DASHBOARD_ADDR" >"$TMPDIR/dashboard.log" 2>&1 &
+DASHBOARD_PID="$!"
+
+SUMMARY=""
+i=0
+while [ "$i" -lt 20 ]; do
+  SUMMARY="$(curl -fsS "http://$DASHBOARD_ADDR/api/summary" 2>/dev/null || true)"
+  if [ -n "$SUMMARY" ]; then
+    break
+  fi
+  i=$((i + 1))
+  sleep 0.25
+done
+
+if [ -z "$SUMMARY" ]; then
+  echo "dashboard did not start"
+  cat "$TMPDIR/dashboard.log" 2>/dev/null || true
+  exit 1
+fi
+
+echo "$SUMMARY" | grep -q "vscode" || {
+  echo "dashboard summary did not include vscode"
+  exit 1
+}
+
+if grep -E '"event":\{"kind":"agent_runtime","action":"(chat|metric\.observed)"' "$LOG" >/dev/null; then
+  echo "runtime log contains noisy chat or metric events"
+  exit 1
+fi
+
+echo "VS Code endpoint smoke events written to $LOG"


### PR DESCRIPTION
## Summary
- Add VS Code as a first-class endpoint surface with Copilot OTel setup/status/validation and optional VS Code hook installation.
- Normalize VS Code Copilot OTel as low-noise `vscode_copilot` events, including prompt extraction from `invoke_agent` and dropping chat/embedding/session-start noise.
- Add VS Code hook adapter handling, dashboard coverage, docs, and a deterministic macOS smoke script.

## Test plan
- `cd cli/beacon && go test ./...`
- `cd cli/beacon-hooks && go test ./...`
- `cd collector-builder/exporter/beaconjsonexporter && go test ./...`
- `sh packaging/macos/test-endpoint-scripts.sh`
- `sh packaging/macos/smoke-vscode-endpoint.sh`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local settings/hook file writes and OTel normalization (including prompt capture when enabled), but changes are scoped to new VS Code paths with tests and validation commands.
> 
> **Overview**
> Adds **VS Code** as a first-class Beacon surface: **Copilot OTLP/HTTP** setup, status, and validation via `beacon endpoint integrations vscode`, optional **hook** install to `.github/hooks/beacon.json` (or user Copilot hooks), and **collector-only** installs when `--harness` is empty.
> 
> **`beacon-hooks`** gains `--platform vscode` (session/CWD resolution, non-controlling pre-tool responses, `raw.vscode` payloads) plus **`subagent-start` / `subagent-stop`** lifecycle commands.
> 
> The **OTel exporter** maps `copilot-chat` to **`vscode_copilot`**, drops noisy chat/metrics/session-start signals by default, and maps useful spans/logs (e.g. `invoke_agent` + `copilot_chat.user_request` → `prompt.submitted`).
> 
> **Dashboard**, discovery/validation, docs, and a **macOS smoke script** cover end-to-end VS Code telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c79bb361ff1263e165461e3a74d4a458ca3601b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->