### PR TITLE
Add VS Code link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Claude Cowork, OpenClaw).
 | [Grok Build](https://docs.asymptotelabs.ai/cli/supported-runtimes-grok-build) | Beacon hook adapter |
 | [OpenClaw Gateway](https://docs.asymptotelabs.ai/cli/supported-runtimes-openclaw-gateway) | Gateway-configured OTLP/HTTP export |
 | [OpenCode](https://docs.asymptotelabs.ai/cli/supported-runtimes-opencode) | Beacon hook adapter |
-| VS Code | VS Code Copilot OpenTelemetry and optional Beacon hook adapter |
+| [VS Code](https://docs.asymptotelabs.ai/cli/supported-runtimes-vscode) | VS Code Copilot OpenTelemetry and optional Beacon hook adapter |
 
 ### SIEM / Output Destinations
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only markdown change with no runtime or security impact.
> 
> **Overview**
> The **Agent Runtimes** table in `README.md` now links **VS Code** to the supported-runtimes docs page (`supported-runtimes-vscode`), matching how every other harness in that table is formatted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bea38f1e05cb1c5d2c976adf0b8b5af6e823274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->