### PR TITLE
Add Asymptote trace module

### DIFF
--- a/cli/beacon-hooks/go.mod
+++ b/cli/beacon-hooks/go.mod
@@ -2,7 +2,12 @@ module github.com/asymptote-labs/agent-beacon/cli/beacon-hooks
 
 go 1.24
 
-require github.com/spf13/cobra v1.8.1
+require (
+	github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace v0.0.0
+	github.com/spf13/cobra v1.8.1
+)
+
+replace github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace => ../../pkg/asymptotetrace
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/cli/beacon-hooks/internal/logging/logging.go
+++ b/cli/beacon-hooks/internal/logging/logging.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -13,14 +12,8 @@ import (
 	"time"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/config"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace"
 )
-
-var endpointSecretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)authorization\s*[:=]\s*bearer\s+[^"',\s]+`),
-	regexp.MustCompile(`(?i)(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*["']?[^"',\s]+`),
-	regexp.MustCompile(`(?i)bearer\s+[a-z0-9._~+/=-]+`),
-	regexp.MustCompile(`sk-[a-zA-Z0-9]{20,}`),
-}
 
 const (
 	defaultEndpointRotateBytes    = 10 * 1024 * 1024
@@ -158,7 +151,7 @@ func (l *Logger) baseEndpointEvent(action, category, severity, message string) m
 		"harness": map[string]interface{}{
 			"name": l.platform,
 		},
-		"message": redactEndpointString(truncateEndpoint(message, 4096)),
+		"message": asymptotetrace.CleanString(message, asymptotetrace.DefaultStringLimit, true),
 	}
 	if l.sessionID != "" {
 		event["session"] = map[string]interface{}{"id": l.sessionID}
@@ -201,69 +194,29 @@ func endpointLogPath() string {
 }
 
 func redactEndpointString(value string) string {
-	for _, pattern := range endpointSecretPatterns {
-		value = pattern.ReplaceAllStringFunc(value, func(match string) string {
-			if strings.Contains(match, "=") {
-				return match[:strings.Index(match, "=")+1] + "[REDACTED]"
-			}
-			if strings.Contains(match, ":") {
-				return match[:strings.Index(match, ":")+1] + "[REDACTED]"
-			}
-			return "[REDACTED]"
-		})
-	}
-	return value
+	return asymptotetrace.RedactString(value)
 }
 
 func retentionAwareRaw(raw map[string]interface{}, retention string) map[string]interface{} {
-	if retention != "metadata" {
-		return raw
-	}
-	return map[string]interface{}{"field_count": len(raw)}
+	return asymptotetrace.RetentionAwareRaw(raw, retention)
 }
 
 func sanitizeEndpointMap(input map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(input))
-	for key, value := range input {
-		switch typed := value.(type) {
-		case string:
-			out[key] = redactEndpointString(truncateEndpoint(typed, 4096))
-		case map[string]interface{}:
-			out[key] = sanitizeEndpointMap(typed)
-		case []interface{}:
-			out[key] = sanitizeEndpointSlice(typed)
-		default:
-			out[key] = typed
-		}
-	}
-	return out
+	return asymptotetrace.SanitizeMap(input, asymptotetrace.PrivacyOptions{
+		RedactSecrets: true,
+		StringLimit:   asymptotetrace.DefaultStringLimit,
+	})
 }
 
 func sanitizeEndpointSlice(input []interface{}) []interface{} {
-	out := make([]interface{}, len(input))
-	for i, value := range input {
-		switch typed := value.(type) {
-		case string:
-			out[i] = redactEndpointString(truncateEndpoint(typed, 4096))
-		case map[string]interface{}:
-			out[i] = sanitizeEndpointMap(typed)
-		case []interface{}:
-			out[i] = sanitizeEndpointSlice(typed)
-		default:
-			out[i] = typed
-		}
-	}
-	return out
+	return asymptotetrace.SanitizeSlice(input, asymptotetrace.PrivacyOptions{
+		RedactSecrets: true,
+		StringLimit:   asymptotetrace.DefaultStringLimit,
+	})
 }
 
 func truncateEndpoint(value string, limit int) string {
-	if len(value) <= limit {
-		return value
-	}
-	if limit < 32 {
-		return value[:limit]
-	}
-	return value[:limit-15] + "...[truncated]"
+	return asymptotetrace.TruncateString(value, limit)
 }
 
 // Keep this rotation contract mirrored with the endpoint CLI and beaconjson exporter.

--- a/cli/beacon/go.mod
+++ b/cli/beacon/go.mod
@@ -2,7 +2,12 @@ module github.com/asymptote-labs/agent-beacon/cli/beacon
 
 go 1.24
 
-require github.com/spf13/cobra v1.8.1
+require (
+	github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace v0.0.0
+	github.com/spf13/cobra v1.8.1
+)
+
+replace github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace => ../../pkg/asymptotetrace
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect

--- a/cli/beacon/internal/endpoint/schema/event.go
+++ b/cli/beacon/internal/endpoint/schema/event.go
@@ -1,226 +1,57 @@
 package schema
 
 import (
-	"errors"
-	"os"
-	"runtime"
-	"time"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace"
 )
 
 const (
-	Vendor        = "beacon"
-	Product       = "endpoint-agent"
-	SchemaVersion = "1.0"
+	Vendor        = asymptotetrace.Vendor
+	Product       = asymptotetrace.Product
+	SchemaVersion = asymptotetrace.SchemaVersion
 )
 
-type Severity string
+type Severity = asymptotetrace.Severity
 
 const (
-	SeverityInfo     Severity = "info"
-	SeverityLow      Severity = "low"
-	SeverityMedium   Severity = "medium"
-	SeverityHigh     Severity = "high"
-	SeverityCritical Severity = "critical"
+	SeverityInfo     = asymptotetrace.SeverityInfo
+	SeverityLow      = asymptotetrace.SeverityLow
+	SeverityMedium   = asymptotetrace.SeverityMedium
+	SeverityHigh     = asymptotetrace.SeverityHigh
+	SeverityCritical = asymptotetrace.SeverityCritical
 )
 
-type EventInfo struct {
-	Kind     string `json:"kind"`
-	Action   string `json:"action"`
-	Category string `json:"category,omitempty"`
-}
-
-type EndpointInfo struct {
-	Hostname     string `json:"hostname,omitempty"`
-	OS           string `json:"os"`
-	AgentVersion string `json:"agent_version,omitempty"`
-}
-
-type UserInfo struct {
-	Name string `json:"name,omitempty"`
-	UID  string `json:"uid,omitempty"`
-}
-
-type HarnessInfo struct {
-	Name           string `json:"name"`
-	Version        string `json:"version,omitempty"`
-	ExecutablePath string `json:"executable_path,omitempty"`
-	ConfigPath     string `json:"config_path,omitempty"`
-}
-
-type SessionInfo struct {
-	ID               string `json:"id,omitempty"`
-	WorkingDirectory string `json:"working_directory,omitempty"`
-}
-
-type ToolInfo struct {
-	Name    string `json:"name,omitempty"`
-	Command string `json:"command,omitempty"`
-	Path    string `json:"path,omitempty"`
-}
-
-type FileInfo struct {
-	Path      string `json:"path,omitempty"`
-	Operation string `json:"operation,omitempty"`
-	Language  string `json:"language,omitempty"`
-	DiffHash  string `json:"diff_hash,omitempty"`
-	DiffBytes int    `json:"diff_bytes,omitempty"`
-}
-
-type CommandInfo struct {
-	Command    string `json:"command,omitempty"`
-	ExitCode   *int   `json:"exit_code,omitempty"`
-	DurationMS int64  `json:"duration_ms,omitempty"`
-}
-
-type MCPInfo struct {
-	Server string `json:"server,omitempty"`
-	Tool   string `json:"tool,omitempty"`
-}
-
-type ApprovalInfo struct {
-	Required bool   `json:"required,omitempty"`
-	Decision string `json:"decision,omitempty"`
-	Reason   string `json:"reason,omitempty"`
-}
-
-type PolicyInfo struct {
-	ID          string `json:"id,omitempty"`
-	Name        string `json:"name,omitempty"`
-	Decision    string `json:"decision,omitempty"`
-	Enforcement string `json:"enforcement,omitempty"`
-	Reason      string `json:"reason,omitempty"`
-}
-
-type PromptInfo struct {
-	Text string `json:"text,omitempty"`
-}
-
-type ContentInfo struct {
-	Retention string `json:"retention"`
-	Included  bool   `json:"included"`
-	Redacted  bool   `json:"redacted,omitempty"`
-	Truncated bool   `json:"truncated,omitempty"`
-}
+type Origin = asymptotetrace.Origin
 
 const (
-	ContentRetentionMetadata = "metadata"
-	ContentRetentionRedacted = "redacted"
-	ContentRetentionFull     = "full"
+	OriginLocal = asymptotetrace.OriginLocal
+	OriginCloud = asymptotetrace.OriginCloud
+	OriginCI    = asymptotetrace.OriginCI
 )
 
-type DestinationInfo struct {
-	Type   string `json:"type,omitempty"`
-	Mode   string `json:"mode,omitempty"`
-	Status string `json:"status,omitempty"`
-}
+type EventInfo = asymptotetrace.EventInfo
+type EndpointInfo = asymptotetrace.EndpointInfo
+type UserInfo = asymptotetrace.UserInfo
+type HarnessInfo = asymptotetrace.HarnessInfo
+type SessionInfo = asymptotetrace.SessionInfo
+type RunInfo = asymptotetrace.RunInfo
+type ToolInfo = asymptotetrace.ToolInfo
+type FileInfo = asymptotetrace.FileInfo
+type CommandInfo = asymptotetrace.CommandInfo
+type MCPInfo = asymptotetrace.MCPInfo
+type ApprovalInfo = asymptotetrace.ApprovalInfo
+type PolicyInfo = asymptotetrace.PolicyInfo
+type PromptInfo = asymptotetrace.PromptInfo
+type ContentInfo = asymptotetrace.ContentInfo
+type DestinationInfo = asymptotetrace.DestinationInfo
+type HealthInfo = asymptotetrace.HealthInfo
+type Event = asymptotetrace.Event
+type NewEventOptions = asymptotetrace.NewEventOptions
+type Envelope = asymptotetrace.Envelope
 
-type HealthInfo struct {
-	Component string `json:"component,omitempty"`
-	Status    string `json:"status,omitempty"`
-	Reason    string `json:"reason,omitempty"`
-}
+const (
+	ContentRetentionMetadata = asymptotetrace.ContentRetentionMetadata
+	ContentRetentionRedacted = asymptotetrace.ContentRetentionRedacted
+	ContentRetentionFull     = asymptotetrace.ContentRetentionFull
+)
 
-type Event struct {
-	Timestamp     string                 `json:"timestamp"`
-	Vendor        string                 `json:"vendor"`
-	Product       string                 `json:"product"`
-	SchemaVersion string                 `json:"schema_version"`
-	Event         EventInfo              `json:"event"`
-	Severity      Severity               `json:"severity"`
-	Endpoint      EndpointInfo           `json:"endpoint"`
-	User          UserInfo               `json:"user,omitempty"`
-	Harness       HarnessInfo            `json:"harness"`
-	Session       *SessionInfo           `json:"session,omitempty"`
-	Tool          *ToolInfo              `json:"tool,omitempty"`
-	File          *FileInfo              `json:"file,omitempty"`
-	Command       *CommandInfo           `json:"command,omitempty"`
-	MCP           *MCPInfo               `json:"mcp,omitempty"`
-	Approval      *ApprovalInfo          `json:"approval,omitempty"`
-	Policy        *PolicyInfo            `json:"policy,omitempty"`
-	Prompt        *PromptInfo            `json:"prompt,omitempty"`
-	Content       *ContentInfo           `json:"content,omitempty"`
-	Destination   *DestinationInfo       `json:"destination,omitempty"`
-	Health        *HealthInfo            `json:"health,omitempty"`
-	Model         string                 `json:"model,omitempty"`
-	Repository    string                 `json:"repository,omitempty"`
-	Branch        string                 `json:"branch,omitempty"`
-	Message       string                 `json:"message,omitempty"`
-	Raw           map[string]interface{} `json:"raw,omitempty"`
-	Truncated     bool                   `json:"field_truncated,omitempty"`
-}
-
-type NewEventOptions struct {
-	Action       string
-	Category     string
-	Severity     Severity
-	Harness      HarnessInfo
-	AgentVersion string
-	Message      string
-}
-
-func NewEvent(opts NewEventOptions) Event {
-	hostname, _ := os.Hostname()
-	userName := os.Getenv("USER")
-	if userName == "" {
-		userName = os.Getenv("USERNAME")
-	}
-	severity := opts.Severity
-	if severity == "" {
-		severity = SeverityInfo
-	}
-	return Event{
-		Timestamp:     time.Now().UTC().Format(time.RFC3339),
-		Vendor:        Vendor,
-		Product:       Product,
-		SchemaVersion: SchemaVersion,
-		Event: EventInfo{
-			Kind:     "agent_runtime",
-			Action:   opts.Action,
-			Category: opts.Category,
-		},
-		Severity: severity,
-		Endpoint: EndpointInfo{
-			Hostname:     hostname,
-			OS:           runtime.GOOS,
-			AgentVersion: opts.AgentVersion,
-		},
-		User: UserInfo{
-			Name: userName,
-			UID:  os.Getenv("UID"),
-		},
-		Harness: opts.Harness,
-		Message: opts.Message,
-	}
-}
-
-func (e Event) Validate() error {
-	if e.Vendor != Vendor {
-		return errors.New("vendor must be beacon")
-	}
-	if e.Product != Product {
-		return errors.New("product must be endpoint-agent")
-	}
-	if e.SchemaVersion == "" {
-		return errors.New("schema_version is required")
-	}
-	if e.Event.Kind == "" || e.Event.Action == "" {
-		return errors.New("event.kind and event.action are required")
-	}
-	if e.Severity == "" {
-		return errors.New("severity is required")
-	}
-	if e.Endpoint.OS == "" {
-		return errors.New("endpoint.os is required")
-	}
-	if e.Harness.Name == "" {
-		return errors.New("harness.name is required")
-	}
-	if e.Content != nil {
-		switch e.Content.Retention {
-		case ContentRetentionMetadata, ContentRetentionRedacted, ContentRetentionFull:
-		default:
-			return errors.New("content.retention must be metadata, redacted, or full")
-		}
-	}
-	return nil
-}
+var NewEvent = asymptotetrace.NewEvent

--- a/cli/beacon/internal/endpoint/writer/writer.go
+++ b/cli/beacon/internal/endpoint/writer/writer.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace"
 )
 
 const (
@@ -22,13 +22,6 @@ const (
 	DefaultRotateArchives = 5
 	RotateBytes           = DefaultRotateBytes
 )
-
-var secretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)authorization\s*[:=]\s*bearer\s+[^"',\s]+`),
-	regexp.MustCompile(`(?i)(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*["']?[^"',\s]+`),
-	regexp.MustCompile(`(?i)bearer\s+[a-z0-9._~+/=-]+`),
-	regexp.MustCompile(`sk-[a-zA-Z0-9]{20,}`),
-}
 
 type Options struct {
 	Path           string
@@ -72,7 +65,7 @@ func AppendEvent(event schema.Event, opts Options) (string, error) {
 	}
 	if len(data) > opts.MaxBytes {
 		event.Raw = nil
-		event.Message = truncate(event.Message, 1024)
+		event.Message = asymptotetrace.TruncateString(event.Message, 1024)
 		event.Truncated = true
 		data, err = json.Marshal(event)
 		if err != nil {
@@ -107,89 +100,7 @@ func LastLine(path string) (string, error) {
 }
 
 func SanitizeEvent(event schema.Event, maxBytes int) schema.Event {
-	event.Message = redact(truncate(event.Message, 4096))
-	if event.Tool != nil {
-		event.Tool.Command = redact(truncate(event.Tool.Command, 4096))
-		event.Tool.Path = truncate(event.Tool.Path, 2048)
-	}
-	if event.Command != nil {
-		event.Command.Command = redact(truncate(event.Command.Command, 4096))
-	}
-	if event.Approval != nil {
-		event.Approval.Reason = redact(truncate(event.Approval.Reason, 4096))
-	}
-	if event.Policy != nil {
-		event.Policy.Reason = redact(truncate(event.Policy.Reason, 4096))
-	}
-	if event.Prompt != nil {
-		event.Prompt.Text = redact(truncate(event.Prompt.Text, 4096))
-	}
-	if event.Raw != nil {
-		event.Raw = sanitizeMap(event.Raw)
-	}
-	if data, err := json.Marshal(event); err == nil && len(data) > maxBytes {
-		event.Truncated = true
-	}
-	return event
-}
-
-func sanitizeMap(input map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(input))
-	for k, v := range input {
-		switch typed := v.(type) {
-		case string:
-			out[k] = redact(truncate(typed, 2048))
-		case map[string]interface{}:
-			out[k] = sanitizeMap(typed)
-		case []interface{}:
-			out[k] = sanitizeSlice(typed)
-		default:
-			out[k] = typed
-		}
-	}
-	return out
-}
-
-func sanitizeSlice(input []interface{}) []interface{} {
-	out := make([]interface{}, len(input))
-	for i, v := range input {
-		switch typed := v.(type) {
-		case string:
-			out[i] = redact(truncate(typed, 2048))
-		case map[string]interface{}:
-			out[i] = sanitizeMap(typed)
-		case []interface{}:
-			out[i] = sanitizeSlice(typed)
-		default:
-			out[i] = typed
-		}
-	}
-	return out
-}
-
-func redact(value string) string {
-	for _, pattern := range secretPatterns {
-		value = pattern.ReplaceAllStringFunc(value, func(match string) string {
-			if strings.Contains(match, "=") {
-				return match[:strings.Index(match, "=")+1] + "[REDACTED]"
-			}
-			if strings.Contains(match, ":") {
-				return match[:strings.Index(match, ":")+1] + "[REDACTED]"
-			}
-			return "[REDACTED]"
-		})
-	}
-	return value
-}
-
-func truncate(value string, limit int) string {
-	if len(value) <= limit {
-		return value
-	}
-	if limit < 32 {
-		return value[:limit]
-	}
-	return value[:limit-15] + "...[truncated]"
+	return asymptotetrace.SanitizeEvent(event, maxBytes)
 }
 
 func appendJSONL(path string, line []byte, rotateBytes int64, rotateArchives int) error {

--- a/collector-builder/exporter/beaconjsonexporter/go.mod
+++ b/collector-builder/exporter/beaconjsonexporter/go.mod
@@ -3,12 +3,15 @@ module github.com/asymptote-labs/agent-beacon/collector-builder/exporter/beaconj
 go 1.24.0
 
 require (
+	github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace v0.0.0
 	go.opentelemetry.io/collector/component v1.27.0
 	go.opentelemetry.io/collector/consumer v1.27.0
 	go.opentelemetry.io/collector/exporter v0.121.0
 	go.opentelemetry.io/collector/pdata v1.27.0
 	go.uber.org/zap v1.27.0
 )
+
+replace github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace => ../../../pkg/asymptotetrace
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/event.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/event.go
@@ -1,111 +1,62 @@
 package beaconevent
 
 import (
-	"os"
-	"runtime"
 	"time"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace"
 )
 
 const (
-	Vendor        = "beacon"
-	Product       = "endpoint-agent"
-	SchemaVersion = "1.0"
+	Vendor        = asymptotetrace.Vendor
+	Product       = asymptotetrace.Product
+	SchemaVersion = asymptotetrace.SchemaVersion
 )
 
-type EventInfo struct {
-	Kind     string `json:"kind"`
-	Action   string `json:"action"`
-	Category string `json:"category,omitempty"`
-}
-
-type EndpointInfo struct {
-	Hostname string `json:"hostname,omitempty"`
-	OS       string `json:"os"`
-}
-
-type UserInfo struct {
-	Name string `json:"name,omitempty"`
-}
-
-type HarnessInfo struct {
-	Name           string `json:"name"`
-	Version        string `json:"version,omitempty"`
-	ExecutablePath string `json:"executable_path,omitempty"`
-	ConfigPath     string `json:"config_path,omitempty"`
-}
-
-type SessionInfo struct {
-	ID               string `json:"id,omitempty"`
-	WorkingDirectory string `json:"working_directory,omitempty"`
-}
-
-type ToolInfo struct {
-	Name    string `json:"name,omitempty"`
-	Command string `json:"command,omitempty"`
-	Path    string `json:"path,omitempty"`
-}
-
-type FileInfo struct {
-	Path      string `json:"path,omitempty"`
-	Operation string `json:"operation,omitempty"`
-	Language  string `json:"language,omitempty"`
-	DiffHash  string `json:"diff_hash,omitempty"`
-	DiffBytes int    `json:"diff_bytes,omitempty"`
-}
-
-type CommandInfo struct {
-	Command    string `json:"command,omitempty"`
-	ExitCode   *int   `json:"exit_code,omitempty"`
-	DurationMS int64  `json:"duration_ms,omitempty"`
-}
-
-type MCPInfo struct {
-	Server string `json:"server,omitempty"`
-	Tool   string `json:"tool,omitempty"`
-}
-
-type ApprovalInfo struct {
-	Required bool   `json:"required,omitempty"`
-	Decision string `json:"decision,omitempty"`
-	Reason   string `json:"reason,omitempty"`
-}
-
-type PromptInfo struct {
-	Text string `json:"text,omitempty"`
-}
-
-type ContentInfo struct {
-	Retention string `json:"retention"`
-	Included  bool   `json:"included"`
-	Redacted  bool   `json:"redacted,omitempty"`
-	Truncated bool   `json:"truncated,omitempty"`
-}
+type EventInfo = asymptotetrace.EventInfo
+type EndpointInfo = asymptotetrace.EndpointInfo
+type UserInfo = asymptotetrace.UserInfo
+type HarnessInfo = asymptotetrace.HarnessInfo
+type SessionInfo = asymptotetrace.SessionInfo
+type RunInfo = asymptotetrace.RunInfo
+type ToolInfo = asymptotetrace.ToolInfo
+type FileInfo = asymptotetrace.FileInfo
+type CommandInfo = asymptotetrace.CommandInfo
+type MCPInfo = asymptotetrace.MCPInfo
+type ApprovalInfo = asymptotetrace.ApprovalInfo
+type PolicyInfo = asymptotetrace.PolicyInfo
+type PromptInfo = asymptotetrace.PromptInfo
+type ContentInfo = asymptotetrace.ContentInfo
 
 type Event struct {
-	ObservedAt    time.Time              `json:"-"`
-	Timestamp     string                 `json:"timestamp"`
-	Vendor        string                 `json:"vendor"`
-	Product       string                 `json:"product"`
-	SchemaVersion string                 `json:"schema_version"`
-	Event         EventInfo              `json:"event"`
-	Severity      string                 `json:"severity"`
-	Endpoint      EndpointInfo           `json:"endpoint"`
-	User          UserInfo               `json:"user,omitempty"`
-	Harness       HarnessInfo            `json:"harness"`
-	Session       *SessionInfo           `json:"session,omitempty"`
-	Tool          *ToolInfo              `json:"tool,omitempty"`
-	File          *FileInfo              `json:"file,omitempty"`
-	Command       *CommandInfo           `json:"command,omitempty"`
-	MCP           *MCPInfo               `json:"mcp,omitempty"`
-	Approval      *ApprovalInfo          `json:"approval,omitempty"`
-	Prompt        *PromptInfo            `json:"prompt,omitempty"`
-	Content       *ContentInfo           `json:"content,omitempty"`
-	Model         string                 `json:"model,omitempty"`
-	Repository    string                 `json:"repository,omitempty"`
-	Branch        string                 `json:"branch,omitempty"`
-	Message       string                 `json:"message,omitempty"`
-	Raw           map[string]interface{} `json:"raw,omitempty"`
-	Truncated     bool                   `json:"field_truncated,omitempty"`
+	ObservedAt    time.Time                       `json:"-"`
+	Timestamp     string                          `json:"timestamp"`
+	Vendor        string                          `json:"vendor"`
+	Product       string                          `json:"product"`
+	SchemaVersion string                          `json:"schema_version"`
+	Event         EventInfo                       `json:"event"`
+	Severity      string                          `json:"severity"`
+	Endpoint      EndpointInfo                    `json:"endpoint"`
+	User          UserInfo                        `json:"user,omitempty"`
+	Harness       HarnessInfo                     `json:"harness"`
+	Origin        asymptotetrace.Origin           `json:"origin,omitempty"`
+	Run           *RunInfo                        `json:"run,omitempty"`
+	Session       *SessionInfo                    `json:"session,omitempty"`
+	Tool          *ToolInfo                       `json:"tool,omitempty"`
+	File          *FileInfo                       `json:"file,omitempty"`
+	Command       *CommandInfo                    `json:"command,omitempty"`
+	MCP           *MCPInfo                        `json:"mcp,omitempty"`
+	Approval      *ApprovalInfo                   `json:"approval,omitempty"`
+	Policy        *PolicyInfo                     `json:"policy,omitempty"`
+	Prompt        *PromptInfo                     `json:"prompt,omitempty"`
+	Content       *ContentInfo                    `json:"content,omitempty"`
+	Destination   *asymptotetrace.DestinationInfo `json:"destination,omitempty"`
+	Health        *asymptotetrace.HealthInfo      `json:"health,omitempty"`
+	Model         string                          `json:"model,omitempty"`
+	Repository    string                          `json:"repository,omitempty"`
+	Branch        string                          `json:"branch,omitempty"`
+	Message       string                          `json:"message,omitempty"`
+	Raw           map[string]interface{}          `json:"raw,omitempty"`
+	Truncated     bool                            `json:"field_truncated,omitempty"`
 }
 
 func NewEvent(action, category, severity, harnessName string, ts time.Time) Event {
@@ -118,24 +69,22 @@ func NewEvent(action, category, severity, harnessName string, ts time.Time) Even
 	if harnessName == "" {
 		harnessName = "unknown"
 	}
-	hostname, _ := os.Hostname()
+	base := asymptotetrace.NewEvent(asymptotetrace.NewEventOptions{
+		Action:   action,
+		Category: category,
+		Severity: asymptotetrace.Severity(severity),
+		Harness:  HarnessInfo{Name: harnessName},
+	})
 	return Event{
 		ObservedAt:    ts.UTC(),
 		Timestamp:     ts.UTC().Format(time.RFC3339),
-		Vendor:        Vendor,
-		Product:       Product,
-		SchemaVersion: SchemaVersion,
-		Event: EventInfo{
-			Kind:     "agent_runtime",
-			Action:   action,
-			Category: category,
-		},
-		Severity: severity,
-		Endpoint: EndpointInfo{
-			Hostname: hostname,
-			OS:       runtime.GOOS,
-		},
-		User:    UserInfo{Name: os.Getenv("USER")},
-		Harness: HarnessInfo{Name: harnessName},
+		Vendor:        base.Vendor,
+		Product:       base.Product,
+		SchemaVersion: base.SchemaVersion,
+		Event:         base.Event,
+		Severity:      string(base.Severity),
+		Endpoint:      base.Endpoint,
+		User:          base.User,
+		Harness:       base.Harness,
 	}
 }

--- a/collector-builder/exporter/beaconjsonexporter/writer.go
+++ b/collector-builder/exporter/beaconjsonexporter/writer.go
@@ -5,18 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
-)
 
-var secretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)authorization\s*[:=]\s*bearer\s+[^"',\s]+`),
-	regexp.MustCompile(`(?i)(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*["']?[^"',\s]+`),
-	regexp.MustCompile(`(?i)bearer\s+[a-z0-9._~+/=-]+`),
-	regexp.MustCompile(`sk-[a-zA-Z0-9]{20,}`),
-}
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace"
+)
 
 type jsonlWriter struct {
 	path           string
@@ -34,7 +28,7 @@ func (w jsonlWriter) append(event beaconEvent) error {
 	}
 	if len(data) > w.maxEventBytes {
 		event.Raw = nil
-		event.Message = truncate(event.Message, 1024)
+		event.Message = asymptotetrace.TruncateString(event.Message, 1024)
 		event.Truncated = true
 		data, err = json.Marshal(event)
 		if err != nil {
@@ -51,19 +45,22 @@ func (w jsonlWriter) append(event beaconEvent) error {
 }
 
 func (w jsonlWriter) sanitize(event beaconEvent) beaconEvent {
-	event.Message = w.cleanString(event.Message, 4096)
+	event.Message = w.cleanString(event.Message, asymptotetrace.DefaultStringLimit)
 	if event.Tool != nil {
-		event.Tool.Command = w.cleanString(event.Tool.Command, 4096)
-		event.Tool.Path = truncate(event.Tool.Path, 2048)
+		event.Tool.Command = w.cleanString(event.Tool.Command, asymptotetrace.DefaultStringLimit)
+		event.Tool.Path = asymptotetrace.TruncateString(event.Tool.Path, asymptotetrace.DefaultRawStringLimit)
 	}
 	if event.Command != nil {
-		event.Command.Command = w.cleanString(event.Command.Command, 4096)
+		event.Command.Command = w.cleanString(event.Command.Command, asymptotetrace.DefaultStringLimit)
 	}
 	if event.Approval != nil {
-		event.Approval.Reason = w.cleanString(event.Approval.Reason, 4096)
+		event.Approval.Reason = w.cleanString(event.Approval.Reason, asymptotetrace.DefaultStringLimit)
+	}
+	if event.Policy != nil {
+		event.Policy.Reason = w.cleanString(event.Policy.Reason, asymptotetrace.DefaultStringLimit)
 	}
 	if event.Prompt != nil {
-		event.Prompt.Text = w.cleanString(event.Prompt.Text, 4096)
+		event.Prompt.Text = w.cleanString(event.Prompt.Text, asymptotetrace.DefaultStringLimit)
 	}
 	if event.Raw != nil {
 		event.Raw = w.sanitizeMap(event.Raw)
@@ -75,70 +72,21 @@ func (w jsonlWriter) sanitize(event beaconEvent) beaconEvent {
 }
 
 func (w jsonlWriter) sanitizeMap(input map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(input))
-	for k, v := range input {
-		switch typed := v.(type) {
-		case string:
-			out[k] = w.cleanString(typed, 2048)
-		case map[string]interface{}:
-			out[k] = w.sanitizeMap(typed)
-		case []interface{}:
-			out[k] = w.sanitizeSlice(typed)
-		default:
-			out[k] = typed
-		}
-	}
-	return out
+	return asymptotetrace.SanitizeMap(input, asymptotetrace.PrivacyOptions{
+		RedactSecrets: w.redactSecrets,
+		StringLimit:   asymptotetrace.DefaultRawStringLimit,
+	})
 }
 
 func (w jsonlWriter) sanitizeSlice(input []interface{}) []interface{} {
-	out := make([]interface{}, len(input))
-	for i, v := range input {
-		switch typed := v.(type) {
-		case string:
-			out[i] = w.cleanString(typed, 2048)
-		case map[string]interface{}:
-			out[i] = w.sanitizeMap(typed)
-		case []interface{}:
-			out[i] = w.sanitizeSlice(typed)
-		default:
-			out[i] = typed
-		}
-	}
-	return out
+	return asymptotetrace.SanitizeSlice(input, asymptotetrace.PrivacyOptions{
+		RedactSecrets: w.redactSecrets,
+		StringLimit:   asymptotetrace.DefaultRawStringLimit,
+	})
 }
 
 func (w jsonlWriter) cleanString(value string, limit int) string {
-	value = truncate(value, limit)
-	if w.redactSecrets {
-		value = redact(value)
-	}
-	return value
-}
-
-func redact(value string) string {
-	for _, pattern := range secretPatterns {
-		value = pattern.ReplaceAllStringFunc(value, func(match string) string {
-			if strings.Contains(match, "=") {
-				return match[:strings.Index(match, "=")+1] + "[REDACTED]"
-			}
-			if strings.Contains(match, ":") {
-				return match[:strings.Index(match, ":")+1] + "[REDACTED]"
-			}
-			return "[REDACTED]"
-		})
-	}
-	return value
-}
-
-func truncate(value string, limit int) string {
-	if len(value) <= limit {
-		return value
-	}
-	if limit < 32 {
-		return value[:limit]
-	}
-	return value[:limit-15] + "...[truncated]"
+	return asymptotetrace.CleanString(value, limit, w.redactSecrets)
 }
 
 // Keep this rotation contract mirrored with the endpoint CLI and hook writer.

--- a/pkg/asymptotetrace/envelope.go
+++ b/pkg/asymptotetrace/envelope.go
@@ -1,0 +1,35 @@
+package asymptotetrace
+
+type Envelope struct {
+	Vendor        string                 `json:"vendor"`
+	SchemaVersion string                 `json:"schema_version"`
+	Origin        Origin                 `json:"origin"`
+	Harness       HarnessInfo            `json:"harness"`
+	Session       *SessionInfo           `json:"session,omitempty"`
+	Run           *RunInfo               `json:"run,omitempty"`
+	Raw           map[string]interface{} `json:"raw,omitempty"`
+}
+
+func NewEnvelope(origin Origin, harness HarnessInfo, raw map[string]interface{}) Envelope {
+	return Envelope{
+		Vendor:        Vendor,
+		SchemaVersion: SchemaVersion,
+		Origin:        origin,
+		Harness:       harness,
+		Raw:           raw,
+	}
+}
+
+func (e Envelope) Validate() error {
+	event := Event{
+		Vendor:        e.Vendor,
+		Product:       Product,
+		SchemaVersion: e.SchemaVersion,
+		Event:         EventInfo{Kind: "agent_runtime", Action: "envelope.received"},
+		Severity:      SeverityInfo,
+		Endpoint:      EndpointInfo{OS: "unknown"},
+		Harness:       e.Harness,
+		Origin:        e.Origin,
+	}
+	return event.Validate()
+}

--- a/pkg/asymptotetrace/envelope_test.go
+++ b/pkg/asymptotetrace/envelope_test.go
@@ -1,0 +1,23 @@
+package asymptotetrace
+
+import "testing"
+
+func TestNewEnvelopeSetsWireIdentity(t *testing.T) {
+	envelope := NewEnvelope(OriginCI, HarnessInfo{Name: "claude"}, map[string]interface{}{"event": "raw"})
+	envelope.Session = &SessionInfo{ID: "session-1"}
+	envelope.Run = &RunInfo{Provider: "github_actions", RunID: "123"}
+
+	if envelope.Vendor != Vendor || envelope.SchemaVersion != SchemaVersion {
+		t.Fatalf("unexpected wire identity: %#v", envelope)
+	}
+	if err := envelope.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+}
+
+func TestEnvelopeValidateRejectsInvalidOrigin(t *testing.T) {
+	envelope := NewEnvelope("lambda", HarnessInfo{Name: "claude"}, nil)
+	if err := envelope.Validate(); err == nil {
+		t.Fatal("expected invalid origin error")
+	}
+}

--- a/pkg/asymptotetrace/event.go
+++ b/pkg/asymptotetrace/event.go
@@ -1,0 +1,257 @@
+package asymptotetrace
+
+import (
+	"errors"
+	"os"
+	"runtime"
+	"time"
+)
+
+const (
+	Vendor        = "beacon"
+	Product       = "endpoint-agent"
+	SchemaVersion = "1.0"
+)
+
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityLow      Severity = "low"
+	SeverityMedium   Severity = "medium"
+	SeverityHigh     Severity = "high"
+	SeverityCritical Severity = "critical"
+)
+
+type Origin string
+
+const (
+	OriginLocal Origin = "local"
+	OriginCloud Origin = "cloud"
+	OriginCI    Origin = "ci"
+)
+
+type EventInfo struct {
+	Kind     string `json:"kind"`
+	Action   string `json:"action"`
+	Category string `json:"category,omitempty"`
+}
+
+type EndpointInfo struct {
+	Hostname     string `json:"hostname,omitempty"`
+	OS           string `json:"os"`
+	AgentVersion string `json:"agent_version,omitempty"`
+}
+
+type UserInfo struct {
+	Name string `json:"name,omitempty"`
+	UID  string `json:"uid,omitempty"`
+}
+
+type HarnessInfo struct {
+	Name           string `json:"name"`
+	Version        string `json:"version,omitempty"`
+	ExecutablePath string `json:"executable_path,omitempty"`
+	ConfigPath     string `json:"config_path,omitempty"`
+}
+
+type SessionInfo struct {
+	ID               string `json:"id,omitempty"`
+	WorkingDirectory string `json:"working_directory,omitempty"`
+}
+
+type RunInfo struct {
+	Provider  string `json:"provider,omitempty"`
+	RunID     string `json:"run_id,omitempty"`
+	Workflow  string `json:"workflow,omitempty"`
+	Commit    string `json:"commit,omitempty"`
+	PR        string `json:"pr,omitempty"`
+	Actor     string `json:"actor,omitempty"`
+	Ephemeral bool   `json:"ephemeral,omitempty"`
+}
+
+type ToolInfo struct {
+	Name    string `json:"name,omitempty"`
+	Command string `json:"command,omitempty"`
+	Path    string `json:"path,omitempty"`
+}
+
+type FileInfo struct {
+	Path      string `json:"path,omitempty"`
+	Operation string `json:"operation,omitempty"`
+	Language  string `json:"language,omitempty"`
+	DiffHash  string `json:"diff_hash,omitempty"`
+	DiffBytes int    `json:"diff_bytes,omitempty"`
+}
+
+type CommandInfo struct {
+	Command    string `json:"command,omitempty"`
+	ExitCode   *int   `json:"exit_code,omitempty"`
+	DurationMS int64  `json:"duration_ms,omitempty"`
+}
+
+type MCPInfo struct {
+	Server string `json:"server,omitempty"`
+	Tool   string `json:"tool,omitempty"`
+}
+
+type ApprovalInfo struct {
+	Required bool   `json:"required,omitempty"`
+	Decision string `json:"decision,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+type PolicyInfo struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Decision    string `json:"decision,omitempty"`
+	Enforcement string `json:"enforcement,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+type PromptInfo struct {
+	Text string `json:"text,omitempty"`
+}
+
+type ContentInfo struct {
+	Retention string `json:"retention"`
+	Included  bool   `json:"included"`
+	Redacted  bool   `json:"redacted,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+const (
+	ContentRetentionMetadata = "metadata"
+	ContentRetentionRedacted = "redacted"
+	ContentRetentionFull     = "full"
+)
+
+type DestinationInfo struct {
+	Type   string `json:"type,omitempty"`
+	Mode   string `json:"mode,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type HealthInfo struct {
+	Component string `json:"component,omitempty"`
+	Status    string `json:"status,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+type Event struct {
+	Timestamp     string                 `json:"timestamp"`
+	Vendor        string                 `json:"vendor"`
+	Product       string                 `json:"product"`
+	SchemaVersion string                 `json:"schema_version"`
+	Event         EventInfo              `json:"event"`
+	Severity      Severity               `json:"severity"`
+	Endpoint      EndpointInfo           `json:"endpoint"`
+	User          UserInfo               `json:"user,omitempty"`
+	Harness       HarnessInfo            `json:"harness"`
+	Origin        Origin                 `json:"origin,omitempty"`
+	Run           *RunInfo               `json:"run,omitempty"`
+	Session       *SessionInfo           `json:"session,omitempty"`
+	Tool          *ToolInfo              `json:"tool,omitempty"`
+	File          *FileInfo              `json:"file,omitempty"`
+	Command       *CommandInfo           `json:"command,omitempty"`
+	MCP           *MCPInfo               `json:"mcp,omitempty"`
+	Approval      *ApprovalInfo          `json:"approval,omitempty"`
+	Policy        *PolicyInfo            `json:"policy,omitempty"`
+	Prompt        *PromptInfo            `json:"prompt,omitempty"`
+	Content       *ContentInfo           `json:"content,omitempty"`
+	Destination   *DestinationInfo       `json:"destination,omitempty"`
+	Health        *HealthInfo            `json:"health,omitempty"`
+	Model         string                 `json:"model,omitempty"`
+	Repository    string                 `json:"repository,omitempty"`
+	Branch        string                 `json:"branch,omitempty"`
+	Message       string                 `json:"message,omitempty"`
+	Raw           map[string]interface{} `json:"raw,omitempty"`
+	Truncated     bool                   `json:"field_truncated,omitempty"`
+}
+
+type NewEventOptions struct {
+	Action       string
+	Category     string
+	Severity     Severity
+	Harness      HarnessInfo
+	AgentVersion string
+	Message      string
+	Origin       Origin
+	Run          *RunInfo
+}
+
+func NewEvent(opts NewEventOptions) Event {
+	hostname, _ := os.Hostname()
+	userName := os.Getenv("USER")
+	if userName == "" {
+		userName = os.Getenv("USERNAME")
+	}
+	severity := opts.Severity
+	if severity == "" {
+		severity = SeverityInfo
+	}
+	return Event{
+		Timestamp:     time.Now().UTC().Format(time.RFC3339),
+		Vendor:        Vendor,
+		Product:       Product,
+		SchemaVersion: SchemaVersion,
+		Event: EventInfo{
+			Kind:     "agent_runtime",
+			Action:   opts.Action,
+			Category: opts.Category,
+		},
+		Severity: severity,
+		Endpoint: EndpointInfo{
+			Hostname:     hostname,
+			OS:           runtime.GOOS,
+			AgentVersion: opts.AgentVersion,
+		},
+		User: UserInfo{
+			Name: userName,
+			UID:  os.Getenv("UID"),
+		},
+		Harness: opts.Harness,
+		Origin:  opts.Origin,
+		Run:     opts.Run,
+		Message: opts.Message,
+	}
+}
+
+func (e Event) Validate() error {
+	if e.Vendor != Vendor {
+		return errors.New("vendor must be beacon")
+	}
+	if e.Product != Product {
+		return errors.New("product must be endpoint-agent")
+	}
+	if e.SchemaVersion == "" {
+		return errors.New("schema_version is required")
+	}
+	if e.Event.Kind == "" || e.Event.Action == "" {
+		return errors.New("event.kind and event.action are required")
+	}
+	if e.Severity == "" {
+		return errors.New("severity is required")
+	}
+	if e.Endpoint.OS == "" {
+		return errors.New("endpoint.os is required")
+	}
+	if e.Harness.Name == "" {
+		return errors.New("harness.name is required")
+	}
+	if e.Origin != "" {
+		switch e.Origin {
+		case OriginLocal, OriginCloud, OriginCI:
+		default:
+			return errors.New("origin must be local, cloud, or ci")
+		}
+	}
+	if e.Content != nil {
+		switch e.Content.Retention {
+		case ContentRetentionMetadata, ContentRetentionRedacted, ContentRetentionFull:
+		default:
+			return errors.New("content.retention must be metadata, redacted, or full")
+		}
+	}
+	return nil
+}

--- a/pkg/asymptotetrace/event_test.go
+++ b/pkg/asymptotetrace/event_test.go
@@ -1,0 +1,181 @@
+package asymptotetrace
+
+import (
+	"encoding/json"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewEventSetsRequiredInvariants(t *testing.T) {
+	event := NewEvent(NewEventOptions{
+		Action:       "telemetry.enabled",
+		Category:     "telemetry",
+		AgentVersion: "test-version",
+		Harness:      HarnessInfo{Name: "endpoint"},
+		Message:      "configured",
+	})
+
+	if err := event.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if event.Vendor != Vendor || event.Product != Product || event.SchemaVersion != SchemaVersion {
+		t.Fatalf("unexpected schema identity: %#v", event)
+	}
+	if event.Event.Kind != "agent_runtime" || event.Event.Action != "telemetry.enabled" || event.Event.Category != "telemetry" {
+		t.Fatalf("unexpected event info: %#v", event.Event)
+	}
+	if event.Severity != SeverityInfo {
+		t.Fatalf("default severity = %q, want %q", event.Severity, SeverityInfo)
+	}
+	if event.Endpoint.OS != runtime.GOOS || event.Endpoint.AgentVersion != "test-version" {
+		t.Fatalf("unexpected endpoint info: %#v", event.Endpoint)
+	}
+	if _, err := time.Parse(time.RFC3339, event.Timestamp); err != nil {
+		t.Fatalf("timestamp is not RFC3339: %q", event.Timestamp)
+	}
+	event.File = &FileInfo{Path: "main.go", Operation: "modify"}
+	event.Command = &CommandInfo{Command: "go test ./..."}
+	event.MCP = &MCPInfo{Server: "github", Tool: "get_issue"}
+	event.Prompt = &PromptInfo{Text: "Summarize this file"}
+	event.Content = &ContentInfo{Retention: ContentRetentionFull, Included: true}
+	if err := event.Validate(); err != nil {
+		t.Fatalf("Validate rejected optional telemetry fields: %v", err)
+	}
+}
+
+func TestValidateContentRetentionValues(t *testing.T) {
+	for _, retention := range []string{ContentRetentionMetadata, ContentRetentionRedacted, ContentRetentionFull} {
+		t.Run(retention, func(t *testing.T) {
+			event := NewEvent(NewEventOptions{
+				Action:  "tool.invoked",
+				Harness: HarnessInfo{Name: "cursor"},
+			})
+			event.Content = &ContentInfo{Retention: retention, Included: retention != ContentRetentionMetadata}
+
+			if err := event.Validate(); err != nil {
+				t.Fatalf("Validate rejected retention %q: %v", retention, err)
+			}
+		})
+	}
+}
+
+func TestValidateOriginValues(t *testing.T) {
+	for _, origin := range []Origin{"", OriginLocal, OriginCloud, OriginCI} {
+		t.Run(string(origin), func(t *testing.T) {
+			event := NewEvent(NewEventOptions{
+				Action:  "tool.invoked",
+				Harness: HarnessInfo{Name: "cursor"},
+				Origin:  origin,
+			})
+			if err := event.Validate(); err != nil {
+				t.Fatalf("Validate rejected origin %q: %v", origin, err)
+			}
+		})
+	}
+
+	event := NewEvent(NewEventOptions{Action: "tool.invoked", Harness: HarnessInfo{Name: "cursor"}, Origin: "serverless"})
+	if err := event.Validate(); err == nil || !strings.Contains(err.Error(), "origin must be local, cloud, or ci") {
+		t.Fatalf("Validate error = %v, want origin error", err)
+	}
+}
+
+func TestRunAndOriginAreOmittedWhenUnset(t *testing.T) {
+	event := NewEvent(NewEventOptions{Action: "tool.invoked", Harness: HarnessInfo{Name: "cursor"}})
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	text := string(data)
+	for _, field := range []string{`"origin"`, `"run"`} {
+		if strings.Contains(text, field) {
+			t.Fatalf("unset additive field %s leaked into JSON: %s", field, text)
+		}
+	}
+}
+
+func TestRunAndOriginSerializeWhenSet(t *testing.T) {
+	event := NewEvent(NewEventOptions{
+		Action:  "tool.invoked",
+		Harness: HarnessInfo{Name: "claude"},
+		Origin:  OriginCI,
+		Run:     &RunInfo{Provider: "github_actions", RunID: "123", PR: "42", Ephemeral: true},
+	})
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{`"origin":"ci"`, `"provider":"github_actions"`, `"run_id":"123"`, `"ephemeral":true`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("JSON missing %s: %s", want, text)
+		}
+	}
+}
+
+func TestValidateRejectsMissingOrInvalidRequiredFields(t *testing.T) {
+	valid := NewEvent(NewEventOptions{
+		Action:   "tool.invoked",
+		Harness:  HarnessInfo{Name: "cursor"},
+		Severity: SeverityHigh,
+	})
+
+	tests := []struct {
+		name string
+		edit func(*Event)
+		want string
+	}{
+		{
+			name: "vendor",
+			edit: func(e *Event) { e.Vendor = "other" },
+			want: "vendor must be beacon",
+		},
+		{
+			name: "product",
+			edit: func(e *Event) { e.Product = "other" },
+			want: "product must be endpoint-agent",
+		},
+		{
+			name: "schema version",
+			edit: func(e *Event) { e.SchemaVersion = "" },
+			want: "schema_version is required",
+		},
+		{
+			name: "action",
+			edit: func(e *Event) { e.Event.Action = "" },
+			want: "event.kind and event.action are required",
+		},
+		{
+			name: "severity",
+			edit: func(e *Event) { e.Severity = "" },
+			want: "severity is required",
+		},
+		{
+			name: "os",
+			edit: func(e *Event) { e.Endpoint.OS = "" },
+			want: "endpoint.os is required",
+		},
+		{
+			name: "harness",
+			edit: func(e *Event) { e.Harness.Name = "" },
+			want: "harness.name is required",
+		},
+		{
+			name: "content retention",
+			edit: func(e *Event) { e.Content = &ContentInfo{Retention: "raw", Included: true} },
+			want: "content.retention must be metadata, redacted, or full",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := valid
+			tt.edit(&event)
+			err := event.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/asymptotetrace/go.mod
+++ b/pkg/asymptotetrace/go.mod
@@ -1,0 +1,3 @@
+module github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace
+
+go 1.24

--- a/pkg/asymptotetrace/privacy.go
+++ b/pkg/asymptotetrace/privacy.go
@@ -1,0 +1,133 @@
+package asymptotetrace
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+const (
+	DefaultStringLimit    = 4096
+	DefaultRawStringLimit = 2048
+)
+
+var secretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)authorization\s*[:=]\s*bearer\s+[^"',\s]+`),
+	regexp.MustCompile(`(?i)(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*["']?[^"',\s]+`),
+	regexp.MustCompile(`(?i)bearer\s+[a-z0-9._~+/=-]+`),
+	regexp.MustCompile(`sk-[a-zA-Z0-9]{20,}`),
+}
+
+type PrivacyOptions struct {
+	RedactSecrets bool
+	StringLimit   int
+}
+
+func RedactString(value string) string {
+	for _, pattern := range secretPatterns {
+		value = pattern.ReplaceAllStringFunc(value, func(match string) string {
+			if strings.Contains(match, "=") {
+				return match[:strings.Index(match, "=")+1] + "[REDACTED]"
+			}
+			if strings.Contains(match, ":") {
+				return match[:strings.Index(match, ":")+1] + "[REDACTED]"
+			}
+			return "[REDACTED]"
+		})
+	}
+	return value
+}
+
+func TruncateString(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	if limit < 32 {
+		return value[:limit]
+	}
+	return value[:limit-15] + "...[truncated]"
+}
+
+func CleanString(value string, limit int, redactSecrets bool) string {
+	value = TruncateString(value, limit)
+	if redactSecrets {
+		value = RedactString(value)
+	}
+	return value
+}
+
+func SanitizeMap(input map[string]interface{}, opts PrivacyOptions) map[string]interface{} {
+	limit := opts.StringLimit
+	if limit <= 0 {
+		limit = DefaultStringLimit
+	}
+	out := make(map[string]interface{}, len(input))
+	for key, value := range input {
+		switch typed := value.(type) {
+		case string:
+			out[key] = CleanString(typed, limit, opts.RedactSecrets)
+		case map[string]interface{}:
+			out[key] = SanitizeMap(typed, opts)
+		case []interface{}:
+			out[key] = SanitizeSlice(typed, opts)
+		default:
+			out[key] = typed
+		}
+	}
+	return out
+}
+
+func SanitizeSlice(input []interface{}, opts PrivacyOptions) []interface{} {
+	limit := opts.StringLimit
+	if limit <= 0 {
+		limit = DefaultStringLimit
+	}
+	out := make([]interface{}, len(input))
+	for index, value := range input {
+		switch typed := value.(type) {
+		case string:
+			out[index] = CleanString(typed, limit, opts.RedactSecrets)
+		case map[string]interface{}:
+			out[index] = SanitizeMap(typed, opts)
+		case []interface{}:
+			out[index] = SanitizeSlice(typed, opts)
+		default:
+			out[index] = typed
+		}
+	}
+	return out
+}
+
+func RetentionAwareRaw(raw map[string]interface{}, retention string) map[string]interface{} {
+	if retention != ContentRetentionMetadata {
+		return raw
+	}
+	return map[string]interface{}{"field_count": len(raw)}
+}
+
+func SanitizeEvent(event Event, maxBytes int) Event {
+	event.Message = CleanString(event.Message, DefaultStringLimit, true)
+	if event.Tool != nil {
+		event.Tool.Command = CleanString(event.Tool.Command, DefaultStringLimit, true)
+		event.Tool.Path = TruncateString(event.Tool.Path, DefaultRawStringLimit)
+	}
+	if event.Command != nil {
+		event.Command.Command = CleanString(event.Command.Command, DefaultStringLimit, true)
+	}
+	if event.Approval != nil {
+		event.Approval.Reason = CleanString(event.Approval.Reason, DefaultStringLimit, true)
+	}
+	if event.Policy != nil {
+		event.Policy.Reason = CleanString(event.Policy.Reason, DefaultStringLimit, true)
+	}
+	if event.Prompt != nil {
+		event.Prompt.Text = CleanString(event.Prompt.Text, DefaultStringLimit, true)
+	}
+	if event.Raw != nil {
+		event.Raw = SanitizeMap(event.Raw, PrivacyOptions{RedactSecrets: true, StringLimit: DefaultRawStringLimit})
+	}
+	if data, err := json.Marshal(event); err == nil && len(data) > maxBytes {
+		event.Truncated = true
+	}
+	return event
+}

--- a/pkg/asymptotetrace/privacy_test.go
+++ b/pkg/asymptotetrace/privacy_test.go
@@ -1,0 +1,81 @@
+package asymptotetrace
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRedactStringRedactsKnownSecretForms(t *testing.T) {
+	tests := []string{
+		"authorization: Bearer secret-token",
+		"token=super-secret",
+		"Bearer abcdef0123456789",
+		"sk-abcdefghijklmnopqrstuvwxyz",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			if got := RedactString(input); strings.Contains(got, "secret") || strings.Contains(got, "abcdefghijklmnopqrstuvwxyz") {
+				t.Fatalf("RedactString(%q) = %q", input, got)
+			}
+		})
+	}
+}
+
+func TestSanitizeMapDoesNotMutateInput(t *testing.T) {
+	input := map[string]interface{}{
+		"token": "token=super-secret",
+		"nested": map[string]interface{}{
+			"authorization": "authorization: Bearer nested-secret",
+		},
+	}
+
+	got := SanitizeMap(input, PrivacyOptions{RedactSecrets: true, StringLimit: DefaultRawStringLimit})
+	if input["token"] != "token=super-secret" {
+		t.Fatalf("SanitizeMap mutated input: %#v", input)
+	}
+	data, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal sanitized map: %v", err)
+	}
+	if strings.Contains(string(data), "super-secret") || strings.Contains(string(data), "nested-secret") {
+		t.Fatalf("SanitizeMap leaked secret: %s", string(data))
+	}
+}
+
+func TestRetentionAwareRawMetadataMode(t *testing.T) {
+	got := RetentionAwareRaw(map[string]interface{}{"a": 1, "b": 2}, ContentRetentionMetadata)
+	if got["field_count"] != 2 {
+		t.Fatalf("field_count = %v, want 2", got["field_count"])
+	}
+}
+
+func TestSanitizeEventRedactsAndTruncates(t *testing.T) {
+	event := NewEvent(NewEventOptions{
+		Action:  "tool.invoked",
+		Harness: HarnessInfo{Name: "test"},
+		Message: "token=message-secret",
+	})
+	event.Tool = &ToolInfo{
+		Command: "curl -H 'Authorization: Bearer command-secret'",
+		Path:    strings.Repeat("p", 3000),
+	}
+	event.Policy = &PolicyInfo{Reason: "api_key=policy-secret"}
+	event.Prompt = &PromptInfo{Text: "token=prompt-secret"}
+	event.Raw = map[string]interface{}{"nested": map[string]interface{}{"token": "token=raw-secret"}}
+
+	sanitized := SanitizeEvent(event, 64*1024)
+	data, err := json.Marshal(sanitized)
+	if err != nil {
+		t.Fatalf("marshal sanitized event: %v", err)
+	}
+	text := string(data)
+	for _, secret := range []string{"message-secret", "command-secret", "policy-secret", "prompt-secret", "raw-secret"} {
+		if strings.Contains(text, secret) {
+			t.Fatalf("secret %q was not redacted: %s", secret, text)
+		}
+	}
+	if len(sanitized.Tool.Path) > DefaultRawStringLimit {
+		t.Fatalf("tool path was not truncated: %d", len(sanitized.Tool.Path))
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches all endpoint JSONL writers and secret redaction paths; behavior should stay equivalent but any drift in sanitization or validation affects logged telemetry across components.
> 
> **Overview**
> Introduces **`pkg/asymptotetrace`** as the shared home for Beacon endpoint telemetry: event/envelope types, validation, **`origin`** / **`run`** metadata, and centralized secret redaction, truncation, and retention-aware raw handling.
> 
> **`beacon`**, **`beacon-hooks`**, and **`beaconjsonexporter`** drop duplicated schema and privacy logic in favor of type aliases and calls into that package (with local `replace` in their `go.mod` files). The exporter’s event shape gains optional fields aligned with the shared model (e.g. policy, destination, health), and policy reasons are sanitized on write.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cc427ef6dd128cb0c053a2e688299ae90104fda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->