### PR TITLE
Add runtime implementation

### DIFF
--- a/pkg/asymptotetrace/client.go
+++ b/pkg/asymptotetrace/client.go
@@ -1,0 +1,218 @@
+package asymptotetrace
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type EmitResult struct {
+	Accepted bool
+	Dropped  bool
+}
+
+type Client struct {
+	opts     Options
+	commands chan workerCommand
+	done     chan struct{}
+	stats    statsCounter
+
+	closeMu   sync.Mutex
+	accepting atomic.Bool
+	closing   atomic.Bool
+}
+
+type workerCommand struct {
+	kind     workerCommandKind
+	envelope Envelope
+	ctx      context.Context
+	ack      chan error
+}
+
+type workerCommandKind int
+
+const (
+	workerCommandEmit workerCommandKind = iota
+	workerCommandFlush
+	workerCommandStop
+)
+
+func Start(opts Options) *Client {
+	opts = opts.withDefaults()
+	client := &Client{
+		opts:     opts,
+		commands: make(chan workerCommand, opts.QueueSize),
+		done:     make(chan struct{}),
+	}
+	client.accepting.Store(true)
+	go client.run()
+	return client
+}
+
+func (c *Client) Emit(envelope Envelope) (EmitResult, error) {
+	envelope = envelope.withDefaults()
+	if err := envelope.Validate(); err != nil {
+		return EmitResult{}, err
+	}
+	if !c.accepting.Load() {
+		c.stats.dropped.Add(1)
+		return EmitResult{Dropped: true}, nil
+	}
+
+	select {
+	case c.commands <- workerCommand{kind: workerCommandEmit, envelope: envelope}:
+		c.stats.accepted.Add(1)
+		return EmitResult{Accepted: true}, nil
+	default:
+		c.stats.dropped.Add(1)
+		return EmitResult{Dropped: true}, nil
+	}
+}
+
+func (c *Client) Flush(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return c.sendBarrier(ctx, workerCommandFlush)
+}
+
+func (c *Client) Close(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if c.closing.Load() {
+		select {
+		case <-c.done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	c.closeMu.Lock()
+	defer c.closeMu.Unlock()
+	if c.closing.Load() {
+		select {
+		case <-c.done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	ack := make(chan error, 1)
+	command := workerCommand{kind: workerCommandStop, ctx: ctx, ack: ack}
+	select {
+	case <-c.done:
+		return nil
+	case c.commands <- command:
+		c.closing.Store(true)
+		c.accepting.Store(false)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	select {
+	case err := <-ack:
+		return err
+	case <-c.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *Client) Stats() Stats {
+	return c.stats.snapshot()
+}
+
+func (c *Client) sendBarrier(ctx context.Context, kind workerCommandKind) error {
+	ack := make(chan error, 1)
+	command := workerCommand{kind: kind, ctx: ctx, ack: ack}
+	select {
+	case <-c.done:
+		return nil
+	case c.commands <- command:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	select {
+	case err := <-ack:
+		return err
+	case <-c.done:
+		if kind == workerCommandStop {
+			return nil
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *Client) run() {
+	defer close(c.done)
+
+	ticker := time.NewTicker(c.opts.FlushInterval)
+	defer ticker.Stop()
+
+	batch := make([]Envelope, 0, c.opts.BatchSize)
+	flushBatch := func(ctx context.Context) error {
+		var firstErr error
+		if len(batch) > 0 {
+			if err := c.opts.Sink.WriteBatch(ctx, batch); err != nil {
+				c.stats.recordError(err)
+				firstErr = err
+			} else {
+				c.stats.written.Add(uint64(len(batch)))
+			}
+			batch = batch[:0]
+		}
+		if err := c.opts.Sink.Flush(ctx); err != nil {
+			c.stats.recordError(err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+		return firstErr
+	}
+
+	for {
+		select {
+		case command := <-c.commands:
+			switch command.kind {
+			case workerCommandEmit:
+				batch = append(batch, c.prepareEnvelope(command.envelope))
+				if len(batch) >= c.opts.BatchSize {
+					_ = flushBatch(context.Background())
+				}
+			case workerCommandFlush:
+				command.ack <- flushBatch(command.ctx)
+			case workerCommandStop:
+				err := flushBatch(command.ctx)
+				if closeErr := c.opts.Sink.Close(); closeErr != nil {
+					c.stats.recordError(closeErr)
+					if err == nil {
+						err = closeErr
+					}
+				}
+				command.ack <- err
+				return
+			}
+		case <-ticker.C:
+			_ = flushBatch(context.Background())
+		}
+	}
+}
+
+func (c *Client) prepareEnvelope(envelope Envelope) Envelope {
+	out := envelope.copy()
+	if out.Raw != nil {
+		out.Raw = SanitizeMap(out.Raw, PrivacyOptions{
+			RedactSecrets: true,
+			StringLimit:   DefaultRawStringLimit,
+		})
+		out.Raw = RetentionAwareRaw(out.Raw, c.opts.ContentRetention)
+	}
+	return out
+}

--- a/pkg/asymptotetrace/client.go
+++ b/pkg/asymptotetrace/client.go
@@ -115,8 +115,6 @@ func (c *Client) Close(ctx context.Context) error {
 	select {
 	case err := <-ack:
 		return err
-	case <-c.done:
-		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -165,12 +163,12 @@ func (c *Client) run() {
 				firstErr = err
 			} else {
 				c.stats.written.Add(uint64(len(batch)))
+				batch = batch[:0]
 			}
-			batch = batch[:0]
 		}
-		if err := c.opts.Sink.Flush(ctx); err != nil {
-			c.stats.recordError(err)
-			if firstErr == nil {
+		if firstErr == nil {
+			if err := c.opts.Sink.Flush(ctx); err != nil {
+				c.stats.recordError(err)
 				firstErr = err
 			}
 		}
@@ -189,6 +187,19 @@ func (c *Client) run() {
 			case workerCommandFlush:
 				command.ack <- flushBatch(command.ctx)
 			case workerCommandStop:
+				// Drain any remaining emit commands that may have been
+				// enqueued concurrently after the stop command.
+			drainLoop:
+				for {
+					select {
+					case pending := <-c.commands:
+						if pending.kind == workerCommandEmit {
+							batch = append(batch, c.prepareEnvelope(pending.envelope))
+						}
+					default:
+						break drainLoop
+					}
+				}
 				err := flushBatch(command.ctx)
 				if closeErr := c.opts.Sink.Close(); closeErr != nil {
 					c.stats.recordError(closeErr)

--- a/pkg/asymptotetrace/client.go
+++ b/pkg/asymptotetrace/client.go
@@ -60,8 +60,9 @@ func (c *Client) Emit(envelope Envelope) (EmitResult, error) {
 		return EmitResult{Dropped: true}, nil
 	}
 
+	snapshot := envelope.copy()
 	select {
-	case c.commands <- workerCommand{kind: workerCommandEmit, envelope: envelope}:
+	case c.commands <- workerCommand{kind: workerCommandEmit, envelope: snapshot}:
 		c.stats.accepted.Add(1)
 		return EmitResult{Accepted: true}, nil
 	default:
@@ -150,6 +151,7 @@ func (c *Client) sendBarrier(ctx context.Context, kind workerCommandKind) error 
 
 func (c *Client) run() {
 	defer close(c.done)
+	defer c.accepting.Store(false)
 
 	ticker := time.NewTicker(c.opts.FlushInterval)
 	defer ticker.Stop()
@@ -163,8 +165,8 @@ func (c *Client) run() {
 				firstErr = err
 			} else {
 				c.stats.written.Add(uint64(len(batch)))
-				batch = batch[:0]
 			}
+			batch = batch[:0]
 		}
 		if firstErr == nil {
 			if err := c.opts.Sink.Flush(ctx); err != nil {
@@ -195,6 +197,8 @@ func (c *Client) run() {
 					case pending := <-c.commands:
 						if pending.kind == workerCommandEmit {
 							batch = append(batch, c.prepareEnvelope(pending.envelope))
+						} else if pending.ack != nil {
+							pending.ack <- nil
 						}
 					default:
 						break drainLoop

--- a/pkg/asymptotetrace/client_test.go
+++ b/pkg/asymptotetrace/client_test.go
@@ -1,0 +1,477 @@
+package asymptotetrace
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type captureSink struct {
+	mu           sync.Mutex
+	batches      [][]Envelope
+	writeErr     error
+	flushErr     error
+	closeErr     error
+	closeCount   int
+	writeStarted chan struct{}
+	releaseWrite chan struct{}
+}
+
+func newCaptureSink() *captureSink {
+	return &captureSink{}
+}
+
+func newBlockingSink() *captureSink {
+	return &captureSink{
+		writeStarted: make(chan struct{}),
+		releaseWrite: make(chan struct{}),
+	}
+}
+
+func (s *captureSink) WriteBatch(ctx context.Context, envelopes []Envelope) error {
+	if s.writeStarted != nil {
+		select {
+		case <-s.writeStarted:
+		default:
+			close(s.writeStarted)
+		}
+	}
+	if s.releaseWrite != nil {
+		select {
+		case <-s.releaseWrite:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if s.writeErr != nil {
+		return s.writeErr
+	}
+	copied := make([]Envelope, len(envelopes))
+	copy(copied, envelopes)
+	s.mu.Lock()
+	s.batches = append(s.batches, copied)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *captureSink) Flush(context.Context) error {
+	return s.flushErr
+}
+
+func (s *captureSink) Close() error {
+	s.mu.Lock()
+	s.closeCount++
+	s.mu.Unlock()
+	return s.closeErr
+}
+
+func (s *captureSink) envelopes() []Envelope {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []Envelope
+	for _, batch := range s.batches {
+		out = append(out, batch...)
+	}
+	return out
+}
+
+func (s *captureSink) closes() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closeCount
+}
+
+func TestStartUsesDefaultOptions(t *testing.T) {
+	client := Start(Options{})
+	defer client.Close(context.Background())
+
+	if client.opts.QueueSize != DefaultQueueSize {
+		t.Fatalf("QueueSize = %d, want %d", client.opts.QueueSize, DefaultQueueSize)
+	}
+	if client.opts.BatchSize != DefaultBatchSize {
+		t.Fatalf("BatchSize = %d, want %d", client.opts.BatchSize, DefaultBatchSize)
+	}
+	if client.opts.ContentRetention != ContentRetentionFull {
+		t.Fatalf("ContentRetention = %q, want full", client.opts.ContentRetention)
+	}
+}
+
+func TestStartInvalidRetentionFailsClosed(t *testing.T) {
+	sink := newCaptureSink()
+	client := Start(Options{Sink: sink, BatchSize: 10, ContentRetention: "metdata"})
+	defer client.Close(context.Background())
+
+	if _, err := client.Emit(Envelope{
+		Origin:  OriginLocal,
+		Harness: HarnessInfo{Name: "custom_agent"},
+		Raw:     map[string]interface{}{"prompt": "sensitive"},
+	}); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush returned error: %v", err)
+	}
+
+	envelopes := sink.envelopes()
+	if len(envelopes) != 1 {
+		t.Fatalf("sink envelopes = %d, want 1", len(envelopes))
+	}
+	if envelopes[0].Raw["field_count"] != 1 {
+		t.Fatalf("invalid retention did not fail closed: %#v", envelopes[0].Raw)
+	}
+}
+
+func TestEmitReturnsAcceptedWhenQueued(t *testing.T) {
+	sink := newCaptureSink()
+	client := Start(Options{Sink: sink, BatchSize: 10})
+	defer client.Close(context.Background())
+
+	result, err := client.Emit(testEnvelope("one"))
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	if !result.Accepted || result.Dropped {
+		t.Fatalf("Emit result = %#v, want accepted", result)
+	}
+	if stats := client.Stats(); stats.Accepted != 1 || stats.Dropped != 0 {
+		t.Fatalf("stats = %#v", stats)
+	}
+}
+
+func TestEmitRejectsInvalidEnvelope(t *testing.T) {
+	client := Start(Options{})
+	defer client.Close(context.Background())
+
+	_, err := client.Emit(Envelope{Origin: "invalid", Harness: HarnessInfo{Name: "test"}})
+	if err == nil || !strings.Contains(err.Error(), "origin") {
+		t.Fatalf("Emit error = %v, want origin validation error", err)
+	}
+	if stats := client.Stats(); stats.Accepted != 0 || stats.Dropped != 0 {
+		t.Fatalf("invalid envelope changed stats: %#v", stats)
+	}
+}
+
+func TestEmitDoesNotCallSinkSynchronously(t *testing.T) {
+	sink := newBlockingSink()
+	client := Start(Options{Sink: sink, BatchSize: 1})
+	defer func() {
+		close(sink.releaseWrite)
+		_ = client.Close(context.Background())
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Emit(testEnvelope("one"))
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Emit returned error: %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Emit blocked on sink write")
+	}
+}
+
+func TestSlowSinkDoesNotBlockEmit(t *testing.T) {
+	sink := newBlockingSink()
+	client := Start(Options{Sink: sink, QueueSize: 4, BatchSize: 1})
+	defer func() {
+		close(sink.releaseWrite)
+		_ = client.Close(context.Background())
+	}()
+
+	if _, err := client.Emit(testEnvelope("first")); err != nil {
+		t.Fatalf("first Emit returned error: %v", err)
+	}
+	select {
+	case <-sink.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("sink write did not start")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Emit(testEnvelope("second"))
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("second Emit returned error: %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Emit blocked behind slow sink")
+	}
+}
+
+func TestEmitDropsWhenQueueFull(t *testing.T) {
+	sink := newBlockingSink()
+	client := Start(Options{Sink: sink, QueueSize: 1, BatchSize: 1})
+	defer func() {
+		close(sink.releaseWrite)
+		_ = client.Close(context.Background())
+	}()
+
+	if _, err := client.Emit(testEnvelope("first")); err != nil {
+		t.Fatalf("first Emit returned error: %v", err)
+	}
+	select {
+	case <-sink.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("sink write did not start")
+	}
+
+	var dropped int
+	for i := 0; i < 100; i++ {
+		result, err := client.Emit(testEnvelope("overflow"))
+		if err != nil {
+			t.Fatalf("overflow Emit returned error: %v", err)
+		}
+		if result.Dropped {
+			dropped++
+		}
+	}
+	if dropped == 0 {
+		t.Fatal("expected at least one dropped event")
+	}
+	if stats := client.Stats(); stats.Dropped == 0 {
+		t.Fatalf("Dropped stat = 0, want drops: %#v", stats)
+	}
+}
+
+func TestFlushDrainsAcceptedEvents(t *testing.T) {
+	sink := newCaptureSink()
+	client := Start(Options{Sink: sink, BatchSize: 10})
+	defer client.Close(context.Background())
+
+	for i := 0; i < 3; i++ {
+		if _, err := client.Emit(testEnvelope("queued")); err != nil {
+			t.Fatalf("Emit returned error: %v", err)
+		}
+	}
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush returned error: %v", err)
+	}
+	if got := len(sink.envelopes()); got != 3 {
+		t.Fatalf("sink envelopes = %d, want 3", got)
+	}
+	if stats := client.Stats(); stats.Written != 3 {
+		t.Fatalf("Written = %d, want 3: %#v", stats.Written, stats)
+	}
+}
+
+func TestFlushRespectsContextCancellation(t *testing.T) {
+	sink := newBlockingSink()
+	client := Start(Options{Sink: sink, QueueSize: 1, BatchSize: 10})
+	defer func() {
+		close(sink.releaseWrite)
+		_ = client.Close(context.Background())
+	}()
+
+	if _, err := client.Emit(testEnvelope("first")); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := client.Flush(ctx); err == nil {
+		t.Fatal("Flush returned nil, want context timeout")
+	}
+	select {
+	case <-sink.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("sink write did not start")
+	}
+}
+
+func TestFlushReturnsSinkErrorAndStats(t *testing.T) {
+	sink := newCaptureSink()
+	sink.writeErr = errors.New("write failed")
+	client := Start(Options{Sink: sink, BatchSize: 10})
+	defer client.Close(context.Background())
+
+	if _, err := client.Emit(testEnvelope("one")); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	err := client.Flush(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "write failed") {
+		t.Fatalf("Flush error = %v, want write failed", err)
+	}
+	if stats := client.Stats(); stats.WriteErrors == 0 || !strings.Contains(stats.LastError, "write failed") {
+		t.Fatalf("stats did not record write error: %#v", stats)
+	}
+}
+
+func TestCloseFlushesAndIsIdempotent(t *testing.T) {
+	sink := newCaptureSink()
+	client := Start(Options{Sink: sink, BatchSize: 10})
+
+	if _, err := client.Emit(testEnvelope("one")); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	if err := client.Close(context.Background()); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if err := client.Close(context.Background()); err != nil {
+		t.Fatalf("second Close returned error: %v", err)
+	}
+	if got := len(sink.envelopes()); got != 1 {
+		t.Fatalf("sink envelopes = %d, want 1", got)
+	}
+	if got := sink.closes(); got != 1 {
+		t.Fatalf("sink Close count = %d, want 1", got)
+	}
+}
+
+func TestCloseCancellationBeforeStopEnqueueCanRetry(t *testing.T) {
+	sink := newBlockingSink()
+	client := Start(Options{Sink: sink, QueueSize: 1, BatchSize: 1})
+
+	if _, err := client.Emit(testEnvelope("first")); err != nil {
+		t.Fatalf("first Emit returned error: %v", err)
+	}
+	select {
+	case <-sink.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("sink write did not start")
+	}
+	if result, err := client.Emit(testEnvelope("queued")); err != nil {
+		t.Fatalf("queued Emit returned error: %v", err)
+	} else if !result.Accepted {
+		t.Fatalf("queued Emit result = %#v, want accepted", result)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := client.Close(ctx); err == nil {
+		t.Fatal("Close returned nil, want context timeout before stop enqueue")
+	}
+
+	close(sink.releaseWrite)
+	if err := client.Close(context.Background()); err != nil {
+		t.Fatalf("retry Close returned error: %v", err)
+	}
+	if got := sink.closes(); got != 1 {
+		t.Fatalf("sink Close count = %d, want 1", got)
+	}
+}
+
+func TestEmitAfterCloseDrops(t *testing.T) {
+	client := Start(Options{})
+	if err := client.Close(context.Background()); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	result, err := client.Emit(testEnvelope("after-close"))
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	if !result.Dropped || result.Accepted {
+		t.Fatalf("Emit result = %#v, want dropped", result)
+	}
+}
+
+func TestPrivacyGateRunsBeforeSinkAndDoesNotMutateCaller(t *testing.T) {
+	sink := newCaptureSink()
+	client := Start(Options{Sink: sink, BatchSize: 10, ContentRetention: ContentRetentionFull})
+	defer client.Close(context.Background())
+
+	raw := map[string]interface{}{
+		"command": "curl -H 'Authorization: Bearer secret-token'",
+		"nested":  map[string]interface{}{"token": "token=nested-secret"},
+	}
+	if _, err := client.Emit(Envelope{
+		Origin:  OriginLocal,
+		Harness: HarnessInfo{Name: "custom_agent"},
+		Raw:     raw,
+	}); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush returned error: %v", err)
+	}
+
+	envelopes := sink.envelopes()
+	if len(envelopes) != 1 {
+		t.Fatalf("sink envelopes = %d, want 1", len(envelopes))
+	}
+	if strings.Contains(envelopes[0].Raw["command"].(string), "secret-token") {
+		t.Fatalf("sink saw unredacted raw: %#v", envelopes[0].Raw)
+	}
+	if raw["command"] != "curl -H 'Authorization: Bearer secret-token'" {
+		t.Fatalf("caller raw map was mutated: %#v", raw)
+	}
+}
+
+func TestMetadataRetentionOmitsRawPayloadDetails(t *testing.T) {
+	sink := newCaptureSink()
+	client := Start(Options{Sink: sink, BatchSize: 10, ContentRetention: ContentRetentionMetadata})
+	defer client.Close(context.Background())
+
+	if _, err := client.Emit(Envelope{
+		Origin:  OriginLocal,
+		Harness: HarnessInfo{Name: "custom_agent"},
+		Raw:     map[string]interface{}{"prompt": "sensitive", "command": "secret"},
+	}); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush returned error: %v", err)
+	}
+
+	envelopes := sink.envelopes()
+	if len(envelopes) != 1 {
+		t.Fatalf("sink envelopes = %d, want 1", len(envelopes))
+	}
+	if envelopes[0].Raw["field_count"] != 2 {
+		t.Fatalf("metadata raw = %#v, want field_count 2", envelopes[0].Raw)
+	}
+	if _, ok := envelopes[0].Raw["prompt"]; ok {
+		t.Fatalf("metadata retention leaked raw prompt: %#v", envelopes[0].Raw)
+	}
+}
+
+func TestConcurrentEmitFlushAndCloseAreRaceSafe(t *testing.T) {
+	sink := newCaptureSink()
+	client := Start(Options{Sink: sink, QueueSize: 512, BatchSize: 32})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				_, _ = client.Emit(testEnvelope("concurrent"))
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			_ = client.Flush(context.Background())
+		}
+	}()
+	wg.Wait()
+
+	if err := client.Close(context.Background()); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	stats := client.Stats()
+	if stats.Accepted+stats.Dropped != 1000 {
+		t.Fatalf("accepted+dropped = %d, want 1000: %#v", stats.Accepted+stats.Dropped, stats)
+	}
+}
+
+func testEnvelope(value string) Envelope {
+	return Envelope{
+		Origin:  OriginLocal,
+		Harness: HarnessInfo{Name: "test_agent"},
+		Raw:     map[string]interface{}{"value": value},
+	}
+}

--- a/pkg/asymptotetrace/envelope.go
+++ b/pkg/asymptotetrace/envelope.go
@@ -33,3 +33,59 @@ func (e Envelope) Validate() error {
 	}
 	return event.Validate()
 }
+
+func (e Envelope) withDefaults() Envelope {
+	if e.Vendor == "" {
+		e.Vendor = Vendor
+	}
+	if e.SchemaVersion == "" {
+		e.SchemaVersion = SchemaVersion
+	}
+	return e
+}
+
+func (e Envelope) copy() Envelope {
+	out := e
+	if e.Session != nil {
+		session := *e.Session
+		out.Session = &session
+	}
+	if e.Run != nil {
+		run := *e.Run
+		out.Run = &run
+	}
+	if e.Raw != nil {
+		out.Raw = copyMap(e.Raw)
+	}
+	return out
+}
+
+func copyMap(input map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(input))
+	for key, value := range input {
+		switch typed := value.(type) {
+		case map[string]interface{}:
+			out[key] = copyMap(typed)
+		case []interface{}:
+			out[key] = copySlice(typed)
+		default:
+			out[key] = typed
+		}
+	}
+	return out
+}
+
+func copySlice(input []interface{}) []interface{} {
+	out := make([]interface{}, len(input))
+	for index, value := range input {
+		switch typed := value.(type) {
+		case map[string]interface{}:
+			out[index] = copyMap(typed)
+		case []interface{}:
+			out[index] = copySlice(typed)
+		default:
+			out[index] = typed
+		}
+	}
+	return out
+}

--- a/pkg/asymptotetrace/jsonl_sink.go
+++ b/pkg/asymptotetrace/jsonl_sink.go
@@ -1,6 +1,7 @@
 package asymptotetrace
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -29,13 +30,8 @@ func (s *JSONLSink) WriteBatch(ctx context.Context, envelopes []Envelope) error 
 	if err := os.MkdirAll(filepath.Dir(s.path), 0755); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	encoder := json.NewEncoder(f)
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
 	for _, envelope := range envelopes {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -44,7 +40,15 @@ func (s *JSONLSink) WriteBatch(ctx context.Context, envelopes []Envelope) error 
 			return err
 		}
 	}
-	return nil
+
+	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(buf.Bytes())
+	return err
 }
 
 func (s *JSONLSink) Flush(context.Context) error {

--- a/pkg/asymptotetrace/jsonl_sink.go
+++ b/pkg/asymptotetrace/jsonl_sink.go
@@ -20,7 +20,9 @@ func NewJSONLSink(path string) *JSONLSink {
 }
 
 func (s *JSONLSink) WriteBatch(ctx context.Context, envelopes []Envelope) error {
-	_ = ctx
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -35,6 +37,9 @@ func (s *JSONLSink) WriteBatch(ctx context.Context, envelopes []Envelope) error 
 
 	encoder := json.NewEncoder(f)
 	for _, envelope := range envelopes {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := encoder.Encode(envelope); err != nil {
 			return err
 		}

--- a/pkg/asymptotetrace/jsonl_sink.go
+++ b/pkg/asymptotetrace/jsonl_sink.go
@@ -1,0 +1,51 @@
+package asymptotetrace
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type JSONLSink struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewJSONLSink creates a local, non-rotating NDJSON sink.
+// It intentionally performs no network I/O.
+func NewJSONLSink(path string) *JSONLSink {
+	return &JSONLSink{path: path}
+}
+
+func (s *JSONLSink) WriteBatch(ctx context.Context, envelopes []Envelope) error {
+	_ = ctx
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(s.path), 0755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	encoder := json.NewEncoder(f)
+	for _, envelope := range envelopes {
+		if err := encoder.Encode(envelope); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *JSONLSink) Flush(context.Context) error {
+	return nil
+}
+
+func (s *JSONLSink) Close() error {
+	return nil
+}

--- a/pkg/asymptotetrace/jsonl_sink_test.go
+++ b/pkg/asymptotetrace/jsonl_sink_test.go
@@ -1,0 +1,132 @@
+package asymptotetrace
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestJSONLSinkWritesOneEnvelopePerLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "trace.jsonl")
+	sink := NewJSONLSink(path)
+
+	envelopes := []Envelope{testEnvelope("one"), testEnvelope("two")}
+	if err := sink.WriteBatch(context.Background(), envelopes); err != nil {
+		t.Fatalf("WriteBatch returned error: %v", err)
+	}
+
+	lines := readJSONLLines(t, path)
+	if len(lines) != 2 {
+		t.Fatalf("lines = %d, want 2", len(lines))
+	}
+	for _, line := range lines {
+		var envelope Envelope
+		if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+			t.Fatalf("line is not an envelope JSON object: %v line=%q", err, line)
+		}
+		if envelope.Vendor != Vendor && envelope.Vendor != "" {
+			t.Fatalf("unexpected vendor: %#v", envelope)
+		}
+	}
+}
+
+func TestJSONLSinkAppendsWithoutOverwriting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trace.jsonl")
+	sink := NewJSONLSink(path)
+
+	if err := sink.WriteBatch(context.Background(), []Envelope{testEnvelope("one")}); err != nil {
+		t.Fatalf("first WriteBatch returned error: %v", err)
+	}
+	if err := sink.WriteBatch(context.Background(), []Envelope{testEnvelope("two")}); err != nil {
+		t.Fatalf("second WriteBatch returned error: %v", err)
+	}
+
+	if lines := readJSONLLines(t, path); len(lines) != 2 {
+		t.Fatalf("lines = %d, want 2", len(lines))
+	}
+}
+
+func TestJSONLSinkRejectsDirectoryPath(t *testing.T) {
+	sink := NewJSONLSink(t.TempDir())
+	if err := sink.WriteBatch(context.Background(), []Envelope{testEnvelope("one")}); err == nil {
+		t.Fatal("WriteBatch returned nil for directory path")
+	}
+}
+
+func TestJSONLSinkSerializesConcurrentWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trace.jsonl")
+	sink := NewJSONLSink(path)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := sink.WriteBatch(context.Background(), []Envelope{testEnvelope("concurrent")}); err != nil {
+				t.Errorf("WriteBatch returned error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	lines := readJSONLLines(t, path)
+	if len(lines) != 20 {
+		t.Fatalf("lines = %d, want 20", len(lines))
+	}
+	for _, line := range lines {
+		var envelope Envelope
+		if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+			t.Fatalf("line is not JSON: %v line=%q", err, line)
+		}
+	}
+}
+
+func TestFlushIntervalWritesBatch(t *testing.T) {
+	sink := newCaptureSink()
+	client := Start(Options{Sink: sink, BatchSize: 10, FlushInterval: 10 * time.Millisecond})
+	defer client.Close(context.Background())
+
+	if _, err := client.Emit(testEnvelope("interval")); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+
+	deadline := time.After(time.Second)
+	for {
+		if len(sink.envelopes()) == 1 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("flush interval did not write batch")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func readJSONLLines(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open JSONL: %v", err)
+	}
+	defer f.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan JSONL: %v", err)
+	}
+	return lines
+}

--- a/pkg/asymptotetrace/options.go
+++ b/pkg/asymptotetrace/options.go
@@ -1,0 +1,49 @@
+package asymptotetrace
+
+import "time"
+
+const (
+	DefaultQueueSize     = 1024
+	DefaultBatchSize     = 64
+	DefaultFlushInterval = 5 * time.Second
+)
+
+type Options struct {
+	Sink             Sink
+	QueueSize        int
+	BatchSize        int
+	FlushInterval    time.Duration
+	ContentRetention string
+}
+
+func (opts Options) withDefaults() Options {
+	if opts.Sink == nil {
+		opts.Sink = NoopSink{}
+	}
+	if opts.QueueSize <= 0 {
+		opts.QueueSize = DefaultQueueSize
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = DefaultBatchSize
+	}
+	if opts.FlushInterval <= 0 {
+		opts.FlushInterval = DefaultFlushInterval
+	}
+	if opts.ContentRetention == "" {
+		opts.ContentRetention = ContentRetentionFull
+	}
+	if !validContentRetention(opts.ContentRetention) {
+		// Retention controls are privacy-sensitive; invalid values fail closed.
+		opts.ContentRetention = ContentRetentionMetadata
+	}
+	return opts
+}
+
+func validContentRetention(retention string) bool {
+	switch retention {
+	case ContentRetentionMetadata, ContentRetentionRedacted, ContentRetentionFull:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/asymptotetrace/sink.go
+++ b/pkg/asymptotetrace/sink.go
@@ -1,0 +1,23 @@
+package asymptotetrace
+
+import "context"
+
+type Sink interface {
+	WriteBatch(ctx context.Context, envelopes []Envelope) error
+	Flush(ctx context.Context) error
+	Close() error
+}
+
+type NoopSink struct{}
+
+func (NoopSink) WriteBatch(context.Context, []Envelope) error {
+	return nil
+}
+
+func (NoopSink) Flush(context.Context) error {
+	return nil
+}
+
+func (NoopSink) Close() error {
+	return nil
+}

--- a/pkg/asymptotetrace/stats.go
+++ b/pkg/asymptotetrace/stats.go
@@ -1,0 +1,48 @@
+package asymptotetrace
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type Stats struct {
+	Accepted    uint64
+	Dropped     uint64
+	Written     uint64
+	WriteErrors uint64
+	LastError   string
+}
+
+type statsCounter struct {
+	accepted    atomic.Uint64
+	dropped     atomic.Uint64
+	written     atomic.Uint64
+	writeErrors atomic.Uint64
+
+	mu        sync.Mutex
+	lastError string
+}
+
+func (s *statsCounter) snapshot() Stats {
+	s.mu.Lock()
+	lastError := s.lastError
+	s.mu.Unlock()
+
+	return Stats{
+		Accepted:    s.accepted.Load(),
+		Dropped:     s.dropped.Load(),
+		Written:     s.written.Load(),
+		WriteErrors: s.writeErrors.Load(),
+		LastError:   lastError,
+	}
+}
+
+func (s *statsCounter) recordError(err error) {
+	if err == nil {
+		return
+	}
+	s.writeErrors.Add(1)
+	s.mu.Lock()
+	s.lastError = err.Error()
+	s.mu.Unlock()
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New concurrency and privacy-sensitive retention/redaction on the emit path; behavior is well-tested but affects what data reaches sinks and when events are dropped.
> 
> **Overview**
> Introduces an **asynchronous trace runtime** in `pkg/asymptotetrace`: `Start` spins a background worker that accepts `Emit` calls on a bounded queue, batches envelopes, flushes on size or interval, and shuts down via `Flush` / `Close` with context-aware barriers.
> 
> Adds a pluggable **`Sink`** (`NoopSink`, local **`JSONLSink`** NDJSON writer), **`Options`** defaults (queue/batch/flush/retention), and **`Stats`** for accepted/dropped/written/errors. Before write, the worker **deep-copies** envelopes and runs **secret redaction** plus **retention-aware** raw shaping; invalid retention strings **fail closed** to metadata-only.
> 
> **`Envelope`** gains `withDefaults` and deep `copy` so caller maps are not mutated. Broad tests cover non-blocking emit under slow sinks, queue drops, privacy/retention gates, JSONL append behavior, and concurrent emit/flush/close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9980ba2c8de52a627ddfc4d09d958a61b1e1a8bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->