### PR TITLE
Add trace interface implementations

### DIFF
--- a/pkg/asymptotetrace/envelope.go
+++ b/pkg/asymptotetrace/envelope.go
@@ -1,5 +1,8 @@
 package asymptotetrace
 
+import "errors"
+
+// Envelope is the raw, language-neutral trace input shape.
 type Envelope struct {
 	Vendor        string                 `json:"vendor"`
 	SchemaVersion string                 `json:"schema_version"`
@@ -21,15 +24,71 @@ func NewEnvelope(origin Origin, harness HarnessInfo, raw map[string]interface{})
 }
 
 func (e Envelope) Validate() error {
-	event := Event{
-		Vendor:        e.Vendor,
-		Product:       Product,
-		SchemaVersion: e.SchemaVersion,
-		Event:         EventInfo{Kind: "agent_runtime", Action: "envelope.received"},
-		Severity:      SeverityInfo,
-		Endpoint:      EndpointInfo{OS: "unknown"},
-		Harness:       e.Harness,
-		Origin:        e.Origin,
+	if e.Vendor != Vendor {
+		return errors.New("vendor must be beacon")
 	}
-	return event.Validate()
+	if e.SchemaVersion == "" {
+		return errors.New("schema_version is required")
+	}
+	if e.Harness.Name == "" {
+		return errors.New("harness.name is required")
+	}
+	if e.Origin != "" {
+		switch e.Origin {
+		case OriginLocal, OriginCloud, OriginCI:
+		default:
+			return errors.New("origin must be local, cloud, or ci")
+		}
+	}
+	return nil
+}
+
+func (e Envelope) withDefaults() Envelope {
+	if e.Vendor == "" {
+		e.Vendor = Vendor
+	}
+	if e.SchemaVersion == "" {
+		e.SchemaVersion = SchemaVersion
+	}
+	return e
+}
+
+func (e Envelope) copy() Envelope {
+	out := e
+	out.Session = cloneSession(e.Session)
+	out.Run = cloneRun(e.Run)
+	if e.Raw != nil {
+		out.Raw = copyMap(e.Raw)
+	}
+	return out
+}
+
+func copyMap(input map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(input))
+	for key, value := range input {
+		switch typed := value.(type) {
+		case map[string]interface{}:
+			out[key] = copyMap(typed)
+		case []interface{}:
+			out[key] = copySlice(typed)
+		default:
+			out[key] = typed
+		}
+	}
+	return out
+}
+
+func copySlice(input []interface{}) []interface{} {
+	out := make([]interface{}, len(input))
+	for index, value := range input {
+		switch typed := value.(type) {
+		case map[string]interface{}:
+			out[index] = copyMap(typed)
+		case []interface{}:
+			out[index] = copySlice(typed)
+		default:
+			out[index] = typed
+		}
+	}
+	return out
 }

--- a/pkg/asymptotetrace/envelope_test.go
+++ b/pkg/asymptotetrace/envelope_test.go
@@ -1,6 +1,9 @@
 package asymptotetrace
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestNewEnvelopeSetsWireIdentity(t *testing.T) {
 	envelope := NewEnvelope(OriginCI, HarnessInfo{Name: "claude"}, map[string]interface{}{"event": "raw"})
@@ -19,5 +22,37 @@ func TestEnvelopeValidateRejectsInvalidOrigin(t *testing.T) {
 	envelope := NewEnvelope("lambda", HarnessInfo{Name: "claude"}, nil)
 	if err := envelope.Validate(); err == nil {
 		t.Fatal("expected invalid origin error")
+	}
+}
+
+func TestEnvelopeValidateRejectsMissingFieldsDirectly(t *testing.T) {
+	tests := []struct {
+		name     string
+		envelope Envelope
+		want     string
+	}{
+		{
+			name:     "vendor",
+			envelope: Envelope{Vendor: "other", SchemaVersion: SchemaVersion, Origin: OriginLocal, Harness: HarnessInfo{Name: "claude"}},
+			want:     "vendor must be beacon",
+		},
+		{
+			name:     "schema",
+			envelope: Envelope{Vendor: Vendor, Origin: OriginLocal, Harness: HarnessInfo{Name: "claude"}},
+			want:     "schema_version is required",
+		},
+		{
+			name:     "harness",
+			envelope: Envelope{Vendor: Vendor, SchemaVersion: SchemaVersion, Origin: OriginLocal},
+			want:     "harness.name is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.envelope.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate error = %v, want %q", err, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/asymptotetrace/event_sink.go
+++ b/pkg/asymptotetrace/event_sink.go
@@ -1,0 +1,25 @@
+package asymptotetrace
+
+import "context"
+
+// Sink receives canonical Beacon events from a trace pipeline.
+type Sink interface {
+	WriteBatch(ctx context.Context, events []Event) error
+	Flush(ctx context.Context) error
+	Close() error
+}
+
+// NoopSink discards all events.
+type NoopSink struct{}
+
+func (NoopSink) WriteBatch(context.Context, []Event) error {
+	return nil
+}
+
+func (NoopSink) Flush(context.Context) error {
+	return nil
+}
+
+func (NoopSink) Close() error {
+	return nil
+}

--- a/pkg/asymptotetrace/jsonl_sink.go
+++ b/pkg/asymptotetrace/jsonl_sink.go
@@ -1,0 +1,64 @@
+package asymptotetrace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// ErrSinkPathRequired is returned when a JSONL sink has no output path.
+var ErrSinkPathRequired = errors.New("sink path is required")
+
+// JSONLSink writes canonical Beacon events to a local JSONL file.
+type JSONLSink struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewJSONLSink creates a local, non-rotating JSONL sink for canonical
+// Beacon events. It performs no network I/O.
+func NewJSONLSink(path string) *JSONLSink {
+	return &JSONLSink{path: path}
+}
+
+func (s *JSONLSink) WriteBatch(ctx context.Context, events []Event) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	if s.path == "" {
+		return ErrSinkPathRequired
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(s.path), 0755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	encoder := json.NewEncoder(f)
+	for _, event := range events {
+		if err := encoder.Encode(event); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *JSONLSink) Flush(context.Context) error {
+	return nil
+}
+
+func (s *JSONLSink) Close() error {
+	return nil
+}

--- a/pkg/asymptotetrace/jsonl_sink.go
+++ b/pkg/asymptotetrace/jsonl_sink.go
@@ -24,7 +24,7 @@ func NewJSONLSink(path string) *JSONLSink {
 	return &JSONLSink{path: path}
 }
 
-func (s *JSONLSink) WriteBatch(ctx context.Context, events []Event) error {
+func (s *JSONLSink) WriteBatch(ctx context.Context, events []Event) (err error) {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -44,7 +44,15 @@ func (s *JSONLSink) WriteBatch(ctx context.Context, events []Event) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			if err != nil {
+				err = errors.Join(err, cerr)
+			} else {
+				err = cerr
+			}
+		}
+	}()
 
 	encoder := json.NewEncoder(f)
 	for _, event := range events {

--- a/pkg/asymptotetrace/jsonl_sink_test.go
+++ b/pkg/asymptotetrace/jsonl_sink_test.go
@@ -1,0 +1,121 @@
+package asymptotetrace
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestJSONLSinkWritesCanonicalEvents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "events.jsonl")
+	sink := NewJSONLSink(path)
+
+	events := []Event{
+		NewEvent(NewEventOptions{Action: "tool.invoked", Harness: HarnessInfo{Name: "cursor"}}),
+		NewEvent(NewEventOptions{Action: "command.executed", Harness: HarnessInfo{Name: "codex"}}),
+	}
+	if err := sink.WriteBatch(context.Background(), events); err != nil {
+		t.Fatalf("WriteBatch returned error: %v", err)
+	}
+
+	lines := readJSONLLines(t, path)
+	if len(lines) != 2 {
+		t.Fatalf("lines = %d, want 2", len(lines))
+	}
+	for _, line := range lines {
+		var event Event
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("line is not canonical event JSON: %v line=%q", err, line)
+		}
+		if event.Vendor != Vendor || event.Product != Product || event.SchemaVersion != SchemaVersion {
+			t.Fatalf("unexpected event identity: %#v", event)
+		}
+	}
+}
+
+func TestJSONLSinkAppendsWithoutOverwriting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	sink := NewJSONLSink(path)
+
+	if err := sink.WriteBatch(context.Background(), []Event{NewEvent(NewEventOptions{Action: "tool.invoked", Harness: HarnessInfo{Name: "cursor"}})}); err != nil {
+		t.Fatalf("first WriteBatch returned error: %v", err)
+	}
+	if err := sink.WriteBatch(context.Background(), []Event{NewEvent(NewEventOptions{Action: "tool.completed", Harness: HarnessInfo{Name: "cursor"}})}); err != nil {
+		t.Fatalf("second WriteBatch returned error: %v", err)
+	}
+	if lines := readJSONLLines(t, path); len(lines) != 2 {
+		t.Fatalf("lines = %d, want 2", len(lines))
+	}
+}
+
+func TestJSONLSinkRejectsDirectoryPath(t *testing.T) {
+	sink := NewJSONLSink(t.TempDir())
+	if err := sink.WriteBatch(context.Background(), []Event{NewEvent(NewEventOptions{Action: "tool.invoked", Harness: HarnessInfo{Name: "cursor"}})}); err == nil {
+		t.Fatal("WriteBatch returned nil for directory path")
+	}
+}
+
+func TestJSONLSinkRejectsEmptyPath(t *testing.T) {
+	sink := NewJSONLSink("")
+	err := sink.WriteBatch(context.Background(), []Event{NewEvent(NewEventOptions{Action: "tool.invoked", Harness: HarnessInfo{Name: "cursor"}})})
+	if !errors.Is(err, ErrSinkPathRequired) {
+		t.Fatalf("WriteBatch error = %v, want ErrSinkPathRequired", err)
+	}
+}
+
+func TestJSONLSinkSerializesConcurrentWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	sink := NewJSONLSink(path)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := sink.WriteBatch(context.Background(), []Event{NewEvent(NewEventOptions{Action: "tool.invoked", Harness: HarnessInfo{Name: "cursor"}})})
+			if err != nil {
+				t.Errorf("WriteBatch returned error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	lines := readJSONLLines(t, path)
+	if len(lines) != 20 {
+		t.Fatalf("lines = %d, want 20", len(lines))
+	}
+	for _, line := range lines {
+		var event Event
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("line is not JSON: %v line=%q", err, line)
+		}
+	}
+}
+
+func readJSONLLines(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open JSONL: %v", err)
+	}
+	defer f.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan JSONL: %v", err)
+	}
+	return lines
+}

--- a/pkg/asymptotetrace/normalizer.go
+++ b/pkg/asymptotetrace/normalizer.go
@@ -1,0 +1,55 @@
+package asymptotetrace
+
+import "context"
+
+const UnclassifiedTraceAction = "trace.unclassified"
+
+// Normalizer maps raw envelopes into canonical Beacon events.
+type Normalizer interface {
+	Normalize(ctx context.Context, envelope Envelope) ([]Event, error)
+}
+
+// UnclassifiedNormalizer preserves raw envelope metadata as an unclassified trace event.
+type UnclassifiedNormalizer struct{}
+
+func (UnclassifiedNormalizer) Normalize(ctx context.Context, envelope Envelope) ([]Event, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	envelope = envelope.withDefaults()
+	if err := envelope.Validate(); err != nil {
+		return nil, err
+	}
+	event := NewEvent(NewEventOptions{
+		Action:   UnclassifiedTraceAction,
+		Category: "trace",
+		Severity: SeverityInfo,
+		Harness:  envelope.Harness,
+		Origin:   envelope.Origin,
+		Run:      cloneRun(envelope.Run),
+		Message:  "Trace received but not classified",
+	})
+	event.Session = cloneSession(envelope.Session)
+	if envelope.Raw != nil {
+		event.Raw = copyMap(envelope.Raw)
+	}
+	return []Event{event}, nil
+}
+
+func cloneSession(session *SessionInfo) *SessionInfo {
+	if session == nil {
+		return nil
+	}
+	out := *session
+	return &out
+}
+
+func cloneRun(run *RunInfo) *RunInfo {
+	if run == nil {
+		return nil
+	}
+	out := *run
+	return &out
+}

--- a/pkg/asymptotetrace/pipeline.go
+++ b/pkg/asymptotetrace/pipeline.go
@@ -1,0 +1,204 @@
+package asymptotetrace
+
+import (
+	"context"
+	"errors"
+)
+
+const DefaultMaxEventBytes = 64 * 1024
+
+var (
+	// ErrPipelineMissingSource is returned when a pipeline has no source.
+	ErrPipelineMissingSource = errors.New("trace pipeline requires a source")
+	// ErrRecordEmpty is returned when a source emits an empty record.
+	ErrRecordEmpty = errors.New("trace record requires envelope or event")
+	// ErrRecordMixed is returned when a source emits both envelope and event.
+	ErrRecordMixed = errors.New("trace record accepts either envelope or event, not both")
+)
+
+// PipelineOptions configures a one-shot trace export pipeline.
+type PipelineOptions struct {
+	Source     Source
+	Normalizer Normalizer
+	Processors []Processor
+	Sink       Sink
+	Privacy    *PrivacyPolicy
+	// KeepSinkOpen leaves sink lifecycle ownership with the caller.
+	KeepSinkOpen bool
+}
+
+// Pipeline exports trace data from a source through normalization, privacy, and a sink.
+type Pipeline struct {
+	opts PipelineOptions
+}
+
+func NewPipeline(opts PipelineOptions) *Pipeline {
+	return &Pipeline{opts: opts.withDefaults()}
+}
+
+// Validate checks whether options can run after defaults are applied.
+func (opts PipelineOptions) Validate() error {
+	if opts.Source == nil {
+		return ErrPipelineMissingSource
+	}
+	return nil
+}
+
+// Run executes a one-shot pipeline and owns the sink lifecycle: it flushes and
+// closes the sink before returning unless KeepSinkOpen is true.
+func (p *Pipeline) Run(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := p.opts.Validate(); err != nil {
+		return err
+	}
+
+	runErr := p.opts.Source.Run(ctx, func(record Record) error {
+		events, err := p.eventsFromRecord(ctx, record)
+		if err != nil {
+			return err
+		}
+		return p.writeEvents(ctx, events)
+	})
+	if runErr != nil {
+		p.closeSink()
+		return runErr
+	}
+	if err := p.opts.Sink.Flush(ctx); err != nil {
+		p.closeSink()
+		return err
+	}
+	return p.closeSink()
+}
+
+func (p *Pipeline) writeEvents(ctx context.Context, events []Event) error {
+	processed := events
+	var err error
+	for _, processor := range p.opts.Processors {
+		processed, err = processor.Process(ctx, processed)
+		if err != nil {
+			return err
+		}
+	}
+	if len(processed) == 0 {
+		return nil
+	}
+	return p.opts.Sink.WriteBatch(ctx, processed)
+}
+
+func (p *Pipeline) eventsFromRecord(ctx context.Context, record Record) ([]Event, error) {
+	if err := record.Validate(); err != nil {
+		return nil, err
+	}
+	if record.Envelope != nil {
+		return p.opts.Normalizer.Normalize(ctx, record.Envelope.copy())
+	}
+	return []Event{copyEvent(*record.Event)}, nil
+}
+
+func (p *Pipeline) closeSink() error {
+	if p.opts.KeepSinkOpen {
+		return nil
+	}
+	return p.opts.Sink.Close()
+}
+
+func (opts PipelineOptions) withDefaults() PipelineOptions {
+	if opts.Normalizer == nil {
+		opts.Normalizer = UnclassifiedNormalizer{}
+	}
+	if opts.Sink == nil {
+		opts.Sink = NoopSink{}
+	}
+	if opts.Privacy != nil && !hasPrivacyProcessor(opts.Processors) {
+		opts.Processors = append([]Processor{NewPrivacyProcessor(*opts.Privacy)}, opts.Processors...)
+	}
+	return opts
+}
+
+func hasPrivacyProcessor(processors []Processor) bool {
+	for _, processor := range processors {
+		if _, ok := processor.(PrivacyProcessor); ok {
+			return true
+		}
+		if _, ok := processor.(*PrivacyProcessor); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func prepareEventForSink(event Event, retention string, maxBytes int) Event {
+	out := copyEvent(event)
+	if out.Content == nil {
+		out.Content = &ContentInfo{}
+	}
+	out.Content.Retention = retention
+	out.Content.Included = retention != ContentRetentionMetadata
+	out.Content.Redacted = retention == ContentRetentionRedacted
+	if out.Raw != nil {
+		out.Raw = SanitizeMap(out.Raw, PrivacyOptions{RedactSecrets: true, StringLimit: DefaultRawStringLimit})
+		out.Raw = RetentionAwareRaw(out.Raw, retention)
+	}
+	return SanitizeEvent(out, maxBytes)
+}
+
+func copyEvent(event Event) Event {
+	out := event
+	out.Run = cloneRun(event.Run)
+	out.Session = cloneSession(event.Session)
+	if event.Tool != nil {
+		tool := *event.Tool
+		out.Tool = &tool
+	}
+	if event.File != nil {
+		file := *event.File
+		out.File = &file
+	}
+	if event.Command != nil {
+		command := *event.Command
+		out.Command = &command
+	}
+	if event.MCP != nil {
+		mcp := *event.MCP
+		out.MCP = &mcp
+	}
+	if event.Approval != nil {
+		approval := *event.Approval
+		out.Approval = &approval
+	}
+	if event.Policy != nil {
+		policy := *event.Policy
+		out.Policy = &policy
+	}
+	if event.Prompt != nil {
+		prompt := *event.Prompt
+		out.Prompt = &prompt
+	}
+	if event.Content != nil {
+		content := *event.Content
+		out.Content = &content
+	}
+	if event.Destination != nil {
+		destination := *event.Destination
+		out.Destination = &destination
+	}
+	if event.Health != nil {
+		health := *event.Health
+		out.Health = &health
+	}
+	if event.Raw != nil {
+		out.Raw = copyMap(event.Raw)
+	}
+	return out
+}
+
+func validContentRetention(retention string) bool {
+	switch retention {
+	case ContentRetentionMetadata, ContentRetentionRedacted, ContentRetentionFull:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/asymptotetrace/pipeline_test.go
+++ b/pkg/asymptotetrace/pipeline_test.go
@@ -1,0 +1,410 @@
+package asymptotetrace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type captureEventSink struct {
+	mu         sync.Mutex
+	events     []Event
+	writeErr   error
+	flushErr   error
+	closeErr   error
+	flushCount int
+	closeCount int
+}
+
+func (s *captureEventSink) WriteBatch(ctx context.Context, events []Event) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	if s.writeErr != nil {
+		return s.writeErr
+	}
+	copied := make([]Event, len(events))
+	for i, event := range events {
+		copied[i] = copyEvent(event)
+	}
+	s.mu.Lock()
+	s.events = append(s.events, copied...)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *captureEventSink) Flush(context.Context) error {
+	s.mu.Lock()
+	s.flushCount++
+	s.mu.Unlock()
+	return s.flushErr
+}
+
+func (s *captureEventSink) Close() error {
+	s.mu.Lock()
+	s.closeCount++
+	s.mu.Unlock()
+	return s.closeErr
+}
+
+func (s *captureEventSink) snapshot() ([]Event, int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	events := make([]Event, len(s.events))
+	copy(events, s.events)
+	return events, s.flushCount, s.closeCount
+}
+
+type errorRawTraceSource struct {
+	err error
+}
+
+func (s errorRawTraceSource) Run(context.Context, func(Record) error) error {
+	return s.err
+}
+
+type errorNormalizer struct {
+	err error
+}
+
+func (n errorNormalizer) Normalize(context.Context, Envelope) ([]Event, error) {
+	return nil, n.err
+}
+
+type captureProcessor struct {
+	seen []Event
+}
+
+func (p *captureProcessor) Process(ctx context.Context, events []Event) ([]Event, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	p.seen = append(p.seen, events...)
+	return events, nil
+}
+
+func TestPipelineEnvelopeRecordNormalizesAndWritesEvents(t *testing.T) {
+	sink := &captureEventSink{}
+	pipeline := NewPipeline(PipelineOptions{
+		Source: staticSource{NewEnvelopeRecord(testEnvelope())},
+		Sink:   sink,
+	})
+
+	if err := pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	events, flushes, closes := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	event := events[0]
+	if event.Vendor != Vendor || event.Product != Product || event.SchemaVersion != SchemaVersion {
+		t.Fatalf("unexpected schema identity: %#v", event)
+	}
+	if event.Event.Action != UnclassifiedTraceAction || event.Event.Category != "trace" {
+		t.Fatalf("unexpected event info: %#v", event.Event)
+	}
+	if event.Harness.Name != "custom_agent" || event.Origin != OriginLocal {
+		t.Fatalf("harness/origin not preserved: %#v", event)
+	}
+	if event.Session == nil || event.Session.ID != "session-1" {
+		t.Fatalf("session not preserved: %#v", event.Session)
+	}
+	if event.Run == nil || event.Run.Provider != "github_actions" {
+		t.Fatalf("run not preserved: %#v", event.Run)
+	}
+	if flushes != 1 || closes != 1 {
+		t.Fatalf("flushes/closes = %d/%d, want 1/1", flushes, closes)
+	}
+}
+
+func TestPipelineEventRecordSkipsNormalizer(t *testing.T) {
+	sink := &captureEventSink{}
+	event := NewEvent(NewEventOptions{
+		Action:   "tool.invoked",
+		Category: "tool",
+		Harness:  HarnessInfo{Name: "cursor"},
+	})
+	pipeline := NewPipeline(PipelineOptions{
+		Source:     staticSource{NewEventRecord(event)},
+		Normalizer: errorNormalizer{err: errors.New("normalizer should not be called")},
+		Sink:       sink,
+	})
+
+	if err := pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	events, _, _ := sink.snapshot()
+	if len(events) != 1 || events[0].Event.Action != "tool.invoked" {
+		t.Fatalf("unexpected events: %#v", events)
+	}
+}
+
+func TestPipelinePrivacyBeforeSinkAndNoEnvelopeMutation(t *testing.T) {
+	sink := &captureEventSink{}
+	envelope := testEnvelope()
+	envelope.Raw["command"] = "curl -H 'Authorization: Bearer secret-token'"
+	envelope.Raw["nested"] = map[string]interface{}{"token": "token=nested-secret"}
+
+	pipeline := NewPipeline(PipelineOptions{
+		Source:  staticSource{NewEnvelopeRecord(envelope)},
+		Sink:    sink,
+		Privacy: &PrivacyPolicy{Retention: ContentRetentionFull, MaxEventBytes: DefaultMaxEventBytes},
+	})
+	if err := pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	events, _, _ := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	rawText := stringify(events[0].Raw)
+	if strings.Contains(rawText, "secret-token") || strings.Contains(rawText, "nested-secret") {
+		t.Fatalf("sink saw unredacted raw: %s", rawText)
+	}
+	if envelope.Raw["command"] != "curl -H 'Authorization: Bearer secret-token'" {
+		t.Fatalf("source envelope was mutated: %#v", envelope.Raw)
+	}
+}
+
+func TestPipelineWithoutPrivacyPassesEventsThrough(t *testing.T) {
+	sink := &captureEventSink{}
+	envelope := testEnvelope()
+	envelope.Raw["token"] = "token=visible-without-privacy"
+
+	pipeline := NewPipeline(PipelineOptions{
+		Source: staticSource{NewEnvelopeRecord(envelope)},
+		Sink:   sink,
+	})
+	if err := pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	events, _, _ := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if rawText := stringify(events[0].Raw); !strings.Contains(rawText, "visible-without-privacy") {
+		t.Fatalf("event was unexpectedly sanitized without privacy: %s", rawText)
+	}
+	if events[0].Content != nil {
+		t.Fatalf("content metadata was unexpectedly set without privacy: %#v", events[0].Content)
+	}
+}
+
+func TestPipelinePrivacyRunsBeforeAdditionalProcessors(t *testing.T) {
+	sink := &captureEventSink{}
+	processor := &captureProcessor{}
+	envelope := testEnvelope()
+	envelope.Raw["token"] = "token=processor-secret"
+
+	pipeline := NewPipeline(PipelineOptions{
+		Source:     staticSource{NewEnvelopeRecord(envelope)},
+		Processors: []Processor{processor},
+		Sink:       sink,
+		Privacy:    &PrivacyPolicy{Retention: ContentRetentionFull},
+	})
+	if err := pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(processor.seen) != 1 {
+		t.Fatalf("processor saw %d events, want 1", len(processor.seen))
+	}
+	if rawText := stringify(processor.seen[0].Raw); strings.Contains(rawText, "processor-secret") {
+		t.Fatalf("processor saw unredacted raw: %s", rawText)
+	}
+}
+
+func TestPipelineMetadataRetentionRemovesRawDetails(t *testing.T) {
+	sink := &captureEventSink{}
+	pipeline := NewPipeline(PipelineOptions{
+		Source:  staticSource{NewEnvelopeRecord(testEnvelope())},
+		Sink:    sink,
+		Privacy: &PrivacyPolicy{Retention: ContentRetentionMetadata},
+	})
+
+	if err := pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	events, _, _ := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].Raw["field_count"] != 2 {
+		t.Fatalf("metadata raw = %#v, want field_count 2", events[0].Raw)
+	}
+	if _, ok := events[0].Raw["prompt"]; ok {
+		t.Fatalf("metadata retention leaked prompt: %#v", events[0].Raw)
+	}
+	if events[0].Content == nil || events[0].Content.Retention != ContentRetentionMetadata || events[0].Content.Included {
+		t.Fatalf("content metadata not set correctly: %#v", events[0].Content)
+	}
+}
+
+func TestPipelineInvalidRetentionFailsClosed(t *testing.T) {
+	sink := &captureEventSink{}
+	pipeline := NewPipeline(PipelineOptions{
+		Source:  staticSource{NewEnvelopeRecord(testEnvelope())},
+		Sink:    sink,
+		Privacy: &PrivacyPolicy{Retention: "metdata"},
+	})
+
+	if err := pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	events, _, _ := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].Raw["field_count"] != 2 {
+		t.Fatalf("invalid retention did not fail closed: %#v", events[0].Raw)
+	}
+}
+
+func TestPipelinePrivacyDefaultRetentionIsFull(t *testing.T) {
+	sink := &captureEventSink{}
+	pipeline := NewPipeline(PipelineOptions{
+		Source:  staticSource{NewEnvelopeRecord(testEnvelope())},
+		Sink:    sink,
+		Privacy: &PrivacyPolicy{},
+	})
+
+	if err := pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	events, _, _ := sink.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].Content == nil || events[0].Content.Retention != ContentRetentionFull || !events[0].Content.Included {
+		t.Fatalf("privacy default did not use full retention: %#v", events[0].Content)
+	}
+	if events[0].Raw["prompt"] != "summarize" {
+		t.Fatalf("full retention unexpectedly removed raw: %#v", events[0].Raw)
+	}
+}
+
+func TestPipelineSourceErrorPropagates(t *testing.T) {
+	want := errors.New("source failed")
+	pipeline := NewPipeline(PipelineOptions{
+		Source: errorRawTraceSource{err: want},
+		Sink:   &captureEventSink{},
+	})
+
+	if err := pipeline.Run(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("Run error = %v, want %v", err, want)
+	}
+}
+
+func TestPipelineNormalizerErrorPropagates(t *testing.T) {
+	want := errors.New("normalize failed")
+	pipeline := NewPipeline(PipelineOptions{
+		Source:     staticSource{NewEnvelopeRecord(testEnvelope())},
+		Normalizer: errorNormalizer{err: want},
+		Sink:       &captureEventSink{},
+	})
+
+	if err := pipeline.Run(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("Run error = %v, want %v", err, want)
+	}
+}
+
+func TestPipelineSinkErrorPropagates(t *testing.T) {
+	want := errors.New("sink failed")
+	pipeline := NewPipeline(PipelineOptions{
+		Source: staticSource{NewEnvelopeRecord(testEnvelope())},
+		Sink:   &captureEventSink{writeErr: want},
+	})
+
+	if err := pipeline.Run(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("Run error = %v, want %v", err, want)
+	}
+}
+
+func TestPipelineFlushErrorPropagates(t *testing.T) {
+	want := errors.New("flush failed")
+	pipeline := NewPipeline(PipelineOptions{
+		Source: staticSource{NewEnvelopeRecord(testEnvelope())},
+		Sink:   &captureEventSink{flushErr: want},
+	})
+
+	if err := pipeline.Run(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("Run error = %v, want %v", err, want)
+	}
+}
+
+func TestPipelineCloseErrorPropagates(t *testing.T) {
+	want := errors.New("close failed")
+	pipeline := NewPipeline(PipelineOptions{
+		Source: staticSource{NewEnvelopeRecord(testEnvelope())},
+		Sink:   &captureEventSink{closeErr: want},
+	})
+
+	if err := pipeline.Run(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("Run error = %v, want %v", err, want)
+	}
+}
+
+func TestPipelineCanLeaveSinkOpen(t *testing.T) {
+	sink := &captureEventSink{}
+	pipeline := NewPipeline(PipelineOptions{
+		Source:       staticSource{NewEnvelopeRecord(testEnvelope())},
+		Sink:         sink,
+		KeepSinkOpen: true,
+	})
+
+	if err := pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	_, flushes, closes := sink.snapshot()
+	if flushes != 1 || closes != 0 {
+		t.Fatalf("flushes/closes = %d/%d, want 1/0", flushes, closes)
+	}
+}
+
+func TestPipelineRejectsMissingSource(t *testing.T) {
+	if err := NewPipeline(PipelineOptions{Sink: &captureEventSink{}}).Run(context.Background()); !errors.Is(err, ErrPipelineMissingSource) {
+		t.Fatalf("missing source error = %v", err)
+	}
+}
+
+func TestPipelineRejectsEmptyOrMixedRecords(t *testing.T) {
+	if err := NewPipeline(PipelineOptions{
+		Source: staticSource{{}},
+		Sink:   &captureEventSink{},
+	}).Run(context.Background()); !errors.Is(err, ErrRecordEmpty) {
+		t.Fatalf("empty record error = %v", err)
+	}
+
+	envelope := testEnvelope()
+	event := NewEvent(NewEventOptions{Action: "tool.invoked", Harness: HarnessInfo{Name: "cursor"}})
+	err := NewPipeline(PipelineOptions{
+		Source: staticSource{{Envelope: &envelope, Event: &event}},
+		Sink:   &captureEventSink{},
+	}).Run(context.Background())
+	if !errors.Is(err, ErrRecordMixed) {
+		t.Fatalf("mixed record error = %v", err)
+	}
+}
+
+func testEnvelope() Envelope {
+	envelope := NewEnvelope(OriginLocal, HarnessInfo{Name: "custom_agent"}, map[string]interface{}{
+		"prompt": "summarize",
+		"tool":   "bash",
+	})
+	envelope.Session = &SessionInfo{ID: "session-1", WorkingDirectory: "/repo"}
+	envelope.Run = &RunInfo{Provider: "github_actions", RunID: "123", Ephemeral: true}
+	return envelope
+}
+
+func stringify(value interface{}) string {
+	return strings.Join(strings.Fields(fmt.Sprint(value)), " ")
+}

--- a/pkg/asymptotetrace/processor.go
+++ b/pkg/asymptotetrace/processor.go
@@ -1,0 +1,50 @@
+package asymptotetrace
+
+import "context"
+
+// Processor transforms canonical events before they reach a sink.
+type Processor interface {
+	Process(ctx context.Context, events []Event) ([]Event, error)
+}
+
+// PrivacyPolicy controls retention and size limits before events reach sinks.
+type PrivacyPolicy struct {
+	Retention     string
+	MaxEventBytes int
+}
+
+// PrivacyProcessor applies redaction, truncation, and retention to events.
+type PrivacyProcessor struct {
+	policy PrivacyPolicy
+}
+
+// NewPrivacyProcessor creates a privacy processor with fail-closed defaults.
+func NewPrivacyProcessor(policy PrivacyPolicy) PrivacyProcessor {
+	return PrivacyProcessor{policy: policy.withDefaults()}
+}
+
+func (p PrivacyProcessor) Process(ctx context.Context, events []Event) ([]Event, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	out := make([]Event, 0, len(events))
+	for _, event := range events {
+		out = append(out, prepareEventForSink(event, p.policy.Retention, p.policy.MaxEventBytes))
+	}
+	return out, nil
+}
+
+func (policy PrivacyPolicy) withDefaults() PrivacyPolicy {
+	if policy.Retention == "" {
+		policy.Retention = ContentRetentionFull
+	}
+	if !validContentRetention(policy.Retention) {
+		policy.Retention = ContentRetentionMetadata
+	}
+	if policy.MaxEventBytes <= 0 {
+		policy.MaxEventBytes = DefaultMaxEventBytes
+	}
+	return policy
+}

--- a/pkg/asymptotetrace/source.go
+++ b/pkg/asymptotetrace/source.go
@@ -1,0 +1,50 @@
+package asymptotetrace
+
+import "context"
+
+// Record is one source emission. Exactly one of Envelope or Event should be set.
+type Record struct {
+	Envelope *Envelope
+	Event    *Event
+}
+
+func NewEnvelopeRecord(envelope Envelope) Record {
+	return Record{Envelope: &envelope}
+}
+
+func NewEventRecord(event Event) Record {
+	return Record{Event: &event}
+}
+
+// Validate checks that the record contains exactly one payload.
+func (r Record) Validate() error {
+	switch {
+	case r.Envelope != nil && r.Event != nil:
+		return ErrRecordMixed
+	case r.Envelope == nil && r.Event == nil:
+		return ErrRecordEmpty
+	default:
+		return nil
+	}
+}
+
+// Source emits raw or normalized trace records from an agent harness or integration.
+type Source interface {
+	Run(ctx context.Context, emit func(Record) error) error
+}
+
+type staticSource []Record
+
+func (s staticSource) Run(ctx context.Context, emit func(Record) error) error {
+	for _, record := range s {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if err := emit(record); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New telemetry path handles secrets, retention, and local file writes; behavior is well-tested but affects what data leaves the agent trace pipeline.
> 
> **Overview**
> Introduces a **one-shot trace export pipeline** in `pkg/asymptotetrace`: **sources** emit `Record`s (envelope or canonical event), an optional **normalizer** maps envelopes to events, **processors** (including auto-injected **privacy** when `PrivacyPolicy` is set) transform events, and a **sink** receives batches.
> 
> **Envelope** validation no longer delegates to a synthetic `Event`; it checks vendor, schema, harness, and origin directly. Adds deep **copy** helpers for envelopes/events/raw maps so pipeline processing does not mutate source data.
> 
> Default path uses **`UnclassifiedNormalizer`** (`trace.unclassified`) and **`NoopSink`**; **`JSONLSink`** appends canonical JSON lines locally (mutex, mkdir, empty-path error). **`Pipeline.Run`** validates options, processes records, flushes/closes the sink unless `KeepSinkOpen`. Privacy runs before other processors and applies secret redaction, retention modes, and size limits via existing sanitize helpers.
> 
> Broad **unit tests** cover JSONL I/O, pipeline happy paths, privacy/retention behavior, error propagation, and record validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed2c541aa69ac1e5ab5848181ec2bfe69bbe58df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->