### PR TITLE
Validate collector + GoReleaser artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Test hooks
         working-directory: cli/beacon-hooks
         run: go test ./...
+      - name: Test collector exporter
+        working-directory: collector-builder/exporter/beaconjsonexporter
+        run: go test ./...
       - name: Public CLI command tree smoke test
         working-directory: cli/beacon
         run: |
@@ -39,6 +42,33 @@ jobs:
               exit 1
             fi
           done
+
+  cross-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+            make_target: build-darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            make_target: build-darwin-arm64
+          - goos: linux
+            goarch: amd64
+            make_target: build-linux-amd64
+          - goos: linux
+            goarch: arm64
+            make_target: build-linux-arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/beacon/go.mod
+      - name: Build Beacon for ${{ matrix.goos }}/${{ matrix.goarch }}
+        working-directory: cli/beacon
+        run: make ${{ matrix.make_target }}
 
   package-smoke:
     runs-on: macos-latest

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,90 @@
+name: Release Check
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  release-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/beacon/go.mod
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          install-only: true
+
+      - name: Install OpenTelemetry Collector Builder
+        run: go install go.opentelemetry.io/collector/cmd/builder@v0.121.0
+
+      - name: Build collector distributions
+        run: bash collector-builder/build-release-collectors.sh
+
+      - name: Validate native collector binary
+        run: collector-builder/dist/beacon-otelcol/linux_amd64/beacon-otelcol --version
+
+      - name: Check GoReleaser config
+        working-directory: cli/beacon
+        env:
+          HOMEBREW_TAP_TOKEN: snapshot
+        run: goreleaser check
+
+      - name: Build snapshot release
+        working-directory: cli/beacon
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HOMEBREW_TAP_TOKEN: snapshot
+        run: goreleaser release --snapshot --clean --parallelism 1
+
+      - name: Assert release archives
+        working-directory: cli/beacon
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          archives=(dist/*.tar.gz)
+          if [ "${#archives[@]}" -eq 0 ]; then
+            echo "no release archives produced"
+            exit 1
+          fi
+
+          linux_archive=""
+          for archive in "${archives[@]}"; do
+            echo "Checking $archive"
+            tar -tzf "$archive" | awk '
+              /(^|\/)beacon$/ { beacon = 1 }
+              /(^|\/)beacon-otelcol$/ { collector = 1 }
+              END {
+                if (!beacon || !collector) {
+                  print "archive is missing beacon or beacon-otelcol"
+                  exit 1
+                }
+              }
+            '
+
+            case "$archive" in
+              *linux_amd64.tar.gz)
+                linux_archive="$archive"
+                ;;
+            esac
+          done
+
+          if [ -z "$linux_archive" ]; then
+            echo "linux_amd64 archive not found"
+            exit 1
+          fi
+
+          extract_dir="$(mktemp -d)"
+          tar -xzf "$linux_archive" -C "$extract_dir"
+          "$extract_dir/beacon" version

--- a/collector-builder/build-release-collectors.sh
+++ b/collector-builder/build-release-collectors.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+builder="${OCB:-$(go env GOPATH)/bin/builder}"
+targets_dir="${BEACON_COLLECTOR_TARGETS_DIR:-/tmp/beacon-otelcol-targets}"
+
+cd "$script_dir"
+
+rm -rf "$targets_dir"
+mkdir -p "$targets_dir"
+
+while read -r goos goarch; do
+  target="${goos}_${goarch}"
+  echo "Building collector for ${goos}/${goarch}"
+  rm -rf dist/beacon-otelcol
+  GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 "$builder" --config builder.yaml
+  test -x dist/beacon-otelcol/beacon-otelcol
+  mkdir -p "$targets_dir/$target"
+  cp dist/beacon-otelcol/beacon-otelcol "$targets_dir/$target/beacon-otelcol"
+done <<'TARGETS'
+darwin amd64
+darwin arm64
+linux amd64
+linux arm64
+TARGETS
+
+rm -rf dist/beacon-otelcol
+mkdir -p dist/beacon-otelcol
+cp -R "$targets_dir"/. dist/beacon-otelcol/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CI/release automation and a build script; no runtime product logic is modified.
> 
> **Overview**
> Expands CI and release validation so the **beacon-otelcol** collector is built, tested, and shipped alongside the CLI.
> 
> **CI** now runs `go test` for `collector-builder/exporter/beaconjsonexporter` and adds a **cross-build** job that runs the CLI `Makefile` targets for darwin/linux on amd64 and arm64.
> 
> A new **`build-release-collectors.sh`** script cross-compiles `beacon-otelcol` for those four platforms via the OpenTelemetry Collector Builder and lays binaries out under `dist/beacon-otelcol/<goos>_<goarch>/`.
> 
> A new **Release Check** workflow (on version tags and manual dispatch) builds those collectors, runs `beacon-otelcol --version`, runs GoReleaser `check` and a **snapshot** release, and asserts each tarball contains both `beacon` and `beacon-otelcol`, then smoke-runs `beacon version` from the linux_amd64 archive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf294bb26c1ed83ec6fad89d32686c4bdd8a3edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->