### PR TITLE
Fix builder

### DIFF
--- a/collector-builder/builder.yaml
+++ b/collector-builder/builder.yaml
@@ -22,6 +22,7 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.121.0
 
 replaces:
+  - github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace => ../../../pkg/asymptotetrace
   - go.opentelemetry.io/otel/exporters/stdout/stdoutlog => go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.19.0
   - go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.19.0
   - go.opentelemetry.io/otel/log/logtest => go.opentelemetry.io/otel/log/logtest v0.19.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-configuration only; no runtime behavior or security-sensitive logic changes.
> 
> **Overview**
> Adds a **`replace`** entry in `collector-builder/builder.yaml` so the OTel collector builder resolves `github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace` to the local `../../../pkg/asymptotetrace` module when assembling `beacon-otelcol`.
> 
> That mirrors the exporter’s existing `go.mod` replace and fixes collector builds that pull in `beaconjsonexporter` (which depends on `asymptotetrace`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9aa6d86c4ac17dcb135f04ca25cc0e3b0535114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->