### PR TITLE
Add discord invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,8 @@ is not required unless a maintainer asks.
 
 If you are unsure whether a change fits Beacon's scope, open a GitHub issue or a
 draft pull request with the problem, proposed approach, and what you can verify
-locally.
+locally. You can also join the
+[Discord community](https://discord.gg/7DjzWWmc) for questions and discussion.
 
 ## Pull Request Checklist
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/asymptote-labs/agent-beacon/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/asymptote-labs/agent-beacon/ci.yml" alt="GitHub Workflow Status"></a>
   <a href="https://github.com/asymptote-labs/agent-beacon/blob/main/LICENSE"><img src="https://img.shields.io/github/license/asymptote-labs/agent-beacon" alt="MIT license"></a>
   <a href="https://docs.asymptotelabs.ai/cli"><img src="https://img.shields.io/badge/docs-asymptotelabs.ai-0369a1" alt="Docs"></a>
+  <a href="https://discord.gg/7DjzWWmc"><img src="https://img.shields.io/badge/discord-community-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 <p align="center">
@@ -18,6 +19,8 @@
 
 <p align="center">
   <a href="https://docs.asymptotelabs.ai/cli">Docs</a>
+  ·
+  <a href="https://discord.gg/7DjzWWmc">Discord</a>
   ·
   <a href="https://docs.asymptotelabs.ai/cli/installation">Install</a>
   ·


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only link additions with no effect on the agent, hooks, or telemetry.
> 
> **Overview**
> This PR surfaces the Beacon **Discord community** (`https://discord.gg/7DjzWWmc`) in contributor and user-facing docs only.
> 
> **README** gains a Discord badge in the header badge row and a **Discord** link in the centered nav line (between Docs and Install). **CONTRIBUTING** extends **Getting Help** so people can join Discord for questions and discussion, in addition to GitHub issues and draft PRs.
> 
> No runtime, packaging, or schema behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 544ecab6e76050a91de8e00110c3f6395c215770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->