### PR TITLE
Update discord link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ is not required unless a maintainer asks.
 If you are unsure whether a change fits Beacon's scope, open a GitHub issue or a
 draft pull request with the problem, proposed approach, and what you can verify
 locally. You can also join the
-[Discord community](https://discord.gg/7DjzWWmc) for questions and discussion.
+[Discord community](https://discord.gg/zdNChS2fBu) for questions and discussion.
 
 ## Pull Request Checklist
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/asymptote-labs/agent-beacon/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/asymptote-labs/agent-beacon/ci.yml" alt="GitHub Workflow Status"></a>
   <a href="https://github.com/asymptote-labs/agent-beacon/blob/main/LICENSE"><img src="https://img.shields.io/github/license/asymptote-labs/agent-beacon" alt="MIT license"></a>
   <a href="https://docs.asymptotelabs.ai/cli"><img src="https://img.shields.io/badge/docs-asymptotelabs.ai-0369a1" alt="Docs"></a>
-  <a href="https://discord.gg/7DjzWWmc"><img src="https://img.shields.io/badge/discord-community-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://discord.gg/zdNChS2fBu"><img src="https://img.shields.io/badge/discord-community-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 <p align="center">
@@ -20,7 +20,7 @@
 <p align="center">
   <a href="https://docs.asymptotelabs.ai/cli">Docs</a>
   ·
-  <a href="https://discord.gg/7DjzWWmc">Discord</a>
+  <a href="https://discord.gg/zdNChS2fBu">Discord</a>
   ·
   <a href="https://docs.asymptotelabs.ai/cli/installation">Install</a>
   ·


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only URL changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> Replaces the community **Discord** invite URL (`discord.gg/7DjzWWmc` → `discord.gg/zdNChS2fBu`) everywhere it appears in contributor-facing docs: the **Getting Help** link in `CONTRIBUTING.md` and the badge plus nav **Discord** links in `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d74d8ceb98eb0760c381fdae445c6ae27c93047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->