### PR TITLE
Fix release collector script

### DIFF
--- a/collector-builder/build-release-collectors.sh
+++ b/collector-builder/build-release-collectors.sh
@@ -8,7 +8,7 @@ targets_dir="${BEACON_COLLECTOR_TARGETS_DIR:-/tmp/beacon-otelcol-targets}"
 cd "$script_dir"
 
 rm -rf "$targets_dir"
-mkdir -p "$targets_dir"
+mkdir -p "$targets_dir" dist
 
 while read -r goos goarch; do
   target="${goos}_${goarch}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line build script fix with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Ensures the release collector build script creates the **`dist`** directory up front, not only **`BEACON_COLLECTOR_TARGETS_DIR`**.
> 
> After wiping the targets dir, **`mkdir -p`** now includes **`dist`** so OpenTelemetry Collector Builder output under **`./dist/beacon-otelcol`** (per **`builder.yaml`**) has a parent path on clean runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adebbba32617dc0646ad0044ee6359d665fb7704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->