### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -31,7 +31,16 @@ jobs:
         run: bash collector-builder/build-release-collectors.sh
 
       - name: Validate native collector binary
-        run: collector-builder/dist/beacon-otelcol/linux_amd64/beacon-otelcol --version
+        shell: bash
+        run: |
+          set -euo pipefail
+          collector=collector-builder/dist/beacon-otelcol/linux_amd64/beacon-otelcol
+          test -x "$collector"
+          "$collector" components | awk '
+            /name: beaconjson/ { beaconjson = 1 }
+            /name: falcon_hec/ { falcon_hec = 1 }
+            END { exit !(beaconjson && falcon_hec) }
+          '
 
       - name: Check GoReleaser config
         working-directory: cli/beacon


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change to release validation; no runtime application or security logic is modified.
> 
> **Overview**
> The **Validate native collector binary** step in `release-check.yml` no longer only runs `beacon-otelcol --version`. It now runs under **bash** with `set -euo pipefail`, confirms the **linux_amd64** binary is executable, and parses **`beacon-otelcol components`** to require both **`beaconjson`** and **`falcon_hec`** are present in the built distribution.
> 
> That ties release CI to the custom collector exporters instead of a shallow version check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cee1ad0483a2c44b7af8887344b4bb338e5fb153. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->