### PR TITLE
Add finegrained output destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,25 +92,43 @@ Claude Cowork, OpenClaw).
 | [OpenCode](https://docs.asymptotelabs.ai/cli/supported-runtimes-opencode) | Beacon hook adapter |
 | [VS Code](https://docs.asymptotelabs.ai/cli/supported-runtimes-vscode) | VS Code Copilot OpenTelemetry and optional Beacon hook adapter |
 
-### SIEM / Output Destinations
+### Output Destinations
 
-Agent Beacon emits agent harness telemetry logs to all the major
-enterprise-grade SIEMs.
+Agent Beacon writes endpoint telemetry to local JSONL by default and supports
+customer-controlled forwarding into common security information and event
+management (SIEM), log aggregation, and object storage destinations.
 
-| SIEMs | Support path |
+#### Security Information and Event Management (SIEM)
+
+| Destination | Support path |
 | --- | --- |
 | [CrowdStrike Falcon LogScale HEC](https://docs.asymptotelabs.ai/cli/siem-forwarding-falcon) | Optional endpoint forwarding with LogScale ingest tokens during install or repair |
-| [Customer-managed SIEM pipelines](https://docs.asymptotelabs.ai/cli/siem-forwarding) | Forwarding from local Beacon JSONL under customer control |
-| [Datadog](https://docs.asymptotelabs.ai/cli/siem-forwarding-datadog) | Datadog Agent custom log collection over local JSONL |
 | [Elastic](https://docs.asymptotelabs.ai/cli/siem-forwarding-elastic) | Filebeat or Elastic Agent content pack over local JSONL |
-| [Google Cloud Storage](https://docs.asymptotelabs.ai/cli/siem-forwarding-gcs) | Vector content pack over local JSONL using customer-managed Google credentials |
-| [Local JSONL](https://docs.asymptotelabs.ai/cli/local-testing-logs) | Default endpoint log and local dashboard source |
 | [Microsoft Sentinel](https://docs.asymptotelabs.ai/cli/siem-forwarding-microsoft-sentinel) | Azure Monitor Agent and Data Collection Rule content pack over local JSONL |
 | [Rapid7 InsightIDR](https://docs.asymptotelabs.ai/cli/siem-forwarding-rapid7) | Custom Logs webhook content pack over local JSONL |
-| [AWS S3](https://docs.asymptotelabs.ai/cli/siem-forwarding-s3) | Vector content pack over local JSONL using customer-managed AWS credentials |
 | [Splunk HEC](https://docs.asymptotelabs.ai/cli/siem-forwarding-splunk) | Optional endpoint forwarding during install or repair |
-| [Sumo Logic](https://docs.asymptotelabs.ai/cli/siem-forwarding-sumo) | HTTP Logs & Metrics Source content pack over local JSONL |
 | [Wazuh](https://docs.asymptotelabs.ai/cli/siem-forwarding-wazuh) | Localfile configuration and Beacon Wazuh content pack |
+
+#### Log Aggregation
+
+| Destination | Support path |
+| --- | --- |
+| [Customer-managed log pipelines](https://docs.asymptotelabs.ai/cli/siem-forwarding) | Forwarding from local Beacon JSONL under customer control |
+| [Datadog](https://docs.asymptotelabs.ai/cli/siem-forwarding-datadog) | Datadog Agent custom log collection over local JSONL |
+| [Sumo Logic](https://docs.asymptotelabs.ai/cli/siem-forwarding-sumo) | HTTP Logs & Metrics Source content pack over local JSONL |
+
+#### Object Storage
+
+| Destination | Support path |
+| --- | --- |
+| [AWS S3](https://docs.asymptotelabs.ai/cli/siem-forwarding-s3) | Vector content pack over local JSONL using customer-managed AWS credentials |
+| [Google Cloud Storage](https://docs.asymptotelabs.ai/cli/siem-forwarding-gcs) | Vector content pack over local JSONL using customer-managed Google credentials |
+
+#### Local
+
+| Destination | Support path |
+| --- | --- |
+| [Local JSONL](https://docs.asymptotelabs.ai/cli/local-testing-logs) | Default endpoint log and local dashboard source |
 
 ### MDM Deployment
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, security, or deployment behavior changes.
> 
> **Overview**
> The README **Output Destinations** section (formerly “SIEM / Output Destinations”) is reframed: copy now states default **local JSONL** and customer-controlled forwarding to SIEM, log aggregation, and object storage—not only enterprise SIEMs.
> 
> The single destination table is split into four subsections—**SIEM**, **Log aggregation**, **Object storage**, and **Local**—with the same doc links regrouped (e.g. Datadog/Sumo under aggregation, S3/GCS under object storage, Local JSONL under Local). CrowdStrike, Elastic, Sentinel, Rapid7, Splunk, and Wazuh stay under SIEM; the generic customer pipeline row moves to log aggregation.
> 
> *Note:* The intro still links to `#siem--output-destinations`, which may no longer match the renamed heading anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00595b741fde54ce307b08f3284dbc2e1da6695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->