### PR TITLE
Add Devin Desktop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Claude Cowork, OpenClaw).
 | [Codex CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-codex-cli) | Local OpenTelemetry configuration |
 | [Cursor](https://docs.asymptotelabs.ai/cli/supported-runtimes-cursor) | Beacon hook adapter |
 | [Devin CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-devin) | Beacon hook adapter |
-| Devin Desktop | Beacon hook adapter |
+| Devin Desktop | Beacon hook adapter via Cascade/Windsurf hooks |
 | [Factory Droid](https://docs.asymptotelabs.ai/cli/supported-runtimes-factory-droid) | Local OpenTelemetry configuration and optional hook adapter |
 | [Gemini CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-gemini-cli) | Opt-in local OpenTelemetry configuration |
 | [GitHub Copilot CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-github-copilot-cli) | MDM-managed OpenTelemetry (OTLP HTTP) |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Claude Cowork, OpenClaw).
 | [Claude Code](https://docs.asymptotelabs.ai/cli/supported-runtimes-claude-code) | Local OpenTelemetry configuration or Beacon hook adapter |
 | [Codex CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-codex-cli) | Local OpenTelemetry configuration |
 | [Cursor](https://docs.asymptotelabs.ai/cli/supported-runtimes-cursor) | Beacon hook adapter |
-| [Devin](https://docs.asymptotelabs.ai/cli/supported-runtimes-devin) | Beacon hook adapter |
+| [Devin CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-devin) | Beacon hook adapter |
+| Devin Desktop | Beacon hook adapter |
 | [Factory Droid](https://docs.asymptotelabs.ai/cli/supported-runtimes-factory-droid) | Local OpenTelemetry configuration and optional hook adapter |
 | [Gemini CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-gemini-cli) | Opt-in local OpenTelemetry configuration |
 | [GitHub Copilot CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-github-copilot-cli) | MDM-managed OpenTelemetry (OTLP HTTP) |

--- a/cli/beacon-hooks/cmd/cascade.go
+++ b/cli/beacon-hooks/cmd/cascade.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/config"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/diff"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
+)
+
+func cascadeActionName(input map[string]interface{}) string {
+	return getFirstStr(input, "agent_action_name", "hook_event_name", "hookEventName")
+}
+
+func cascadeExecutionID(input map[string]interface{}) string {
+	return getFirstStr(input, "execution_id", "executionId")
+}
+
+func cascadeToolInfo(input map[string]interface{}) map[string]interface{} {
+	if info, ok := input["tool_info"].(map[string]interface{}); ok {
+		return info
+	}
+	if info, ok := input["toolInfo"].(map[string]interface{}); ok {
+		return info
+	}
+	return nil
+}
+
+func cascadePrompt(input map[string]interface{}) string {
+	if info := cascadeToolInfo(input); info != nil {
+		if prompt := firstToolString(info, "user_prompt", "userPrompt", "prompt", "text"); prompt != "" {
+			return prompt
+		}
+	}
+	return getFirstStr(input, "user_prompt", "userPrompt", "prompt", "text")
+}
+
+func cascadeToolName(input map[string]interface{}) string {
+	if info := cascadeToolInfo(input); info != nil {
+		if name := firstToolString(info, "tool_name", "toolName", "name", "command_name"); name != "" {
+			return name
+		}
+	}
+	switch cascadeActionName(input) {
+	case "post_run_command", "pre_run_command":
+		return "run_command"
+	case "post_mcp_tool_use", "pre_mcp_tool_use":
+		return "mcp_tool"
+	case "post_read_code", "pre_read_code":
+		return "read_code"
+	case "post_write_code", "pre_write_code":
+		return "write_code"
+	case "pre_user_prompt":
+		return "user_prompt"
+	default:
+		return cascadeActionName(input)
+	}
+}
+
+func cascadeMetadataFields(sessionID string, input map[string]interface{}) map[string]interface{} {
+	fields := sessionFields(sessionID, input)
+	if executionID := cascadeExecutionID(input); executionID != "" {
+		fields["session"] = mergeNested(fields["session"], map[string]interface{}{"execution_id": executionID})
+	}
+	fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"cascade": input})
+	return fields
+}
+
+func cascadeToolEventFields(input map[string]interface{}) map[string]interface{} {
+	sessionID := resolveSessionID(input, platformFlag)
+	fields := cascadeMetadataFields(sessionID, input)
+	toolName := cascadeToolName(input)
+	toolInfo := cascadeToolInfo(input)
+	for key, value := range toolFields(toolName, toolInfo) {
+		fields[key] = value
+	}
+	if action := cascadeActionName(input); action != "" {
+		fields["tool"] = mergeNested(fields["tool"], map[string]interface{}{"action": action})
+	}
+	if executionID := cascadeExecutionID(input); executionID != "" {
+		fields["tool"] = mergeNested(fields["tool"], map[string]interface{}{"execution_id": executionID})
+	}
+	return fields
+}
+
+func emitCascadePostToolObserved(logger *logging.Logger, input map[string]interface{}) {
+	actionName := cascadeActionName(input)
+	action, category, message := cascadeEventClassification(actionName, cascadeToolName(input))
+	emitHookEvent(logger, action, category, "info", message, input, cascadeToolEventFields(input))
+}
+
+func cascadeEventClassification(actionName, toolName string) (action, category, message string) {
+	switch actionName {
+	case "post_run_command":
+		return "command.executed", "command", "Shell command executed"
+	case "post_mcp_tool_use":
+		return "mcp.tool_invoked", "mcp", "MCP tool invocation observed"
+	case "post_read_code":
+		return "file.read", "file", "File read observed"
+	case "post_write_code":
+		return "file.modified", "file", "File edit observed"
+	}
+	if strings.Contains(strings.ToLower(toolName), "mcp") {
+		return "mcp.tool_invoked", "mcp", "MCP tool invocation observed"
+	}
+	return actionForTool(actionName, toolName), "tool", "Tool execution observed"
+}
+
+func parseCascadeWriteInput(input map[string]interface{}, logger *logging.Logger) *evaluationParams {
+	if cascadeActionName(input) != "post_write_code" {
+		return nil
+	}
+	toolInfo := cascadeToolInfo(input)
+	if toolInfo == nil {
+		return nil
+	}
+	filePath := firstToolString(toolInfo, "file_path", "filePath", "path")
+	filePath = diff.NormalizePath(filePath)
+	if filePath == "" || !config.IsScannableFile(filePath) {
+		return nil
+	}
+	edits, _ := toolInfo["edits"].([]interface{})
+	if len(edits) == 0 {
+		logger.Debug("No Cascade edits in input, skipping", "file_path", filePath)
+		return nil
+	}
+	diffStr := diff.FromCursorEdits(filePath, edits)
+	if diffStr == "" {
+		logger.Debug("Could not construct diff from Cascade edits, skipping", "file_path", filePath)
+		return nil
+	}
+	return &evaluationParams{
+		sessionID:   resolveSessionID(input, platformFlag),
+		toolName:    cascadeToolName(input),
+		filePath:    filePath,
+		diffStr:     diffStr,
+		extraFields: cascadeMetadataFields(resolveSessionID(input, platformFlag), input),
+	}
+}

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -161,7 +161,7 @@ func actionForTool(hookEvent, toolName string) string {
 			return "file.modified"
 		}
 	}
-	if platformFlag == "devin" {
+	if isDevinLikePlatform(platformFlag) {
 		switch {
 		case strings.HasPrefix(lower, "mcp__"):
 			return "mcp.tool_invoked"

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -21,6 +21,9 @@ func emitHookEvent(logger *logging.Logger, action, category, severity, message s
 	if platformFlag == "vscode" {
 		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"vscode": input})
 	}
+	if isCascadePlatform(platformFlag) {
+		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"cascade": input})
+	}
 	if model := getFirstStr(input, "model"); model != "" {
 		fields["model"] = model
 	}

--- a/cli/beacon-hooks/cmd/helpers.go
+++ b/cli/beacon-hooks/cmd/helpers.go
@@ -29,7 +29,11 @@ func outputJSONAndExit(data map[string]interface{}) {
 var emptyResponse = map[string]interface{}{}
 
 func isDevinLikePlatform(platform string) bool {
-	return platform == "devin" || platform == "devin-cli" || platform == "devin-desktop"
+	return platform == "devin" || platform == "devin-cli"
+}
+
+func isCascadePlatform(platform string) bool {
+	return platform == "devin-desktop"
 }
 
 // getFirstStr returns the first non-empty string value from input for the given keys.
@@ -59,8 +63,10 @@ func resolveSessionID(input map[string]interface{}, platform string) string {
 		return getFirstStr(input, "conversation_id")
 	case "vscode":
 		return getFirstStr(input, "sessionId", "session_id", "conversation_id", "gen_ai.conversation.id")
-	case "devin", "devin-cli", "devin-desktop":
+	case "devin", "devin-cli":
 		return getFirstStr(input, "session_id", "sessionId", "conversation_id")
+	case "devin-desktop":
+		return getFirstStr(input, "trajectory_id", "session_id", "sessionId", "conversation_id")
 	case "grok":
 		return getFirstStr(input, "sessionId", "session_id", "sessionID")
 	case "opencode":
@@ -94,8 +100,12 @@ func resolveSessionIDWithTranscript(input map[string]interface{}, platform strin
 		sessionID = getFirstStr(input, "sessionId", "session_id", "conversation_id", "gen_ai.conversation.id")
 		transcriptPath = getFirstStr(input, "transcript_path", "transcriptPath")
 		return
-	case "devin", "devin-cli", "devin-desktop":
+	case "devin", "devin-cli":
 		sessionID = getFirstStr(input, "session_id", "sessionId", "conversation_id")
+		transcriptPath = getFirstStr(input, "transcript_path", "transcriptPath")
+		return
+	case "devin-desktop":
+		sessionID = getFirstStr(input, "trajectory_id", "session_id", "sessionId", "conversation_id")
 		transcriptPath = getFirstStr(input, "transcript_path", "transcriptPath")
 		return
 	case "grok":
@@ -176,6 +186,17 @@ func resolveCwd(input map[string]interface{}, platform string) string {
 	if isDevinLikePlatform(platform) {
 		if cwd := getFirstStr(input, "cwd", "project_dir", "projectDir"); cwd != "" {
 			return cwd
+		}
+		return os.Getenv("DEVIN_PROJECT_DIR")
+	}
+	if isCascadePlatform(platform) {
+		if cwd := getFirstStr(input, "cwd", "workspace_path", "project_path"); cwd != "" {
+			return cwd
+		}
+		if info := cascadeToolInfo(input); info != nil {
+			if cwd := firstToolString(info, "cwd", "workspace_path", "project_path", "directory", "working_directory"); cwd != "" {
+				return cwd
+			}
 		}
 		return os.Getenv("DEVIN_PROJECT_DIR")
 	}

--- a/cli/beacon-hooks/cmd/helpers.go
+++ b/cli/beacon-hooks/cmd/helpers.go
@@ -28,6 +28,10 @@ func outputJSONAndExit(data map[string]interface{}) {
 // emptyResponse is a reusable empty JSON response.
 var emptyResponse = map[string]interface{}{}
 
+func isDevinLikePlatform(platform string) bool {
+	return platform == "devin" || platform == "devin-cli" || platform == "devin-desktop"
+}
+
 // getFirstStr returns the first non-empty string value from input for the given keys.
 func getFirstStr(input map[string]interface{}, keys ...string) string {
 	for _, key := range keys {
@@ -55,7 +59,7 @@ func resolveSessionID(input map[string]interface{}, platform string) string {
 		return getFirstStr(input, "conversation_id")
 	case "vscode":
 		return getFirstStr(input, "sessionId", "session_id", "conversation_id", "gen_ai.conversation.id")
-	case "devin":
+	case "devin", "devin-cli", "devin-desktop":
 		return getFirstStr(input, "session_id", "sessionId", "conversation_id")
 	case "grok":
 		return getFirstStr(input, "sessionId", "session_id", "sessionID")
@@ -90,7 +94,7 @@ func resolveSessionIDWithTranscript(input map[string]interface{}, platform strin
 		sessionID = getFirstStr(input, "sessionId", "session_id", "conversation_id", "gen_ai.conversation.id")
 		transcriptPath = getFirstStr(input, "transcript_path", "transcriptPath")
 		return
-	case "devin":
+	case "devin", "devin-cli", "devin-desktop":
 		sessionID = getFirstStr(input, "session_id", "sessionId", "conversation_id")
 		transcriptPath = getFirstStr(input, "transcript_path", "transcriptPath")
 		return
@@ -169,7 +173,7 @@ func resolveCwd(input map[string]interface{}, platform string) string {
 			return cwd
 		}
 	}
-	if platform == "devin" {
+	if isDevinLikePlatform(platform) {
 		if cwd := getFirstStr(input, "cwd", "project_dir", "projectDir"); cwd != "" {
 			return cwd
 		}

--- a/cli/beacon-hooks/cmd/permission_request.go
+++ b/cli/beacon-hooks/cmd/permission_request.go
@@ -22,7 +22,7 @@ var devinApproveResponse = map[string]interface{}{"decision": "approve"}
 func runPermissionRequest(cmd *cobra.Command, args []string) {
 	input, err := readStdinJSON()
 	if err != nil {
-		if platformFlag == "devin" {
+		if isDevinLikePlatform(platformFlag) {
 			outputJSON(devinApproveResponse)
 			return
 		}
@@ -38,7 +38,7 @@ func runPermissionRequest(cmd *cobra.Command, args []string) {
 		logger = logging.NewLoggerForPlatform("permission-request", platformFlag)
 	}
 
-	if platformFlag == "devin" {
+	if isDevinLikePlatform(platformFlag) {
 		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "approve", "Permission request approved")
 		outputJSON(devinApproveResponse)
 		return

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -119,7 +119,7 @@ func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logge
 	var sessionID, toolName string
 	var toolInput, toolResponse map[string]interface{}
 
-	if platformFlag == "antigravity" || platformFlag == "copilot" || platformFlag == "devin" || platformFlag == "grok" || platformFlag == "vscode" {
+	if platformFlag == "antigravity" || platformFlag == "copilot" || isDevinLikePlatform(platformFlag) || platformFlag == "grok" || platformFlag == "vscode" {
 		sessionID = resolveSessionID(input, platformFlag)
 		toolName = getFirstStr(input, "toolName", "tool_name")
 		if platformFlag == "antigravity" {
@@ -157,7 +157,7 @@ func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logge
 	}
 	filePath = diff.NormalizePath(filePath)
 
-	if (sessionID == "" && platformFlag != "devin") || toolName == "" || filePath == "" {
+	if (sessionID == "" && !isDevinLikePlatform(platformFlag)) || toolName == "" || filePath == "" {
 		return nil
 	}
 
@@ -307,7 +307,7 @@ func isFileEditTool(platform, toolName string) bool {
 	if platform == "factory" {
 		return toolName == "Write" || toolName == "Edit" || toolName == "MultiEdit" || toolName == "Create"
 	}
-	if platform == "devin" {
+	if isDevinLikePlatform(platform) {
 		lower := strings.ToLower(toolName)
 		return lower == "edit" || lower == "write"
 	}

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -25,10 +25,11 @@ func init() {
 
 // evaluationParams holds the platform-independent fields needed for local hook handling.
 type evaluationParams struct {
-	sessionID string
-	toolName  string
-	filePath  string
-	diffStr   string
+	sessionID   string
+	toolName    string
+	filePath    string
+	diffStr     string
+	extraFields map[string]interface{}
 }
 
 func runPostTool(cmd *cobra.Command, args []string) {
@@ -49,7 +50,14 @@ func runPostTool(cmd *cobra.Command, args []string) {
 
 	var params *evaluationParams
 
-	if platformFlag == "cursor" {
+	if isCascadePlatform(platformFlag) {
+		params = parseCascadeWriteInput(input, logger)
+		if params == nil {
+			emitCascadePostToolObserved(logger, input)
+			outputJSON(emptyResponse)
+			return
+		}
+	} else if platformFlag == "cursor" {
 		// Cursor fires two hook types through post-tool:
 		//   - afterFileEdit: has "edits" array and top-level "file_path" (no output supported)
 		//   - postToolUse: has "tool_name" and "tool_input" (supports additional_context/followup via stop)
@@ -187,12 +195,15 @@ func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logge
 func recordLocalEdit(params *evaluationParams, logger *logging.Logger) {
 	logger.Info("File edit observed", "file_path", params.filePath, "tool_name", params.toolName)
 	fields := map[string]interface{}{}
+	for key, value := range params.extraFields {
+		fields[key] = value
+	}
 	for key, value := range diffFields(params.filePath, params.diffStr) {
 		fields[key] = value
 	}
-	fields["tool"] = map[string]interface{}{"name": params.toolName, "path": params.filePath}
+	fields["tool"] = mergeNested(fields["tool"], map[string]interface{}{"name": params.toolName, "path": params.filePath})
 	if params.sessionID != "" {
-		fields["session"] = map[string]interface{}{"id": params.sessionID}
+		fields["session"] = mergeNested(fields["session"], map[string]interface{}{"id": params.sessionID})
 	}
 	logger.EndpointEvent("file.modified", "file", "info", "File edit observed", fields)
 }
@@ -310,6 +321,10 @@ func isFileEditTool(platform, toolName string) bool {
 	if isDevinLikePlatform(platform) {
 		lower := strings.ToLower(toolName)
 		return lower == "edit" || lower == "write"
+	}
+	if isCascadePlatform(platform) {
+		lower := strings.ToLower(toolName)
+		return lower == "post_write_code" || lower == "write_code"
 	}
 	if platform == "grok" {
 		lower := strings.ToLower(toolName)

--- a/cli/beacon-hooks/cmd/post_tool_test.go
+++ b/cli/beacon-hooks/cmd/post_tool_test.go
@@ -201,13 +201,19 @@ func TestRunPostToolEmitsDevinDesktopFileModifiedEvent(t *testing.T) {
 	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
 
 	out := runHookWithInput(t, runPostTool, map[string]interface{}{
-		"cwd":       "/repo",
-		"tool_name": "write",
-		"tool_input": map[string]interface{}{
-			"file_path": "/repo/main.go",
-			"content":   "new token=devin-secret",
+		"agent_action_name": "post_write_code",
+		"trajectory_id":     "cascade-session",
+		"execution_id":      "cascade-turn",
+		"tool_info": map[string]interface{}{
+			"file_path":      "/repo/main.go",
+			"workspace_path": "/repo",
+			"edits": []interface{}{
+				map[string]interface{}{
+					"old_string": "old",
+					"new_string": "new token=devin-secret",
+				},
+			},
 		},
-		"tool_response": map[string]interface{}{"success": true},
 	})
 	if len(out) != 0 {
 		t.Fatalf("post-tool response = %#v, want empty response", out)
@@ -220,10 +226,9 @@ func TestRunPostToolEmitsDevinDesktopFileModifiedEvent(t *testing.T) {
 	if harness := event["harness"].(map[string]interface{})["name"]; harness != "devin-desktop" {
 		t.Fatalf("harness = %q, want devin-desktop", harness)
 	}
-	if session, ok := event["session"].(map[string]interface{}); ok {
-		if _, hasID := session["id"]; hasID {
-			t.Fatalf("devin desktop file event should not include empty session id: %#v", session)
-		}
+	session := event["session"].(map[string]interface{})
+	if session["id"] != "cascade-session" || session["execution_id"] != "cascade-turn" {
+		t.Fatalf("session = %#v, want Cascade trajectory and execution IDs", session)
 	}
 	file := event["file"].(map[string]interface{})
 	if file["path"] != "/repo/main.go" {
@@ -231,6 +236,71 @@ func TestRunPostToolEmitsDevinDesktopFileModifiedEvent(t *testing.T) {
 	}
 	if _, ok := file["diff_hash"]; !ok {
 		t.Fatalf("file diff_hash missing: %#v", file)
+	}
+	if _, ok := event["raw"].(map[string]interface{})["cascade"]; !ok {
+		t.Fatalf("raw.cascade missing: %#v", event["raw"])
+	}
+}
+
+func TestRunPostToolEmitsDevinDesktopCascadeObservedEvents(t *testing.T) {
+	tests := []struct {
+		name       string
+		actionName string
+		toolInfo   map[string]interface{}
+		wantAction string
+		wantField  string
+	}{
+		{
+			name:       "command",
+			actionName: "post_run_command",
+			toolInfo:   map[string]interface{}{"command": "go test ./...", "workspace_path": "/repo"},
+			wantAction: "command.executed",
+			wantField:  "command",
+		},
+		{
+			name:       "mcp",
+			actionName: "post_mcp_tool_use",
+			toolInfo:   map[string]interface{}{"server_name": "linear", "tool_name": "issue-get", "workspace_path": "/repo"},
+			wantAction: "mcp.tool_invoked",
+			wantField:  "mcp",
+		},
+		{
+			name:       "read",
+			actionName: "post_read_code",
+			toolInfo:   map[string]interface{}{"file_path": "/repo/main.go", "workspace_path": "/repo"},
+			wantAction: "file.read",
+			wantField:  "file",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupHookConfigDirs(t)
+			platformFlag = "devin-desktop"
+			logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+			t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+			out := runHookWithInput(t, runPostTool, map[string]interface{}{
+				"agent_action_name": tt.actionName,
+				"trajectory_id":     "cascade-session",
+				"execution_id":      "cascade-turn",
+				"tool_info":         tt.toolInfo,
+			})
+			if len(out) != 0 {
+				t.Fatalf("post-tool response = %#v, want empty response", out)
+			}
+
+			event := lastEndpointEvent(t, logPath)
+			if action := event["event"].(map[string]interface{})["action"]; action != tt.wantAction {
+				t.Fatalf("event.action = %q, want %q", action, tt.wantAction)
+			}
+			if _, ok := event[tt.wantField]; !ok {
+				t.Fatalf("event missing %q field: %#v", tt.wantField, event)
+			}
+			tool := event["tool"].(map[string]interface{})
+			if tool["execution_id"] != "cascade-turn" || tool["action"] != tt.actionName {
+				t.Fatalf("tool = %#v, want Cascade action and execution IDs", tool)
+			}
+		})
 	}
 }
 

--- a/cli/beacon-hooks/cmd/post_tool_test.go
+++ b/cli/beacon-hooks/cmd/post_tool_test.go
@@ -194,6 +194,46 @@ func TestRunPostToolEmitsDevinFileModifiedEvent(t *testing.T) {
 	}
 }
 
+func TestRunPostToolEmitsDevinDesktopFileModifiedEvent(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "devin-desktop"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPostTool, map[string]interface{}{
+		"cwd":       "/repo",
+		"tool_name": "write",
+		"tool_input": map[string]interface{}{
+			"file_path": "/repo/main.go",
+			"content":   "new token=devin-secret",
+		},
+		"tool_response": map[string]interface{}{"success": true},
+	})
+	if len(out) != 0 {
+		t.Fatalf("post-tool response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "file.modified" {
+		t.Fatalf("event.action = %q, want file.modified", action)
+	}
+	if harness := event["harness"].(map[string]interface{})["name"]; harness != "devin-desktop" {
+		t.Fatalf("harness = %q, want devin-desktop", harness)
+	}
+	if session, ok := event["session"].(map[string]interface{}); ok {
+		if _, hasID := session["id"]; hasID {
+			t.Fatalf("devin desktop file event should not include empty session id: %#v", session)
+		}
+	}
+	file := event["file"].(map[string]interface{})
+	if file["path"] != "/repo/main.go" {
+		t.Fatalf("file = %#v, want /repo/main.go", file)
+	}
+	if _, ok := file["diff_hash"]; !ok {
+		t.Fatalf("file diff_hash missing: %#v", file)
+	}
+}
+
 func TestRunPostToolEmitsFactoryFileModifiedEvent(t *testing.T) {
 	setupHookConfigDirs(t)
 	platformFlag = "factory"

--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -48,7 +48,7 @@ func runPreTool(cmd *cobra.Command, args []string) {
 	if platformFlag == "antigravity" {
 		emitAntigravityPromptFromTranscript(logger, input, sessionID)
 		emitPreToolObserved(logger, input, sessionID)
-	} else if platformFlag == "claude" || platformFlag == "devin" || platformFlag == "grok" || platformFlag == "vscode" {
+	} else if platformFlag == "claude" || isDevinLikePlatform(platformFlag) || platformFlag == "grok" || platformFlag == "vscode" {
 		emitPreToolObserved(logger, input, sessionID)
 	} else {
 		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "Pre-tool observed")
@@ -75,7 +75,7 @@ func preToolResponse() map[string]interface{} {
 	if platformFlag == "antigravity" || platformFlag == "grok" {
 		return map[string]interface{}{"decision": "allow"}
 	}
-	if platformFlag == "claude" || platformFlag == "devin" || platformFlag == "vscode" {
+	if platformFlag == "claude" || isDevinLikePlatform(platformFlag) || platformFlag == "vscode" {
 		return emptyResponse
 	}
 	return allowResponse

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -284,6 +284,34 @@ func TestRunPromptSubmitEmitsDevinPromptWithoutSession(t *testing.T) {
 	}
 }
 
+func TestRunPromptSubmitEmitsDevinDesktopPromptWithDesktopHarness(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "devin-desktop"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "full")
+	t.Setenv("DEVIN_PROJECT_DIR", "/repo")
+
+	out := runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"hook_event_name": "UserPromptSubmit",
+		"prompt":          "summarize token=desktop-secret",
+	})
+	if len(out) != 0 {
+		t.Fatalf("devin desktop prompt response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "prompt.submitted" {
+		t.Fatalf("event.action = %q, want prompt.submitted", action)
+	}
+	if harness := event["harness"].(map[string]interface{})["name"]; harness != "devin-desktop" {
+		t.Fatalf("harness = %q, want devin-desktop", harness)
+	}
+	if got := event["repository"]; got != "/repo" {
+		t.Fatalf("repository = %q, want DEVIN_PROJECT_DIR", got)
+	}
+}
+
 func TestRunPreToolEmitsDevinToolTelemetryWithoutApproval(t *testing.T) {
 	setupHookConfigDirs(t)
 	platformFlag = "devin"
@@ -310,6 +338,31 @@ func TestRunPreToolEmitsDevinToolTelemetryWithoutApproval(t *testing.T) {
 	}
 	if command := event["command"].(map[string]interface{})["command"]; command != "git status" {
 		t.Fatalf("command = %q, want git status", command)
+	}
+}
+
+func TestRunPermissionRequestApprovesDevinCLI(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "devin-cli"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPermissionRequest, map[string]interface{}{
+		"tool_name": "exec",
+		"tool_input": map[string]interface{}{
+			"command": "git status",
+		},
+	})
+	if out["decision"] != "approve" {
+		t.Fatalf("devin-cli permission response = %#v, want approve", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if harness := event["harness"].(map[string]interface{})["name"]; harness != "devin-cli" {
+		t.Fatalf("harness = %q, want devin-cli", harness)
+	}
+	if action := event["event"].(map[string]interface{})["action"]; action != "approval.allowed" {
+		t.Fatalf("event.action = %q, want approval.allowed", action)
 	}
 }
 

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -290,11 +290,15 @@ func TestRunPromptSubmitEmitsDevinDesktopPromptWithDesktopHarness(t *testing.T) 
 	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
 	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
 	t.Setenv("BEACON_CONTENT_RETENTION", "full")
-	t.Setenv("DEVIN_PROJECT_DIR", "/repo")
 
 	out := runHookWithInput(t, runPromptSubmit, map[string]interface{}{
-		"hook_event_name": "UserPromptSubmit",
-		"prompt":          "summarize token=desktop-secret",
+		"agent_action_name": "pre_user_prompt",
+		"trajectory_id":     "cascade-session",
+		"execution_id":      "cascade-turn",
+		"tool_info": map[string]interface{}{
+			"user_prompt":    "summarize token=desktop-secret",
+			"workspace_path": "/repo",
+		},
 	})
 	if len(out) != 0 {
 		t.Fatalf("devin desktop prompt response = %#v, want empty response", out)
@@ -307,8 +311,40 @@ func TestRunPromptSubmitEmitsDevinDesktopPromptWithDesktopHarness(t *testing.T) 
 	if harness := event["harness"].(map[string]interface{})["name"]; harness != "devin-desktop" {
 		t.Fatalf("harness = %q, want devin-desktop", harness)
 	}
+	session := event["session"].(map[string]interface{})
+	if session["id"] != "cascade-session" || session["execution_id"] != "cascade-turn" {
+		t.Fatalf("session = %#v, want Cascade trajectory and execution IDs", session)
+	}
 	if got := event["repository"]; got != "/repo" {
-		t.Fatalf("repository = %q, want DEVIN_PROJECT_DIR", got)
+		t.Fatalf("repository = %q, want Cascade workspace path", got)
+	}
+}
+
+func TestRunPromptSubmitOmitsDevinDesktopPromptForMetadataRetention(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "devin-desktop"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "metadata")
+
+	out := runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"agent_action_name": "pre_user_prompt",
+		"trajectory_id":     "cascade-session",
+		"tool_info": map[string]interface{}{
+			"user_prompt": "summarize token=desktop-secret",
+		},
+	})
+	if len(out) != 0 {
+		t.Fatalf("devin desktop prompt response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if _, ok := event["prompt"]; ok {
+		t.Fatalf("metadata retention should omit prompt: %#v", event["prompt"])
+	}
+	content := event["content"].(map[string]interface{})
+	if content["included"] != false {
+		t.Fatalf("content = %#v, want included=false", content)
 	}
 }
 

--- a/cli/beacon-hooks/cmd/prompt_submit.go
+++ b/cli/beacon-hooks/cmd/prompt_submit.go
@@ -42,7 +42,13 @@ func runPromptSubmit(cmd *cobra.Command, args []string) {
 
 	logger.Debug("Prompt submit observed")
 	fields := sessionFields(sessionID, input)
+	if isCascadePlatform(platformFlag) {
+		fields = cascadeMetadataFields(sessionID, input)
+	}
 	prompt := getFirstStr(input, "prompt", "user_prompt", "userPrompt", "text", "promptText", "input")
+	if isCascadePlatform(platformFlag) {
+		prompt = cascadePrompt(input)
+	}
 	hasPrompt := prompt != ""
 	if hasPrompt && config.ContentRetentionMode() != config.ContentRetentionMetadata {
 		fields["prompt"] = map[string]interface{}{"text": prompt}

--- a/cli/beacon-hooks/cmd/root.go
+++ b/cli/beacon-hooks/cmd/root.go
@@ -21,7 +21,7 @@ Use --platform to specify the calling platform (default: claude).`,
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, antigravity, copilot, cursor, vscode, devin, factory, grok, or opencode")
+	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, antigravity, copilot, cursor, vscode, devin, devin-cli, devin-desktop, factory, grok, or opencode")
 }
 
 // Execute runs the root command

--- a/cli/beacon-hooks/cmd/session_end.go
+++ b/cli/beacon-hooks/cmd/session_end.go
@@ -41,7 +41,7 @@ func runSessionEnd(cmd *cobra.Command, args []string) {
 		if err := os.Remove(logFile); err != nil && !os.IsNotExist(err) {
 			platformLogger.Warn("Failed to remove session log", "session_id", sessionID, "error", err.Error())
 		}
-	} else if platformFlag == "devin" {
+	} else if isDevinLikePlatform(platformFlag) {
 		platformLogger.Info("Session ended", "platform", platformFlag)
 		emitHookEvent(platformLogger, "session.ended", "session", "info", "Agent session ended", input, sessionFields("", input))
 	}

--- a/cli/beacon-hooks/cmd/session_start.go
+++ b/cli/beacon-hooks/cmd/session_start.go
@@ -32,7 +32,7 @@ func runSessionStart(cmd *cobra.Command, args []string) {
 
 	sessionID := resolveSessionID(input, platformFlag)
 	if sessionID == "" {
-		if platformFlag == "devin" {
+		if isDevinLikePlatform(platformFlag) {
 			logger := logging.NewLoggerForPlatform("session-start", platformFlag)
 			logger.Info("Session initialized", "platform", platformFlag)
 			emitHookEvent(logger, "session.started", "session", "info", "Agent session started", input, sessionFields("", input))

--- a/cli/beacon-hooks/cmd/stop.go
+++ b/cli/beacon-hooks/cmd/stop.go
@@ -47,7 +47,7 @@ func runStop(cmd *cobra.Command, args []string) {
 
 	logger.Debug("Stop hook called", "session_id", sessionID, "has_transcript", transcriptPath != "", "platform", platformFlag)
 	if sessionID == "" {
-		if platformFlag == "devin" {
+		if isDevinLikePlatform(platformFlag) {
 			logger.Info("stop completed")
 			emitHookEvent(logger, "tool.completed", "tool", "info", "Agent response completed", input, sessionFields("", input))
 			outputJSON(emptyResponse)
@@ -88,7 +88,7 @@ func platformToTranscriptName(platform string) string {
 		return "vscode"
 	case "factory":
 		return "factory"
-	case "devin":
+	case "devin", "devin-cli", "devin-desktop":
 		return "devin"
 	default:
 		return "claude_code"
@@ -104,7 +104,7 @@ func extractMessages(transcriptPath, platform string) []map[string]interface{} {
 		return extractMessagesFromCursorTranscript(transcriptPath)
 	case "factory":
 		return extractMessagesFromFactoryTranscript(transcriptPath)
-	case "devin":
+	case "devin", "devin-cli", "devin-desktop":
 		return extractMessagesFromClaudeTranscript(transcriptPath)
 	default:
 		return extractMessagesFromClaudeTranscript(transcriptPath)

--- a/cli/beacon-hooks/internal/config/config.go
+++ b/cli/beacon-hooks/internal/config/config.go
@@ -99,7 +99,7 @@ func GetStateDir(platform string) string {
 		return CursorDir
 	case "vscode":
 		return VSCodeDir
-	case "devin":
+	case "devin", "devin-cli", "devin-desktop":
 		return DevinDir
 	case "factory":
 		return FactoryDir

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -248,10 +248,14 @@ use `.devin/hooks.v1.json`; user-level installs use
 local Go hook binary and write normalized prompt, tool, command, file, approval,
 and session events to the configured runtime JSONL log.
 
-Devin Desktop is exposed separately as `devin-desktop` and uses the same
-Devin-compatible hook file format with `--platform devin-desktop` event
-attribution. After installation, generate a Devin Desktop event and check the
-Beacon runtime log to validate that the Desktop app executed the hook file.
+Devin Desktop is exposed separately as `devin-desktop` and uses Devin
+Desktop-compatible Cascade/Windsurf hooks. User-level installs write
+`~/.codeium/windsurf/hooks.json`; project-level installs write
+`.windsurf/hooks.json`, which may also affect Windsurf/Cascade in that
+workspace. Beacon installs visibility-only hooks for prompt submission, file
+writes, command execution, MCP tool use, and file reads; the hooks do not block
+or enforce policy. After installation, generate a Devin Desktop event and check
+the Beacon runtime log to validate that the Desktop app executed the hook file.
 The main `beacon endpoint install --harness ...` path also handles hook-backed
 Devin targets, so `--harness claude,codex,devin-cli,devin-desktop` configures
 OTLP-backed Claude/Codex telemetry and Devin hook telemetry in one flow.

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -199,8 +199,12 @@ tooling, not in Beacon endpoint configuration.
 ./beacon endpoint hooks install --harness grok
 ./beacon endpoint hooks status --harness grok
 
-./beacon endpoint hooks install --harness devin --level project
-./beacon endpoint hooks status --harness devin --level project
+./beacon endpoint hooks install --harness devin-cli --level project
+./beacon endpoint hooks status --harness devin-cli --level project
+./beacon endpoint hooks install --harness devin-desktop --level user
+./beacon endpoint hooks status --harness devin-desktop --level user
+
+./beacon endpoint install --harness claude,codex,devin-cli,devin-desktop
 
 ./beacon endpoint integrations claude-cowork setup --endpoint https://collector.example.com --open
 ./beacon endpoint integrations claude-cowork setup --ngrok --open
@@ -237,11 +241,20 @@ The Grok Build integration writes Beacon's owned local hook file at
 for project-level installs. Project hooks require trusting the project in Grok
 with `/hooks-trust` before they execute.
 
-The Devin integration writes Claude-compatible command hooks for Devin for
-Terminal. Project-level installs use `.devin/hooks.v1.json`; user-level installs
-use `~/.config/devin/config.json` under the `hooks` key. The hooks invoke
-Beacon's local Go hook binary and write normalized prompt, tool, command, file,
-approval, and session events to the configured runtime JSONL log.
+The Devin CLI integration writes Claude-compatible command hooks for Devin for
+Terminal. `devin` remains a legacy alias for `devin-cli`. Project-level installs
+use `.devin/hooks.v1.json`; user-level installs use
+`~/.config/devin/config.json` under the `hooks` key. The hooks invoke Beacon's
+local Go hook binary and write normalized prompt, tool, command, file, approval,
+and session events to the configured runtime JSONL log.
+
+Devin Desktop is exposed separately as `devin-desktop` and uses the same
+Devin-compatible hook file format with `--platform devin-desktop` event
+attribution. After installation, generate a Devin Desktop event and check the
+Beacon runtime log to validate that the Desktop app executed the hook file.
+The main `beacon endpoint install --harness ...` path also handles hook-backed
+Devin targets, so `--harness claude,codex,devin-cli,devin-desktop` configures
+OTLP-backed Claude/Codex telemetry and Devin hook telemetry in one flow.
 
 Claude Cowork monitoring is configured in the Claude admin console at
 `https://claude.ai/admin-settings/cowork`. The OTLP endpoint must be reachable

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -935,212 +935,259 @@ func init() {
 }
 
 func runEndpointHooksInstall(cmd *cobra.Command, args []string) error {
+	targets, err := hookTargets()
+	if err != nil {
+		return err
+	}
 	if endpointOpts.dryRun {
 		actions := []plannedAction{}
-		for _, name := range hookTargets() {
+		for _, name := range targets {
 			actions = append(actions, plannedAction{Action: "configure_harness", Target: name, Message: "install endpoint hook integration"})
 		}
 		return printPlannedActions(actions)
 	}
 	cfg := loadOrDefaultConfig()
-	for _, name := range hookTargets() {
-		switch strings.TrimSpace(name) {
-		case "antigravity", "antigravity_cli":
-			status, err := endpointhooks.InstallAntigravity(endpointhooks.AntigravityOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Printf("Antigravity hooks installed: %s\n", status.ConfigPath)
-		case "cursor":
-			status, err := endpointhooks.InstallCursor(endpointhooks.CursorOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Printf("Cursor hooks installed: %s\n", status.HooksJSONPath)
-		case "claude", "claude_code":
-			status, err := endpointhooks.InstallClaude(endpointhooks.ClaudeOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Printf("Claude Code hooks installed: %s\n", status.SettingsPath)
-		case "vscode", "vs_code":
-			status, err := endpointhooks.InstallVSCode(endpointhooks.VSCodeOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Printf("VS Code hooks installed: %s\n", status.HooksPath)
-		case "factory", "droid":
-			status, err := endpointhooks.InstallFactory(endpointhooks.FactoryOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Printf("Factory hooks installed: %s\n", status.SettingsPath)
-		case "opencode":
-			status, err := endpointhooks.InstallOpenCode(endpointhooks.OpenCodeOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Printf("opencode plugin installed: %s\n", status.PluginPath)
-		case "grok":
-			status, err := endpointhooks.InstallGrok(endpointhooks.GrokOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Printf("Grok hooks installed: %s\n", status.HooksPath)
-			if strings.Contains(status.Message, "/hooks-trust") {
-				fmt.Println(status.Message)
-			}
-		case "devin":
-			status, err := endpointhooks.InstallDevin(endpointhooks.DevinOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Printf("Devin hooks installed: %s\n", status.ConfigPath)
-		case "":
-		default:
-			return fmt.Errorf("unsupported hook harness %q", name)
+	for _, name := range targets {
+		if err := installEndpointHookTarget(name, cfg); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+func installEndpointHookTarget(name string, cfg endpointconfig.Config) error {
+	switch strings.TrimSpace(name) {
+	case "antigravity":
+		status, err := endpointhooks.InstallAntigravity(endpointhooks.AntigravityOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Antigravity hooks installed: %s\n", status.ConfigPath)
+	case "cursor":
+		status, err := endpointhooks.InstallCursor(endpointhooks.CursorOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Cursor hooks installed: %s\n", status.HooksJSONPath)
+	case "claude":
+		status, err := endpointhooks.InstallClaude(endpointhooks.ClaudeOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Claude Code hooks installed: %s\n", status.SettingsPath)
+	case "vscode":
+		status, err := endpointhooks.InstallVSCode(endpointhooks.VSCodeOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("VS Code hooks installed: %s\n", status.HooksPath)
+	case "factory":
+		status, err := endpointhooks.InstallFactory(endpointhooks.FactoryOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Factory hooks installed: %s\n", status.SettingsPath)
+	case "opencode":
+		status, err := endpointhooks.InstallOpenCode(endpointhooks.OpenCodeOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("opencode plugin installed: %s\n", status.PluginPath)
+	case "grok":
+		status, err := endpointhooks.InstallGrok(endpointhooks.GrokOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Grok hooks installed: %s\n", status.HooksPath)
+		if strings.Contains(status.Message, "/hooks-trust") {
+			fmt.Println(status.Message)
+		}
+	case "devin-cli":
+		status, err := endpointhooks.InstallDevin(endpointhooks.DevinOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Devin CLI hooks installed: %s\n", status.ConfigPath)
+	case "devin-desktop":
+		status, err := endpointhooks.InstallDevinDesktop(endpointhooks.DevinDesktopOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Devin Desktop hooks installed: %s\n", status.ConfigPath)
+		fmt.Println("Devin Desktop hook files are installed; generate a Desktop event and check the runtime log to validate execution.")
+	case "":
+	default:
+		return fmt.Errorf("unsupported hook harness %q", name)
 	}
 	return nil
 }
 
 func runEndpointHooksUninstall(cmd *cobra.Command, args []string) error {
+	targets, err := hookTargets()
+	if err != nil {
+		return err
+	}
 	if endpointOpts.dryRun {
 		actions := []plannedAction{}
-		for _, name := range hookTargets() {
+		for _, name := range targets {
 			actions = append(actions, plannedAction{Action: "remove_hook", Target: name, Message: "uninstall endpoint hook integration"})
 		}
 		return printPlannedActions(actions)
 	}
 	cfg := loadOrDefaultConfig()
-	for _, name := range hookTargets() {
-		switch strings.TrimSpace(name) {
-		case "antigravity", "antigravity_cli":
-			status, err := endpointhooks.UninstallAntigravity(endpointhooks.AntigravityOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Println(status.Message)
-		case "cursor":
-			status, err := endpointhooks.UninstallCursor(endpointhooks.CursorOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Println(status.Message)
-		case "claude", "claude_code":
-			status, err := endpointhooks.UninstallClaude(endpointhooks.ClaudeOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Println(status.Message)
-		case "vscode", "vs_code":
-			status, err := endpointhooks.UninstallVSCode(endpointhooks.VSCodeOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Println(status.Message)
-		case "factory", "droid":
-			status, err := endpointhooks.UninstallFactory(endpointhooks.FactoryOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Println(status.Message)
-		case "opencode":
-			status, err := endpointhooks.UninstallOpenCode(endpointhooks.OpenCodeOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Println(status.Message)
-		case "grok":
-			status, err := endpointhooks.UninstallGrok(endpointhooks.GrokOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Println(status.Message)
-		case "devin":
-			status, err := endpointhooks.UninstallDevin(endpointhooks.DevinOptions{
-				Level:    endpointhooks.Level(endpointOpts.hookLevel),
-				LogPath:  cfg.LogPath,
-				UserMode: cfg.UserMode,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Println(status.Message)
-		case "":
-		default:
-			return fmt.Errorf("unsupported hook harness %q", name)
+	for _, name := range targets {
+		if err := uninstallEndpointHookTarget(name, cfg); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
+func uninstallEndpointHookTarget(name string, cfg endpointconfig.Config) error {
+	switch strings.TrimSpace(name) {
+	case "antigravity":
+		status, err := endpointhooks.UninstallAntigravity(endpointhooks.AntigravityOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
+	case "cursor":
+		status, err := endpointhooks.UninstallCursor(endpointhooks.CursorOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
+	case "claude":
+		status, err := endpointhooks.UninstallClaude(endpointhooks.ClaudeOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
+	case "vscode":
+		status, err := endpointhooks.UninstallVSCode(endpointhooks.VSCodeOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
+	case "factory":
+		status, err := endpointhooks.UninstallFactory(endpointhooks.FactoryOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
+	case "opencode":
+		status, err := endpointhooks.UninstallOpenCode(endpointhooks.OpenCodeOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
+	case "grok":
+		status, err := endpointhooks.UninstallGrok(endpointhooks.GrokOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
+	case "devin-cli":
+		status, err := endpointhooks.UninstallDevin(endpointhooks.DevinOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
+	case "devin-desktop":
+		status, err := endpointhooks.UninstallDevinDesktop(endpointhooks.DevinDesktopOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
+	case "":
+	default:
+		return fmt.Errorf("unsupported hook harness %q", name)
+	}
+	return nil
+}
+
 func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
+	targets, err := hookTargets()
+	if err != nil {
+		return err
+	}
 	cfg := loadOrDefaultConfig()
 	statuses := map[string]interface{}{}
-	for _, name := range hookTargets() {
+	for _, name := range targets {
 		switch strings.TrimSpace(name) {
-		case "antigravity", "antigravity_cli":
+		case "antigravity":
 			statuses["antigravity"] = endpointhooks.AntigravityHookStatus(endpointhooks.AntigravityOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
 				LogPath:  cfg.LogPath,
@@ -1152,19 +1199,19 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
-		case "claude", "claude_code":
+		case "claude":
 			statuses["claude"] = endpointhooks.ClaudeHookStatus(endpointhooks.ClaudeOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
-		case "vscode", "vs_code":
+		case "vscode":
 			statuses["vscode"] = endpointhooks.VSCodeHookStatus(endpointhooks.VSCodeOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
-		case "factory", "droid":
+		case "factory":
 			statuses["factory"] = endpointhooks.FactoryHookStatus(endpointhooks.FactoryOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
 				LogPath:  cfg.LogPath,
@@ -1182,8 +1229,14 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
-		case "devin":
-			statuses["devin"] = endpointhooks.DevinHookStatus(endpointhooks.DevinOptions{
+		case "devin-cli":
+			statuses["devin-cli"] = endpointhooks.DevinHookStatus(endpointhooks.DevinOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
+		case "devin-desktop":
+			statuses["devin-desktop"] = endpointhooks.DevinDesktopHookStatus(endpointhooks.DevinDesktopOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
@@ -1196,9 +1249,9 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 	if endpointOpts.jsonOutput {
 		return json.NewEncoder(os.Stdout).Encode(statuses)
 	}
-	for _, name := range hookTargets() {
+	for _, name := range targets {
 		switch strings.TrimSpace(name) {
-		case "antigravity", "antigravity_cli":
+		case "antigravity":
 			status := statuses["antigravity"].(endpointhooks.AntigravityStatus)
 			fmt.Printf("Antigravity hooks: installed=%t path=%s\n", status.Installed, status.ConfigPath)
 			fmt.Println(status.Message)
@@ -1206,15 +1259,15 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 			status := statuses["cursor"].(endpointhooks.CursorStatus)
 			fmt.Printf("Cursor hooks: installed=%t path=%s\n", status.Installed, status.HooksJSONPath)
 			fmt.Println(status.Message)
-		case "claude", "claude_code":
+		case "claude":
 			status := statuses["claude"].(endpointhooks.ClaudeStatus)
 			fmt.Printf("Claude Code hooks: installed=%t path=%s\n", status.Installed, status.SettingsPath)
 			fmt.Println(status.Message)
-		case "vscode", "vs_code":
+		case "vscode":
 			status := statuses["vscode"].(endpointhooks.VSCodeStatus)
 			fmt.Printf("VS Code hooks: installed=%t path=%s\n", status.Installed, status.HooksPath)
 			fmt.Println(status.Message)
-		case "factory", "droid":
+		case "factory":
 			status := statuses["factory"].(endpointhooks.FactoryStatus)
 			fmt.Printf("Factory hooks: installed=%t path=%s\n", status.Installed, status.SettingsPath)
 			fmt.Println(status.Message)
@@ -1226,9 +1279,13 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 			status := statuses["grok"].(endpointhooks.GrokStatus)
 			fmt.Printf("Grok hooks: installed=%t path=%s\n", status.Installed, status.HooksPath)
 			fmt.Println(status.Message)
-		case "devin":
-			status := statuses["devin"].(endpointhooks.DevinStatus)
-			fmt.Printf("Devin hooks: installed=%t path=%s\n", status.Installed, status.ConfigPath)
+		case "devin-cli":
+			status := statuses["devin-cli"].(endpointhooks.DevinStatus)
+			fmt.Printf("Devin CLI hooks: installed=%t path=%s\n", status.Installed, status.ConfigPath)
+			fmt.Println(status.Message)
+		case "devin-desktop":
+			status := statuses["devin-desktop"].(endpointhooks.DevinStatus)
+			fmt.Printf("Devin Desktop hooks: installed=%t path=%s\n", status.Installed, status.ConfigPath)
 			fmt.Println(status.Message)
 		}
 	}
@@ -1656,13 +1713,17 @@ func runEndpointDashboard(cmd *cobra.Command, args []string) error {
 }
 
 func runEndpointInstall(cmd *cobra.Command, args []string) error {
+	otlpHarnesses, hookHarnesses, err := splitEndpointTargets(splitHarnessCSV(endpointOpts.harnesses))
+	if err != nil {
+		return err
+	}
 	if endpointOpts.dryRun {
 		return printPlannedActions(plannedInstallActions(false))
 	}
 	result, err := lifecycle.Install(lifecycle.InstallOptions{
 		UserMode:              endpointUserMode(),
 		LogPath:               endpointOpts.logPath,
-		Harnesses:             splitHarnessCSV(endpointOpts.harnesses),
+		Harnesses:             otlpHarnesses,
 		GRPCPort:              endpointOpts.grpcPort,
 		HTTPPort:              endpointOpts.httpPort,
 		CollectorPath:         endpointOpts.collectorPath,
@@ -1681,6 +1742,9 @@ func runEndpointInstall(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Launch plist written to %s\n", result.PlistPath)
 	fmt.Printf("Install manifest written to %s\n", result.ManifestPath)
 	fmt.Printf("Runtime log: %s\n", result.LogPath)
+	if err := installHookTargetsFromEndpointInstall(hookHarnesses); err != nil {
+		return fmt.Errorf("endpoint install completed, but hook installation failed: %w", err)
+	}
 	return nil
 }
 
@@ -1791,13 +1855,17 @@ func runEndpointUninstall(cmd *cobra.Command, args []string) error {
 }
 
 func runEndpointRepair(cmd *cobra.Command, args []string) error {
+	otlpHarnesses, hookHarnesses, err := splitEndpointTargets(splitHarnessCSV(endpointOpts.harnesses))
+	if err != nil {
+		return err
+	}
 	if endpointOpts.dryRun {
 		return printPlannedActions(plannedInstallActions(true))
 	}
 	result, err := lifecycle.Repair(lifecycle.InstallOptions{
 		UserMode:              endpointUserMode(),
 		LogPath:               endpointOpts.logPath,
-		Harnesses:             splitHarnessCSV(endpointOpts.harnesses),
+		Harnesses:             otlpHarnesses,
 		GRPCPort:              endpointOpts.grpcPort,
 		HTTPPort:              endpointOpts.httpPort,
 		CollectorPath:         endpointOpts.collectorPath,
@@ -1812,6 +1880,25 @@ func runEndpointRepair(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	fmt.Printf("Endpoint repaired. Manifest: %s\n", result.ManifestPath)
+	if err := installHookTargetsFromEndpointInstall(hookHarnesses); err != nil {
+		return fmt.Errorf("endpoint repair completed, but hook installation failed: %w", err)
+	}
+	return nil
+}
+
+func installHookTargetsFromEndpointInstall(targets []string) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	cfg := loadOrDefaultConfig()
+	if endpointOpts.logPath != "" {
+		cfg.LogPath = endpointOpts.logPath
+	}
+	for _, target := range targets {
+		if err := installEndpointHookTarget(target, cfg); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -109,6 +109,10 @@ func runEndpointDoctor(cmd *cobra.Command, args []string) error {
 func runEndpointInventory(cmd *cobra.Command, args []string) error {
 	status := lifecycle.GetStatus(endpointUserMode(), endpointOpts.logPath)
 	effectiveCfg := loadConfigForMode(status.RuntimeLog.EffectiveUserMode, status.LogPath)
+	hookTargetNames, err := hookTargets()
+	if err != nil {
+		return err
+	}
 	result := inventoryResult{
 		GeneratedAt:       time.Now().UTC().Format(time.RFC3339),
 		RuntimeLog:        status.RuntimeLog,
@@ -116,7 +120,7 @@ func runEndpointInventory(cmd *cobra.Command, args []string) error {
 		LogPath:           status.LogPath,
 		ContentRetention:  effectiveCfg.ContentRetention,
 		Harnesses:         status.Harnesses,
-		Hooks:             hookStatusesWithConfig(hookTargets(), effectiveCfg),
+		Hooks:             hookStatusesWithConfig(hookTargetNames, effectiveCfg),
 		Destinations:      status.Destinations,
 		LastEventObserved: status.LastEvent != "",
 	}
@@ -141,7 +145,7 @@ func runEndpointInventory(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("Harness: %s detected=%t telemetry=%s\n", h.DisplayName, h.Detected, h.TelemetryStatus)
 	}
-	for _, name := range hookTargets() {
+	for _, name := range hookTargetNames {
 		if hook, ok := result.Hooks[name]; ok {
 			fmt.Printf("Hook: %s status=%s installed=%t\n", name, hook.Status, hook.Installed)
 		}
@@ -317,6 +321,7 @@ func plannedInstallActions(repair bool) []plannedAction {
 	if endpointOpts.logPath != "" {
 		cfg.LogPath = endpointOpts.logPath
 	}
+	otlpTargets, hookTargets, _ := splitEndpointTargets(splitHarnessCSV(endpointOpts.harnesses))
 	actions := []plannedAction{}
 	if repair {
 		actions = append(actions, plannedAction{Action: "unload_service", Message: "repair unloads existing endpoint service if present"})
@@ -326,8 +331,11 @@ func plannedInstallActions(repair bool) []plannedAction {
 		plannedAction{Action: "write_plist", Message: "launchd service definition"},
 		plannedAction{Action: "write_file", Target: endpointconfig.ConfigPath(cfg.UserMode), Message: "endpoint configuration"},
 	)
-	for _, h := range splitHarnessCSV(endpointOpts.harnesses) {
+	for _, h := range otlpTargets {
 		actions = append(actions, plannedAction{Action: "configure_harness", Target: h})
+	}
+	for _, h := range hookTargets {
+		actions = append(actions, plannedAction{Action: "configure_harness", Target: h, Message: "install endpoint hook integration"})
 	}
 	if !endpointOpts.noStart {
 		actions = append(actions, plannedAction{Action: "load_service", Message: "start endpoint collector service"})
@@ -365,11 +373,11 @@ func printPlannedActions(actions []plannedAction) error {
 	return nil
 }
 
-func hookTargets() []string {
+func hookTargets() ([]string, error) {
 	if endpointOpts.allTargets {
-		return []string{"cursor", "vscode", "factory", "opencode", "grok", "devin", "antigravity"}
+		return []string{"cursor", "vscode", "factory", "opencode", "grok", "devin-cli", "devin-desktop", "antigravity"}, nil
 	}
-	return splitCSV(endpointOpts.hookHarnesses)
+	return canonicalHookTargets(splitCSV(endpointOpts.hookHarnesses))
 }
 
 func hookStatuses(targets []string) map[string]hookTargetResult {
@@ -379,21 +387,25 @@ func hookStatuses(targets []string) map[string]hookTargetResult {
 
 func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[string]hookTargetResult {
 	statuses := map[string]hookTargetResult{}
-	for _, name := range targets {
+	canonical, err := canonicalHookTargets(targets)
+	if err != nil {
+		return statuses
+	}
+	for _, name := range canonical {
 		switch strings.TrimSpace(name) {
-		case "antigravity", "antigravity_cli":
+		case "antigravity":
 			status := endpointhooks.AntigravityHookStatus(endpointhooks.AntigravityOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ConfigPath, Raw: status}
 		case "cursor":
 			status := endpointhooks.CursorHookStatus(endpointhooks.CursorOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksJSONPath, Raw: status}
-		case "claude", "claude_code":
+		case "claude":
 			status := endpointhooks.ClaudeHookStatus(endpointhooks.ClaudeOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.SettingsPath, Raw: status}
-		case "vscode", "vs_code":
+		case "vscode":
 			status := endpointhooks.VSCodeHookStatus(endpointhooks.VSCodeOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
-		case "factory", "droid":
+		case "factory":
 			status := endpointhooks.FactoryHookStatus(endpointhooks.FactoryOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.SettingsPath, Raw: status}
 		case "opencode":
@@ -402,9 +414,12 @@ func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[str
 		case "grok":
 			status := endpointhooks.GrokHookStatus(endpointhooks.GrokOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
-		case "devin":
+		case "devin-cli":
 			status := endpointhooks.DevinHookStatus(endpointhooks.DevinOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
-			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ConfigPath, Raw: status}
+			statuses["devin-cli"] = hookTargetResult{Target: "devin-cli", Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ConfigPath, Raw: status}
+		case "devin-desktop":
+			status := endpointhooks.DevinDesktopHookStatus(endpointhooks.DevinDesktopOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses["devin-desktop"] = hookTargetResult{Target: "devin-desktop", Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ConfigPath, Raw: status}
 		}
 	}
 	return statuses

--- a/cli/beacon/cmd/endpoint_targets.go
+++ b/cli/beacon/cmd/endpoint_targets.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+type endpointTargetKind string
+
+const (
+	endpointTargetOTLP endpointTargetKind = "otlp"
+	endpointTargetHook endpointTargetKind = "hook"
+)
+
+type endpointTarget struct {
+	Name string
+	Kind endpointTargetKind
+}
+
+func normalizeEndpointTarget(name string) (endpointTarget, bool) {
+	key := strings.ToLower(strings.TrimSpace(name))
+	key = strings.ReplaceAll(key, "_", "-")
+	switch key {
+	case "":
+		return endpointTarget{}, false
+	case "claude", "claude-code":
+		return endpointTarget{Name: "claude", Kind: endpointTargetOTLP}, true
+	case "codex", "codex-cli":
+		return endpointTarget{Name: "codex", Kind: endpointTargetOTLP}, true
+	case "gemini", "gemini-cli":
+		return endpointTarget{Name: "gemini", Kind: endpointTargetOTLP}, true
+	case "vscode", "vs-code", "vscode-copilot":
+		return endpointTarget{Name: "vscode", Kind: endpointTargetOTLP}, true
+	case "cursor":
+		return endpointTarget{Name: "cursor", Kind: endpointTargetHook}, true
+	case "claude-hooks":
+		return endpointTarget{Name: "claude", Kind: endpointTargetHook}, true
+	case "factory", "droid":
+		return endpointTarget{Name: "factory", Kind: endpointTargetHook}, true
+	case "opencode":
+		return endpointTarget{Name: "opencode", Kind: endpointTargetHook}, true
+	case "grok":
+		return endpointTarget{Name: "grok", Kind: endpointTargetHook}, true
+	case "antigravity", "antigravity-cli":
+		return endpointTarget{Name: "antigravity", Kind: endpointTargetHook}, true
+	case "devin", "devin-cli":
+		return endpointTarget{Name: "devin-cli", Kind: endpointTargetHook}, true
+	case "devin-desktop":
+		return endpointTarget{Name: "devin-desktop", Kind: endpointTargetHook}, true
+	default:
+		return endpointTarget{}, false
+	}
+}
+
+func splitEndpointTargets(values []string) (otlp []string, hooks []string, err error) {
+	seenOTLP := map[string]bool{}
+	seenHooks := map[string]bool{}
+	for _, value := range values {
+		target, ok := normalizeEndpointTarget(value)
+		if !ok {
+			if strings.TrimSpace(value) == "" {
+				continue
+			}
+			return nil, nil, fmt.Errorf("unsupported harness %q", value)
+		}
+		switch target.Kind {
+		case endpointTargetOTLP:
+			if !seenOTLP[target.Name] {
+				otlp = append(otlp, target.Name)
+				seenOTLP[target.Name] = true
+			}
+		case endpointTargetHook:
+			if !seenHooks[target.Name] {
+				hooks = append(hooks, target.Name)
+				seenHooks[target.Name] = true
+			}
+		}
+	}
+	return otlp, hooks, nil
+}
+
+func canonicalHookTargets(values []string) ([]string, error) {
+	seen := map[string]bool{}
+	targets := []string{}
+	for _, value := range values {
+		target, ok := normalizeHookTarget(value)
+		if !ok {
+			if strings.TrimSpace(value) == "" {
+				continue
+			}
+			return nil, fmt.Errorf("unsupported hook harness %q", value)
+		}
+		if !seen[target] {
+			targets = append(targets, target)
+			seen[target] = true
+		}
+	}
+	return targets, nil
+}
+
+func normalizeHookTarget(name string) (string, bool) {
+	key := strings.ToLower(strings.TrimSpace(name))
+	key = strings.ReplaceAll(key, "_", "-")
+	switch key {
+	case "":
+		return "", false
+	case "antigravity", "antigravity-cli":
+		return "antigravity", true
+	case "cursor":
+		return "cursor", true
+	case "claude", "claude-code":
+		return "claude", true
+	case "vscode", "vs-code":
+		return "vscode", true
+	case "factory", "droid":
+		return "factory", true
+	case "opencode":
+		return "opencode", true
+	case "grok":
+		return "grok", true
+	case "devin", "devin-cli":
+		return "devin-cli", true
+	case "devin-desktop":
+		return "devin-desktop", true
+	default:
+		if target, ok := normalizeEndpointTarget(key); ok && target.Kind == endpointTargetHook {
+			return target.Name, true
+		}
+		return "", false
+	}
+}

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -39,6 +39,53 @@ func TestSplitHarnessCSVAllowsCollectorOnly(t *testing.T) {
 	}
 }
 
+func TestSplitEndpointTargetsDedupesHookAliases(t *testing.T) {
+	otlp, hooks, err := splitEndpointTargets([]string{"claude", "codex", "devin", "devin-cli", "devin_desktop"})
+	if err != nil {
+		t.Fatalf("splitEndpointTargets returned error: %v", err)
+	}
+	if got, want := strings.Join(otlp, ","), "claude,codex"; got != want {
+		t.Fatalf("otlp targets = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(hooks, ","), "devin-cli,devin-desktop"; got != want {
+		t.Fatalf("hook targets = %q, want %q", got, want)
+	}
+}
+
+func TestCanonicalHookTargetsNormalizesAliasesToSwitchNames(t *testing.T) {
+	got, err := canonicalHookTargets([]string{"claude_code", "vs_code", "droid", "devin", "devin_desktop", "antigravity_cli"})
+	if err != nil {
+		t.Fatalf("canonicalHookTargets returned error: %v", err)
+	}
+	want := []string{"claude", "vscode", "factory", "devin-cli", "devin-desktop", "antigravity"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("canonicalHookTargets = %#v, want %#v", got, want)
+	}
+}
+
+func TestPlannedInstallActionsSeparatesHookHarnesses(t *testing.T) {
+	old := endpointOpts
+	t.Cleanup(func() { endpointOpts = old })
+	endpointOpts.userMode = true
+	endpointOpts.harnesses = "claude,devin,devin-cli,devin-desktop"
+	endpointOpts.logPath = filepath.Join(t.TempDir(), "runtime.jsonl")
+	endpointOpts.noStart = true
+
+	actions := plannedInstallActions(false)
+	counts := map[string]int{}
+	for _, action := range actions {
+		if action.Action == "configure_harness" {
+			counts[action.Target]++
+		}
+	}
+	if counts["claude"] != 1 || counts["devin-cli"] != 1 || counts["devin-desktop"] != 1 {
+		t.Fatalf("configure_harness counts = %#v, want claude/devin-cli/devin-desktop once", counts)
+	}
+	if counts["devin"] != 0 {
+		t.Fatalf("legacy devin alias should be deduped, counts=%#v", counts)
+	}
+}
+
 func TestEndpointDashboardCommandRegistered(t *testing.T) {
 	cmd, _, err := endpointCmd.Find([]string{"dashboard"})
 	if err != nil {

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -268,14 +268,17 @@ func DiscoverDevinDesktop() Harness {
 		h.Detected = true
 		h.ExecutablePath = appPath
 	}
-	userConfig := filepath.Join(home, ".config", "devin", "config.json")
-	projectConfig := filepath.Join(".devin", "hooks.v1.json")
+	userConfig := filepath.Join(home, ".codeium", "windsurf", "hooks.json")
+	projectConfig := filepath.Join(".windsurf", "hooks.json")
 	h.ConfigPath = userConfig
 	if fileExists(projectConfig) {
 		h.ConfigPath = projectConfig
 	}
+	if !h.Detected && (dirExists(filepath.Join(home, ".codeium", "windsurf")) || dirExists(".windsurf")) {
+		h.Detected = true
+	}
 	if fileExists(h.ConfigPath) {
-		status, msg := devinStatus(h.ConfigPath, "devin-desktop")
+		status, msg := windsurfCascadeStatus(h.ConfigPath, "devin-desktop")
 		h.TelemetryStatus = status
 		if status == TelemetryEnabled {
 			h.Message = msg + "; generate a Devin Desktop event and check the Beacon runtime log to validate hook execution"
@@ -284,7 +287,7 @@ func DiscoverDevinDesktop() Harness {
 		}
 	} else {
 		h.TelemetryStatus = TelemetryMissing
-		h.Message = "Devin Desktop-compatible endpoint hooks were not found"
+		h.Message = "Devin Desktop Cascade/Windsurf hooks.json was not found"
 	}
 	return h
 }
@@ -555,6 +558,38 @@ func hasBeaconDevinHooks(data []byte, platforms ...string) (bool, error) {
 						}
 					}
 				}
+			}
+		}
+	}
+	return false, nil
+}
+
+func windsurfCascadeStatus(path string, platform string) (TelemetryStatus, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return TelemetryMissing, err.Error()
+	}
+	if hasHooks, err := hasBeaconWindsurfHooks(data, platform); err != nil {
+		return TelemetryMisconfigured, "Cascade/Windsurf hooks JSON is invalid"
+	} else if hasHooks {
+		return TelemetryEnabled, "Devin Desktop Cascade/Windsurf endpoint hooks are configured"
+	}
+	return TelemetryDisabled, "Cascade/Windsurf hooks exist but Devin Desktop endpoint hooks were not found"
+}
+
+func hasBeaconWindsurfHooks(data []byte, platform string) (bool, error) {
+	var root struct {
+		Hooks map[string][]struct {
+			Command string `json:"command"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false, err
+	}
+	for _, hooks := range root.Hooks {
+		for _, hook := range hooks {
+			if strings.Contains(hook.Command, "BEACON_ENDPOINT_MODE=1") && commandHasPlatform(hook.Command, platform) {
+				return true, nil
 			}
 		}
 	}

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -56,6 +56,7 @@ func DiscoverAll() []Harness {
 		DiscoverVSCode(),
 		DiscoverCursor(),
 		DiscoverDevin(),
+		DiscoverDevinDesktop(),
 		DiscoverClaudeCowork(),
 	}
 }
@@ -226,7 +227,7 @@ func DiscoverCursor() Harness {
 }
 
 func DiscoverDevin() Harness {
-	h := Harness{Name: "devin", DisplayName: "Devin", Capability: "hooks"}
+	h := Harness{Name: "devin-cli", DisplayName: "Devin CLI", Capability: "hooks"}
 	path, err := exec.LookPath("devin")
 	if err == nil {
 		h.Detected = true
@@ -244,12 +245,46 @@ func DiscoverDevin() Harness {
 		h.Detected = true
 	}
 	if fileExists(h.ConfigPath) {
-		status, msg := devinStatus(h.ConfigPath)
+		status, msg := devinStatus(h.ConfigPath, "devin", "devin-cli")
 		h.TelemetryStatus = status
 		h.Message = msg
 	} else {
 		h.TelemetryStatus = TelemetryMissing
-		h.Message = "Devin endpoint hooks were not found"
+		h.Message = "Devin CLI endpoint hooks were not found"
+	}
+	return h
+}
+
+func DiscoverDevinDesktop() Harness {
+	h := Harness{Name: "devin-desktop", DisplayName: "Devin Desktop", Capability: "hooks"}
+	home, _ := os.UserHomeDir()
+	appSupport := filepath.Join(home, "Library", "Application Support", "Devin")
+	appPath := "/Applications/Devin.app"
+	if dirExists(appSupport) {
+		h.Detected = true
+		h.ExecutablePath = appSupport
+	}
+	if fileExists(filepath.Join(appPath, "Contents", "Info.plist")) {
+		h.Detected = true
+		h.ExecutablePath = appPath
+	}
+	userConfig := filepath.Join(home, ".config", "devin", "config.json")
+	projectConfig := filepath.Join(".devin", "hooks.v1.json")
+	h.ConfigPath = userConfig
+	if fileExists(projectConfig) {
+		h.ConfigPath = projectConfig
+	}
+	if fileExists(h.ConfigPath) {
+		status, msg := devinStatus(h.ConfigPath, "devin-desktop")
+		h.TelemetryStatus = status
+		if status == TelemetryEnabled {
+			h.Message = msg + "; generate a Devin Desktop event and check the Beacon runtime log to validate hook execution"
+		} else {
+			h.Message = msg
+		}
+	} else {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = "Devin Desktop-compatible endpoint hooks were not found"
 	}
 	return h
 }
@@ -477,12 +512,12 @@ func factoryStatus(path string) (TelemetryStatus, string) {
 	return TelemetryEnabled, "Factory Droid telemetry is configured for local OTLP HTTP"
 }
 
-func devinStatus(path string) (TelemetryStatus, string) {
+func devinStatus(path string, platforms ...string) (TelemetryStatus, string) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return TelemetryMissing, err.Error()
 	}
-	if hasBeaconDevinHooks, err := hasBeaconDevinHooks(data); err != nil {
+	if hasBeaconDevinHooks, err := hasBeaconDevinHooks(data, platforms...); err != nil {
 		return TelemetryMisconfigured, "Devin hooks JSON is invalid"
 	} else if hasBeaconDevinHooks {
 		return TelemetryEnabled, "Devin endpoint hooks are configured"
@@ -490,7 +525,10 @@ func devinStatus(path string) (TelemetryStatus, string) {
 	return TelemetryDisabled, "Devin hooks exist but endpoint hooks were not found"
 }
 
-func hasBeaconDevinHooks(data []byte) (bool, error) {
+func hasBeaconDevinHooks(data []byte, platforms ...string) (bool, error) {
+	if len(platforms) == 0 {
+		platforms = []string{"devin"}
+	}
 	var root map[string]json.RawMessage
 	if err := json.Unmarshal(data, &root); err != nil {
 		return false, err
@@ -510,13 +548,30 @@ func hasBeaconDevinHooks(data []byte) (bool, error) {
 	for _, groups := range hooks {
 		for _, group := range groups {
 			for _, hook := range group.Hooks {
-				if strings.Contains(hook.Command, "BEACON_ENDPOINT_MODE=1") && strings.Contains(hook.Command, "--platform devin") {
-					return true, nil
+				if strings.Contains(hook.Command, "BEACON_ENDPOINT_MODE=1") {
+					for _, platform := range platforms {
+						if commandHasPlatform(hook.Command, platform) {
+							return true, nil
+						}
+					}
 				}
 			}
 		}
 	}
 	return false, nil
+}
+
+func commandHasPlatform(command, platform string) bool {
+	fields := strings.Fields(command)
+	for i, field := range fields {
+		if field == "--platform" && i+1 < len(fields) {
+			return strings.Trim(fields[i+1], `"'`) == platform
+		}
+		if strings.HasPrefix(field, "--platform=") {
+			return strings.Trim(strings.TrimPrefix(field, "--platform="), `"'`) == platform
+		}
+	}
+	return false
 }
 
 func antigravityStatus(path string) (TelemetryStatus, string) {

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -537,6 +537,9 @@ func TestDiscoverDevinDetectsExecutableOnPath(t *testing.T) {
 	if !h.Detected {
 		t.Fatalf("DiscoverDevin did not detect executable on PATH: %#v", h)
 	}
+	if h.Name != "devin-cli" || h.DisplayName != "Devin CLI" {
+		t.Fatalf("Devin harness identity = %s/%s, want devin-cli/Devin CLI", h.Name, h.DisplayName)
+	}
 	if h.ExecutablePath != devinPath {
 		t.Fatalf("ExecutablePath = %q, want %q", h.ExecutablePath, devinPath)
 	}
@@ -545,6 +548,26 @@ func TestDiscoverDevinDetectsExecutableOnPath(t *testing.T) {
 	}
 	if h.ConfigPath != filepath.Join(home, ".config", "devin", "config.json") {
 		t.Fatalf("ConfigPath = %q, want user config path", h.ConfigPath)
+	}
+}
+
+func TestDiscoverDevinDesktopDetectsAppSupport(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	appSupport := filepath.Join(home, "Library", "Application Support", "Devin")
+	if err := os.MkdirAll(appSupport, 0755); err != nil {
+		t.Fatalf("mkdir app support: %v", err)
+	}
+
+	h := DiscoverDevinDesktop()
+	if !h.Detected {
+		t.Fatalf("DiscoverDevinDesktop did not detect app support: %#v", h)
+	}
+	if h.Name != "devin-desktop" || h.DisplayName != "Devin Desktop" {
+		t.Fatalf("Desktop harness identity = %s/%s, want devin-desktop/Devin Desktop", h.Name, h.DisplayName)
+	}
+	if h.ExecutablePath != appSupport && h.ExecutablePath != "/Applications/Devin.app" {
+		t.Fatalf("ExecutablePath = %q, want app support or app path", h.ExecutablePath)
 	}
 }
 
@@ -559,6 +582,8 @@ func TestDevinStatusVariants(t *testing.T) {
 		{name: "no beacon hooks", body: `{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"echo keep"}]}]}}`, status: TelemetryDisabled},
 		{name: "enabled", body: `{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin pre-tool"}]}]}}`, status: TelemetryEnabled},
 		{name: "standalone enabled", body: `{"PreToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin pre-tool"}]}]}`, status: TelemetryEnabled},
+		{name: "devin cli enabled", body: `{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-cli pre-tool"}]}]}}`, status: TelemetryEnabled},
+		{name: "desktop does not satisfy cli", body: `{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-desktop pre-tool"}]}]}}`, status: TelemetryDisabled},
 		{name: "beacon string outside hooks", body: `{"note":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin pre-tool"}`, status: TelemetryDisabled},
 	}
 
@@ -568,11 +593,23 @@ func TestDevinStatusVariants(t *testing.T) {
 			if err := os.WriteFile(path, []byte(tt.body), 0600); err != nil {
 				t.Fatalf("write fixture: %v", err)
 			}
-			status, _ := devinStatus(path)
+			status, _ := devinStatus(path, "devin", "devin-cli")
 			if status != tt.status {
 				t.Fatalf("devinStatus = %q, want %q", status, tt.status)
 			}
 		})
+	}
+}
+
+func TestDevinDesktopStatusVariants(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "desktop.json")
+	body := `{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-desktop pre-tool"}]}]}}`
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	status, _ := devinStatus(path, "devin-desktop")
+	if status != TelemetryEnabled {
+		t.Fatalf("devinStatus desktop = %q, want enabled", status)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -569,6 +569,9 @@ func TestDiscoverDevinDesktopDetectsAppSupport(t *testing.T) {
 	if h.ExecutablePath != appSupport && h.ExecutablePath != "/Applications/Devin.app" {
 		t.Fatalf("ExecutablePath = %q, want app support or app path", h.ExecutablePath)
 	}
+	if h.ConfigPath != filepath.Join(home, ".codeium", "windsurf", "hooks.json") {
+		t.Fatalf("ConfigPath = %q, want Windsurf user hooks path", h.ConfigPath)
+	}
 }
 
 func TestDevinStatusVariants(t *testing.T) {
@@ -603,13 +606,13 @@ func TestDevinStatusVariants(t *testing.T) {
 
 func TestDevinDesktopStatusVariants(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "desktop.json")
-	body := `{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-desktop pre-tool"}]}]}}`
+	body := `{"hooks":{"post_write_code":[{"command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-desktop post-tool"}]}}`
 	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
-	status, _ := devinStatus(path, "devin-desktop")
+	status, _ := windsurfCascadeStatus(path, "devin-desktop")
 	if status != TelemetryEnabled {
-		t.Fatalf("devinStatus desktop = %q, want enabled", status)
+		t.Fatalf("windsurfCascadeStatus desktop = %q, want enabled", status)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/hooks/devin.go
+++ b/cli/beacon/internal/endpoint/hooks/devin.go
@@ -37,6 +37,16 @@ type devinHookRef struct {
 	Timeout int    `json:"timeout,omitempty"`
 }
 
+type windsurfHookRef struct {
+	Command    string `json:"command"`
+	ShowOutput *bool  `json:"show_output,omitempty"`
+}
+
+type windsurfHooksFile struct {
+	values map[string]json.RawMessage
+	hooks  map[string][]windsurfHookRef
+}
+
 type devinConfig struct {
 	values     map[string]json.RawMessage
 	hooks      map[string][]devinHookGroup
@@ -52,8 +62,8 @@ var devinRuntime = hookRuntime{
 }
 
 var devinDesktopRuntime = hookRuntime{
-	displayName: "Devin Desktop",
-	configPath:  devinConfigPath,
+	displayName: "Devin Desktop via Cascade/Windsurf",
+	configPath:  devinDesktopConfigPath,
 	install:     installDevinDesktopHooks,
 	uninstall:   removeDevinDesktopEndpointHooks,
 	isInstalled: isDevinDesktopInstalledAt,
@@ -117,7 +127,27 @@ func installDevinCLIHooks(path, binaryPath, logPath, configPath string) error {
 }
 
 func installDevinDesktopHooks(path, binaryPath, logPath, configPath string) error {
-	return installDevinHooksForPlatform(path, binaryPath, logPath, configPath, "devin-desktop", []string{"devin-desktop"})
+	config, err := readWindsurfHooks(path)
+	if err != nil {
+		return err
+	}
+	prefix := endpointCommandPrefix("devin-desktop", binaryPath, logPath, configPath)
+	hideOutput := false
+	endpointHooks := map[string]windsurfHookRef{
+		"pre_user_prompt":   {Command: prefix + " prompt-submit", ShowOutput: &hideOutput},
+		"post_write_code":   {Command: prefix + " post-tool", ShowOutput: &hideOutput},
+		"post_run_command":  {Command: prefix + " post-tool", ShowOutput: &hideOutput},
+		"post_mcp_tool_use": {Command: prefix + " post-tool", ShowOutput: &hideOutput},
+		"post_read_code":    {Command: prefix + " post-tool", ShowOutput: &hideOutput},
+	}
+	for eventName, hook := range endpointHooks {
+		config.hooks[eventName] = mergeWindsurfEndpointHook(config.hooks[eventName], hook, "devin-desktop")
+	}
+	data, err := config.marshal()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
 }
 
 func installDevinHooks(path, binaryPath, logPath, configPath string) error {
@@ -180,6 +210,47 @@ func readDevinConfig(path string) (devinConfig, error) {
 	return config, nil
 }
 
+func readWindsurfHooks(path string) (windsurfHooksFile, error) {
+	config := windsurfHooksFile{
+		values: map[string]json.RawMessage{},
+		hooks:  map[string][]windsurfHookRef{},
+	}
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if err := json.Unmarshal(data, &config.values); err != nil {
+			return windsurfHooksFile{}, err
+		}
+		if rawHooks, ok := config.values["hooks"]; ok {
+			if err := json.Unmarshal(rawHooks, &config.hooks); err != nil {
+				return windsurfHooksFile{}, err
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return windsurfHooksFile{}, err
+	}
+	if config.hooks == nil {
+		config.hooks = map[string][]windsurfHookRef{}
+	}
+	return config, nil
+}
+
+func (config windsurfHooksFile) marshal() ([]byte, error) {
+	out := make(map[string]json.RawMessage, len(config.values)+1)
+	for key, value := range config.values {
+		if key != "hooks" {
+			out[key] = value
+		}
+	}
+	if len(config.hooks) > 0 {
+		data, err := json.Marshal(config.hooks)
+		if err != nil {
+			return nil, err
+		}
+		out["hooks"] = data
+	}
+	return json.MarshalIndent(out, "", "  ")
+}
+
 func (config devinConfig) marshal() ([]byte, error) {
 	if config.standalone {
 		if len(config.hooks) == 0 {
@@ -217,6 +288,17 @@ func mergeDevinEndpointHook(existing []devinHookGroup, group devinHookGroup, pla
 	return append(out, group)
 }
 
+func mergeWindsurfEndpointHook(existing []windsurfHookRef, hook windsurfHookRef, platform string) []windsurfHookRef {
+	out := make([]windsurfHookRef, 0, len(existing)+1)
+	for _, item := range existing {
+		if isWindsurfEndpointHookCommand(item.Command, platform) {
+			continue
+		}
+		out = append(out, item)
+	}
+	return append(out, hook)
+}
+
 func removeDevinEndpointHooks(path string) (bool, error) {
 	return removeDevinEndpointHooksForPlatforms(path, "devin")
 }
@@ -226,7 +308,37 @@ func removeDevinCLIEndpointHooks(path string) (bool, error) {
 }
 
 func removeDevinDesktopEndpointHooks(path string) (bool, error) {
-	return removeDevinEndpointHooksForPlatforms(path, "devin-desktop")
+	config, err := readWindsurfHooks(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	changed := false
+	for eventName, hooks := range config.hooks {
+		filtered := hooks[:0]
+		for _, hook := range hooks {
+			if isWindsurfEndpointHookCommand(hook.Command, "devin-desktop") {
+				changed = true
+				continue
+			}
+			filtered = append(filtered, hook)
+		}
+		if len(filtered) == 0 {
+			delete(config.hooks, eventName)
+		} else {
+			config.hooks[eventName] = filtered
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+	out, err := config.marshal()
+	if err != nil {
+		return false, err
+	}
+	return true, os.WriteFile(path, out, 0600)
 }
 
 func removeDevinEndpointHooksForPlatforms(path string, platforms ...string) (bool, error) {
@@ -301,7 +413,18 @@ func isDevinCLIInstalledAt(path string) bool {
 }
 
 func isDevinDesktopInstalledAt(path string) bool {
-	return isDevinInstalledAtPlatforms(path, "devin-desktop")
+	config, err := readWindsurfHooks(path)
+	if err != nil {
+		return false
+	}
+	for _, hooks := range config.hooks {
+		for _, hook := range hooks {
+			if isWindsurfEndpointHookCommand(hook.Command, "devin-desktop") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func isDevinInstalledAtPlatforms(path string, platforms ...string) bool {
@@ -331,6 +454,10 @@ func isDevinEndpointHookCommand(command string, platforms ...string) bool {
 	return false
 }
 
+func isWindsurfEndpointHookCommand(command, platform string) bool {
+	return isEndpointHookCommand(command, platform)
+}
+
 func devinConfigPath(level Level) (string, error) {
 	switch level {
 	case LevelProject:
@@ -345,6 +472,25 @@ func devinConfigPath(level Level) (string, error) {
 			return "", err
 		}
 		return filepath.Join(home, ".config", "devin", "config.json"), nil
+	default:
+		return "", fmt.Errorf("unknown hook level %q", level)
+	}
+}
+
+func devinDesktopConfigPath(level Level) (string, error) {
+	switch level {
+	case LevelProject:
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cwd, ".windsurf", "hooks.json"), nil
+	case "", LevelUser:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".codeium", "windsurf", "hooks.json"), nil
 	default:
 		return "", fmt.Errorf("unknown hook level %q", level)
 	}

--- a/cli/beacon/internal/endpoint/hooks/devin.go
+++ b/cli/beacon/internal/endpoint/hooks/devin.go
@@ -13,6 +13,12 @@ type DevinOptions struct {
 	UserMode bool
 }
 
+type DevinDesktopOptions struct {
+	Level    Level
+	LogPath  string
+	UserMode bool
+}
+
 type DevinStatus struct {
 	Installed  bool   `json:"installed"`
 	BinaryPath string `json:"binary_path,omitempty"`
@@ -38,11 +44,19 @@ type devinConfig struct {
 }
 
 var devinRuntime = hookRuntime{
-	displayName: "Devin",
+	displayName: "Devin CLI",
 	configPath:  devinConfigPath,
-	install:     installDevinHooks,
-	uninstall:   removeDevinEndpointHooks,
-	isInstalled: isDevinInstalledAt,
+	install:     installDevinCLIHooks,
+	uninstall:   removeDevinCLIEndpointHooks,
+	isInstalled: isDevinCLIInstalledAt,
+}
+
+var devinDesktopRuntime = hookRuntime{
+	displayName: "Devin Desktop",
+	configPath:  devinConfigPath,
+	install:     installDevinDesktopHooks,
+	uninstall:   removeDevinDesktopEndpointHooks,
+	isInstalled: isDevinDesktopInstalledAt,
 }
 
 func InstallDevin(opts DevinOptions) (DevinStatus, error) {
@@ -69,6 +83,26 @@ func IsDevinInstalled(opts DevinOptions) bool {
 	return isRuntimeInstalled(devinRuntime, RuntimeOptions(opts))
 }
 
+func InstallDevinDesktop(opts DevinDesktopOptions) (DevinStatus, error) {
+	status, err := installRuntimeHooks(devinDesktopRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return DevinStatus{}, err
+	}
+	return devinStatusFromRuntime(status), nil
+}
+
+func UninstallDevinDesktop(opts DevinDesktopOptions) (DevinStatus, error) {
+	status, err := uninstallRuntimeHooks(devinDesktopRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return DevinStatus{}, err
+	}
+	return devinStatusFromRuntime(status), nil
+}
+
+func DevinDesktopHookStatus(opts DevinDesktopOptions) DevinStatus {
+	return devinStatusFromRuntime(runtimeHookStatus(devinDesktopRuntime, RuntimeOptions(opts)))
+}
+
 func devinStatusFromRuntime(status runtimeStatus) DevinStatus {
 	return DevinStatus{
 		Installed:  status.Installed,
@@ -78,12 +112,24 @@ func devinStatusFromRuntime(status runtimeStatus) DevinStatus {
 	}
 }
 
+func installDevinCLIHooks(path, binaryPath, logPath, configPath string) error {
+	return installDevinHooksForPlatform(path, binaryPath, logPath, configPath, "devin-cli", []string{"devin", "devin-cli"})
+}
+
+func installDevinDesktopHooks(path, binaryPath, logPath, configPath string) error {
+	return installDevinHooksForPlatform(path, binaryPath, logPath, configPath, "devin-desktop", []string{"devin-desktop"})
+}
+
 func installDevinHooks(path, binaryPath, logPath, configPath string) error {
+	return installDevinHooksForPlatform(path, binaryPath, logPath, configPath, "devin", []string{"devin"})
+}
+
+func installDevinHooksForPlatform(path, binaryPath, logPath, configPath, platform string, replacePlatforms []string) error {
 	config, err := readDevinConfig(path)
 	if err != nil {
 		return err
 	}
-	prefix := endpointCommandPrefix("devin", binaryPath, logPath, configPath)
+	prefix := endpointCommandPrefix(platform, binaryPath, logPath, configPath)
 	endpointHooks := map[string]devinHookGroup{
 		"SessionStart":      {Hooks: []devinHookRef{{Type: "command", Command: prefix + " session-start"}}},
 		"UserPromptSubmit":  {Hooks: []devinHookRef{{Type: "command", Command: prefix + " prompt-submit", Timeout: 30}}},
@@ -94,7 +140,7 @@ func installDevinHooks(path, binaryPath, logPath, configPath string) error {
 		"SessionEnd":        {Hooks: []devinHookRef{{Type: "command", Command: prefix + " session-end"}}},
 	}
 	for eventName, group := range endpointHooks {
-		config.hooks[eventName] = mergeDevinEndpointHook(config.hooks[eventName], group)
+		config.hooks[eventName] = mergeDevinEndpointHook(config.hooks[eventName], group, replacePlatforms...)
 	}
 	data, err := config.marshal()
 	if err != nil {
@@ -157,10 +203,10 @@ func (config devinConfig) marshal() ([]byte, error) {
 	return json.MarshalIndent(out, "", "  ")
 }
 
-func mergeDevinEndpointHook(existing []devinHookGroup, group devinHookGroup) []devinHookGroup {
+func mergeDevinEndpointHook(existing []devinHookGroup, group devinHookGroup, platforms ...string) []devinHookGroup {
 	out := make([]devinHookGroup, 0, len(existing)+1)
 	for _, item := range existing {
-		filtered, changed := filterDevinEndpointHooks(item)
+		filtered, changed := filterDevinEndpointHooks(item, platforms...)
 		if !changed || len(filtered.Hooks) > 0 {
 			out = append(out, item)
 			if changed {
@@ -172,6 +218,18 @@ func mergeDevinEndpointHook(existing []devinHookGroup, group devinHookGroup) []d
 }
 
 func removeDevinEndpointHooks(path string) (bool, error) {
+	return removeDevinEndpointHooksForPlatforms(path, "devin")
+}
+
+func removeDevinCLIEndpointHooks(path string) (bool, error) {
+	return removeDevinEndpointHooksForPlatforms(path, "devin", "devin-cli")
+}
+
+func removeDevinDesktopEndpointHooks(path string) (bool, error) {
+	return removeDevinEndpointHooksForPlatforms(path, "devin-desktop")
+}
+
+func removeDevinEndpointHooksForPlatforms(path string, platforms ...string) (bool, error) {
 	config, err := readDevinConfig(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -183,7 +241,7 @@ func removeDevinEndpointHooks(path string) (bool, error) {
 	for eventName, groups := range config.hooks {
 		filtered := groups[:0]
 		for _, group := range groups {
-			withoutEndpointHooks, groupChanged := filterDevinEndpointHooks(group)
+			withoutEndpointHooks, groupChanged := filterDevinEndpointHooks(group, platforms...)
 			if groupChanged {
 				changed = true
 			}
@@ -211,21 +269,21 @@ func removeDevinEndpointHooks(path string) (bool, error) {
 	return true, os.WriteFile(path, out, 0600)
 }
 
-func isDevinEndpointHookGroup(group devinHookGroup) bool {
+func isDevinEndpointHookGroup(group devinHookGroup, platforms ...string) bool {
 	for _, hook := range group.Hooks {
-		if isEndpointHookCommand(hook.Command, "devin") {
+		if isDevinEndpointHookCommand(hook.Command, platforms...) {
 			return true
 		}
 	}
 	return false
 }
 
-func filterDevinEndpointHooks(group devinHookGroup) (devinHookGroup, bool) {
+func filterDevinEndpointHooks(group devinHookGroup, platforms ...string) (devinHookGroup, bool) {
 	filtered := group
 	filtered.Hooks = group.Hooks[:0]
 	changed := false
 	for _, hook := range group.Hooks {
-		if isEndpointHookCommand(hook.Command, "devin") {
+		if isDevinEndpointHookCommand(hook.Command, platforms...) {
 			changed = true
 			continue
 		}
@@ -235,15 +293,39 @@ func filterDevinEndpointHooks(group devinHookGroup) (devinHookGroup, bool) {
 }
 
 func isDevinInstalledAt(path string) bool {
+	return isDevinInstalledAtPlatforms(path, "devin")
+}
+
+func isDevinCLIInstalledAt(path string) bool {
+	return isDevinInstalledAtPlatforms(path, "devin", "devin-cli")
+}
+
+func isDevinDesktopInstalledAt(path string) bool {
+	return isDevinInstalledAtPlatforms(path, "devin-desktop")
+}
+
+func isDevinInstalledAtPlatforms(path string, platforms ...string) bool {
 	config, err := readDevinConfig(path)
 	if err != nil {
 		return false
 	}
 	for _, groups := range config.hooks {
 		for _, group := range groups {
-			if isDevinEndpointHookGroup(group) {
+			if isDevinEndpointHookGroup(group, platforms...) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func isDevinEndpointHookCommand(command string, platforms ...string) bool {
+	if len(platforms) == 0 {
+		platforms = []string{"devin"}
+	}
+	for _, platform := range platforms {
+		if isEndpointHookCommand(command, platform) {
+			return true
 		}
 	}
 	return false

--- a/cli/beacon/internal/endpoint/hooks/devin_test.go
+++ b/cli/beacon/internal/endpoint/hooks/devin_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,6 +62,58 @@ func TestInstallDevinUserConfigPreservesUnrelatedKeys(t *testing.T) {
 	}
 }
 
+func TestInstallDevinUserConfigPreservesImportConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	existing := `{"theme":"dark","read_config_from":{"cursor":true,"windsurf":false,"claude":true}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installDevinCLIHooks(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installDevinCLIHooks returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("unmarshal config: %v\n%s", err, data)
+	}
+	readConfigFrom := config["read_config_from"].(map[string]interface{})
+	if readConfigFrom["claude"] != true {
+		t.Fatalf("read_config_from.claude = %#v, want preserved true", readConfigFrom["claude"])
+	}
+	if readConfigFrom["cursor"] != true || readConfigFrom["windsurf"] != false {
+		t.Fatalf("read_config_from did not preserve other values: %#v", readConfigFrom)
+	}
+	if config["theme"] != "dark" {
+		t.Fatalf("theme = %#v, want preserved dark", config["theme"])
+	}
+}
+
+func TestInstallDevinDesktopHooksUsesCascadeEvents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hooks.json")
+	if err := installDevinDesktopHooks(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installDevinDesktopHooks returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{"pre_user_prompt", "post_write_code", "post_run_command", "post_mcp_tool_use", "post_read_code", "--platform devin-desktop", "prompt-submit", "post-tool"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("Devin Desktop hooks missing %q:\n%s", want, text)
+		}
+	}
+	for _, notWant := range []string{"PreToolUse", "PostToolUse", "SessionStart", "read_config_from"} {
+		if strings.Contains(text, notWant) {
+			t.Fatalf("Devin Desktop hooks should not contain %q:\n%s", notWant, text)
+		}
+	}
+}
+
 func TestInstallDevinHooksReplacesOldBeaconHooks(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "hooks.v1.json")
 	existing := `{"PostToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 old-beacon-hooks --platform devin post-tool"}]},{"hooks":[{"type":"command","command":"echo keep"}]}]}`
@@ -108,8 +161,8 @@ func TestInstallDevinCLIHooksReplacesLegacyHooksWithExplicitPlatform(t *testing.
 }
 
 func TestInstallDevinDesktopHooksDoesNotRemoveCLIHooks(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "hooks.v1.json")
-	existing := `{"PostToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-cli post-tool"}]}]}`
+	path := filepath.Join(t.TempDir(), "hooks.json")
+	existing := `{"hooks":{"post_write_code":[{"command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-cli post-tool"}]}}`
 	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
 		t.Fatal(err)
 	}
@@ -155,8 +208,8 @@ func TestRemoveDevinEndpointHooksPreservesOtherHooks(t *testing.T) {
 }
 
 func TestRemoveDevinDesktopEndpointHooksPreservesCLIHooks(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "hooks.v1.json")
-	existing := `{"SessionStart":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-cli session-start"}]},{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-desktop session-start"}]}]}`
+	path := filepath.Join(t.TempDir(), "hooks.json")
+	existing := `{"hooks":{"post_write_code":[{"command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-cli post-tool"},{"command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-desktop post-tool"}]}}`
 	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
 		t.Fatal(err)
 	}
@@ -228,11 +281,11 @@ func TestDevinHookStatusDetectsInstalled(t *testing.T) {
 func TestDevinDesktopHookStatusDetectsInstalled(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	path := filepath.Join(home, ".config", "devin", "config.json")
+	path := filepath.Join(home, ".codeium", "windsurf", "hooks.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-desktop stop"}]}]}}`), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(`{"hooks":{"post_write_code":[{"command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-desktop post-tool"}]}}`), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -242,5 +295,18 @@ func TestDevinDesktopHookStatusDetectsInstalled(t *testing.T) {
 	}
 	if status.ConfigPath != path {
 		t.Fatalf("ConfigPath = %q, want %q", status.ConfigPath, path)
+	}
+}
+
+func TestDevinDesktopConfigPathProjectLevel(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	target, err := devinDesktopConfigPath(LevelProject)
+	if err != nil {
+		t.Fatalf("devinDesktopConfigPath returned error: %v", err)
+	}
+	if got, want := target, filepath.Join(dir, ".windsurf", "hooks.json"); got != want {
+		t.Fatalf("project config path = %q, want %q", got, want)
 	}
 }

--- a/cli/beacon/internal/endpoint/hooks/devin_test.go
+++ b/cli/beacon/internal/endpoint/hooks/devin_test.go
@@ -84,6 +84,49 @@ func TestInstallDevinHooksReplacesOldBeaconHooks(t *testing.T) {
 	}
 }
 
+func TestInstallDevinCLIHooksReplacesLegacyHooksWithExplicitPlatform(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hooks.v1.json")
+	existing := `{"PostToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 old-beacon-hooks --platform devin post-tool"}]},{"hooks":[{"type":"command","command":"echo keep"}]}]}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installDevinCLIHooks(path, "/tmp/new-beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installDevinCLIHooks returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "--platform devin post-tool") || strings.Contains(text, "old-beacon-hooks") {
+		t.Fatalf("legacy devin hook was not replaced:\n%s", text)
+	}
+	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "--platform devin-cli") {
+		t.Fatalf("expected preserved hook and explicit devin-cli hook:\n%s", text)
+	}
+}
+
+func TestInstallDevinDesktopHooksDoesNotRemoveCLIHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hooks.v1.json")
+	existing := `{"PostToolUse":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-cli post-tool"}]}]}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installDevinDesktopHooks(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installDevinDesktopHooks returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "--platform devin-cli") || !strings.Contains(text, "--platform devin-desktop") {
+		t.Fatalf("expected CLI and Desktop hooks to coexist:\n%s", text)
+	}
+}
+
 func TestRemoveDevinEndpointHooksPreservesOtherHooks(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "hooks.v1.json")
 	existing := `{"SessionStart":[{"hooks":[{"type":"command","command":"echo keep"}]},{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin session-start"}]}]}`
@@ -108,6 +151,33 @@ func TestRemoveDevinEndpointHooksPreservesOtherHooks(t *testing.T) {
 	}
 	if strings.Contains(text, "BEACON_ENDPOINT_MODE=1") {
 		t.Fatalf("endpoint hook was not removed:\n%s", text)
+	}
+}
+
+func TestRemoveDevinDesktopEndpointHooksPreservesCLIHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hooks.v1.json")
+	existing := `{"SessionStart":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-cli session-start"}]},{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-desktop session-start"}]}]}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := removeDevinDesktopEndpointHooks(path)
+	if err != nil {
+		t.Fatalf("removeDevinDesktopEndpointHooks returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected desktop endpoint hook removal")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "--platform devin-cli") {
+		t.Fatalf("Devin CLI hook was not preserved:\n%s", text)
+	}
+	if strings.Contains(text, "--platform devin-desktop") {
+		t.Fatalf("Devin Desktop hook was not removed:\n%s", text)
 	}
 }
 
@@ -149,6 +219,26 @@ func TestDevinHookStatusDetectsInstalled(t *testing.T) {
 	status := DevinHookStatus(DevinOptions{Level: LevelUser, UserMode: true})
 	if !status.Installed {
 		t.Fatalf("DevinHookStatus installed = false, status=%#v", status)
+	}
+	if status.ConfigPath != path {
+		t.Fatalf("ConfigPath = %q, want %q", status.ConfigPath, path)
+	}
+}
+
+func TestDevinDesktopHookStatusDetectsInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".config", "devin", "config.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"BEACON_ENDPOINT_MODE=1 beacon-hooks --platform devin-desktop stop"}]}]}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	status := DevinDesktopHookStatus(DevinDesktopOptions{Level: LevelUser, UserMode: true})
+	if !status.Installed {
+		t.Fatalf("DevinDesktopHookStatus installed = false, status=%#v", status)
 	}
 	if status.ConfigPath != path {
 		t.Fatalf("ConfigPath = %q, want %q", status.ConfigPath, path)

--- a/cli/beacon/internal/endpoint/hooks/runtime.go
+++ b/cli/beacon/internal/endpoint/hooks/runtime.go
@@ -115,7 +115,7 @@ func endpointCommandPrefix(platform, binaryPath, logPath, configPath string) str
 }
 
 func isEndpointHookCommand(command, platform string) bool {
-	hasPlatform := platform == "" || strings.Contains(command, "--platform "+platform)
+	hasPlatform := platform == "" || commandHasPlatform(command, platform)
 	hasBeaconBinary := strings.Contains(command, embedded.GetBinaryName())
 	hasLegacyBinary := strings.Contains(command, "asym-hooks")
 
@@ -126,6 +126,19 @@ func isEndpointHookCommand(command, platform string) bool {
 		return true
 	}
 	return hasLegacyBinary && hasPlatform
+}
+
+func commandHasPlatform(command, platform string) bool {
+	fields := strings.Fields(command)
+	for i, field := range fields {
+		if field == "--platform" && i+1 < len(fields) {
+			return strings.Trim(fields[i+1], `"'`) == platform
+		}
+		if strings.HasPrefix(field, "--platform=") {
+			return strings.Trim(strings.TrimPrefix(field, "--platform="), `"'`) == platform
+		}
+	}
+	return false
 }
 
 func writeEndpointHookBinary(userMode bool) (string, error) {

--- a/cli/beacon/internal/endpoint/hooks/settings_hooks.go
+++ b/cli/beacon/internal/endpoint/hooks/settings_hooks.go
@@ -12,9 +12,10 @@ type settingsHookGroup struct {
 }
 
 type settingsHookRef struct {
-	Type    string `json:"type"`
-	Command string `json:"command"`
-	Timeout int    `json:"timeout,omitempty"`
+	Type       string `json:"type,omitempty"`
+	Command    string `json:"command"`
+	Timeout    int    `json:"timeout,omitempty"`
+	ShowOutput *bool  `json:"show_output,omitempty"`
 }
 
 type settingsHooksFile struct {

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -163,13 +163,14 @@ Recommended rollout:
 4. Scope repair/remediation to unhealthy devices.
 5. Broaden deployment in stages after inventory and validation stay healthy.
 
-Cursor, Devin, Factory, Grok Build, and opencode hook installation is separate from the base
-system package because these integrations write per-user or per-project runtime
-settings. Run hook helpers only when an interactive console user is present.
-Cursor hooks use `.cursor/hooks.json`; Devin hooks use `.devin/hooks.v1.json`
-for project installs or `~/.config/devin/config.json` for user installs; Factory
-hooks use `.factory/settings.json`; Grok Build uses `.grok/hooks/beacon-endpoint.json`
-or `~/.grok/hooks/beacon-endpoint.json`; opencode uses Beacon's owned plugin at
+Cursor, Devin CLI, Devin Desktop, Factory, Grok Build, and opencode hook
+installation is separate from the base system package because these integrations
+write per-user or per-project runtime settings. Run hook helpers only when an
+interactive console user is present. Cursor hooks use `.cursor/hooks.json`;
+Devin CLI and Devin Desktop hooks use `.devin/hooks.v1.json` for project
+installs or `~/.config/devin/config.json` for user installs; Factory hooks use
+`.factory/settings.json`; Grok Build uses `.grok/hooks/beacon-endpoint.json` or
+`~/.grok/hooks/beacon-endpoint.json`; opencode uses Beacon's owned plugin at
 `~/.config/opencode/plugins/beacon.ts`. Restart the runtime after installation
 so new sessions pick up the settings. Install hooks with the same endpoint log
 path as the collector when you want hook telemetry and OTLP telemetry to appear
@@ -212,12 +213,20 @@ beacon endpoint hooks install --harness grok --level project --log-path /var/log
 ```
 
 For Devin prompt/session/tool/approval/file telemetry, install Beacon's Devin
-hooks in the logged-in user's context or project context:
+CLI or Devin Desktop hooks in the logged-in user's context or project context.
+`devin` remains a legacy alias for `devin-cli`:
 
 ```bash
-beacon endpoint hooks install --harness devin --level user --log-path /var/log/beacon-agent/runtime.jsonl
-beacon endpoint hooks install --harness devin --level project --log-path /var/log/beacon-agent/runtime.jsonl
+beacon endpoint hooks install --harness devin-cli --level user --log-path /var/log/beacon-agent/runtime.jsonl
+beacon endpoint hooks install --harness devin-cli --level project --log-path /var/log/beacon-agent/runtime.jsonl
+beacon endpoint hooks install --harness devin-desktop --level user --log-path /var/log/beacon-agent/runtime.jsonl
 ```
+
+The main install path can also configure hook-backed Devin targets alongside
+OTLP-backed harnesses, for example
+`beacon endpoint install --harness claude,codex,devin-cli,devin-desktop`.
+After installing Devin Desktop hooks, generate a Desktop event and check the
+runtime log to confirm the Desktop app executed the hook file.
 
 The opencode plugin is a small Beacon-owned TypeScript adapter that calls the
 Beacon Go hook binary with raw opencode payloads. It does not depend on the
@@ -276,7 +285,7 @@ Use `/opt/beacon/jamf/scripts/repair.sh` as a remediation policy for Macs where
 Extension Attributes report a stale or unhealthy install. Use
 `/opt/beacon/jamf/scripts/install-cursor-hooks.sh` as a separate user-context
 policy for hook telemetry. Set
-`BEACON_HOOK_HARNESSES=cursor,devin,factory,opencode` to install supported hook
+`BEACON_HOOK_HARNESSES=cursor,devin-cli,devin-desktop,factory,opencode` to install supported hook
 integrations; the helper writes hook events to
 `/var/log/beacon-agent/runtime.jsonl` by default.
 
@@ -410,7 +419,7 @@ removal remains under the MDM/package receipt lifecycle.
   writable by the collector.
 - No recent runtime events: confirm supported harnesses are configured and the
   local OTLP ports are not in use by another process.
-- Cursor, Devin, Factory, or opencode hooks are missing: run the hook helper
+- Cursor, Devin CLI/Desktop, Factory, or opencode hooks are missing: run the hook helper
   while a non-root console user is logged in, and confirm the helper uses the
   same runtime log path as the endpoint collector.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches per-user/project hook config (including Windsurf paths) and expands prompt/command/file telemetry parsing; mistakes could mis-attribute events or disturb coexisting Devin CLI hooks, though installs are designed to merge/replace Beacon entries only.
> 
> **Overview**
> Adds **Devin Desktop** as a first-class harness (`devin-desktop`) alongside a renamed **Devin CLI** (`devin-cli`, with `devin` kept as a legacy alias). Terminal Devin keeps Claude-style hooks; Desktop is wired through **Cascade/Windsurf** hook files (`~/.codeium/windsurf/hooks.json` or `.windsurf/hooks.json`) for visibility-only events (prompt, writes, commands, MCP, reads).
> 
> The **beacon-hooks** binary gains Cascade parsing (`cascade.go`): `trajectory_id` / `execution_id`, `tool_info`, diff construction from `post_write_code` edits, and normalized events (`file.modified`, `command.executed`, etc.) with `raw.cascade` metadata. Shared helpers treat `devin` / `devin-cli` and `devin-desktop` separately for session, cwd, and platform flags.
> 
> **Endpoint install/repair** now splits harness lists into OTLP vs hook targets so one `--harness` flow can configure e.g. `claude,codex,devin-cli,devin-desktop`. Hook install/status/uninstall paths are refactored and extended for `devin-desktop`, with discovery/status checks for Windsurf hook commands using `--platform devin-desktop`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d52fa903c7315f29d5af710627f10b4a70dcfb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->