### PR TITLE
ci: enrich GitHub Actions run context for Claude Code telemetry

### DIFF
--- a/cli/beacon/internal/ci/session.go
+++ b/cli/beacon/internal/ci/session.go
@@ -316,12 +316,15 @@ func detectRunInfo() *schema.RunInfo {
 		} else {
 			info.Branch = os.Getenv("GITHUB_REF_NAME")
 		}
-		// GITHUB_REF is a non-PR ref (e.g. refs/heads/main) on push events, so
-		// only record PR fields when the trigger is actually a pull request.
+		// Only populate PR fields when the ref is actually a pull-request ref.
+		// pull_request_target sets GITHUB_REF to the base branch, not the
+		// merge ref, so we guard on the ref shape rather than just the event.
 		if isPullRequestEvent(eventName) {
 			ref := os.Getenv("GITHUB_REF")
-			info.PR = ref
-			info.PRNumber = parsePRNumber(ref)
+			if strings.HasPrefix(ref, "refs/pull/") {
+				info.PR = ref
+				info.PRNumber = parsePRNumber(ref)
+			}
 		}
 		return info
 	}

--- a/cli/beacon/internal/ci/session.go
+++ b/cli/beacon/internal/ci/session.go
@@ -296,20 +296,63 @@ func DefaultLogPath() string {
 
 func detectRunInfo() *schema.RunInfo {
 	if os.Getenv("GITHUB_ACTIONS") == "true" {
-		return &schema.RunInfo{
-			Provider:  "github_actions",
-			RunID:     os.Getenv("GITHUB_RUN_ID"),
-			Workflow:  os.Getenv("GITHUB_WORKFLOW"),
-			Commit:    os.Getenv("GITHUB_SHA"),
-			PR:        os.Getenv("GITHUB_REF"),
-			Actor:     os.Getenv("GITHUB_ACTOR"),
-			Ephemeral: true,
+		eventName := os.Getenv("GITHUB_EVENT_NAME")
+		info := &schema.RunInfo{
+			Provider:   "github_actions",
+			RunID:      os.Getenv("GITHUB_RUN_ID"),
+			RunAttempt: os.Getenv("GITHUB_RUN_ATTEMPT"),
+			Workflow:   os.Getenv("GITHUB_WORKFLOW"),
+			Job:        os.Getenv("GITHUB_JOB"),
+			EventName:  eventName,
+			Commit:     os.Getenv("GITHUB_SHA"),
+			Repository: os.Getenv("GITHUB_REPOSITORY"),
+			Actor:      os.Getenv("GITHUB_ACTOR"),
+			Ephemeral:  true,
 		}
+		// Prefer the pull-request head ref as the human-readable branch; fall
+		// back to the pushed ref's short name on non-PR events.
+		if head := strings.TrimSpace(os.Getenv("GITHUB_HEAD_REF")); head != "" {
+			info.Branch = head
+		} else {
+			info.Branch = os.Getenv("GITHUB_REF_NAME")
+		}
+		// GITHUB_REF is a non-PR ref (e.g. refs/heads/main) on push events, so
+		// only record PR fields when the trigger is actually a pull request.
+		if isPullRequestEvent(eventName) {
+			ref := os.Getenv("GITHUB_REF")
+			info.PR = ref
+			info.PRNumber = parsePRNumber(ref)
+		}
+		return info
 	}
 	if os.Getenv("CI") != "" {
 		return &schema.RunInfo{Provider: "ci", Ephemeral: true}
 	}
 	return nil
+}
+
+func isPullRequestEvent(eventName string) bool {
+	return eventName == "pull_request" || eventName == "pull_request_target"
+}
+
+// parsePRNumber extracts the pull-request number from a ref of the form
+// refs/pull/<number>/merge (or /head). It returns an empty string when the ref
+// is not a pull-request ref or the number is not purely numeric.
+func parsePRNumber(ref string) string {
+	const prefix = "refs/pull/"
+	if !strings.HasPrefix(ref, prefix) {
+		return ""
+	}
+	num, _, ok := strings.Cut(strings.TrimPrefix(ref, prefix), "/")
+	if !ok || num == "" {
+		return ""
+	}
+	for _, r := range num {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	return num
 }
 
 func terminateProcess(process *os.Process) error {

--- a/cli/beacon/internal/ci/session_test.go
+++ b/cli/beacon/internal/ci/session_test.go
@@ -135,6 +135,100 @@ func TestRunChildInjectsClaudeEnvAndBeaconPaths(t *testing.T) {
 	}
 }
 
+func TestDetectRunInfoPullRequest(t *testing.T) {
+	t.Setenv("CI", "true")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_RUN_ID", "123")
+	t.Setenv("GITHUB_RUN_ATTEMPT", "2")
+	t.Setenv("GITHUB_WORKFLOW", "ci")
+	t.Setenv("GITHUB_JOB", "telemetry")
+	t.Setenv("GITHUB_SHA", "deadbeef")
+	t.Setenv("GITHUB_REPOSITORY", "asymptote-labs/agent-beacon")
+	t.Setenv("GITHUB_ACTOR", "octocat")
+	t.Setenv("GITHUB_HEAD_REF", "feature/telemetry")
+	t.Setenv("GITHUB_REF_NAME", "12/merge")
+	t.Setenv("GITHUB_REF", "refs/pull/12/merge")
+
+	info := detectRunInfo()
+	if info == nil {
+		t.Fatal("detectRunInfo returned nil in GitHub Actions")
+	}
+	if info.Provider != "github_actions" {
+		t.Fatalf("Provider = %q, want github_actions", info.Provider)
+	}
+	if info.RunAttempt != "2" || info.Job != "telemetry" || info.EventName != "pull_request" {
+		t.Fatalf("unexpected run context: %+v", info)
+	}
+	if info.Repository != "asymptote-labs/agent-beacon" {
+		t.Fatalf("Repository = %q", info.Repository)
+	}
+	if info.Branch != "feature/telemetry" {
+		t.Fatalf("Branch = %q, want PR head ref", info.Branch)
+	}
+	if info.PR != "refs/pull/12/merge" || info.PRNumber != "12" {
+		t.Fatalf("PR = %q, PRNumber = %q", info.PR, info.PRNumber)
+	}
+}
+
+func TestDetectRunInfoPushOmitsPR(t *testing.T) {
+	t.Setenv("CI", "true")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_EVENT_NAME", "push")
+	t.Setenv("GITHUB_HEAD_REF", "")
+	t.Setenv("GITHUB_REF_NAME", "main")
+	t.Setenv("GITHUB_REF", "refs/heads/main")
+
+	info := detectRunInfo()
+	if info == nil {
+		t.Fatal("detectRunInfo returned nil in GitHub Actions")
+	}
+	if info.Branch != "main" {
+		t.Fatalf("Branch = %q, want ref name on push", info.Branch)
+	}
+	if info.PR != "" || info.PRNumber != "" {
+		t.Fatalf("push build should not record PR fields: PR=%q PRNumber=%q", info.PR, info.PRNumber)
+	}
+}
+
+func TestDetectRunInfoGenericCIFallback(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("CI", "true")
+
+	info := detectRunInfo()
+	if info == nil {
+		t.Fatal("detectRunInfo returned nil for generic CI")
+	}
+	if info.Provider != "ci" || !info.Ephemeral {
+		t.Fatalf("unexpected generic CI run info: %+v", info)
+	}
+}
+
+func TestDetectRunInfoNotCI(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("CI", "")
+
+	if info := detectRunInfo(); info != nil {
+		t.Fatalf("detectRunInfo = %+v, want nil outside CI", info)
+	}
+}
+
+func TestParsePRNumber(t *testing.T) {
+	cases := map[string]string{
+		"refs/pull/12/merge": "12",
+		"refs/pull/7/head":   "7",
+		"refs/heads/main":    "",
+		"refs/pull//merge":   "",
+		"refs/pull/abc/head": "",
+		"":                   "",
+	}
+	for ref, want := range cases {
+		if got := parsePRNumber(ref); got != want {
+			t.Fatalf("parsePRNumber(%q) = %q, want %q", ref, got, want)
+		}
+	}
+}
+
 func fakeExecutable(t *testing.T, name, script string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), name)

--- a/cli/beacon/internal/ci/session_test.go
+++ b/cli/beacon/internal/ci/session_test.go
@@ -171,6 +171,26 @@ func TestDetectRunInfoPullRequest(t *testing.T) {
 	}
 }
 
+func TestDetectRunInfoPullRequestTargetOmitsPR(t *testing.T) {
+	t.Setenv("CI", "true")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request_target")
+	t.Setenv("GITHUB_HEAD_REF", "feature/telemetry")
+	t.Setenv("GITHUB_REF_NAME", "main")
+	t.Setenv("GITHUB_REF", "refs/heads/main")
+
+	info := detectRunInfo()
+	if info == nil {
+		t.Fatal("detectRunInfo returned nil in GitHub Actions")
+	}
+	if info.Branch != "feature/telemetry" {
+		t.Fatalf("Branch = %q, want PR head ref", info.Branch)
+	}
+	if info.PR != "" || info.PRNumber != "" {
+		t.Fatalf("pull_request_target with base-branch ref should not record PR fields: PR=%q PRNumber=%q", info.PR, info.PRNumber)
+	}
+}
+
 func TestDetectRunInfoPushOmitsPR(t *testing.T) {
 	t.Setenv("CI", "true")
 	t.Setenv("GITHUB_ACTIONS", "true")

--- a/pkg/asymptotetrace/event.go
+++ b/pkg/asymptotetrace/event.go
@@ -61,11 +61,20 @@ type SessionInfo struct {
 }
 
 type RunInfo struct {
-	Provider  string `json:"provider,omitempty"`
-	RunID     string `json:"run_id,omitempty"`
-	Workflow  string `json:"workflow,omitempty"`
-	Commit    string `json:"commit,omitempty"`
+	Provider   string `json:"provider,omitempty"`
+	RunID      string `json:"run_id,omitempty"`
+	RunAttempt string `json:"run_attempt,omitempty"`
+	Workflow   string `json:"workflow,omitempty"`
+	Job        string `json:"job,omitempty"`
+	EventName  string `json:"event_name,omitempty"`
+	Commit     string `json:"commit,omitempty"`
+	Repository string `json:"repository,omitempty"`
+	Branch     string `json:"branch,omitempty"`
+	// PR holds the raw pull-request ref (e.g. refs/pull/12/merge) and is only
+	// populated on pull-request events; it is left empty for non-PR refs such
+	// as push builds. PRNumber is the parsed pull-request number.
 	PR        string `json:"pr,omitempty"`
+	PRNumber  string `json:"pr_number,omitempty"`
 	Actor     string `json:"actor,omitempty"`
 	Ephemeral bool   `json:"ephemeral,omitempty"`
 }


### PR DESCRIPTION
## Summary

Phase 1 of extending Beacon's CI telemetry support for Claude Code: enrich the run context captured for CI-origin events so they can be correlated per-workflow and per-PR downstream.

`beacon ci exec` already provisions an ephemeral collector and tags events with `origin: "ci"`; this change makes the `run` block carry enough provenance to be useful in a SIEM or artifact.

## Changes

- **`RunInfo` extended** (`pkg/asymptotetrace/event.go`) with `run_attempt`, `job`, `event_name`, `repository`, `branch`, and `pr_number`. All fields are additive and `omitempty`; `schema_version` stays `1.0` per the schema contract.
- **`detectRunInfo()`** (`cli/beacon/internal/ci/session.go`) populates the richer GitHub Actions context, with small `isPullRequestEvent` / `parsePRNumber` helpers.

## Design decisions (from review)

- **No top-level field collision.** CI provenance stays inside `run.*`. The VCS-sourced top-level `repository`/`branch` fields (set by the collector exporter from `vcs.repository.url` / `git.branch`) are left untouched, so `owner/repo` slugs never mix with repo URLs in the dashboard's `CountsByRepository`.
- **Honest PR fields.** `pr` / `pr_number` are only recorded on `pull_request` / `pull_request_target` events, where `GITHUB_REF` is a real `refs/pull/N/merge` ref. Push builds no longer stuff a misleading `refs/heads/main` into `pr`. `branch` prefers `GITHUB_HEAD_REF`, falling back to `GITHUB_REF_NAME`.

## Tests

Five new deterministic `t.Setenv` tests in `session_test.go`: PR event, push event, generic-CI fallback, non-CI (nil), and `parsePRNumber` edge cases. `internal/ci`, `internal/endpoint/schema`, and `pkg/asymptotetrace` all green; `go vet` and `gofmt` clean.

> Note: pre-existing `endpoint/harness` and `lifecycle` test failures in a full local run are container artifacts (checked-in embedded hooks binary is a macOS Mach-O build on a Linux container) and are unrelated to this change — confirmed by reproducing them without these edits.

## Follow-ups (planned, not in this PR)

- **Phase 2 — egress:** `--forward` to a customer SIEM with env-only tokens, forwarder config kept out of the artifact glob, best-effort delivery that never fails the job.
- **Phase 3 — composite GitHub Action:** version/checksum-pinned binary, `binary-path` override.
- Dashboard/activity `run`-fallback read so CI events correlate without overwriting the VCS top-level fields.

https://claude.ai/code/session_01XeN6mjkot19NzydHEazaWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeN6mjkot19NzydHEazaWq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive telemetry fields and env parsing only; no auth, egress, or schema version changes.
> 
> **Overview**
> CI telemetry **run** metadata is expanded so GitHub Actions runs can be correlated by workflow, job, repo, branch, and PR without touching top-level VCS `repository` / `branch` on events.
> 
> `RunInfo` gains optional fields (`run_attempt`, `job`, `event_name`, `repository`, `branch`, `pr_number`) in `pkg/asymptotetrace/event.go`. `detectRunInfo()` reads more `GITHUB_*` env vars, sets **branch** from `GITHUB_HEAD_REF` when present else `GITHUB_REF_NAME`, and only sets **pr** / **pr_number** on `pull_request` / `pull_request_target` when `GITHUB_REF` is a real `refs/pull/...` ref (so `pull_request_target` with a base-branch ref and push builds no longer get misleading PR data). Helpers `isPullRequestEvent` and `parsePRNumber` back that logic.
> 
> `session_test.go` adds table-style coverage for PR, `pull_request_target`, push, generic CI, non-CI, and `parsePRNumber` edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c8c9b6c9b46f9ac0805c9159ed51d31f2a758c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->