### PR TITLE
Update releaser

### DIFF
--- a/cli/beacon/.goreleaser.yaml
+++ b/cli/beacon/.goreleaser.yaml
@@ -76,13 +76,13 @@ changelog:
     - title: Other
       order: 999
 
-brews:
+homebrew_casks:
   - name: beacon
     repository:
       owner: asymptote-labs
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
+    directory: Casks
     homepage: https://asymptotelabs.ai
     description: "Open-source endpoint agent for local AI runtime telemetry"
     license: "MIT"
@@ -90,14 +90,12 @@ brews:
       name: asymptote-bot
       email: bot@asymptotelabs.ai
     commit_msg_template: "Homebrew formula update for {{ .ProjectName }} version {{ .Tag }}"
-    install: |
-      bin.install "beacon"
-      bin.install "beacon-otelcol"
+    binaries:
+      - beacon
+      - beacon-otelcol
     caveats: |
       To configure local endpoint telemetry, run:
         beacon endpoint install
-    test: |
-      system "#{bin}/beacon", "version"
 
 release:
   github:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release and tap packaging config only; no application runtime or security logic changes.
> 
> **Overview**
> GoReleaser’s Homebrew integration in `cli/beacon/.goreleaser.yaml` is switched from **`brews`** (formula under `Formula/`) to **`homebrew_casks`** (cask under `Casks/`).
> 
> Packaging is now declarative: custom `install` / `test` blocks are removed in favor of a **`binaries`** list that ships **`beacon`** and **`beacon-otelcol`**. Tap metadata (repo, caveats, commit message) is largely unchanged; only the artifact type and how binaries are declared differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6745b11af11e56836652a07b7bcc22cfd3e228e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->