### PR TITLE
Go release fix

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -21,7 +21,8 @@ jobs:
           go-version-file: cli/beacon/go.mod
       - uses: goreleaser/goreleaser-action@v6
         with:
-          version: "~> v2"
+          # Keep formulas working until we intentionally migrate the tap to casks.
+          version: "v2.13.3"
           install-only: true
 
       - name: Install OpenTelemetry Collector Builder

--- a/cli/beacon/.goreleaser.yaml
+++ b/cli/beacon/.goreleaser.yaml
@@ -76,13 +76,13 @@ changelog:
     - title: Other
       order: 999
 
-homebrew_casks:
+brews:
   - name: beacon
     repository:
       owner: asymptote-labs
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Casks
+    directory: Formula
     homepage: https://asymptotelabs.ai
     description: "Open-source endpoint agent for local AI runtime telemetry"
     license: "MIT"
@@ -90,12 +90,14 @@ homebrew_casks:
       name: asymptote-bot
       email: bot@asymptotelabs.ai
     commit_msg_template: "Homebrew formula update for {{ .ProjectName }} version {{ .Tag }}"
-    binaries:
-      - beacon
-      - beacon-otelcol
+    install: |
+      bin.install "beacon"
+      bin.install "beacon-otelcol"
     caveats: |
       To configure local endpoint telemetry, run:
         beacon endpoint install
+    test: |
+      system "#{bin}/beacon", "version"
 
 release:
   github:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes only affect release CI and Homebrew tap packaging, not runtime agent behavior.
> 
> **Overview**
> Pins **GoReleaser** to **v2.13.3** in the release-check workflow (replacing a floating `~> v2` pin) so Homebrew formula generation stays compatible until the tap is intentionally moved to casks.
> 
> Updates **`.goreleaser.yaml`** to publish a **Homebrew formula** instead of a cask: `homebrew_casks` becomes `brews`, tap output goes under **`Formula`** (not `Casks`), and binary installation is expressed via an **`install`** block plus a **`beacon version`** **`test`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a49649c10e4577522385b973f36ce6ded79122c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->