### PR TITLE
Add devin desktop hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Claude Cowork, OpenClaw).
 | [Codex CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-codex-cli) | Local OpenTelemetry configuration |
 | [Cursor](https://docs.asymptotelabs.ai/cli/supported-runtimes-cursor) | Beacon hook adapter |
 | [Devin CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-devin) | Beacon hook adapter |
-| Devin Desktop | Beacon hook adapter via Cascade/Windsurf hooks |
+| [Devin Desktop](https://docs.asymptotelabs.ai/cli/supported-runtimes-devin-desktop) | Beacon hook adapter via Cascade/Windsurf hooks |
 | [Factory Droid](https://docs.asymptotelabs.ai/cli/supported-runtimes-factory-droid) | Local OpenTelemetry configuration and optional hook adapter |
 | [Gemini CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-gemini-cli) | Opt-in local OpenTelemetry configuration |
 | [GitHub Copilot CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-github-copilot-cli) | MDM-managed OpenTelemetry (OTLP HTTP) |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only README edit with no runtime or security impact.
> 
> **Overview**
> The **Coding Agent Harnesses** table in `README.md` now links **Devin Desktop** to the supported-runtime docs page (`supported-runtimes-devin-desktop`), matching how other harnesses in that table are documented. The support path text is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f355cba95b080fa068a07086ec3841c4206805df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->