### PR TITLE
ci: add sidecar start/stop lifecycle for Claude Code telemetry

### DIFF
--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -148,6 +148,39 @@ which surfaces a broken telemetry pipeline. Pass `--require-telemetry=false` to
 downgrade that to a warning when you do not want telemetry health to gate the
 build.
 
+### Sidecar mode (start / stop)
+
+`ci exec` wraps the Claude invocation, which is ideal when you control the
+command. When Claude runs inside another action or a later step that you cannot
+wrap, use the sidecar lifecycle instead: `ci start` launches a background
+collector and exports the Claude telemetry environment variables (appending them
+to `$GITHUB_ENV` in GitHub Actions), and `ci stop` terminates the collector and
+validates the log.
+
+```yaml
+- name: Start Beacon telemetry
+  run: beacon ci start --forward splunk --forward-endpoint "$SPLUNK_HEC_URL"
+  env:
+    BEACON_CI_SPLUNK_HEC_TOKEN: ${{ secrets.SPLUNK_HEC_TOKEN }}
+
+# Any later step that runs Claude now emits OTLP to the sidecar, including
+# third-party actions you cannot wrap with `ci exec`.
+- uses: some-org/claude-code-action@v1
+  with:
+    prompt: "Review this pull request"
+
+- name: Stop Beacon telemetry
+  if: always()
+  run: beacon ci stop
+```
+
+`ci start` records a small session state file (default
+`$RUNNER_TEMP/beacon/session.json`, with no token) that `ci stop` reads to find
+and terminate the collector; pass `--state-file` if you relocate it. The
+forwarding token is read from the environment when the collector starts and is
+never written to the state file. Always run `ci stop` in an `if: always()` step
+so the collector is torn down even when an earlier step fails.
+
 ## Wazuh
 
 ```bash

--- a/cli/beacon/cmd/ci.go
+++ b/cli/beacon/cmd/ci.go
@@ -231,19 +231,33 @@ func runCIStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer logFile.Close()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
 	if _, err := session.StartDetached(logFile); err != nil {
 		return err
 	}
+
+	cleanup := func() { _ = session.StopDetached(5 * time.Second) }
+	go func() {
+		if _, ok := <-sigCh; ok {
+			cleanup()
+			os.Exit(1)
+		}
+	}()
+
 	statePath := ciOpts.stateFile
 	if statePath == "" {
 		statePath = filepath.Join(session.BaseDir, beaconci.StateFileName)
 	}
 	if err := session.WriteState(statePath); err != nil {
-		_ = session.StopDetached(5 * time.Second)
+		cleanup()
 		return err
 	}
 	if err := emitClaudeTelemetryEnv(session.GRPCEndpoint, retention); err != nil {
-		_ = session.StopDetached(5 * time.Second)
+		cleanup()
 		return err
 	}
 	if ciOpts.jsonOutput {
@@ -264,6 +278,8 @@ func runCIStop(cmd *cobra.Command, args []string) error {
 	if statePath == "" {
 		if ciOpts.baseDir != "" {
 			statePath = filepath.Join(ciOpts.baseDir, beaconci.StateFileName)
+		} else if ciOpts.logPath != "" {
+			statePath = filepath.Join(filepath.Dir(ciOpts.logPath), beaconci.StateFileName)
 		} else {
 			statePath = beaconci.DefaultStatePath()
 		}

--- a/cli/beacon/cmd/ci.go
+++ b/cli/beacon/cmd/ci.go
@@ -90,9 +90,12 @@ func init() {
 	for _, cmd := range []*cobra.Command{ciExecCmd, ciValidateCmd, ciStopCmd} {
 		cmd.Flags().IntVar(&ciOpts.minEvents, "min-events", beaconci.DefaultValidationMin, "Minimum matching events required during validation")
 	}
+	// base-dir is used by exec, start, and stop to locate CI session artifacts.
+	for _, cmd := range []*cobra.Command{ciExecCmd, ciStartCmd, ciStopCmd} {
+		cmd.Flags().StringVar(&ciOpts.baseDir, "base-dir", "", "CI session base directory (defaults to $RUNNER_TEMP/beacon or a temp directory)")
+	}
 	// Collector provisioning flags shared by exec (foreground) and start (detached).
 	for _, cmd := range []*cobra.Command{ciExecCmd, ciStartCmd} {
-		cmd.Flags().StringVar(&ciOpts.baseDir, "base-dir", "", "CI session base directory (defaults to $RUNNER_TEMP/beacon or a temp directory)")
 		cmd.Flags().StringVar(&ciOpts.collectorPath, "collector", "", "Path to a beacon-otelcol binary")
 		cmd.Flags().IntVar(&ciOpts.grpcPort, "otlp-grpc-port", endpointconfig.DefaultGRPCPort, "Local OTLP gRPC port")
 		cmd.Flags().IntVar(&ciOpts.httpPort, "otlp-http-port", endpointconfig.DefaultHTTPPort, "Local OTLP HTTP port")
@@ -114,6 +117,7 @@ func init() {
 	for _, name := range []string{"base-dir", "collector", "otlp-grpc-port", "otlp-http-port"} {
 		_ = ciStartCmd.Flags().MarkHidden(name)
 	}
+	_ = ciStopCmd.Flags().MarkHidden("base-dir")
 }
 
 func runCIExec(cmd *cobra.Command, args []string) error {

--- a/cli/beacon/cmd/ci.go
+++ b/cli/beacon/cmd/ci.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -30,6 +32,7 @@ var ciOpts struct {
 	forward          string
 	forwardEndpoint  string
 	requireTelemetry bool
+	stateFile        string
 }
 
 var ciCmd = &cobra.Command{
@@ -54,28 +57,62 @@ var ciValidateCmd = &cobra.Command{
 	RunE:         runCIValidate,
 }
 
+var ciStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start a background collector and export Claude telemetry env for later steps",
+	Long: `Start an ephemeral collector in the background and export the Claude Code
+OpenTelemetry environment variables so subsequent CI steps (including third-party
+actions that invoke Claude) emit to it. Stop and validate the session later with
+'beacon ci stop'. In GitHub Actions the telemetry variables are appended to
+$GITHUB_ENV automatically.`,
+	SilenceUsage: true,
+	RunE:         runCIStart,
+}
+
+var ciStopCmd = &cobra.Command{
+	Use:          "stop",
+	Short:        "Stop a background collector started by 'beacon ci start' and validate",
+	SilenceUsage: true,
+	RunE:         runCIStop,
+}
+
 func init() {
 	rootCmd.AddCommand(ciCmd)
 	ciCmd.AddCommand(ciExecCmd)
 	ciCmd.AddCommand(ciValidateCmd)
-	for _, cmd := range []*cobra.Command{ciExecCmd, ciValidateCmd} {
+	ciCmd.AddCommand(ciStartCmd)
+	ciCmd.AddCommand(ciStopCmd)
+	for _, cmd := range []*cobra.Command{ciExecCmd, ciValidateCmd, ciStartCmd, ciStopCmd} {
 		cmd.Flags().StringVar(&ciOpts.logPath, "log-path", "", "CI runtime JSONL log path")
 		cmd.Flags().StringVar(&ciOpts.harness, "harness", beaconci.DefaultHarness, "CI harness to configure (currently only claude)")
 		cmd.Flags().BoolVar(&ciOpts.jsonOutput, "json", false, "Print result as JSON")
+	}
+	for _, cmd := range []*cobra.Command{ciExecCmd, ciValidateCmd, ciStopCmd} {
 		cmd.Flags().IntVar(&ciOpts.minEvents, "min-events", beaconci.DefaultValidationMin, "Minimum matching events required during validation")
 	}
-	ciExecCmd.Flags().StringVar(&ciOpts.baseDir, "base-dir", "", "CI session base directory (defaults to $RUNNER_TEMP/beacon or a temp directory)")
+	// Collector provisioning flags shared by exec (foreground) and start (detached).
+	for _, cmd := range []*cobra.Command{ciExecCmd, ciStartCmd} {
+		cmd.Flags().StringVar(&ciOpts.baseDir, "base-dir", "", "CI session base directory (defaults to $RUNNER_TEMP/beacon or a temp directory)")
+		cmd.Flags().StringVar(&ciOpts.collectorPath, "collector", "", "Path to a beacon-otelcol binary")
+		cmd.Flags().IntVar(&ciOpts.grpcPort, "otlp-grpc-port", endpointconfig.DefaultGRPCPort, "Local OTLP gRPC port")
+		cmd.Flags().IntVar(&ciOpts.httpPort, "otlp-http-port", endpointconfig.DefaultHTTPPort, "Local OTLP HTTP port")
+		cmd.Flags().StringVar(&ciOpts.contentRetention, "content-retention", string(endpointconfig.ContentRetentionFull), "Content retention mode: metadata, redacted, or full")
+		cmd.Flags().StringVar(&ciOpts.forward, "forward", "", "Optionally forward events to a customer-managed SIEM: splunk or falcon (token read from the environment)")
+		cmd.Flags().StringVar(&ciOpts.forwardEndpoint, "forward-endpoint", "", "SIEM HEC endpoint URL for --forward (token comes from BEACON_CI_*_HEC_TOKEN)")
+	}
 	ciExecCmd.Flags().StringVar(&ciOpts.workDir, "work-dir", "", "Working directory for the child command")
-	ciExecCmd.Flags().StringVar(&ciOpts.collectorPath, "collector", "", "Path to a beacon-otelcol binary")
-	ciExecCmd.Flags().IntVar(&ciOpts.grpcPort, "otlp-grpc-port", endpointconfig.DefaultGRPCPort, "Local OTLP gRPC port")
-	ciExecCmd.Flags().IntVar(&ciOpts.httpPort, "otlp-http-port", endpointconfig.DefaultHTTPPort, "Local OTLP HTTP port")
-	ciExecCmd.Flags().StringVar(&ciOpts.contentRetention, "content-retention", string(endpointconfig.ContentRetentionFull), "Content retention mode: metadata, redacted, or full")
-	ciExecCmd.Flags().BoolVar(&ciOpts.keepArtifacts, "keep-artifacts", true, "Keep CI runtime log and collector config after exit")
-	ciExecCmd.Flags().StringVar(&ciOpts.forward, "forward", "", "Optionally forward events to a customer-managed SIEM: splunk or falcon (token read from the environment)")
-	ciExecCmd.Flags().StringVar(&ciOpts.forwardEndpoint, "forward-endpoint", "", "SIEM HEC endpoint URL for --forward (token comes from BEACON_CI_*_HEC_TOKEN)")
-	ciExecCmd.Flags().BoolVar(&ciOpts.requireTelemetry, "require-telemetry", true, "Fail the command when telemetry validation fails; set false to warn only")
+	for _, cmd := range []*cobra.Command{ciExecCmd, ciStopCmd} {
+		cmd.Flags().BoolVar(&ciOpts.keepArtifacts, "keep-artifacts", true, "Keep CI runtime log and collector config after exit")
+		cmd.Flags().BoolVar(&ciOpts.requireTelemetry, "require-telemetry", true, "Fail the command when telemetry validation fails; set false to warn only")
+	}
+	for _, cmd := range []*cobra.Command{ciStartCmd, ciStopCmd} {
+		cmd.Flags().StringVar(&ciOpts.stateFile, "state-file", "", "Sidecar session state file (defaults to <base-dir>/session.json)")
+	}
 	for _, name := range []string{"base-dir", "work-dir", "collector", "otlp-grpc-port", "otlp-http-port"} {
 		_ = ciExecCmd.Flags().MarkHidden(name)
+	}
+	for _, name := range []string{"base-dir", "collector", "otlp-grpc-port", "otlp-http-port"} {
+		_ = ciStartCmd.Flags().MarkHidden(name)
 	}
 }
 
@@ -169,6 +206,123 @@ func runCIValidate(cmd *cobra.Command, args []string) error {
 	}
 	if result.Status == "fail" {
 		return fmt.Errorf("Beacon CI telemetry validation failed")
+	}
+	return nil
+}
+
+func runCIStart(cmd *cobra.Command, args []string) error {
+	retention := endpointconfig.ContentRetention(ciOpts.contentRetention)
+	session, err := beaconci.Provision(beaconci.Options{
+		BaseDir:          ciOpts.baseDir,
+		LogPath:          ciOpts.logPath,
+		CollectorPath:    ciOpts.collectorPath,
+		GRPCPort:         ciOpts.grpcPort,
+		HTTPPort:         ciOpts.httpPort,
+		Harness:          ciOpts.harness,
+		ContentRetention: retention,
+		Forward:          ciOpts.forward,
+		ForwardEndpoint:  ciOpts.forwardEndpoint,
+	})
+	if err != nil {
+		return err
+	}
+	logFile, err := os.OpenFile(filepath.Join(session.BaseDir, "collector.log"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+	if _, err := session.StartDetached(logFile); err != nil {
+		return err
+	}
+	statePath := ciOpts.stateFile
+	if statePath == "" {
+		statePath = filepath.Join(session.BaseDir, beaconci.StateFileName)
+	}
+	if err := session.WriteState(statePath); err != nil {
+		_ = session.StopDetached(5 * time.Second)
+		return err
+	}
+	if err := emitClaudeTelemetryEnv(session.GRPCEndpoint, retention); err != nil {
+		_ = session.StopDetached(5 * time.Second)
+		return err
+	}
+	if ciOpts.jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(session)
+	}
+	fmt.Printf("Beacon CI collector started (pid=%d)\n", session.PID)
+	fmt.Printf("OTLP endpoint: %s\n", session.GRPCEndpoint)
+	fmt.Printf("Runtime log: %s\n", session.LogPath)
+	fmt.Printf("State file: %s\n", statePath)
+	if session.Forward != "" {
+		fmt.Printf("Forwarding: %s -> %s\n", session.Forward, session.ForwardEndpoint)
+	}
+	return nil
+}
+
+func runCIStop(cmd *cobra.Command, args []string) error {
+	statePath := ciOpts.stateFile
+	if statePath == "" {
+		if ciOpts.baseDir != "" {
+			statePath = filepath.Join(ciOpts.baseDir, beaconci.StateFileName)
+		} else {
+			statePath = beaconci.DefaultStatePath()
+		}
+	}
+	session, err := beaconci.LoadSession(statePath)
+	if err != nil {
+		return fmt.Errorf("load CI session state (%s): %w", statePath, err)
+	}
+	if err := session.StopDetached(10 * time.Second); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: collector stop: %v\n", err)
+	}
+	harness := ciOpts.harness
+	if harness == "" {
+		harness = session.Harness
+	}
+	result := beaconci.Validate(beaconci.ValidationOptions{
+		LogPath:        session.LogPath,
+		MinEvents:      ciOpts.minEvents,
+		RequireHarness: harness,
+		Since:          session.StartedAtTime(),
+	})
+	if !ciOpts.keepArtifacts && result.Status != "fail" {
+		if err := os.RemoveAll(session.BaseDir); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: artifact cleanup: %v\n", err)
+		}
+	}
+	if ciOpts.jsonOutput {
+		_ = json.NewEncoder(os.Stdout).Encode(result)
+	} else {
+		printCIValidation(result)
+	}
+	if result.Status == "fail" {
+		if ciOpts.requireTelemetry {
+			return fmt.Errorf("Beacon CI telemetry validation failed")
+		}
+		fmt.Fprintln(os.Stderr, "Warning: Beacon CI telemetry validation failed (continuing because --require-telemetry=false)")
+	}
+	return nil
+}
+
+// emitClaudeTelemetryEnv appends the Claude Code OTLP variables to $GITHUB_ENV
+// (when running in GitHub Actions) so subsequent steps export to the collector,
+// and always prints them for visibility. No secret is emitted.
+func emitClaudeTelemetryEnv(endpoint string, retention endpointconfig.ContentRetention) error {
+	vars := beaconci.ClaudeTelemetryVars(endpoint, retention)
+	if ghEnv := strings.TrimSpace(os.Getenv("GITHUB_ENV")); ghEnv != "" {
+		f, err := os.OpenFile(ghEnv, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		for _, kv := range vars {
+			if _, err := fmt.Fprintf(f, "%s=%s\n", kv[0], kv[1]); err != nil {
+				return err
+			}
+		}
+	}
+	for _, kv := range vars {
+		fmt.Printf("%s=%s\n", kv[0], kv[1])
 	}
 	return nil
 }

--- a/cli/beacon/internal/ci/harness.go
+++ b/cli/beacon/internal/ci/harness.go
@@ -7,20 +7,35 @@ import (
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 )
 
+// ClaudeTelemetryVars returns the Claude Code OpenTelemetry environment
+// variables Beacon configures for an OTLP endpoint, as ordered key/value pairs.
+// OTEL_LOG_USER_PROMPTS is omitted in metadata retention mode. This is the
+// single source of truth for both in-process injection (ci exec) and exporting
+// to a downstream step environment (ci start).
+func ClaudeTelemetryVars(endpoint string, retention endpointconfig.ContentRetention) [][2]string {
+	vars := [][2]string{
+		{"CLAUDE_CODE_ENABLE_TELEMETRY", "1"},
+		{"OTEL_LOGS_EXPORTER", "otlp"},
+		{"OTEL_METRICS_EXPORTER", "otlp"},
+		{"OTEL_EXPORTER_OTLP_PROTOCOL", "grpc"},
+		{"OTEL_EXPORTER_OTLP_ENDPOINT", endpoint},
+	}
+	if retention != endpointconfig.ContentRetentionMetadata {
+		vars = append(vars, [2]string{"OTEL_LOG_USER_PROMPTS", "1"})
+	}
+	return vars
+}
+
 func ClaudeEnv(base []string, endpoint string, retention endpointconfig.ContentRetention) []string {
 	env := envMap(base)
-	env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
-	env["OTEL_LOGS_EXPORTER"] = "otlp"
-	env["OTEL_METRICS_EXPORTER"] = "otlp"
-	env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc"
-	env["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
+	for _, kv := range ClaudeTelemetryVars(endpoint, retention) {
+		env[kv[0]] = kv[1]
+	}
 	delete(env, "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT")
 	delete(env, "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
 	delete(env, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
 	if retention == endpointconfig.ContentRetentionMetadata {
 		delete(env, "OTEL_LOG_USER_PROMPTS")
-	} else {
-		env["OTEL_LOG_USER_PROMPTS"] = "1"
 	}
 	return flattenEnv(env)
 }

--- a/cli/beacon/internal/ci/harness_test.go
+++ b/cli/beacon/internal/ci/harness_test.go
@@ -26,3 +26,26 @@ func TestClaudeEnvMetadataRetentionOmitsPromptLogging(t *testing.T) {
 		t.Fatalf("ClaudeEnv metadata retention should omit OTEL_LOG_USER_PROMPTS:\n%s", env)
 	}
 }
+
+func TestClaudeTelemetryVarsRetention(t *testing.T) {
+	full := ClaudeTelemetryVars("http://127.0.0.1:4317", endpointconfig.ContentRetentionFull)
+	got := map[string]string{}
+	for _, kv := range full {
+		got[kv[0]] = kv[1]
+	}
+	if got["OTEL_EXPORTER_OTLP_ENDPOINT"] != "http://127.0.0.1:4317" {
+		t.Fatalf("endpoint var = %q", got["OTEL_EXPORTER_OTLP_ENDPOINT"])
+	}
+	if got["CLAUDE_CODE_ENABLE_TELEMETRY"] != "1" {
+		t.Fatal("missing CLAUDE_CODE_ENABLE_TELEMETRY")
+	}
+	if _, ok := got["OTEL_LOG_USER_PROMPTS"]; !ok {
+		t.Fatal("full retention should include OTEL_LOG_USER_PROMPTS")
+	}
+
+	for _, kv := range ClaudeTelemetryVars("http://127.0.0.1:4317", endpointconfig.ContentRetentionMetadata) {
+		if kv[0] == "OTEL_LOG_USER_PROMPTS" {
+			t.Fatal("metadata retention should omit OTEL_LOG_USER_PROMPTS")
+		}
+	}
+}

--- a/cli/beacon/internal/ci/session.go
+++ b/cli/beacon/internal/ci/session.go
@@ -64,6 +64,8 @@ type Session struct {
 	// is never recorded here so it cannot leak into --json output.
 	Forward         string `json:"forward,omitempty"`
 	ForwardEndpoint string `json:"forward_endpoint,omitempty"`
+	// PID is the detached collector process id for sidecar sessions (ci start).
+	PID int `json:"pid,omitempty"`
 
 	cfg       endpointconfig.Config
 	startedAt time.Time

--- a/cli/beacon/internal/ci/sidecar.go
+++ b/cli/beacon/internal/ci/sidecar.go
@@ -1,0 +1,115 @@
+package ci
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// StateFileName is the sidecar session state file written by ci start and read
+// by ci stop. It lives in the session base directory and never contains a
+// forwarding token.
+const StateFileName = "session.json"
+
+// DefaultStatePath returns the default sidecar state file path, alongside the
+// default runtime log (under $RUNNER_TEMP/beacon when available).
+func DefaultStatePath() string {
+	return filepath.Join(filepath.Dir(DefaultLogPath()), StateFileName)
+}
+
+// StartDetached launches the collector as a background process that outlives
+// this process, waits for it to become ready, and records its PID on the
+// session. Collector output is written to logWriter. Use this for the sidecar
+// lifecycle (ci start); Start is the foreground variant used by ci exec.
+func (s *Session) StartDetached(logWriter io.Writer) (int, error) {
+	if s == nil {
+		return 0, errors.New("ci session is nil")
+	}
+	if logWriter == nil {
+		logWriter = io.Discard
+	}
+	cmd := collectorCommand(s.CollectorBinary, "--config", s.ConfigPath)
+	cmd.Stdout = logWriter
+	cmd.Stderr = logWriter
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+	s.PID = cmd.Process.Pid
+	// Reap the child if it exits while this (short-lived) process is still
+	// alive, so it does not linger as a zombie. In normal use ci start exits
+	// right after returning and the running collector is reparented to init,
+	// which reaps it after ci stop signals it by PID.
+	go func() { _ = cmd.Wait() }()
+	if err := waitCollectorReady(s.cfg, 10*time.Second); err != nil {
+		_ = s.StopDetached(5 * time.Second)
+		s.PID = 0
+		return 0, err
+	}
+	return s.PID, nil
+}
+
+// StopDetached terminates a previously detached collector by PID, escalating to
+// kill if it does not exit within the timeout. It is a no-op when no PID is set.
+func (s *Session) StopDetached(timeout time.Duration) error {
+	if s == nil || s.PID <= 0 {
+		return nil
+	}
+	proc, err := os.FindProcess(s.PID)
+	if err != nil {
+		return nil
+	}
+	_ = terminateProcess(proc)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !processAlive(s.PID) {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return proc.Kill()
+}
+
+// WriteState persists the session as JSON so a later ci stop can find and stop
+// the collector and validate the log. The state never includes a forwarding
+// token.
+func (s *Session) WriteState(path string) error {
+	if s == nil {
+		return errors.New("ci session is nil")
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// LoadSession reads a sidecar session state file written by WriteState.
+func LoadSession(path string) (*Session, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var session Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, err
+	}
+	return &session, nil
+}
+
+// processAlive reports whether a process with the given PID exists. Signal 0
+// performs an existence check on Unix; on platforms where it is unsupported the
+// process is treated as gone (the collector is only built for Unix targets).
+func processAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/cli/beacon/internal/ci/sidecar_test.go
+++ b/cli/beacon/internal/ci/sidecar_test.go
@@ -1,0 +1,125 @@
+package ci
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+)
+
+func TestStartDetachedAndStopDetached(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fake uses POSIX signal semantics")
+	}
+	collector := fakeExecutable(t, "collector", "#!/bin/sh\ntrap 'exit 0' TERM\nwhile true; do sleep 1; done\n")
+	oldWait := waitCollectorReady
+	waitCollectorReady = func(endpointconfig.Config, time.Duration) error { return nil }
+	t.Cleanup(func() { waitCollectorReady = oldWait })
+
+	dir := t.TempDir()
+	session := &Session{
+		CollectorBinary: collector,
+		ConfigPath:      filepath.Join(dir, "otelcol.yaml"),
+		cfg:             endpointconfig.Default(true, filepath.Join(dir, "runtime.jsonl")),
+	}
+	if err := os.WriteFile(session.ConfigPath, []byte("receivers: {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	pid, err := session.StartDetached(nil)
+	if err != nil {
+		t.Fatalf("StartDetached returned error: %v", err)
+	}
+	if pid <= 0 || session.PID != pid {
+		t.Fatalf("unexpected pid: returned=%d session=%d", pid, session.PID)
+	}
+	if !processAlive(pid) {
+		t.Fatal("collector should be alive after StartDetached")
+	}
+
+	if err := session.StopDetached(3 * time.Second); err != nil {
+		t.Fatalf("StopDetached returned error: %v", err)
+	}
+	// Give the kernel a moment to reap before the final liveness check.
+	deadline := time.Now().Add(2 * time.Second)
+	for processAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if processAlive(pid) {
+		t.Fatal("collector should be stopped after StopDetached")
+	}
+}
+
+func TestStartDetachedReadyFailureReturnsError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fake uses POSIX signal semantics")
+	}
+	collector := fakeExecutable(t, "collector", "#!/bin/sh\ntrap 'exit 0' TERM\nwhile true; do sleep 1; done\n")
+	oldWait := waitCollectorReady
+	waitCollectorReady = func(endpointconfig.Config, time.Duration) error {
+		return errors.New("collector not ready")
+	}
+	t.Cleanup(func() { waitCollectorReady = oldWait })
+
+	dir := t.TempDir()
+	session := &Session{
+		CollectorBinary: collector,
+		ConfigPath:      filepath.Join(dir, "otelcol.yaml"),
+		cfg:             endpointconfig.Default(true, filepath.Join(dir, "runtime.jsonl")),
+	}
+	if err := os.WriteFile(session.ConfigPath, []byte("receivers: {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := session.StartDetached(nil); err == nil {
+		t.Fatal("StartDetached should fail when the collector never becomes ready")
+	}
+	if session.PID != 0 {
+		t.Fatalf("PID should be reset after a failed start, got %d", session.PID)
+	}
+}
+
+func TestWriteAndLoadSessionRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, StateFileName)
+	original := &Session{
+		BaseDir:         dir,
+		LogPath:         filepath.Join(dir, "runtime.jsonl"),
+		ConfigPath:      filepath.Join(dir, "otelcol.yaml"),
+		GRPCEndpoint:    "http://127.0.0.1:4317",
+		Harness:         DefaultHarness,
+		StartedAt:       time.Now().UTC().Format(time.RFC3339),
+		Forward:         ForwardSplunk,
+		ForwardEndpoint: "https://splunk.example/services/collector",
+		PID:             4242,
+	}
+	if err := original.WriteState(statePath); err != nil {
+		t.Fatalf("WriteState returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.ToLower(string(raw)), "token") {
+		t.Fatalf("state file must not reference a token:\n%s", raw)
+	}
+
+	loaded, err := LoadSession(statePath)
+	if err != nil {
+		t.Fatalf("LoadSession returned error: %v", err)
+	}
+	if loaded.PID != original.PID || loaded.LogPath != original.LogPath ||
+		loaded.Harness != original.Harness || loaded.Forward != original.Forward ||
+		loaded.ForwardEndpoint != original.ForwardEndpoint {
+		t.Fatalf("round-trip mismatch: %+v vs %+v", loaded, original)
+	}
+	if loaded.StartedAtTime().IsZero() {
+		t.Fatal("StartedAtTime should parse from the restored StartedAt")
+	}
+}

--- a/examples/github-actions/claude-code-telemetry-sidecar.yml
+++ b/examples/github-actions/claude-code-telemetry-sidecar.yml
@@ -1,0 +1,55 @@
+# Reference workflow for capturing Claude Code telemetry in CI using Beacon's
+# sidecar lifecycle (beacon ci start / stop). Use this when Claude runs inside
+# another action or a later step that you cannot wrap with `beacon ci exec`.
+#
+# This file lives under examples/ (not .github/workflows/) so it is a
+# reference only and does not run in this repository.
+
+name: Claude Code telemetry (sidecar)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  claude-telemetry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install the Beacon CLI however you distribute it (release download,
+      # Homebrew, etc.) so `beacon` is on PATH for the start/stop steps.
+      - name: Install Beacon
+        run: |
+          curl -fsSL https://github.com/asymptote-labs/agent-beacon/releases/download/v0.0.39/beacon_0.0.39_linux_amd64.tar.gz \
+            | tar -xz -C /usr/local/bin beacon beacon-otelcol
+
+      # Start the background collector and export the Claude OTLP env vars to
+      # $GITHUB_ENV so every later step in this job emits to it. The SIEM token
+      # is read from the environment here and never written to the state file.
+      - name: Start Beacon telemetry
+        run: beacon ci start --forward splunk --forward-endpoint "${SPLUNK_HEC_URL}"
+        env:
+          SPLUNK_HEC_URL: https://splunk.example:8088/services/collector
+          BEACON_CI_SPLUNK_HEC_TOKEN: ${{ secrets.SPLUNK_HEC_TOKEN }}
+
+      # Any step that runs Claude now emits telemetry to the sidecar, including
+      # third-party actions. Replace this with your real Claude step.
+      - name: Run Claude
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: claude --print "Summarize the changes in this pull request"
+
+      # Always stop and validate so the collector is torn down even if an
+      # earlier step failed.
+      - name: Stop Beacon telemetry
+        if: always()
+        run: beacon ci stop
+
+      - name: Upload Beacon telemetry
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: beacon-runtime-log
+          path: ${{ runner.temp }}/beacon/runtime.jsonl
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

Adds a **sidecar lifecycle** (`beacon ci start` / `beacon ci stop`) for Claude Code CI telemetry. `ci exec` only captures telemetry when it can wrap the Claude invocation; the sidecar covers the common case where Claude runs **inside another action** or a later step you can't wrap.

```yaml
- name: Start Beacon telemetry
  run: beacon ci start --forward splunk --forward-endpoint "$SPLUNK_HEC_URL"
  env:
    BEACON_CI_SPLUNK_HEC_TOKEN: ${{ secrets.SPLUNK_HEC_TOKEN }}

- uses: some-org/claude-code-action@v1   # emits OTLP to the sidecar
  with: { prompt: "Review this PR" }

- name: Stop Beacon telemetry
  if: always()
  run: beacon ci stop
```

## How it works

- **`ci start`** provisions and launches the collector **detached** (background, reparented to init on exit), records a small **tokenless** session state file (`$RUNNER_TEMP/beacon/session.json`), and **exports the Claude OTLP env vars** — appending them to `$GITHUB_ENV` in GitHub Actions so every later step in the job emits to the sidecar.
- **`ci stop`** reads the state file, terminates the collector by PID (SIGTERM, escalating to kill after a grace period), validates the runtime log, and honors `--require-telemetry` / `--keep-artifacts` exactly like `ci exec`.

## Notable details

- **Single source of truth for the env vars.** New `ClaudeTelemetryVars` is shared by in-process injection (`ci exec`) and the `$GITHUB_ENV` export (`ci start`); `ClaudeEnv` is refactored to use it.
- **Token never persisted.** The forwarding token is read from the collector's environment at start time (the merged-in `${env:...}` mechanism) and is never written to the state file; a round-trip test asserts the state contains no token.
- **No zombies.** `StartDetached` reaps the child via a goroutine if it exits while the short-lived `ci start` process is alive; in normal use `ci start` exits immediately and the OS reparents/reaps after `ci stop` signals by PID.

## Tests

New `sidecar_test.go` (start→stop lifecycle with a fake collector, readiness-failure returns error + resets PID, state round-trip with no-token assertion) and a `ClaudeTelemetryVars` retention test. `internal/ci` passes under `-race`; `cmd` green; `go vet` and `gofmt` clean.

> Note: pre-existing `endpoint/harness` and `lifecycle` failures in a full local run are container artifacts (macOS embedded binary on a Linux container) and are unrelated to this change.

## Relationship to other PRs

Independent of the composite action (#106). The two compose: a future JS action with a `post:` hook could wrap `start`/`stop`, but the documented `start … always()-stop` steps already deliver the capability today. Includes a reference workflow in `examples/`.

https://claude.ai/code/session_01XeN6mjkot19NzydHEazaWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeN6mjkot19NzydHEazaWq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces background process management and persists session metadata on disk; SIEM tokens are excluded from state but collector config on disk may still hold env-referenced secrets as in exec.
> 
> **Overview**
> Adds a **sidecar CI lifecycle** (`beacon ci start` / `beacon ci stop`) so Claude Code telemetry can be collected when later steps or third-party actions run Claude without wrapping them in `beacon ci exec`.
> 
> **`ci start`** provisions the ephemeral collector, runs it **detached** with PID recorded in a tokenless `session.json`, appends Claude OTLP env vars to **`$GITHUB_ENV`** on GitHub Actions (and prints them), and supports the same forwarding/collector flags as exec. **`ci stop`** loads that state, stops the collector by PID, validates the runtime log (including `--require-telemetry` / `--keep-artifacts`), and can clean up artifacts.
> 
> Refactors Claude OTLP configuration into shared **`ClaudeTelemetryVars`** (used by `ClaudeEnv` and `ci start`). New **`sidecar.go`** implements detached start/stop, state I/O, and process liveness checks, with tests and README plus an example GitHub Actions workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f5bb3f2d19d429a09eb620b925c397cfe95fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->