### PR TITLE
Add Hermes agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Claude Cowork, OpenClaw).
 | [Gemini CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-gemini-cli) | Opt-in local OpenTelemetry configuration |
 | [GitHub Copilot CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-github-copilot-cli) | MDM-managed OpenTelemetry (OTLP HTTP) |
 | [Grok Build](https://docs.asymptotelabs.ai/cli/supported-runtimes-grok-build) | Beacon hook adapter |
+| [Hermes Agent](https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks) | Beacon hook adapter via Hermes shell hooks |
 | [OpenCode](https://docs.asymptotelabs.ai/cli/supported-runtimes-opencode) | Beacon hook adapter |
 | [VS Code](https://docs.asymptotelabs.ai/cli/supported-runtimes-vscode) | VS Code Copilot OpenTelemetry and optional Beacon hook adapter |
 

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -18,6 +18,9 @@ func emitHookEvent(logger *logging.Logger, action, category, severity, message s
 	if platformFlag == "grok" {
 		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"grok": input})
 	}
+	if platformFlag == "hermes" {
+		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"hermes": input})
+	}
 	if platformFlag == "vscode" {
 		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"vscode": input})
 	}

--- a/cli/beacon-hooks/cmd/helpers.go
+++ b/cli/beacon-hooks/cmd/helpers.go
@@ -70,7 +70,7 @@ func resolveSessionID(input map[string]interface{}, platform string) string {
 	case "grok":
 		return getFirstStr(input, "sessionId", "session_id", "sessionID")
 	case "hermes":
-		return getFirstStr(input, "session_id", "sessionId", "task_id")
+		return hermesFirstString(input, "session_id", "sessionId", "session_key", "task_id")
 	case "opencode":
 		return getFirstStr(input, "session_id", "sessionID")
 	default:
@@ -114,8 +114,8 @@ func resolveSessionIDWithTranscript(input map[string]interface{}, platform strin
 		sessionID = getFirstStr(input, "sessionId", "session_id", "sessionID")
 		return
 	case "hermes":
-		sessionID = getFirstStr(input, "session_id", "sessionId", "task_id")
-		transcriptPath = getFirstStr(input, "transcript_path", "transcriptPath")
+		sessionID = hermesFirstString(input, "session_id", "sessionId", "session_key", "task_id")
+		transcriptPath = hermesFirstString(input, "transcript_path", "transcriptPath")
 		return
 	case "opencode":
 		sessionID = getFirstStr(input, "session_id", "sessionID")

--- a/cli/beacon-hooks/cmd/helpers.go
+++ b/cli/beacon-hooks/cmd/helpers.go
@@ -69,6 +69,8 @@ func resolveSessionID(input map[string]interface{}, platform string) string {
 		return getFirstStr(input, "trajectory_id", "session_id", "sessionId", "conversation_id")
 	case "grok":
 		return getFirstStr(input, "sessionId", "session_id", "sessionID")
+	case "hermes":
+		return getFirstStr(input, "session_id", "sessionId", "task_id")
 	case "opencode":
 		return getFirstStr(input, "session_id", "sessionID")
 	default:
@@ -110,6 +112,10 @@ func resolveSessionIDWithTranscript(input map[string]interface{}, platform strin
 		return
 	case "grok":
 		sessionID = getFirstStr(input, "sessionId", "session_id", "sessionID")
+		return
+	case "hermes":
+		sessionID = getFirstStr(input, "session_id", "sessionId", "task_id")
+		transcriptPath = getFirstStr(input, "transcript_path", "transcriptPath")
 		return
 	case "opencode":
 		sessionID = getFirstStr(input, "session_id", "sessionID")
@@ -206,6 +212,34 @@ func resolveCwd(input map[string]interface{}, platform string) string {
 		}
 		return os.Getenv("GROK_WORKSPACE_ROOT")
 	}
+	if platform == "hermes" {
+		if cwd := getFirstStr(input, "cwd", "working_directory", "workingDirectory"); cwd != "" {
+			return cwd
+		}
+		if extra := hermesExtra(input); extra != nil {
+			if cwd := firstToolString(extra, "cwd", "working_directory", "workingDirectory"); cwd != "" {
+				return cwd
+			}
+		}
+		return os.Getenv("HERMES_WORKSPACE_ROOT")
+	}
 	cwd, _ := input["cwd"].(string)
 	return cwd
+}
+
+func hermesExtra(input map[string]interface{}) map[string]interface{} {
+	if extra, ok := input["extra"].(map[string]interface{}); ok {
+		return extra
+	}
+	return nil
+}
+
+func hermesFirstString(input map[string]interface{}, keys ...string) string {
+	if value := getFirstStr(input, keys...); value != "" {
+		return value
+	}
+	if extra := hermesExtra(input); extra != nil {
+		return firstToolString(extra, keys...)
+	}
+	return ""
 }

--- a/cli/beacon-hooks/cmd/helpers_test.go
+++ b/cli/beacon-hooks/cmd/helpers_test.go
@@ -51,6 +51,53 @@ func TestResolveSessionID_Cursor(t *testing.T) {
 			platform: "copilot",
 			want:     "ff2d7803-5799-4f18-83f0-3633b2c11809",
 		},
+		{
+			name: "hermes uses top-level session_id",
+			input: map[string]interface{}{
+				"session_id": "hermes-sess-1",
+			},
+			platform: "hermes",
+			want:     "hermes-sess-1",
+		},
+		{
+			name: "hermes uses session_key",
+			input: map[string]interface{}{
+				"session_key": "hermes-key-1",
+			},
+			platform: "hermes",
+			want:     "hermes-key-1",
+		},
+		{
+			name: "hermes reads session_id from extra",
+			input: map[string]interface{}{
+				"extra": map[string]interface{}{
+					"session_id": "hermes-extra-sess",
+				},
+			},
+			platform: "hermes",
+			want:     "hermes-extra-sess",
+		},
+		{
+			name: "hermes reads session_key from extra",
+			input: map[string]interface{}{
+				"extra": map[string]interface{}{
+					"session_key": "hermes-extra-key",
+				},
+			},
+			platform: "hermes",
+			want:     "hermes-extra-key",
+		},
+		{
+			name: "hermes top-level session_id takes precedence over extra",
+			input: map[string]interface{}{
+				"session_id": "top-level",
+				"extra": map[string]interface{}{
+					"session_id": "from-extra",
+				},
+			},
+			platform: "hermes",
+			want:     "top-level",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/beacon-hooks/cmd/hermes_hooks_test.go
+++ b/cli/beacon-hooks/cmd/hermes_hooks_test.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestHermesPromptSubmitReadsExtraUserMessage(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "hermes"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "full")
+
+	out := runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"hook_event_name": "pre_llm_call",
+		"session_id":      "hermes-session",
+		"cwd":             "/repo",
+		"extra": map[string]interface{}{
+			"user_message": "summarize token=prompt-secret",
+			"model":        "nous/hermes",
+		},
+	})
+	if len(out) != 0 {
+		t.Fatalf("hermes prompt response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "prompt.submitted" {
+		t.Fatalf("event.action = %q, want prompt.submitted", action)
+	}
+	if harness := event["harness"].(map[string]interface{})["name"]; harness != "hermes" {
+		t.Fatalf("harness = %q, want hermes", harness)
+	}
+	prompt := event["prompt"].(map[string]interface{})
+	if got := prompt["text"]; got != "summarize token=[REDACTED]" {
+		t.Fatalf("prompt.text = %q, want redacted prompt", got)
+	}
+}
+
+func TestHermesPreToolEmitsObservedToolEvent(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "hermes"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPreTool, map[string]interface{}{
+		"hook_event_name": "pre_tool_call",
+		"session_id":      "hermes-session",
+		"cwd":             "/repo",
+		"tool_name":       "terminal",
+		"tool_input": map[string]interface{}{
+			"command": "git status",
+		},
+	})
+	if len(out) != 0 {
+		t.Fatalf("hermes pre-tool response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "tool.invoked" {
+		t.Fatalf("event.action = %q, want tool.invoked", action)
+	}
+	if command := event["command"].(map[string]interface{})["command"]; command != "git status" {
+		t.Fatalf("command = %q, want git status", command)
+	}
+	if _, ok := event["approval"]; ok {
+		t.Fatalf("Hermes pre_tool_call should not emit approval telemetry: %#v", event["approval"])
+	}
+}
+
+func TestHermesPostToolEmitsCommandEvent(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "hermes"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPostTool, map[string]interface{}{
+		"hook_event_name": "post_tool_call",
+		"session_id":      "hermes-session",
+		"cwd":             "/repo",
+		"tool_name":       "terminal",
+		"tool_input": map[string]interface{}{
+			"command": "go test ./...",
+		},
+		"extra": map[string]interface{}{
+			"result":      `{"exit_code":0}`,
+			"duration_ms": 123,
+		},
+	})
+	if len(out) != 0 {
+		t.Fatalf("hermes post-tool response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "command.executed" {
+		t.Fatalf("event.action = %q, want command.executed", action)
+	}
+	if command := event["command"].(map[string]interface{})["command"]; command != "go test ./..." {
+		t.Fatalf("command = %q, want go test ./...", command)
+	}
+}
+
+func TestHermesApprovalRequestAndResponse(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "hermes"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	runHookWithInput(t, runPermissionRequest, map[string]interface{}{
+		"hook_event_name": "pre_approval_request",
+		"session_id":      "hermes-session",
+		"extra": map[string]interface{}{
+			"command":     "rm -rf build",
+			"description": "destructive command",
+		},
+	})
+	requested := lastEndpointEvent(t, logPath)
+	if action := requested["event"].(map[string]interface{})["action"]; action != "approval.requested" {
+		t.Fatalf("request action = %q, want approval.requested", action)
+	}
+	if decision := requested["approval"].(map[string]interface{})["decision"]; decision != "requested" {
+		t.Fatalf("request decision = %q, want requested", decision)
+	}
+
+	runHookWithInput(t, runPermissionRequest, map[string]interface{}{
+		"hook_event_name": "post_approval_response",
+		"session_id":      "hermes-session",
+		"extra": map[string]interface{}{
+			"command": "rm -rf build",
+			"choice":  "deny",
+		},
+	})
+	denied := lastEndpointEvent(t, logPath)
+	if action := denied["event"].(map[string]interface{})["action"]; action != "approval.denied" {
+		t.Fatalf("response action = %q, want approval.denied", action)
+	}
+	if decision := denied["approval"].(map[string]interface{})["decision"]; decision != "deny" {
+		t.Fatalf("response decision = %q, want deny", decision)
+	}
+}
+
+func TestHermesSubagentStopIncludesExtraMetadata(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "hermes"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	runHookWithInput(t, func(cmd *cobra.Command, args []string) {
+		runSubagentLifecycle("subagent.stopped", "Subagent stopped")
+	}, map[string]interface{}{
+		"hook_event_name": "subagent_stop",
+		"session_id":      "parent-session",
+		"extra": map[string]interface{}{
+			"child_role":   "researcher",
+			"child_status": "completed",
+			"duration_ms":  float64(42),
+		},
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "subagent.stopped" {
+		t.Fatalf("event.action = %q, want subagent.stopped", action)
+	}
+	raw := event["raw"].(map[string]interface{})["subagent"].(map[string]interface{})
+	if raw["role"] != "researcher" || raw["status"] != "completed" {
+		t.Fatalf("subagent raw = %#v, want role/status metadata", raw)
+	}
+}

--- a/cli/beacon-hooks/cmd/permission_request.go
+++ b/cli/beacon-hooks/cmd/permission_request.go
@@ -43,7 +43,47 @@ func runPermissionRequest(cmd *cobra.Command, args []string) {
 		outputJSON(devinApproveResponse)
 		return
 	}
+	if platformFlag == "hermes" {
+		emitHermesApproval(logger, input, sessionID)
+		outputJSON(emptyResponse)
+		return
+	}
 
 	emitPreToolDecision(logger, input, sessionID, "approval.requested", "requested", "Permission request observed")
 	outputJSON(emptyResponse)
+}
+
+func emitHermesApproval(logger *logging.Logger, input map[string]interface{}, sessionID string) {
+	command := hermesFirstString(input, "command")
+	description := hermesFirstString(input, "description", "reason")
+	choice := hermesFirstString(input, "choice", "decision")
+	hookEvent := getFirstStr(input, "hook_event_name", "hookEventName")
+	if hookEvent == "" {
+		hookEvent = hermesFirstString(input, "hook_event_name", "hookEventName")
+	}
+	decision := "requested"
+	action := "approval.requested"
+	message := "Permission request observed"
+	if hookEvent == "post_approval_response" || choice != "" {
+		decision = choice
+		if decision == "" {
+			decision = "unknown"
+		}
+		action = "approval.allowed"
+		message = "Permission response observed"
+		if decision == "deny" || decision == "denied" || decision == "timeout" {
+			action = "approval.denied"
+		}
+	}
+	fields := sessionFields(sessionID, input)
+	if command != "" {
+		fields["command"] = map[string]interface{}{"command": command}
+		fields["tool"] = mergeNested(fields["tool"], map[string]interface{}{"name": "terminal", "command": command})
+	}
+	fields["approval"] = map[string]interface{}{
+		"required": true,
+		"decision": decision,
+		"reason":   description,
+	}
+	emitHookEvent(logger, action, "approval", "info", message, input, fields)
 }

--- a/cli/beacon-hooks/cmd/permission_request.go
+++ b/cli/beacon-hooks/cmd/permission_request.go
@@ -73,6 +73,8 @@ func emitHermesApproval(logger *logging.Logger, input map[string]interface{}, se
 		message = "Permission response observed"
 		if decision == "deny" || decision == "denied" || decision == "timeout" {
 			action = "approval.denied"
+		} else if decision == "unknown" {
+			action = "approval.requested"
 		}
 	}
 	fields := sessionFields(sessionID, input)

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -127,7 +127,7 @@ func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logge
 	var sessionID, toolName string
 	var toolInput, toolResponse map[string]interface{}
 
-	if platformFlag == "antigravity" || platformFlag == "copilot" || isDevinLikePlatform(platformFlag) || platformFlag == "grok" || platformFlag == "vscode" {
+	if platformFlag == "antigravity" || platformFlag == "copilot" || isDevinLikePlatform(platformFlag) || platformFlag == "grok" || platformFlag == "hermes" || platformFlag == "vscode" {
 		sessionID = resolveSessionID(input, platformFlag)
 		toolName = getFirstStr(input, "toolName", "tool_name")
 		if platformFlag == "antigravity" {
@@ -262,6 +262,16 @@ func resolveToolResponse(input map[string]interface{}) map[string]interface{} {
 	if m, ok := input["toolResult"].(map[string]interface{}); ok {
 		return m
 	}
+	if platformFlag == "hermes" {
+		if extra := hermesExtra(input); extra != nil {
+			if result, ok := extra["result"].(map[string]interface{}); ok {
+				return result
+			}
+			if result, ok := extra["result"].(string); ok && result != "" {
+				return map[string]interface{}{"result": result}
+			}
+		}
+	}
 	// If tool_response is a plain string, wrap it for downstream compatibility
 	if respStr, ok := input["tool_response"].(string); ok && respStr != "" {
 		return map[string]interface{}{"result": respStr}
@@ -329,6 +339,13 @@ func isFileEditTool(platform, toolName string) bool {
 	if platform == "grok" {
 		lower := strings.ToLower(toolName)
 		return lower == "search_replace" || lower == "write_file" || strings.Contains(lower, "edit") || strings.Contains(lower, "write")
+	}
+	if platform == "hermes" {
+		lower := strings.ToLower(toolName)
+		return strings.Contains(lower, "edit") ||
+			strings.Contains(lower, "write") ||
+			strings.Contains(lower, "create") ||
+			strings.Contains(lower, "patch")
 	}
 	if platform == "antigravity" {
 		lower := strings.ToLower(toolName)

--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -48,7 +48,7 @@ func runPreTool(cmd *cobra.Command, args []string) {
 	if platformFlag == "antigravity" {
 		emitAntigravityPromptFromTranscript(logger, input, sessionID)
 		emitPreToolObserved(logger, input, sessionID)
-	} else if platformFlag == "claude" || isDevinLikePlatform(platformFlag) || platformFlag == "grok" || platformFlag == "vscode" {
+	} else if platformFlag == "claude" || isDevinLikePlatform(platformFlag) || platformFlag == "grok" || platformFlag == "hermes" || platformFlag == "vscode" {
 		emitPreToolObserved(logger, input, sessionID)
 	} else {
 		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "Pre-tool observed")
@@ -75,7 +75,7 @@ func preToolResponse() map[string]interface{} {
 	if platformFlag == "antigravity" || platformFlag == "grok" {
 		return map[string]interface{}{"decision": "allow"}
 	}
-	if platformFlag == "claude" || isDevinLikePlatform(platformFlag) || platformFlag == "vscode" {
+	if platformFlag == "claude" || isDevinLikePlatform(platformFlag) || platformFlag == "hermes" || platformFlag == "vscode" {
 		return emptyResponse
 	}
 	return allowResponse

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -747,6 +747,7 @@ func setupHookConfigDirs(t *testing.T) {
 	origDevinDir := hookconfig.DevinDir
 	origFactoryDir := hookconfig.FactoryDir
 	origGrokDir := hookconfig.GrokDir
+	origHermesDir := hookconfig.HermesDir
 	origOpenCodeDir := hookconfig.OpenCodeDir
 	origPlatform := platformFlag
 	hookconfig.BeaconDir = tmp
@@ -758,6 +759,7 @@ func setupHookConfigDirs(t *testing.T) {
 	hookconfig.DevinDir = filepath.Join(tmp, "devin")
 	hookconfig.FactoryDir = filepath.Join(tmp, "factory")
 	hookconfig.GrokDir = filepath.Join(tmp, "grok")
+	hookconfig.HermesDir = filepath.Join(tmp, "hermes")
 	hookconfig.OpenCodeDir = filepath.Join(tmp, "opencode")
 	t.Cleanup(func() {
 		hookconfig.BeaconDir = origBeaconDir
@@ -769,6 +771,7 @@ func setupHookConfigDirs(t *testing.T) {
 		hookconfig.DevinDir = origDevinDir
 		hookconfig.FactoryDir = origFactoryDir
 		hookconfig.GrokDir = origGrokDir
+		hookconfig.HermesDir = origHermesDir
 		hookconfig.OpenCodeDir = origOpenCodeDir
 		platformFlag = origPlatform
 	})

--- a/cli/beacon-hooks/cmd/prompt_submit.go
+++ b/cli/beacon-hooks/cmd/prompt_submit.go
@@ -46,6 +46,9 @@ func runPromptSubmit(cmd *cobra.Command, args []string) {
 		fields = cascadeMetadataFields(sessionID, input)
 	}
 	prompt := getFirstStr(input, "prompt", "user_prompt", "userPrompt", "text", "promptText", "input")
+	if platformFlag == "hermes" {
+		prompt = hermesFirstString(input, "user_message", "prompt", "input", "text")
+	}
 	if isCascadePlatform(platformFlag) {
 		prompt = cascadePrompt(input)
 	}

--- a/cli/beacon-hooks/cmd/root.go
+++ b/cli/beacon-hooks/cmd/root.go
@@ -11,8 +11,8 @@ var platformFlag string
 
 var rootCmd = &cobra.Command{
 	Use:   "beacon-hooks",
-	Short: "Beacon hooks for Claude Code, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Antigravity, and opencode",
-	Long: `Beacon hooks binary for Claude Code, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Antigravity, and opencode integration.
+	Short: "Beacon hooks for Claude Code, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Hermes, Antigravity, and opencode",
+	Long: `Beacon hooks binary for Claude Code, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Hermes, Antigravity, and opencode integration.
 
 This binary provides hook commands that are called by IDE plugin systems
 to evaluate code changes for security violations.
@@ -21,7 +21,7 @@ Use --platform to specify the calling platform (default: claude).`,
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, antigravity, copilot, cursor, vscode, devin, devin-cli, devin-desktop, factory, grok, or opencode")
+	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, antigravity, copilot, cursor, vscode, devin, devin-cli, devin-desktop, factory, grok, hermes, or opencode")
 }
 
 // Execute runs the root command

--- a/cli/beacon-hooks/cmd/subagent.go
+++ b/cli/beacon-hooks/cmd/subagent.go
@@ -41,9 +41,27 @@ func runSubagentLifecycle(action, message string) {
 		logger = logging.NewLoggerForPlatform("subagent", platformFlag)
 	}
 	fields := sessionFields(sessionID, input)
-	fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"subagent": map[string]interface{}{
+	subagent := map[string]interface{}{
 		"id":   getFirstStr(input, "agent_id", "agentId"),
 		"type": getFirstStr(input, "agent_type", "agentType"),
+	}
+	if platformFlag == "hermes" {
+		if extra := hermesExtra(input); extra != nil {
+			subagent = mergeNested(subagent, map[string]interface{}{
+				"role":        firstToolString(extra, "child_role"),
+				"status":      firstToolString(extra, "child_status"),
+				"summary":     firstToolString(extra, "child_summary"),
+				"duration_ms": extra["duration_ms"],
+			})
+		}
+	}
+	fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"subagent": map[string]interface{}{
+		"id":          subagent["id"],
+		"type":        subagent["type"],
+		"role":        subagent["role"],
+		"status":      subagent["status"],
+		"summary":     subagent["summary"],
+		"duration_ms": subagent["duration_ms"],
 	}})
 	emitHookEvent(logger, action, "session", "info", message, input, fields)
 	outputJSON(emptyResponse)

--- a/cli/beacon-hooks/internal/config/config.go
+++ b/cli/beacon-hooks/internal/config/config.go
@@ -20,6 +20,7 @@ var (
 	DevinDir       = filepath.Join(BeaconDir, "devin")
 	FactoryDir     = filepath.Join(BeaconDir, "factory")
 	GrokDir        = filepath.Join(BeaconDir, "grok")
+	HermesDir      = filepath.Join(BeaconDir, "hermes")
 	OpenCodeDir    = filepath.Join(BeaconDir, "opencode")
 )
 
@@ -105,6 +106,8 @@ func GetStateDir(platform string) string {
 		return FactoryDir
 	case "grok":
 		return GrokDir
+	case "hermes":
+		return HermesDir
 	case "opencode":
 		return OpenCodeDir
 	default:

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -240,6 +240,9 @@ tooling, not in Beacon endpoint configuration.
 ./beacon endpoint hooks install --harness grok
 ./beacon endpoint hooks status --harness grok
 
+./beacon endpoint hooks install --harness hermes
+./beacon endpoint hooks status --harness hermes
+
 ./beacon endpoint hooks install --harness devin-cli --level project
 ./beacon endpoint hooks status --harness devin-cli --level project
 ./beacon endpoint hooks install --harness devin-desktop --level user
@@ -281,6 +284,12 @@ The Grok Build integration writes Beacon's owned local hook file at
 `~/.grok/hooks/beacon-endpoint.json` for user-level installs or `.grok/hooks/beacon-endpoint.json`
 for project-level installs. Project hooks require trusting the project in Grok
 with `/hooks-trust` before they execute.
+
+The Hermes Agent integration writes shell-hook entries into
+`~/.hermes/config.yaml`. Hermes prompts for first-use consent for each
+`(event, command)` pair; for non-interactive gateway, cron, or CI runs, set
+`HERMES_ACCEPT_HOOKS=1`, start Hermes with `--accept-hooks`, or configure
+`hooks_auto_accept: true` in the Hermes config.
 
 The Devin CLI integration writes Claude-compatible command hooks for Devin for
 Terminal. `devin` remains a legacy alias for `devin-cli`. Project-level installs

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -1030,6 +1030,17 @@ func installEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 		if strings.Contains(status.Message, "/hooks-trust") {
 			fmt.Println(status.Message)
 		}
+	case "hermes":
+		status, err := endpointhooks.InstallHermes(endpointhooks.HermesOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Hermes Agent hooks installed: %s\n", status.ConfigPath)
+		fmt.Println("Hermes may prompt to trust new shell hooks on first use; use HERMES_ACCEPT_HOOKS=1 or hooks_auto_accept: true for non-TTY runs.")
 	case "devin-cli":
 		status, err := endpointhooks.InstallDevin(endpointhooks.DevinOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -1151,6 +1162,16 @@ func uninstallEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 			return err
 		}
 		fmt.Println(status.Message)
+	case "hermes":
+		status, err := endpointhooks.UninstallHermes(endpointhooks.HermesOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
 	case "devin-cli":
 		status, err := endpointhooks.UninstallDevin(endpointhooks.DevinOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -1229,6 +1250,12 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
+		case "hermes":
+			statuses["hermes"] = endpointhooks.HermesHookStatus(endpointhooks.HermesOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
 		case "devin-cli":
 			statuses["devin-cli"] = endpointhooks.DevinHookStatus(endpointhooks.DevinOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -1278,6 +1305,10 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 		case "grok":
 			status := statuses["grok"].(endpointhooks.GrokStatus)
 			fmt.Printf("Grok hooks: installed=%t path=%s\n", status.Installed, status.HooksPath)
+			fmt.Println(status.Message)
+		case "hermes":
+			status := statuses["hermes"].(endpointhooks.HermesStatus)
+			fmt.Printf("Hermes Agent hooks: installed=%t path=%s\n", status.Installed, status.ConfigPath)
 			fmt.Println(status.Message)
 		case "devin-cli":
 			status := statuses["devin-cli"].(endpointhooks.DevinStatus)

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -375,7 +375,7 @@ func printPlannedActions(actions []plannedAction) error {
 
 func hookTargets() ([]string, error) {
 	if endpointOpts.allTargets {
-		return []string{"cursor", "vscode", "factory", "opencode", "grok", "devin-cli", "devin-desktop", "antigravity"}, nil
+		return []string{"cursor", "vscode", "factory", "opencode", "grok", "hermes", "devin-cli", "devin-desktop", "antigravity"}, nil
 	}
 	return canonicalHookTargets(splitCSV(endpointOpts.hookHarnesses))
 }
@@ -414,6 +414,9 @@ func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[str
 		case "grok":
 			status := endpointhooks.GrokHookStatus(endpointhooks.GrokOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
+		case "hermes":
+			status := endpointhooks.HermesHookStatus(endpointhooks.HermesOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ConfigPath, Raw: status}
 		case "devin-cli":
 			status := endpointhooks.DevinHookStatus(endpointhooks.DevinOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses["devin-cli"] = hookTargetResult{Target: "devin-cli", Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ConfigPath, Raw: status}

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -375,7 +375,18 @@ func printPlannedActions(actions []plannedAction) error {
 
 func hookTargets() ([]string, error) {
 	if endpointOpts.allTargets {
-		return []string{"cursor", "vscode", "factory", "opencode", "grok", "hermes", "devin-cli", "devin-desktop", "antigravity"}, nil
+		all := []string{"cursor", "vscode", "factory", "opencode", "grok", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+		if endpointOpts.hookLevel == "project" {
+			filtered := all[:0:0]
+			for _, t := range all {
+				if t == "hermes" {
+					continue
+				}
+				filtered = append(filtered, t)
+			}
+			return filtered, nil
+		}
+		return all, nil
 	}
 	return canonicalHookTargets(splitCSV(endpointOpts.hookHarnesses))
 }

--- a/cli/beacon/cmd/endpoint_targets.go
+++ b/cli/beacon/cmd/endpoint_targets.go
@@ -41,6 +41,8 @@ func normalizeEndpointTarget(name string) (endpointTarget, bool) {
 		return endpointTarget{Name: "opencode", Kind: endpointTargetHook}, true
 	case "grok":
 		return endpointTarget{Name: "grok", Kind: endpointTargetHook}, true
+	case "hermes", "hermes-agent":
+		return endpointTarget{Name: "hermes", Kind: endpointTargetHook}, true
 	case "antigravity", "antigravity-cli":
 		return endpointTarget{Name: "antigravity", Kind: endpointTargetHook}, true
 	case "devin", "devin-cli":
@@ -118,6 +120,8 @@ func normalizeHookTarget(name string) (string, bool) {
 		return "opencode", true
 	case "grok":
 		return "grok", true
+	case "hermes", "hermes-agent":
+		return "hermes", true
 	case "devin", "devin-cli":
 		return "devin-cli", true
 	case "devin-desktop":

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -40,24 +40,24 @@ func TestSplitHarnessCSVAllowsCollectorOnly(t *testing.T) {
 }
 
 func TestSplitEndpointTargetsDedupesHookAliases(t *testing.T) {
-	otlp, hooks, err := splitEndpointTargets([]string{"claude", "codex", "devin", "devin-cli", "devin_desktop"})
+	otlp, hooks, err := splitEndpointTargets([]string{"claude", "codex", "devin", "devin-cli", "devin_desktop", "hermes-agent"})
 	if err != nil {
 		t.Fatalf("splitEndpointTargets returned error: %v", err)
 	}
 	if got, want := strings.Join(otlp, ","), "claude,codex"; got != want {
 		t.Fatalf("otlp targets = %q, want %q", got, want)
 	}
-	if got, want := strings.Join(hooks, ","), "devin-cli,devin-desktop"; got != want {
+	if got, want := strings.Join(hooks, ","), "devin-cli,devin-desktop,hermes"; got != want {
 		t.Fatalf("hook targets = %q, want %q", got, want)
 	}
 }
 
 func TestCanonicalHookTargetsNormalizesAliasesToSwitchNames(t *testing.T) {
-	got, err := canonicalHookTargets([]string{"claude_code", "vs_code", "droid", "devin", "devin_desktop", "antigravity_cli"})
+	got, err := canonicalHookTargets([]string{"claude_code", "vs_code", "droid", "devin", "devin_desktop", "antigravity_cli", "hermes-agent"})
 	if err != nil {
 		t.Fatalf("canonicalHookTargets returned error: %v", err)
 	}
-	want := []string{"claude", "vscode", "factory", "devin-cli", "devin-desktop", "antigravity"}
+	want := []string{"claude", "vscode", "factory", "devin-cli", "devin-desktop", "antigravity", "hermes"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("canonicalHookTargets = %#v, want %#v", got, want)
 	}

--- a/cli/beacon/go.mod
+++ b/cli/beacon/go.mod
@@ -5,6 +5,7 @@ go 1.24
 require (
 	github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace v0.0.0
 	github.com/spf13/cobra v1.8.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 replace github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace => ../../pkg/asymptotetrace
@@ -14,5 +15,4 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 type TelemetryStatus string
@@ -52,6 +54,7 @@ func DiscoverAll() []Harness {
 		DiscoverAntigravity(),
 		DiscoverCopilotCLI(),
 		DiscoverOpenCode(),
+		DiscoverHermes(),
 		DiscoverFactory(),
 		DiscoverVSCode(),
 		DiscoverCursor(),
@@ -193,6 +196,30 @@ func DiscoverOpenCode() Harness {
 	} else {
 		h.TelemetryStatus = TelemetryMissing
 		h.Message = "Beacon opencode plugin was not found"
+	}
+	return h
+}
+
+func DiscoverHermes() Harness {
+	h := Harness{Name: "hermes", DisplayName: "Hermes Agent", Capability: "hooks"}
+	path, err := exec.LookPath("hermes")
+	if err == nil {
+		h.Detected = true
+		h.ExecutablePath = path
+		h.Version = commandVersion(path)
+	}
+	home, _ := os.UserHomeDir()
+	h.ConfigPath = filepath.Join(home, ".hermes", "config.yaml")
+	if !h.Detected && dirExists(filepath.Join(home, ".hermes")) {
+		h.Detected = true
+	}
+	if fileExists(h.ConfigPath) {
+		status, msg := hermesStatus(h.ConfigPath)
+		h.TelemetryStatus = status
+		h.Message = msg
+	} else {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = "Hermes config.yaml was not found"
 	}
 	return h
 }
@@ -589,6 +616,43 @@ func hasBeaconWindsurfHooks(data []byte, platform string) (bool, error) {
 	for _, hooks := range root.Hooks {
 		for _, hook := range hooks {
 			if strings.Contains(hook.Command, "BEACON_ENDPOINT_MODE=1") && commandHasPlatform(hook.Command, platform) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func hermesStatus(path string) (TelemetryStatus, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return TelemetryMissing, err.Error()
+	}
+	hasHooks, err := hasBeaconHermesHooks(data)
+	if err != nil {
+		return TelemetryMisconfigured, "Hermes config.yaml is invalid"
+	}
+	if hasHooks {
+		return TelemetryEnabled, "Hermes Agent endpoint hooks are configured"
+	}
+	return TelemetryDisabled, "Hermes config exists but endpoint hooks were not found"
+}
+
+func hasBeaconHermesHooks(data []byte) (bool, error) {
+	var root struct {
+		Hooks map[string][]struct {
+			Command string `yaml:"command"`
+		} `yaml:"hooks"`
+	}
+	if len(data) == 0 {
+		return false, nil
+	}
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return false, err
+	}
+	for _, refs := range root.Hooks {
+		for _, ref := range refs {
+			if strings.Contains(ref.Command, "BEACON_ENDPOINT_MODE=1") && commandHasPlatform(ref.Command, "hermes") {
 				return true, nil
 			}
 		}

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -262,6 +262,36 @@ func TestDiscoverCodexDetectsExecutableOnPath(t *testing.T) {
 	}
 }
 
+func TestHermesStatusDetectsBeaconHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(`hooks:
+  pre_tool_call:
+    - matcher: .*
+      command: env BEACON_ENDPOINT_MODE=1 beacon-hooks --platform hermes pre-tool
+  post_tool_call:
+    - command: echo keep
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, message := hermesStatus(path)
+	if status != TelemetryEnabled {
+		t.Fatalf("hermesStatus = %q (%s), want enabled", status, message)
+	}
+}
+
+func TestHermesStatusReportsInvalidYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("hooks:\n  pre_tool_call: ["), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, _ := hermesStatus(path)
+	if status != TelemetryMisconfigured {
+		t.Fatalf("hermesStatus = %q, want misconfigured", status)
+	}
+}
+
 func TestCodexStatusVariants(t *testing.T) {
 	dir := t.TempDir()
 	tests := []struct {

--- a/cli/beacon/internal/endpoint/hooks/hermes.go
+++ b/cli/beacon/internal/endpoint/hooks/hermes.go
@@ -1,0 +1,227 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+type HermesOptions struct {
+	Level    Level
+	LogPath  string
+	UserMode bool
+}
+
+type HermesStatus struct {
+	Installed  bool   `json:"installed"`
+	BinaryPath string `json:"binary_path,omitempty"`
+	ConfigPath string `json:"config_path,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+type hermesConfig struct {
+	values map[string]interface{}
+	hooks  map[string][]hermesHookRef
+}
+
+type hermesHookRef struct {
+	Matcher string `yaml:"matcher,omitempty"`
+	Command string `yaml:"command"`
+	Timeout int    `yaml:"timeout,omitempty"`
+}
+
+var hermesRuntime = hookRuntime{
+	displayName: "Hermes Agent",
+	configPath:  hermesConfigPath,
+	install:     installHermesConfig,
+	uninstall:   removeHermesEndpointHooks,
+	isInstalled: isHermesInstalledAt,
+}
+
+func InstallHermes(opts HermesOptions) (HermesStatus, error) {
+	status, err := installRuntimeHooks(hermesRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return HermesStatus{}, err
+	}
+	return hermesStatusFromRuntime(status), nil
+}
+
+func UninstallHermes(opts HermesOptions) (HermesStatus, error) {
+	status, err := uninstallRuntimeHooks(hermesRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return HermesStatus{}, err
+	}
+	return hermesStatusFromRuntime(status), nil
+}
+
+func HermesHookStatus(opts HermesOptions) HermesStatus {
+	return hermesStatusFromRuntime(runtimeHookStatus(hermesRuntime, RuntimeOptions(opts)))
+}
+
+func IsHermesInstalled(opts HermesOptions) bool {
+	return isRuntimeInstalled(hermesRuntime, RuntimeOptions(opts))
+}
+
+func hermesStatusFromRuntime(status runtimeStatus) HermesStatus {
+	return HermesStatus{
+		Installed:  status.Installed,
+		BinaryPath: status.BinaryPath,
+		ConfigPath: status.ConfigPath,
+		Message:    status.Message,
+	}
+}
+
+func installHermesConfig(path, binaryPath, logPath, configPath string) error {
+	config, err := readHermesConfig(path)
+	if err != nil {
+		return err
+	}
+	prefix := hermesEndpointCommandPrefix(binaryPath, logPath, configPath)
+	endpointHooks := map[string]hermesHookRef{
+		"on_session_start":       {Command: prefix + " session-start"},
+		"pre_llm_call":           {Command: prefix + " prompt-submit", Timeout: 30},
+		"pre_tool_call":          {Matcher: ".*", Command: prefix + " pre-tool", Timeout: 10},
+		"post_tool_call":         {Matcher: ".*", Command: prefix + " post-tool", Timeout: 10},
+		"pre_approval_request":   {Command: prefix + " permission-request", Timeout: 10},
+		"post_approval_response": {Command: prefix + " permission-request", Timeout: 10},
+		"subagent_stop":          {Command: prefix + " subagent-stop", Timeout: 10},
+		"on_session_end":         {Command: prefix + " session-end"},
+		"on_session_finalize":    {Command: prefix + " session-end"},
+	}
+	for eventName, ref := range endpointHooks {
+		config.hooks[eventName] = mergeHermesEndpointHook(config.hooks[eventName], ref)
+	}
+	return writeHermesConfig(path, config)
+}
+
+func hermesEndpointCommandPrefix(binaryPath, logPath, configPath string) string {
+	return fmt.Sprintf("env BEACON_ENDPOINT_MODE=1 BEACON_ENDPOINT_LOG=%s BEACON_ENDPOINT_CONFIG=%s %s --platform hermes", shellQuote(logPath), shellQuote(configPath), shellQuote(binaryPath))
+}
+
+func readHermesConfig(path string) (hermesConfig, error) {
+	config := hermesConfig{
+		values: map[string]interface{}{},
+		hooks:  map[string][]hermesHookRef{},
+	}
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if len(data) > 0 {
+			if err := yaml.Unmarshal(data, &config.values); err != nil {
+				return hermesConfig{}, err
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return hermesConfig{}, err
+	}
+	if config.values == nil {
+		config.values = map[string]interface{}{}
+	}
+	if rawHooks, ok := config.values["hooks"]; ok && rawHooks != nil {
+		data, err := yaml.Marshal(rawHooks)
+		if err != nil {
+			return hermesConfig{}, err
+		}
+		if err := yaml.Unmarshal(data, &config.hooks); err != nil {
+			return hermesConfig{}, err
+		}
+	}
+	if config.hooks == nil {
+		config.hooks = map[string][]hermesHookRef{}
+	}
+	return config, nil
+}
+
+func writeHermesConfig(path string, config hermesConfig) error {
+	out := make(map[string]interface{}, len(config.values)+1)
+	for key, value := range config.values {
+		if key != "hooks" {
+			out[key] = value
+		}
+	}
+	if len(config.hooks) > 0 {
+		out["hooks"] = config.hooks
+	}
+	data, err := yaml.Marshal(out)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+func mergeHermesEndpointHook(existing []hermesHookRef, ref hermesHookRef) []hermesHookRef {
+	out := make([]hermesHookRef, 0, len(existing)+1)
+	for _, item := range existing {
+		if !isEndpointHookCommand(item.Command, "hermes") {
+			out = append(out, item)
+		}
+	}
+	return append(out, ref)
+}
+
+func removeHermesEndpointHooks(path string) (bool, error) {
+	config, err := readHermesConfig(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	changed := false
+	for eventName, refs := range config.hooks {
+		filtered := refs[:0]
+		for _, ref := range refs {
+			if isEndpointHookCommand(ref.Command, "hermes") {
+				changed = true
+				continue
+			}
+			filtered = append(filtered, ref)
+		}
+		if len(filtered) == 0 {
+			delete(config.hooks, eventName)
+		} else {
+			config.hooks[eventName] = filtered
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+	if len(config.hooks) == 0 {
+		delete(config.values, "hooks")
+	}
+	if len(config.values) == 0 && len(config.hooks) == 0 {
+		return true, os.Remove(path)
+	}
+	return true, writeHermesConfig(path, config)
+}
+
+func isHermesInstalledAt(path string) bool {
+	config, err := readHermesConfig(path)
+	if err != nil {
+		return false
+	}
+	for _, refs := range config.hooks {
+		for _, ref := range refs {
+			if isEndpointHookCommand(ref.Command, "hermes") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hermesConfigPath(level Level) (string, error) {
+	switch level {
+	case "", LevelUser:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".hermes", "config.yaml"), nil
+	case LevelProject:
+		return "", fmt.Errorf("Hermes Agent endpoint hooks support user-level config only")
+	default:
+		return "", fmt.Errorf("unknown hook level %q", level)
+	}
+}

--- a/cli/beacon/internal/endpoint/hooks/hermes_test.go
+++ b/cli/beacon/internal/endpoint/hooks/hermes_test.go
@@ -1,0 +1,148 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallHermesConfigPreservesExistingSettingsAndHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	existing := `model: anthropic/claude-sonnet-4.6
+hooks_auto_accept: true
+hooks:
+  pre_tool_call:
+    - matcher: terminal
+      command: ~/.hermes/agent-hooks/user-policy.sh
+      timeout: 5
+`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installHermesConfig(path, "/tmp/beacon hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installHermesConfig returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"model:",
+		"anthropic/claude-sonnet-4.6",
+		"hooks_auto_accept: true",
+		"~/.hermes/agent-hooks/user-policy.sh",
+		"env BEACON_ENDPOINT_MODE=1",
+		"BEACON_ENDPOINT_LOG='/tmp/runtime.jsonl'",
+		"BEACON_ENDPOINT_CONFIG='/tmp/config.json'",
+		"'/tmp/beacon hooks' --platform hermes",
+		"on_session_start:",
+		"pre_llm_call:",
+		"pre_tool_call:",
+		"post_tool_call:",
+		"pre_approval_request:",
+		"post_approval_response:",
+		"subagent_stop:",
+		"on_session_end:",
+		"on_session_finalize:",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("Hermes config missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestInstallHermesConfigReplacesOnlyHermesBeaconHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	existing := `hooks:
+  post_tool_call:
+    - command: env BEACON_ENDPOINT_MODE=1 old-beacon-hooks --platform hermes post-tool
+    - command: /tmp/asym-hooks --platform hermes post-tool
+    - command: env BEACON_ENDPOINT_MODE=1 beacon-hooks --platform factory post-tool
+    - command: echo keep
+`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installHermesConfig(path, "/tmp/new-beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installHermesConfig returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "old-beacon-hooks") || strings.Contains(text, "asym-hooks") {
+		t.Fatalf("old Hermes endpoint hook was not replaced:\n%s", text)
+	}
+	for _, want := range []string{"--platform factory", "echo keep", "/tmp/new-beacon-hooks"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected preserved hooks and new hook %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRemoveHermesEndpointHooksPreservesOtherHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	existing := `hooks:
+  pre_tool_call:
+    - matcher: terminal
+      command: echo keep
+    - command: env BEACON_ENDPOINT_MODE=1 beacon-hooks --platform hermes pre-tool
+    - command: env BEACON_ENDPOINT_MODE=1 beacon-hooks --platform factory pre-tool
+`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := removeHermesEndpointHooks(path)
+	if err != nil {
+		t.Fatalf("removeHermesEndpointHooks returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected endpoint hook removal")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "--platform hermes") {
+		t.Fatalf("Hermes endpoint hook was not removed:\n%s", text)
+	}
+	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "--platform factory") {
+		t.Fatalf("non-Hermes hooks were not preserved:\n%s", text)
+	}
+}
+
+func TestHermesHookStatusDetectsInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".hermes", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`hooks:
+  on_session_end:
+    - command: env BEACON_ENDPOINT_MODE=1 beacon-hooks --platform hermes session-end
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	status := HermesHookStatus(HermesOptions{Level: LevelUser, UserMode: true})
+	if !status.Installed {
+		t.Fatalf("HermesHookStatus installed = false, status=%#v", status)
+	}
+	if status.ConfigPath != path {
+		t.Fatalf("ConfigPath = %q, want %q", status.ConfigPath, path)
+	}
+}
+
+func TestHermesProjectLevelReturnsClearError(t *testing.T) {
+	if _, err := hermesConfigPath(LevelProject); err == nil || !strings.Contains(err.Error(), "user-level config only") {
+		t.Fatalf("hermesConfigPath project err = %v, want user-level config only", err)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive integration following existing hook-runtime patterns; no changes to auth, payment, or core data paths beyond new optional telemetry fields.
> 
> **Overview**
> Adds **Hermes Agent** as a first-class Beacon hook harness end-to-end.
> 
> **CLI & install:** `beacon endpoint hooks` gains install/uninstall/status for `--harness hermes` (alias `hermes-agent`), wired through endpoint targets and diagnostics. Hooks are merged into user-level `~/.hermes/config.yaml` only—project-level install is rejected, and bulk `--all` omits Hermes when `--level project`. Harness discovery reports whether Beacon Hermes shell hooks are present (YAML parse + `BEACON_ENDPOINT_MODE` / `--platform hermes`).
> 
> **`beacon-hooks`:** New `--platform hermes` path normalizes session/CWD from top-level and `extra`, attaches raw Hermes payloads, maps prompts (`user_message`), tools (observe-only pre-tool, no fake approvals), post-tool results, Hermes-specific approval request/response events, and subagent stop metadata. Docs list Hermes in supported runtimes and note hook trust options for non-TTY runs.
> 
> **Tests:** Coverage for config merge/replace/uninstall, discovery status, session ID resolution, and integration-style hook telemetry (prompt redaction, tools, approvals, subagent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbd9baffe8023c1d058d7ed950da48dd6637257a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->