### PR TITLE
Fix Hermes docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Claude Cowork, OpenClaw).
 | [Gemini CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-gemini-cli) | Opt-in local OpenTelemetry configuration |
 | [GitHub Copilot CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-github-copilot-cli) | MDM-managed OpenTelemetry (OTLP HTTP) |
 | [Grok Build](https://docs.asymptotelabs.ai/cli/supported-runtimes-grok-build) | Beacon hook adapter |
-| [Hermes Agent](https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks) | Beacon hook adapter via Hermes shell hooks |
 | [OpenCode](https://docs.asymptotelabs.ai/cli/supported-runtimes-opencode) | Beacon hook adapter |
 | [VS Code](https://docs.asymptotelabs.ai/cli/supported-runtimes-vscode) | VS Code Copilot OpenTelemetry and optional Beacon hook adapter |
 
@@ -99,6 +98,7 @@ Claude Cowork, OpenClaw).
 | Agent harness | Support path |
 | --- | --- |
 | [Claude Cowork](https://docs.asymptotelabs.ai/cli/supported-runtimes-claude-cowork) | Admin-configured OpenTelemetry setup |
+| [Hermes Agent](https://docs.asymptotelabs.ai/cli/supported-runtimes-hermes-agent) | Beacon hook adapter via Hermes shell hooks |
 | [OpenClaw Gateway](https://docs.asymptotelabs.ai/cli/supported-runtimes-openclaw-gateway) | Gateway-configured OTLP/HTTP export |
 
 ### Output Destinations


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> README-only table reorder and hyperlink update with no runtime or security impact.
> 
> **Overview**
> **Moves Hermes Agent** from the coding harnesses table to **Knowledge Worker Agent Harnesses** and **replaces the docs URL** with the Asymptote runtime page (`supported-runtimes-hermes-agent`) instead of the third-party Hermes user-guide hooks link.
> 
> The support path text is unchanged: Beacon hook adapter via Hermes shell hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27627cfc9b01ad48f0be3766fa97c00b3c0e5f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->