### PR TITLE
Inventory all agent configs

### DIFF
--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -22,6 +22,12 @@ const (
 	formatYAML         = "yaml"
 	formatMetadataOnly = "metadata_only"
 
+	KindNativeConfig  = "native_config"
+	KindHookConfig    = "hook_config"
+	KindPlugin        = "plugin"
+	KindProfile       = "profile"
+	KindManagedConfig = "managed_config"
+
 	TransportStdio     = "stdio"
 	TransportHTTP      = "http"
 	TransportSSE       = "sse"
@@ -74,6 +80,8 @@ type Config struct {
 	Path           string `json:"path,omitempty"`
 	PathHash       string `json:"path_hash,omitempty"`
 	Scope          string `json:"scope"`
+	ConfigKind     string `json:"config_kind"`
+	ParserMode     string `json:"parser_mode"`
 	Exists         bool   `json:"exists"`
 	Readable       bool   `json:"readable"`
 	Reason         string `json:"reason,omitempty"`
@@ -110,6 +118,7 @@ type candidate struct {
 	path    string
 	scope   string
 	format  string
+	kind    string
 }
 
 func Scan(opts Options) Result {
@@ -173,81 +182,81 @@ func candidates(home, wd string) []candidate {
 
 func claudeCandidates(home, wd string) []candidate {
 	return []candidate{
-		{runtime: "claude_code", path: filepath.Join(home, ".claude", "settings.json"), scope: ScopeUser, format: formatJSON},
-		{runtime: "claude_code", path: filepath.Join(wd, ".claude", "settings.json"), scope: ScopeProject, format: formatJSON},
-		{runtime: "claude_code", path: "/Library/Application Support/ClaudeCode/managed-settings.json", scope: ScopeManaged, format: formatJSON},
+		{runtime: "claude_code", path: filepath.Join(home, ".claude", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "claude_code", path: filepath.Join(wd, ".claude", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "claude_code", path: "/Library/Application Support/ClaudeCode/managed-settings.json", scope: ScopeManaged, format: formatJSON, kind: KindManagedConfig},
 	}
 }
 
 func codexCandidates(home string) []candidate {
-	return []candidate{{runtime: "codex_cli", path: filepath.Join(home, ".codex", "config.toml"), scope: ScopeUser, format: formatTOML}}
+	return []candidate{{runtime: "codex_cli", path: filepath.Join(home, ".codex", "config.toml"), scope: ScopeUser, format: formatTOML, kind: KindNativeConfig}}
 }
 
 func cursorCandidates(home, wd string) []candidate {
 	return []candidate{
-		{runtime: "cursor", path: filepath.Join(home, ".cursor", "mcp.json"), scope: ScopeUser, format: formatJSON},
-		{runtime: "cursor", path: filepath.Join(wd, ".cursor", "mcp.json"), scope: ScopeProject, format: formatJSON},
-		{runtime: "cursor", path: filepath.Join(home, ".cursor", "hooks.json"), scope: ScopeUser, format: formatJSON},
-		{runtime: "cursor", path: filepath.Join(wd, ".cursor", "hooks.json"), scope: ScopeProject, format: formatJSON},
+		{runtime: "cursor", path: filepath.Join(home, ".cursor", "mcp.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "cursor", path: filepath.Join(wd, ".cursor", "mcp.json"), scope: ScopeProject, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "cursor", path: filepath.Join(home, ".cursor", "hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "cursor", path: filepath.Join(wd, ".cursor", "hooks.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 	}
 }
 
 func geminiCandidates(home string) []candidate {
-	return []candidate{{runtime: "gemini_cli", path: filepath.Join(home, ".gemini", "settings.json"), scope: ScopeUser, format: formatJSON}}
+	return []candidate{{runtime: "gemini_cli", path: filepath.Join(home, ".gemini", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig}}
 }
 
 func antigravityCandidates(home, wd string) []candidate {
 	return []candidate{
-		{runtime: "antigravity_cli", path: filepath.Join(home, ".gemini", "config", "hooks.json"), scope: ScopeUser, format: formatJSON},
-		{runtime: "antigravity_cli", path: filepath.Join(wd, ".agents", "hooks.json"), scope: ScopeProject, format: formatJSON},
+		{runtime: "antigravity_cli", path: filepath.Join(home, ".gemini", "config", "hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "antigravity_cli", path: filepath.Join(wd, ".agents", "hooks.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 	}
 }
 
 func vscodeCandidates(home, wd string) []candidate {
 	return []candidate{
-		{runtime: "vscode", path: vscodeUserSettingsPath(home), scope: ScopeUser, format: formatJSON},
-		{runtime: "vscode", path: filepath.Join(wd, ".vscode", "settings.json"), scope: ScopeProject, format: formatJSON},
-		{runtime: "vscode", path: filepath.Join(home, ".copilot", "hooks", "beacon.json"), scope: ScopeUser, format: formatJSON},
-		{runtime: "vscode", path: filepath.Join(wd, ".github", "hooks", "beacon.json"), scope: ScopeProject, format: formatJSON},
+		{runtime: "vscode", path: vscodeUserSettingsPath(home), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "vscode", path: filepath.Join(wd, ".vscode", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "vscode", path: filepath.Join(home, ".copilot", "hooks", "beacon.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "vscode", path: filepath.Join(wd, ".github", "hooks", "beacon.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 	}
 }
 
 func factoryCandidates(home, wd string) []candidate {
 	return []candidate{
-		{runtime: "factory", path: shellProfilePath(home), scope: ScopeUser, format: formatMetadataOnly},
-		{runtime: "factory", path: filepath.Join(home, ".factory", "settings.json"), scope: ScopeUser, format: formatJSON},
-		{runtime: "factory", path: filepath.Join(wd, ".factory", "settings.json"), scope: ScopeProject, format: formatJSON},
+		{runtime: "factory", path: shellProfilePath(home), scope: ScopeUser, format: formatMetadataOnly, kind: KindProfile},
+		{runtime: "factory", path: filepath.Join(home, ".factory", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "factory", path: filepath.Join(wd, ".factory", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 	}
 }
 
 func copilotCandidates(home string) []candidate {
-	return []candidate{{runtime: "copilot_cli", path: shellProfilePath(home), scope: ScopeUser, format: formatMetadataOnly}}
+	return []candidate{{runtime: "copilot_cli", path: shellProfilePath(home), scope: ScopeUser, format: formatMetadataOnly, kind: KindProfile}}
 }
 
 func opencodeCandidates(home, wd string) []candidate {
 	return []candidate{
-		{runtime: "opencode", path: filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly},
-		{runtime: "opencode", path: filepath.Join(wd, ".opencode", "plugins", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly},
+		{runtime: "opencode", path: filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
+		{runtime: "opencode", path: filepath.Join(wd, ".opencode", "plugins", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
 	}
 }
 
 func hermesCandidates(home string) []candidate {
-	return []candidate{{runtime: "hermes", path: filepath.Join(home, ".hermes", "config.yaml"), scope: ScopeUser, format: formatYAML}}
+	return []candidate{{runtime: "hermes", path: filepath.Join(home, ".hermes", "config.yaml"), scope: ScopeUser, format: formatYAML, kind: KindNativeConfig}}
 }
 
 func devinCandidates(home, wd string) []candidate {
 	return []candidate{
-		{runtime: "devin-cli", path: filepath.Join(home, ".config", "devin", "config.json"), scope: ScopeUser, format: formatJSON},
-		{runtime: "devin-cli", path: filepath.Join(wd, ".devin", "hooks.v1.json"), scope: ScopeProject, format: formatJSON},
-		{runtime: "devin-desktop", path: filepath.Join(home, ".codeium", "windsurf", "hooks.json"), scope: ScopeUser, format: formatJSON},
-		{runtime: "devin-desktop", path: filepath.Join(wd, ".windsurf", "hooks.json"), scope: ScopeProject, format: formatJSON},
+		{runtime: "devin-cli", path: filepath.Join(home, ".config", "devin", "config.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "devin-cli", path: filepath.Join(wd, ".devin", "hooks.v1.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+		{runtime: "devin-desktop", path: filepath.Join(home, ".codeium", "windsurf", "hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "devin-desktop", path: filepath.Join(wd, ".windsurf", "hooks.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 	}
 }
 
 func grokCandidates(home, wd string) []candidate {
 	return []candidate{
-		{runtime: "grok", path: filepath.Join(home, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeUser, format: formatJSON},
-		{runtime: "grok", path: filepath.Join(wd, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeProject, format: formatJSON},
+		{runtime: "grok", path: filepath.Join(home, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "grok", path: filepath.Join(wd, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 	}
 }
 
@@ -285,6 +294,8 @@ func inspectCandidate(item candidate, redaction string) (Config, []MCPServer) {
 		Path:         valueForPath(item.path, redaction),
 		PathHash:     hashString(item.path),
 		Scope:        item.scope,
+		ConfigKind:   item.kind,
+		ParserMode:   item.format,
 		ParserStatus: StatusNotFound,
 		Redaction:    redaction,
 	}
@@ -311,7 +322,7 @@ func inspectCandidate(item candidate, redaction string) (Config, []MCPServer) {
 	}
 	config.Readable = true
 	config.FileSHA256 = hashBytes(data)
-	config.BeaconManaged = beaconManaged(data)
+	config.BeaconManaged = beaconManaged(item, data)
 
 	servers, parseErr := parseMCPServers(item, data, redaction)
 	config.MCPServerCount = len(servers)
@@ -547,14 +558,34 @@ func firstString(raw interface{}) string {
 	}
 }
 
-func beaconManaged(data []byte) bool {
+func beaconManaged(item candidate, data []byte) bool {
 	text := string(data)
-	return strings.Contains(text, "BEACON_ENDPOINT_MODE=1") ||
-		strings.Contains(text, "beacon-managed-opencode-plugin:v1") ||
-		strings.Contains(text, "beacon-managed-grok-hooks:v1") ||
-		strings.Contains(text, "OTEL_EXPORTER_OTLP_ENDPOINT") && (strings.Contains(text, "127.0.0.1") || strings.Contains(text, "localhost")) ||
-		strings.Contains(text, "OTEL_TELEMETRY_ENDPOINT") && (strings.Contains(text, "127.0.0.1") || strings.Contains(text, "localhost")) ||
-		strings.Contains(text, "COPILOT_OTEL_ENABLED") && (strings.Contains(text, "127.0.0.1") || strings.Contains(text, "localhost"))
+	switch item.runtime {
+	case "claude_code", "cursor", "antigravity_cli", "vscode", "factory", "hermes", "devin-cli", "devin-desktop":
+		if strings.Contains(text, "BEACON_ENDPOINT_MODE=1") {
+			return true
+		}
+	case "opencode":
+		return strings.Contains(text, "beacon-managed-opencode-plugin:v1")
+	case "grok":
+		return strings.Contains(text, "beacon-managed-grok-hooks:v1")
+	}
+	if item.runtime == "claude_code" || item.runtime == "codex_cli" || item.runtime == "gemini_cli" || item.runtime == "vscode" {
+		if strings.Contains(text, "OTEL_EXPORTER_OTLP_ENDPOINT") && localEndpointText(text) {
+			return true
+		}
+	}
+	if item.runtime == "factory" && strings.Contains(text, "OTEL_TELEMETRY_ENDPOINT") && localEndpointText(text) {
+		return true
+	}
+	if item.runtime == "copilot_cli" && strings.Contains(text, "COPILOT_OTEL_ENABLED") && localEndpointText(text) {
+		return true
+	}
+	return false
+}
+
+func localEndpointText(text string) bool {
+	return strings.Contains(text, "127.0.0.1") || strings.Contains(text, "localhost")
 }
 
 func hashString(value string) string {

--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -581,8 +581,10 @@ func beaconManaged(item candidate, data []byte) bool {
 	if item.runtime == "vscode" && strings.Contains(text, "github.copilot.chat.otel.otlpEndpoint") && localEndpointText(text) {
 		return true
 	}
-	if item.runtime == "factory" && strings.Contains(text, "OTEL_TELEMETRY_ENDPOINT") && localEndpointText(text) {
-		return true
+	if item.runtime == "factory" {
+		if ep := shellExportValue(text, "OTEL_TELEMETRY_ENDPOINT"); ep != "" && localEndpointText(ep) {
+			return true
+		}
 	}
 	if item.runtime == "copilot_cli" && copilotOTELEnabled(text) {
 		return true

--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -570,10 +570,16 @@ func beaconManaged(item candidate, data []byte) bool {
 	case "grok":
 		return strings.Contains(text, "beacon-managed-grok-hooks:v1")
 	}
-	if item.runtime == "claude_code" || item.runtime == "codex_cli" || item.runtime == "gemini_cli" || item.runtime == "vscode" {
+	if item.runtime == "claude_code" || item.runtime == "codex_cli" {
 		if strings.Contains(text, "OTEL_EXPORTER_OTLP_ENDPOINT") && localEndpointText(text) {
 			return true
 		}
+	}
+	if item.runtime == "gemini_cli" && strings.Contains(text, "otlpEndpoint") && localEndpointText(text) {
+		return true
+	}
+	if item.runtime == "vscode" && strings.Contains(text, "github.copilot.chat.otel.otlpEndpoint") && localEndpointText(text) {
+		return true
 	}
 	if item.runtime == "factory" && strings.Contains(text, "OTEL_TELEMETRY_ENDPOINT") && localEndpointText(text) {
 		return true

--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -224,7 +224,7 @@ func vscodeCandidates(home, wd string) []candidate {
 func factoryCandidates(home, wd string) []candidate {
 	return []candidate{
 		{runtime: "factory", path: shellProfilePath(home), scope: ScopeUser, format: formatMetadataOnly, kind: KindProfile},
-		{runtime: "factory", path: filepath.Join(home, ".factory", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "factory", path: filepath.Join(home, ".factory", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		{runtime: "factory", path: filepath.Join(wd, ".factory", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 	}
 }
@@ -578,10 +578,46 @@ func beaconManaged(item candidate, data []byte) bool {
 	if item.runtime == "factory" && strings.Contains(text, "OTEL_TELEMETRY_ENDPOINT") && localEndpointText(text) {
 		return true
 	}
-	if item.runtime == "copilot_cli" && strings.Contains(text, "COPILOT_OTEL_ENABLED") && localEndpointText(text) {
+	if item.runtime == "copilot_cli" && copilotOTELEnabled(text) {
 		return true
 	}
 	return false
+}
+
+func copilotOTELEnabled(text string) bool {
+	enabled := shellExportValue(text, "COPILOT_OTEL_ENABLED")
+	if !truthyValue(enabled) {
+		return false
+	}
+	endpoint := shellExportValue(text, "COPILOT_OTEL_ENDPOINT")
+	if endpoint == "" {
+		endpoint = shellExportValue(text, "OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+	if endpoint == "" {
+		return false
+	}
+	return localEndpointText(endpoint)
+}
+
+func shellExportValue(text, key string) string {
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		if !strings.HasPrefix(line, key+"=") {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(line, key+"="))
+		return strings.Trim(value, `"'`)
+	}
+	return ""
+}
+
+func truthyValue(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	return normalized == "true" || normalized == "1"
 }
 
 func localEndpointText(text string) bool {

--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -7,14 +7,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/pelletier/go-toml/v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (
+	formatJSON         = "json"
+	formatTOML         = "toml"
+	formatYAML         = "yaml"
+	formatMetadataOnly = "metadata_only"
+
 	TransportStdio     = "stdio"
 	TransportHTTP      = "http"
 	TransportSSE       = "sse"
@@ -138,16 +145,19 @@ func Scan(opts Options) Result {
 }
 
 func candidates(home, wd string) []candidate {
-	items := []candidate{
-		{runtime: "claude_code", path: filepath.Join(home, ".claude", "settings.json"), scope: ScopeUser, format: "json"},
-		{runtime: "claude_code", path: filepath.Join(wd, ".claude", "settings.json"), scope: ScopeProject, format: "json"},
-		{runtime: "claude_code", path: "/Library/Application Support/ClaudeCode/managed-settings.json", scope: ScopeManaged, format: "json"},
-		{runtime: "codex_cli", path: filepath.Join(home, ".codex", "config.toml"), scope: ScopeUser, format: "toml"},
-		{runtime: "cursor", path: filepath.Join(home, ".cursor", "mcp.json"), scope: ScopeUser, format: "json"},
-		{runtime: "cursor", path: filepath.Join(wd, ".cursor", "mcp.json"), scope: ScopeProject, format: "json"},
-		{runtime: "cursor", path: filepath.Join(home, ".cursor", "hooks.json"), scope: ScopeUser, format: "json"},
-		{runtime: "cursor", path: filepath.Join(wd, ".cursor", "hooks.json"), scope: ScopeProject, format: "json"},
-	}
+	items := []candidate{}
+	items = append(items, claudeCandidates(home, wd)...)
+	items = append(items, codexCandidates(home)...)
+	items = append(items, cursorCandidates(home, wd)...)
+	items = append(items, geminiCandidates(home)...)
+	items = append(items, antigravityCandidates(home, wd)...)
+	items = append(items, vscodeCandidates(home, wd)...)
+	items = append(items, factoryCandidates(home, wd)...)
+	items = append(items, copilotCandidates(home)...)
+	items = append(items, opencodeCandidates(home, wd)...)
+	items = append(items, hermesCandidates(home)...)
+	items = append(items, devinCandidates(home, wd)...)
+	items = append(items, grokCandidates(home, wd)...)
 	seen := map[string]bool{}
 	out := make([]candidate, 0, len(items))
 	for _, item := range items {
@@ -159,6 +169,114 @@ func candidates(home, wd string) []candidate {
 		out = append(out, item)
 	}
 	return out
+}
+
+func claudeCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "claude_code", path: filepath.Join(home, ".claude", "settings.json"), scope: ScopeUser, format: formatJSON},
+		{runtime: "claude_code", path: filepath.Join(wd, ".claude", "settings.json"), scope: ScopeProject, format: formatJSON},
+		{runtime: "claude_code", path: "/Library/Application Support/ClaudeCode/managed-settings.json", scope: ScopeManaged, format: formatJSON},
+	}
+}
+
+func codexCandidates(home string) []candidate {
+	return []candidate{{runtime: "codex_cli", path: filepath.Join(home, ".codex", "config.toml"), scope: ScopeUser, format: formatTOML}}
+}
+
+func cursorCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "cursor", path: filepath.Join(home, ".cursor", "mcp.json"), scope: ScopeUser, format: formatJSON},
+		{runtime: "cursor", path: filepath.Join(wd, ".cursor", "mcp.json"), scope: ScopeProject, format: formatJSON},
+		{runtime: "cursor", path: filepath.Join(home, ".cursor", "hooks.json"), scope: ScopeUser, format: formatJSON},
+		{runtime: "cursor", path: filepath.Join(wd, ".cursor", "hooks.json"), scope: ScopeProject, format: formatJSON},
+	}
+}
+
+func geminiCandidates(home string) []candidate {
+	return []candidate{{runtime: "gemini_cli", path: filepath.Join(home, ".gemini", "settings.json"), scope: ScopeUser, format: formatJSON}}
+}
+
+func antigravityCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "antigravity_cli", path: filepath.Join(home, ".gemini", "config", "hooks.json"), scope: ScopeUser, format: formatJSON},
+		{runtime: "antigravity_cli", path: filepath.Join(wd, ".agents", "hooks.json"), scope: ScopeProject, format: formatJSON},
+	}
+}
+
+func vscodeCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "vscode", path: vscodeUserSettingsPath(home), scope: ScopeUser, format: formatJSON},
+		{runtime: "vscode", path: filepath.Join(wd, ".vscode", "settings.json"), scope: ScopeProject, format: formatJSON},
+		{runtime: "vscode", path: filepath.Join(home, ".copilot", "hooks", "beacon.json"), scope: ScopeUser, format: formatJSON},
+		{runtime: "vscode", path: filepath.Join(wd, ".github", "hooks", "beacon.json"), scope: ScopeProject, format: formatJSON},
+	}
+}
+
+func factoryCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "factory", path: shellProfilePath(home), scope: ScopeUser, format: formatMetadataOnly},
+		{runtime: "factory", path: filepath.Join(home, ".factory", "settings.json"), scope: ScopeUser, format: formatJSON},
+		{runtime: "factory", path: filepath.Join(wd, ".factory", "settings.json"), scope: ScopeProject, format: formatJSON},
+	}
+}
+
+func copilotCandidates(home string) []candidate {
+	return []candidate{{runtime: "copilot_cli", path: shellProfilePath(home), scope: ScopeUser, format: formatMetadataOnly}}
+}
+
+func opencodeCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "opencode", path: filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly},
+		{runtime: "opencode", path: filepath.Join(wd, ".opencode", "plugins", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly},
+	}
+}
+
+func hermesCandidates(home string) []candidate {
+	return []candidate{{runtime: "hermes", path: filepath.Join(home, ".hermes", "config.yaml"), scope: ScopeUser, format: formatYAML}}
+}
+
+func devinCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "devin-cli", path: filepath.Join(home, ".config", "devin", "config.json"), scope: ScopeUser, format: formatJSON},
+		{runtime: "devin-cli", path: filepath.Join(wd, ".devin", "hooks.v1.json"), scope: ScopeProject, format: formatJSON},
+		{runtime: "devin-desktop", path: filepath.Join(home, ".codeium", "windsurf", "hooks.json"), scope: ScopeUser, format: formatJSON},
+		{runtime: "devin-desktop", path: filepath.Join(wd, ".windsurf", "hooks.json"), scope: ScopeProject, format: formatJSON},
+	}
+}
+
+func grokCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "grok", path: filepath.Join(home, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeUser, format: formatJSON},
+		{runtime: "grok", path: filepath.Join(wd, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeProject, format: formatJSON},
+	}
+}
+
+func vscodeUserSettingsPath(home string) string {
+	switch runtime.GOOS {
+	case "linux":
+		base := os.Getenv("XDG_CONFIG_HOME")
+		if base == "" {
+			base = filepath.Join(home, ".config")
+		}
+		return filepath.Join(base, "Code", "User", "settings.json")
+	case "windows":
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			return filepath.Join(appData, "Code", "User", "settings.json")
+		}
+		return filepath.Join(home, "AppData", "Roaming", "Code", "User", "settings.json")
+	}
+	return filepath.Join(home, "Library", "Application Support", "Code", "User", "settings.json")
+}
+
+func shellProfilePath(home string) string {
+	switch filepath.Base(os.Getenv("SHELL")) {
+	case "zsh":
+		return filepath.Join(home, ".zshrc")
+	case "bash":
+		return filepath.Join(home, ".bash_profile")
+	default:
+		return filepath.Join(home, ".profile")
+	}
 }
 
 func inspectCandidate(item candidate, redaction string) (Config, []MCPServer) {
@@ -207,15 +325,23 @@ func inspectCandidate(item candidate, redaction string) (Config, []MCPServer) {
 
 func parseMCPServers(item candidate, data []byte, redaction string) ([]MCPServer, error) {
 	switch item.format {
-	case "json":
+	case formatMetadataOnly:
+		return nil, nil
+	case formatJSON:
 		var root map[string]interface{}
 		if err := json.Unmarshal(data, &root); err != nil {
 			return nil, err
 		}
 		return serversFromMap(item, root, redaction), nil
-	case "toml":
+	case formatTOML:
 		var root map[string]interface{}
 		if err := toml.Unmarshal(data, &root); err != nil {
+			return nil, err
+		}
+		return serversFromMap(item, root, redaction), nil
+	case formatYAML:
+		var root map[string]interface{}
+		if err := yaml.Unmarshal(data, &root); err != nil {
 			return nil, err
 		}
 		return serversFromMap(item, root, redaction), nil
@@ -425,7 +551,10 @@ func beaconManaged(data []byte) bool {
 	text := string(data)
 	return strings.Contains(text, "BEACON_ENDPOINT_MODE=1") ||
 		strings.Contains(text, "beacon-managed-opencode-plugin:v1") ||
-		strings.Contains(text, "OTEL_EXPORTER_OTLP_ENDPOINT") && (strings.Contains(text, "127.0.0.1") || strings.Contains(text, "localhost"))
+		strings.Contains(text, "beacon-managed-grok-hooks:v1") ||
+		strings.Contains(text, "OTEL_EXPORTER_OTLP_ENDPOINT") && (strings.Contains(text, "127.0.0.1") || strings.Contains(text, "localhost")) ||
+		strings.Contains(text, "OTEL_TELEMETRY_ENDPOINT") && (strings.Contains(text, "127.0.0.1") || strings.Contains(text, "localhost")) ||
+		strings.Contains(text, "COPILOT_OTEL_ENABLED") && (strings.Contains(text, "127.0.0.1") || strings.Contains(text, "localhost"))
 }
 
 func hashString(value string) string {

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -189,7 +189,7 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 		{runtime: "vscode", path: filepath.Join(home, ".copilot", "hooks", "beacon.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		{runtime: "vscode", path: filepath.Join(work, ".github", "hooks", "beacon.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 		{runtime: "factory", path: filepath.Join(home, ".bash_profile"), scope: ScopeUser, format: formatMetadataOnly, kind: KindProfile},
-		{runtime: "factory", path: filepath.Join(home, ".factory", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "factory", path: filepath.Join(home, ".factory", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		{runtime: "factory", path: filepath.Join(work, ".factory", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 		{runtime: "copilot_cli", path: filepath.Join(home, ".bash_profile"), scope: ScopeUser, format: formatMetadataOnly, kind: KindProfile},
 		{runtime: "opencode", path: filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
@@ -267,6 +267,78 @@ mcpServers:
 	}
 	if copilotProfile.BeaconManaged {
 		t.Fatal("factory OTEL marker should not make copilot profile Beacon-managed")
+	}
+}
+
+func TestCopilotManagedDetectionFalsePositives(t *testing.T) {
+	t.Setenv("SHELL", "/bin/zsh")
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "commented_out",
+			content: "# export COPILOT_OTEL_ENABLED=true\nexport OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318\n",
+			want:    false,
+		},
+		{
+			name:    "disabled_false",
+			content: "export COPILOT_OTEL_ENABLED=false\nexport OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318\n",
+			want:    false,
+		},
+		{
+			name:    "disabled_zero",
+			content: "export COPILOT_OTEL_ENABLED=0\nexport COPILOT_OTEL_ENDPOINT=http://127.0.0.1:4318\n",
+			want:    false,
+		},
+		{
+			name:    "enabled_no_endpoint",
+			content: "export COPILOT_OTEL_ENABLED=true\n",
+			want:    false,
+		},
+		{
+			name:    "enabled_remote_endpoint",
+			content: "export COPILOT_OTEL_ENABLED=true\nexport COPILOT_OTEL_ENDPOINT=http://remote.example.com:4318\n",
+			want:    false,
+		},
+		{
+			name:    "enabled_with_local_endpoint",
+			content: "export COPILOT_OTEL_ENABLED=true\nexport COPILOT_OTEL_ENDPOINT=http://127.0.0.1:4318\n",
+			want:    true,
+		},
+		{
+			name:    "enabled_with_generic_otlp_endpoint",
+			content: "export COPILOT_OTEL_ENABLED=1\nexport OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318\n",
+			want:    true,
+		},
+		{
+			name:    "factory_endpoint_only",
+			content: "export OTEL_TELEMETRY_ENDPOINT=http://127.0.0.1:4318\n",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			work := t.TempDir()
+			writeFile(t, filepath.Join(home, ".zshrc"), tc.content)
+
+			result := Scan(Options{
+				ContentRetention: RedactionRedacted,
+				HomeDir:          home,
+				WorkingDir:       work,
+				Now:              fixedNow,
+			})
+
+			copilotProfile := findConfig(result.Configs, "copilot_cli", filepath.Join(home, ".zshrc"))
+			if copilotProfile == nil {
+				t.Fatal("copilot shell profile config not found")
+			}
+			if copilotProfile.BeaconManaged != tc.want {
+				t.Fatalf("copilot BeaconManaged = %t, want %t", copilotProfile.BeaconManaged, tc.want)
+			}
+		})
 	}
 }
 

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -157,6 +157,100 @@ func TestMissingCandidatesAreReportedAsNotFound(t *testing.T) {
 	}
 }
 
+func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("SHELL", "/bin/bash")
+
+	result := Scan(Options{
+		ContentRetention: RedactionRedacted,
+		HomeDir:          home,
+		WorkingDir:       work,
+		Now:              fixedNow,
+	})
+
+	expected := []candidate{
+		{runtime: "claude_code", path: filepath.Join(home, ".claude", "settings.json"), scope: ScopeUser},
+		{runtime: "claude_code", path: filepath.Join(work, ".claude", "settings.json"), scope: ScopeProject},
+		{runtime: "claude_code", path: "/Library/Application Support/ClaudeCode/managed-settings.json", scope: ScopeManaged},
+		{runtime: "codex_cli", path: filepath.Join(home, ".codex", "config.toml"), scope: ScopeUser},
+		{runtime: "cursor", path: filepath.Join(home, ".cursor", "mcp.json"), scope: ScopeUser},
+		{runtime: "cursor", path: filepath.Join(work, ".cursor", "mcp.json"), scope: ScopeProject},
+		{runtime: "cursor", path: filepath.Join(home, ".cursor", "hooks.json"), scope: ScopeUser},
+		{runtime: "cursor", path: filepath.Join(work, ".cursor", "hooks.json"), scope: ScopeProject},
+		{runtime: "gemini_cli", path: filepath.Join(home, ".gemini", "settings.json"), scope: ScopeUser},
+		{runtime: "antigravity_cli", path: filepath.Join(home, ".gemini", "config", "hooks.json"), scope: ScopeUser},
+		{runtime: "antigravity_cli", path: filepath.Join(work, ".agents", "hooks.json"), scope: ScopeProject},
+		{runtime: "vscode", path: vscodeUserSettingsPath(home), scope: ScopeUser},
+		{runtime: "vscode", path: filepath.Join(work, ".vscode", "settings.json"), scope: ScopeProject},
+		{runtime: "vscode", path: filepath.Join(home, ".copilot", "hooks", "beacon.json"), scope: ScopeUser},
+		{runtime: "vscode", path: filepath.Join(work, ".github", "hooks", "beacon.json"), scope: ScopeProject},
+		{runtime: "factory", path: filepath.Join(home, ".bash_profile"), scope: ScopeUser},
+		{runtime: "factory", path: filepath.Join(home, ".factory", "settings.json"), scope: ScopeUser},
+		{runtime: "factory", path: filepath.Join(work, ".factory", "settings.json"), scope: ScopeProject},
+		{runtime: "copilot_cli", path: filepath.Join(home, ".bash_profile"), scope: ScopeUser},
+		{runtime: "opencode", path: filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), scope: ScopeUser},
+		{runtime: "opencode", path: filepath.Join(work, ".opencode", "plugins", "beacon.ts"), scope: ScopeProject},
+		{runtime: "hermes", path: filepath.Join(home, ".hermes", "config.yaml"), scope: ScopeUser},
+		{runtime: "devin-cli", path: filepath.Join(home, ".config", "devin", "config.json"), scope: ScopeUser},
+		{runtime: "devin-cli", path: filepath.Join(work, ".devin", "hooks.v1.json"), scope: ScopeProject},
+		{runtime: "devin-desktop", path: filepath.Join(home, ".codeium", "windsurf", "hooks.json"), scope: ScopeUser},
+		{runtime: "devin-desktop", path: filepath.Join(work, ".windsurf", "hooks.json"), scope: ScopeProject},
+		{runtime: "grok", path: filepath.Join(home, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeUser},
+		{runtime: "grok", path: filepath.Join(work, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeProject},
+	}
+	if got, want := len(result.Configs), len(expected); got != want {
+		t.Fatalf("config candidates = %d, want %d", got, want)
+	}
+	for _, item := range expected {
+		config := findConfig(result.Configs, item.runtime, item.path)
+		if config == nil {
+			t.Fatalf("missing candidate %s %s", item.runtime, item.path)
+		}
+		if config.Scope != item.scope {
+			t.Fatalf("%s %s scope = %s, want %s", item.runtime, item.path, config.Scope, item.scope)
+		}
+	}
+}
+
+func TestScanYAMLAndMetadataOnlyConfigs(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("SHELL", "/bin/zsh")
+	writeFile(t, filepath.Join(home, ".hermes", "config.yaml"), `
+mcpServers:
+  memory:
+    command: uvx
+    args:
+      - mcp-server-memory
+`)
+	writeFile(t, filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), `// beacon-managed-opencode-plugin:v1`)
+	writeFile(t, filepath.Join(home, ".zshrc"), `export OTEL_TELEMETRY_ENDPOINT=http://127.0.0.1:4318`)
+
+	result := Scan(Options{
+		ContentRetention: RedactionRedacted,
+		HomeDir:          home,
+		WorkingDir:       work,
+		Now:              fixedNow,
+	})
+
+	assertServer(t, result.MCPServers, "hermes", "memory", TransportStdio, true, 1, 0, 0)
+	opencode := findConfig(result.Configs, "opencode", filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"))
+	if opencode == nil {
+		t.Fatal("opencode metadata-only config not found")
+	}
+	if opencode.ParserStatus != StatusOK || !opencode.BeaconManaged {
+		t.Fatalf("opencode status = %s managed=%t, want ok/managed", opencode.ParserStatus, opencode.BeaconManaged)
+	}
+	factoryProfile := findConfig(result.Configs, "factory", filepath.Join(home, ".zshrc"))
+	if factoryProfile == nil {
+		t.Fatal("factory shell profile config not found")
+	}
+	if factoryProfile.ParserStatus != StatusOK || !factoryProfile.BeaconManaged {
+		t.Fatalf("factory profile status = %s managed=%t, want ok/managed", factoryProfile.ParserStatus, factoryProfile.BeaconManaged)
+	}
+}
+
 func fixedNow() time.Time {
 	return time.Date(2026, 6, 5, 7, 0, 0, 0, time.UTC)
 }
@@ -197,4 +291,14 @@ func assertServer(t *testing.T, servers []MCPServer, runtime, name, transport st
 		}
 	}
 	t.Fatalf("server %s/%s not found in %#v", runtime, name, servers)
+}
+
+func findConfig(configs []Config, runtime, path string) *Config {
+	pathHash := hashString(path)
+	for i := range configs {
+		if configs[i].Runtime == runtime && configs[i].PathHash == pathHash {
+			return &configs[i]
+		}
+	}
+	return nil
 }

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -63,6 +63,9 @@ GITHUB_TOKEN = "secret"
 			if config.FileSHA256 == "" || config.PathHash == "" {
 				t.Fatal("Claude config missing hashes")
 			}
+			if config.ParserMode != formatJSON || config.ConfigKind != KindNativeConfig {
+				t.Fatalf("Claude config mode/kind = %s/%s, want %s/%s", config.ParserMode, config.ConfigKind, formatJSON, KindNativeConfig)
+			}
 		}
 	}
 	if !foundClaudeConfig {
@@ -170,34 +173,34 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 	})
 
 	expected := []candidate{
-		{runtime: "claude_code", path: filepath.Join(home, ".claude", "settings.json"), scope: ScopeUser},
-		{runtime: "claude_code", path: filepath.Join(work, ".claude", "settings.json"), scope: ScopeProject},
-		{runtime: "claude_code", path: "/Library/Application Support/ClaudeCode/managed-settings.json", scope: ScopeManaged},
-		{runtime: "codex_cli", path: filepath.Join(home, ".codex", "config.toml"), scope: ScopeUser},
-		{runtime: "cursor", path: filepath.Join(home, ".cursor", "mcp.json"), scope: ScopeUser},
-		{runtime: "cursor", path: filepath.Join(work, ".cursor", "mcp.json"), scope: ScopeProject},
-		{runtime: "cursor", path: filepath.Join(home, ".cursor", "hooks.json"), scope: ScopeUser},
-		{runtime: "cursor", path: filepath.Join(work, ".cursor", "hooks.json"), scope: ScopeProject},
-		{runtime: "gemini_cli", path: filepath.Join(home, ".gemini", "settings.json"), scope: ScopeUser},
-		{runtime: "antigravity_cli", path: filepath.Join(home, ".gemini", "config", "hooks.json"), scope: ScopeUser},
-		{runtime: "antigravity_cli", path: filepath.Join(work, ".agents", "hooks.json"), scope: ScopeProject},
-		{runtime: "vscode", path: vscodeUserSettingsPath(home), scope: ScopeUser},
-		{runtime: "vscode", path: filepath.Join(work, ".vscode", "settings.json"), scope: ScopeProject},
-		{runtime: "vscode", path: filepath.Join(home, ".copilot", "hooks", "beacon.json"), scope: ScopeUser},
-		{runtime: "vscode", path: filepath.Join(work, ".github", "hooks", "beacon.json"), scope: ScopeProject},
-		{runtime: "factory", path: filepath.Join(home, ".bash_profile"), scope: ScopeUser},
-		{runtime: "factory", path: filepath.Join(home, ".factory", "settings.json"), scope: ScopeUser},
-		{runtime: "factory", path: filepath.Join(work, ".factory", "settings.json"), scope: ScopeProject},
-		{runtime: "copilot_cli", path: filepath.Join(home, ".bash_profile"), scope: ScopeUser},
-		{runtime: "opencode", path: filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), scope: ScopeUser},
-		{runtime: "opencode", path: filepath.Join(work, ".opencode", "plugins", "beacon.ts"), scope: ScopeProject},
-		{runtime: "hermes", path: filepath.Join(home, ".hermes", "config.yaml"), scope: ScopeUser},
-		{runtime: "devin-cli", path: filepath.Join(home, ".config", "devin", "config.json"), scope: ScopeUser},
-		{runtime: "devin-cli", path: filepath.Join(work, ".devin", "hooks.v1.json"), scope: ScopeProject},
-		{runtime: "devin-desktop", path: filepath.Join(home, ".codeium", "windsurf", "hooks.json"), scope: ScopeUser},
-		{runtime: "devin-desktop", path: filepath.Join(work, ".windsurf", "hooks.json"), scope: ScopeProject},
-		{runtime: "grok", path: filepath.Join(home, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeUser},
-		{runtime: "grok", path: filepath.Join(work, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeProject},
+		{runtime: "claude_code", path: filepath.Join(home, ".claude", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "claude_code", path: filepath.Join(work, ".claude", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "claude_code", path: "/Library/Application Support/ClaudeCode/managed-settings.json", scope: ScopeManaged, format: formatJSON, kind: KindManagedConfig},
+		{runtime: "codex_cli", path: filepath.Join(home, ".codex", "config.toml"), scope: ScopeUser, format: formatTOML, kind: KindNativeConfig},
+		{runtime: "cursor", path: filepath.Join(home, ".cursor", "mcp.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "cursor", path: filepath.Join(work, ".cursor", "mcp.json"), scope: ScopeProject, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "cursor", path: filepath.Join(home, ".cursor", "hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "cursor", path: filepath.Join(work, ".cursor", "hooks.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+		{runtime: "gemini_cli", path: filepath.Join(home, ".gemini", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "antigravity_cli", path: filepath.Join(home, ".gemini", "config", "hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "antigravity_cli", path: filepath.Join(work, ".agents", "hooks.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+		{runtime: "vscode", path: vscodeUserSettingsPath(home), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "vscode", path: filepath.Join(work, ".vscode", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "vscode", path: filepath.Join(home, ".copilot", "hooks", "beacon.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "vscode", path: filepath.Join(work, ".github", "hooks", "beacon.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+		{runtime: "factory", path: filepath.Join(home, ".bash_profile"), scope: ScopeUser, format: formatMetadataOnly, kind: KindProfile},
+		{runtime: "factory", path: filepath.Join(home, ".factory", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "factory", path: filepath.Join(work, ".factory", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+		{runtime: "copilot_cli", path: filepath.Join(home, ".bash_profile"), scope: ScopeUser, format: formatMetadataOnly, kind: KindProfile},
+		{runtime: "opencode", path: filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
+		{runtime: "opencode", path: filepath.Join(work, ".opencode", "plugins", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
+		{runtime: "hermes", path: filepath.Join(home, ".hermes", "config.yaml"), scope: ScopeUser, format: formatYAML, kind: KindNativeConfig},
+		{runtime: "devin-cli", path: filepath.Join(home, ".config", "devin", "config.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: "devin-cli", path: filepath.Join(work, ".devin", "hooks.v1.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+		{runtime: "devin-desktop", path: filepath.Join(home, ".codeium", "windsurf", "hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "devin-desktop", path: filepath.Join(work, ".windsurf", "hooks.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+		{runtime: "grok", path: filepath.Join(home, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "grok", path: filepath.Join(work, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 	}
 	if got, want := len(result.Configs), len(expected); got != want {
 		t.Fatalf("config candidates = %d, want %d", got, want)
@@ -209,6 +212,9 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 		}
 		if config.Scope != item.scope {
 			t.Fatalf("%s %s scope = %s, want %s", item.runtime, item.path, config.Scope, item.scope)
+		}
+		if config.ParserMode != item.format || config.ConfigKind != item.kind {
+			t.Fatalf("%s %s mode/kind = %s/%s, want %s/%s", item.runtime, item.path, config.ParserMode, config.ConfigKind, item.format, item.kind)
 		}
 	}
 }
@@ -242,12 +248,25 @@ mcpServers:
 	if opencode.ParserStatus != StatusOK || !opencode.BeaconManaged {
 		t.Fatalf("opencode status = %s managed=%t, want ok/managed", opencode.ParserStatus, opencode.BeaconManaged)
 	}
+	if opencode.ParserMode != formatMetadataOnly || opencode.ConfigKind != KindPlugin {
+		t.Fatalf("opencode mode/kind = %s/%s, want %s/%s", opencode.ParserMode, opencode.ConfigKind, formatMetadataOnly, KindPlugin)
+	}
 	factoryProfile := findConfig(result.Configs, "factory", filepath.Join(home, ".zshrc"))
 	if factoryProfile == nil {
 		t.Fatal("factory shell profile config not found")
 	}
 	if factoryProfile.ParserStatus != StatusOK || !factoryProfile.BeaconManaged {
 		t.Fatalf("factory profile status = %s managed=%t, want ok/managed", factoryProfile.ParserStatus, factoryProfile.BeaconManaged)
+	}
+	if factoryProfile.ParserMode != formatMetadataOnly || factoryProfile.ConfigKind != KindProfile {
+		t.Fatalf("factory profile mode/kind = %s/%s, want %s/%s", factoryProfile.ParserMode, factoryProfile.ConfigKind, formatMetadataOnly, KindProfile)
+	}
+	copilotProfile := findConfig(result.Configs, "copilot_cli", filepath.Join(home, ".zshrc"))
+	if copilotProfile == nil {
+		t.Fatal("copilot shell profile config not found")
+	}
+	if copilotProfile.BeaconManaged {
+		t.Fatal("factory OTEL marker should not make copilot profile Beacon-managed")
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broadens filesystem scanning and changes inventory JSON shape (`config_kind`, `parser_mode`); Beacon-managed heuristics affect diagnostics accuracy but not auth or data paths.
> 
> **Overview**
> Expands Beacon endpoint **inventory** from a handful of Claude/Codex/Cursor paths to a broad set of AI agent runtimes (Gemini, VS Code, Factory, Copilot CLI, OpenCode, Hermes, Devin, Grok, Antigravity, etc.), with per-runtime candidate helpers and deduplication.
> 
> Inventory output now includes **`config_kind`** and **`parser_mode`** on each config, plus new kinds (native config, hooks, plugins, shell profiles, managed config). Parsing adds **YAML** (Hermes) and **`metadata_only`** paths (shell profiles, OpenCode plugins) that skip MCP extraction but still report presence and hashes.
> 
> **Beacon-managed** detection is **runtime-specific**: hook markers, plugin version strings, and OTLP/local endpoint checks (including VS Code Copilot settings, Factory shell exports, and Copilot CLI with stricter enabled/endpoint rules and comment skipping). VS Code user settings paths are resolved per OS; shell profile paths follow `SHELL`.
> 
> Tests assert the full candidate list, YAML/metadata-only behavior, and Copilot false-positive cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04dcb4d142ebd6c4eb3b6155e8fd5db86ea13928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->