### PR TITLE
Beacon doctor fixes

### DIFF
--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -74,6 +75,38 @@ type plannedAction struct {
 	Target  string `json:"target,omitempty"`
 	Message string `json:"message,omitempty"`
 }
+
+type repairServiceManager interface {
+	PlistPath() (string, error)
+	WritePlist(program, configPath string) (string, error)
+	Load() error
+	Unload() error
+}
+
+type repairFileSnapshot struct {
+	existed bool
+	data    []byte
+	mode    os.FileMode
+}
+
+type repairRollback struct {
+	manager          repairServiceManager
+	serviceWasLoaded bool
+	serviceLoaded    bool
+	files            []string
+	snapshots        map[string]repairFileSnapshot
+}
+
+var (
+	repairLoadEndpointConfig     = endpointconfig.Load
+	repairSaveEndpointConfig     = endpointconfig.Save
+	repairResolveCollectorBinary = endpointcollector.ResolveBinary
+	repairWriteCollectorConfig   = endpointcollector.WriteConfig
+	repairWaitCollectorReady     = endpointcollector.WaitUntilReady
+	newRepairServiceManager      = func(userMode bool) repairServiceManager {
+		return service.Manager{UserMode: userMode}
+	}
+)
 
 func runEndpointDoctor(cmd *cobra.Command, args []string) error {
 	status := lifecycle.GetStatus(endpointUserMode(), endpointOpts.logPath)
@@ -834,48 +867,141 @@ func planDoctorFixes(result doctorResult, status lifecycle.Status) doctorFixPlan
 }
 
 func applyDoctorFixes(plan doctorFixPlan, status lifecycle.Status) error {
+	var errs []error
 	for _, action := range plan.Fixes {
 		switch action.Action {
 		case "create_runtime_log":
 			if err := ensureLogFile(action.Target); err != nil {
-				return err
+				errs = append(errs, fmt.Errorf("%s %s: %w", action.Action, action.Target, err))
 			}
 		case "repair_collector_service":
 			if err := repairCollectorServiceFromStatus(status); err != nil {
-				return err
+				errs = append(errs, fmt.Errorf("%s %s: %w", action.Action, action.Target, err))
 			}
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func repairCollectorServiceFromStatus(status lifecycle.Status) error {
 	userMode := status.RuntimeLog.EffectiveUserMode
-	cfg, err := endpointconfig.Load(userMode)
+	cfg, err := repairLoadEndpointConfig(userMode)
 	if err != nil {
 		return err
 	}
+	manager := newRepairServiceManager(userMode)
+	plistPath, err := manager.PlistPath()
+	if err != nil {
+		return err
+	}
+	rollback := newRepairRollback(manager, status.Service.Loaded)
+	rollback.Track(endpointconfig.ConfigPath(userMode))
+	rollback.Track(cfg.Collector.ConfigPath)
+	rollback.Track(plistPath)
+
 	if endpointOpts.logPath != "" {
 		cfg.LogPath = endpointOpts.logPath
-		if _, err := endpointconfig.Save(cfg); err != nil {
-			return err
+		if _, err := repairSaveEndpointConfig(cfg); err != nil {
+			return rollbackRepairError(err, rollback)
 		}
 	}
-	binary, err := endpointcollector.ResolveBinary(cfg.Collector.BinaryPath)
+	binary, err := repairResolveCollectorBinary(cfg.Collector.BinaryPath)
 	if err != nil {
-		return err
+		return rollbackRepairError(err, rollback)
 	}
-	if err := endpointcollector.WriteConfig(cfg); err != nil {
-		return err
+	if err := repairWriteCollectorConfig(cfg); err != nil {
+		return rollbackRepairError(err, rollback)
 	}
-	manager := service.Manager{UserMode: userMode}
 	if _, err := manager.WritePlist(binary, cfg.Collector.ConfigPath); err != nil {
-		return err
+		return rollbackRepairError(err, rollback)
 	}
 	if err := manager.Load(); err != nil {
+		return rollbackRepairError(err, rollback)
+	}
+	rollback.serviceLoaded = true
+	if err := repairWaitCollectorReady(cfg, 10*time.Second); err != nil {
+		return rollbackRepairError(err, rollback)
+	}
+	return nil
+}
+
+func newRepairRollback(manager repairServiceManager, serviceWasLoaded bool) *repairRollback {
+	return &repairRollback{
+		manager:          manager,
+		serviceWasLoaded: serviceWasLoaded,
+		snapshots:        map[string]repairFileSnapshot{},
+	}
+}
+
+func (r *repairRollback) Track(path string) {
+	if r == nil || path == "" {
+		return
+	}
+	if _, ok := r.snapshots[path]; ok {
+		return
+	}
+	r.snapshots[path] = snapshotRepairFile(path)
+	r.files = append(r.files, path)
+}
+
+func (r *repairRollback) Rollback() error {
+	if r == nil {
+		return nil
+	}
+	var errs []error
+	if r.serviceLoaded {
+		if err := r.manager.Unload(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for i := len(r.files) - 1; i >= 0; i-- {
+		path := r.files[i]
+		if err := restoreRepairFile(path, r.snapshots[path]); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if r.serviceWasLoaded {
+		if err := r.manager.Load(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func rollbackRepairError(err error, rollback *repairRollback) error {
+	if rollbackErr := rollback.Rollback(); rollbackErr != nil {
+		return errors.Join(err, fmt.Errorf("rollback collector service repair: %w", rollbackErr))
+	}
+	return err
+}
+
+func snapshotRepairFile(path string) repairFileSnapshot {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return repairFileSnapshot{}
+	}
+	snapshot := repairFileSnapshot{existed: true, data: data}
+	if info, statErr := os.Stat(path); statErr == nil {
+		snapshot.mode = info.Mode().Perm()
+	}
+	return snapshot
+}
+
+func restoreRepairFile(path string, snapshot repairFileSnapshot) error {
+	if !snapshot.existed {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	return endpointcollector.WaitUntilReady(cfg, 10*time.Second)
+	mode := snapshot.mode
+	if mode == 0 {
+		mode = 0600
+	}
+	return os.WriteFile(path, snapshot.data, mode)
 }
 
 func checkLogWritable(cfg endpointconfig.Config) diagnostics.Check {

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -87,6 +87,7 @@ type repairFileSnapshot struct {
 	existed bool
 	data    []byte
 	mode    os.FileMode
+	readErr error
 }
 
 type repairRollback struct {
@@ -978,7 +979,10 @@ func rollbackRepairError(err error, rollback *repairRollback) error {
 func snapshotRepairFile(path string) repairFileSnapshot {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return repairFileSnapshot{}
+		if errors.Is(err, os.ErrNotExist) {
+			return repairFileSnapshot{}
+		}
+		return repairFileSnapshot{existed: true, readErr: err}
 	}
 	snapshot := repairFileSnapshot{existed: true, data: data}
 	if info, statErr := os.Stat(path); statErr == nil {
@@ -993,6 +997,9 @@ func restoreRepairFile(path string, snapshot repairFileSnapshot) error {
 			return err
 		}
 		return nil
+	}
+	if snapshot.readErr != nil {
+		return fmt.Errorf("cannot restore %s: pre-repair snapshot failed: %w", path, snapshot.readErr)
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -2,17 +2,20 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/diagnostics"
 	endpointinventory "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/inventory"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/service"
 
 	"github.com/spf13/cobra"
 )
@@ -129,6 +132,124 @@ func TestFalconHECOptionsDefaultIsNil(t *testing.T) {
 	endpointOpts.falconSourcetype = endpointconfig.DefaultFalconSourcetype
 	if got := falconHECOptions(); got != nil {
 		t.Fatalf("falconHECOptions() = %#v, want nil", got)
+	}
+}
+
+func TestRepairCollectorServiceRollsBackWhenReadinessFails(t *testing.T) {
+	oldOpts := endpointOpts
+	oldLoadConfig := repairLoadEndpointConfig
+	oldSaveConfig := repairSaveEndpointConfig
+	oldResolveBinary := repairResolveCollectorBinary
+	oldWriteConfig := repairWriteCollectorConfig
+	oldWaitReady := repairWaitCollectorReady
+	oldNewManager := newRepairServiceManager
+	t.Cleanup(func() {
+		endpointOpts = oldOpts
+		repairLoadEndpointConfig = oldLoadConfig
+		repairSaveEndpointConfig = oldSaveConfig
+		repairResolveCollectorBinary = oldResolveBinary
+		repairWriteCollectorConfig = oldWriteConfig
+		repairWaitCollectorReady = oldWaitReady
+		newRepairServiceManager = oldNewManager
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	collectorConfigPath := filepath.Join(home, "otelcol.yaml")
+	plistPath := filepath.Join(home, "agent.plist")
+	cfg := endpointconfig.Config{
+		UserMode:         true,
+		LogPath:          filepath.Join(home, "old-runtime.jsonl"),
+		ContentRetention: endpointconfig.ContentRetentionFull,
+		Collector: endpointconfig.Collector{
+			ConfigPath: collectorConfigPath,
+			SpoolPath:  filepath.Join(home, "spool", "otlp.jsonl"),
+			GRPCPort:   endpointconfig.DefaultGRPCPort,
+			HTTPPort:   endpointconfig.DefaultHTTPPort,
+		},
+	}
+	if _, err := endpointconfig.Save(cfg); err != nil {
+		t.Fatalf("save original config: %v", err)
+	}
+	if err := os.WriteFile(collectorConfigPath, []byte("old collector config"), 0644); err != nil {
+		t.Fatalf("write original collector config: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("old plist"), 0644); err != nil {
+		t.Fatalf("write original plist: %v", err)
+	}
+	originalConfig, err := os.ReadFile(endpointconfig.ConfigPath(true))
+	if err != nil {
+		t.Fatalf("read original config: %v", err)
+	}
+
+	fakeManager := &fakeRepairServiceManager{plistPath: plistPath}
+	newRepairServiceManager = func(userMode bool) repairServiceManager {
+		if !userMode {
+			t.Fatal("repair should use effective user mode")
+		}
+		return fakeManager
+	}
+	repairResolveCollectorBinary = func(configured string) (string, error) {
+		return filepath.Join(home, "beacon-otelcol"), nil
+	}
+	repairWriteCollectorConfig = func(cfg endpointconfig.Config) error {
+		return os.WriteFile(cfg.Collector.ConfigPath, []byte("new collector config"), 0644)
+	}
+	repairWaitCollectorReady = func(cfg endpointconfig.Config, timeout time.Duration) error {
+		return errors.New("collector did not become ready before timeout")
+	}
+	endpointOpts.logPath = filepath.Join(home, "new-runtime.jsonl")
+
+	err = repairCollectorServiceFromStatus(lifecycle.Status{
+		RuntimeLog: lifecycle.RuntimeLogSource{EffectiveUserMode: true},
+		Service:    service.Status{Loaded: true, Running: true},
+	})
+	if err == nil || !strings.Contains(err.Error(), "collector did not become ready") {
+		t.Fatalf("repairCollectorServiceFromStatus error = %v, want readiness failure", err)
+	}
+	if fakeManager.loads != 2 {
+		t.Fatalf("Load calls = %d, want repair load plus rollback reload", fakeManager.loads)
+	}
+	if fakeManager.unloads != 1 {
+		t.Fatalf("Unload calls = %d, want rollback unload", fakeManager.unloads)
+	}
+	assertFileContent(t, endpointconfig.ConfigPath(true), string(originalConfig))
+	assertFileContent(t, collectorConfigPath, "old collector config")
+	assertFileContent(t, plistPath, "old plist")
+}
+
+type fakeRepairServiceManager struct {
+	plistPath string
+	loads     int
+	unloads   int
+}
+
+func (m *fakeRepairServiceManager) PlistPath() (string, error) {
+	return m.plistPath, nil
+}
+
+func (m *fakeRepairServiceManager) WritePlist(program, configPath string) (string, error) {
+	return m.plistPath, os.WriteFile(m.plistPath, []byte("new plist"), 0644)
+}
+
+func (m *fakeRepairServiceManager) Load() error {
+	m.loads++
+	return nil
+}
+
+func (m *fakeRepairServiceManager) Unload() error {
+	m.unloads++
+	return nil
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(data) != want {
+		t.Fatalf("%s = %q, want %q", path, string(data), want)
 	}
 }
 
@@ -819,6 +940,33 @@ func TestPlanDoctorFixesDoesNotTreatMissingEventAsAppliedFix(t *testing.T) {
 	}
 	if len(plan.Skipped) != 1 || !strings.Contains(plan.Skipped[0].Message, "test-event") {
 		t.Fatalf("missing last event should suggest test-event: %#v", plan)
+	}
+}
+
+func TestApplyDoctorFixesContinuesAfterCollectorRepairFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logPath := filepath.Join(t.TempDir(), "logs", "runtime.jsonl")
+	status := lifecycle.Status{
+		LogPath:    logPath,
+		RuntimeLog: lifecycle.RuntimeLogSource{EffectiveUserMode: true},
+	}
+	plan := doctorFixPlan{
+		Fixes: []plannedAction{
+			{Action: "repair_collector_service", Target: filepath.Join(home, "missing-config.json")},
+			{Action: "create_runtime_log", Target: logPath},
+		},
+	}
+
+	err := applyDoctorFixes(plan, status)
+	if err == nil {
+		t.Fatal("applyDoctorFixes returned nil, want collector repair error")
+	}
+	if !strings.Contains(err.Error(), "repair_collector_service") {
+		t.Fatalf("applyDoctorFixes error = %q, want repair action context", err)
+	}
+	if _, statErr := os.Stat(logPath); statErr != nil {
+		t.Fatalf("runtime log was not created after collector repair failure: %v", statErr)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes modify launchd service load/unload and on-disk endpoint/collector config during automated repair; rollback reduces breakage risk but failed rollback could still leave a mixed state.
> 
> **Overview**
> **Beacon endpoint doctor `--fix`** is more resilient when repairing the managed collector and applying multiple fixes.
> 
> **Collector service repair** now snapshots the endpoint config, collector config, and launchd plist before rewriting them, loads the service, and waits for collector readiness. If any step fails (including readiness timeout), it **rolls back**: unloads a service started during repair, restores prior file contents (or removes files that did not exist), and reloads the service if it was loaded beforehand. Repair steps use injectable hooks so tests can simulate failures without touching real launchd.
> 
> **`applyDoctorFixes`** no longer stops on the first failure; it runs all planned fixes and returns a combined error via `errors.Join`, so actions like **create_runtime_log** still run when collector repair fails.
> 
> Tests cover rollback on readiness failure and continuing fixes after a collector repair error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1549b059dce69dc1954fb5e488d146dfaa5c53aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->