### PR TITLE
test(endpoint): fix cross-platform lifecycle test and raise lifecycle/service coverage

### DIFF
--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/harness"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/service"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/writer"
@@ -387,9 +388,12 @@ func TestConfigureHarnessesAcceptsVSCode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("configureHarnesses returned error: %v", err)
 	}
-	settingsPath := filepath.Join(home, "Library", "Application Support", "Code", "User", "settings.json")
+	settingsPath, err := harness.VSCodeUserSettingsPath()
+	if err != nil {
+		t.Fatalf("VSCodeUserSettingsPath returned error: %v", err)
+	}
 	if len(paths) != 1 || paths[0] != settingsPath {
-		t.Fatalf("paths = %#v, want VS Code settings path", paths)
+		t.Fatalf("paths = %#v, want VS Code settings path %q", paths, settingsPath)
 	}
 	data, err := os.ReadFile(settingsPath)
 	if err != nil {
@@ -575,4 +579,216 @@ func freePort(t *testing.T) int {
 	}
 	defer ln.Close()
 	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func TestConfigureHarnessesAcceptsClaude(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := endpointconfig.Config{
+		UserMode:         true,
+		Harnesses:        []string{"claude"},
+		ContentRetention: endpointconfig.ContentRetentionFull,
+		Collector:        endpointconfig.Collector{GRPCPort: 54317},
+	}
+
+	paths, err := configureHarnesses(cfg)
+	if err != nil {
+		t.Fatalf("configureHarnesses returned error: %v", err)
+	}
+	wantPath := filepath.Join(home, ".claude", "settings.json")
+	if len(paths) != 1 || paths[0] != wantPath {
+		t.Fatalf("paths = %#v, want %q", paths, wantPath)
+	}
+	data, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read Claude settings: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `"CLAUDE_CODE_ENABLE_TELEMETRY": "1"`) ||
+		!strings.Contains(text, `"OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:54317"`) {
+		t.Fatalf("Claude settings were not configured for local OTLP:\n%s", text)
+	}
+}
+
+func TestSameCollectorPorts(t *testing.T) {
+	base := endpointconfig.Config{Collector: endpointconfig.Collector{GRPCPort: 4317, HTTPPort: 4318}}
+	same := endpointconfig.Config{Collector: endpointconfig.Collector{GRPCPort: 4317, HTTPPort: 4318}}
+	if !sameCollectorPorts(base, same) {
+		t.Fatal("sameCollectorPorts returned false for equal ports")
+	}
+	differentGRPC := endpointconfig.Config{Collector: endpointconfig.Collector{GRPCPort: 14317, HTTPPort: 4318}}
+	if sameCollectorPorts(base, differentGRPC) {
+		t.Fatal("sameCollectorPorts returned true for differing gRPC port")
+	}
+	differentHTTP := endpointconfig.Config{Collector: endpointconfig.Collector{GRPCPort: 4317, HTTPPort: 14318}}
+	if sameCollectorPorts(base, differentHTTP) {
+		t.Fatal("sameCollectorPorts returned true for differing HTTP port")
+	}
+}
+
+func TestLoadOrDefaultFallsBackToDefaultThenLoadsSavedConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logPath := filepath.Join(home, "runtime.jsonl")
+
+	// No config saved yet: returns a default with the requested log path.
+	got := loadOrDefault(true, logPath)
+	if got.LogPath != logPath {
+		t.Fatalf("default LogPath = %q, want %q", got.LogPath, logPath)
+	}
+	if !got.UserMode {
+		t.Fatal("default config should preserve user mode")
+	}
+
+	// Persist a config and confirm it is loaded back.
+	saved := endpointconfig.Default(true, filepath.Join(home, "saved.jsonl"))
+	saved.ContentRetention = endpointconfig.ContentRetentionMetadata
+	if _, err := endpointconfig.Save(saved); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+	loaded := loadOrDefault(true, "")
+	if loaded.ContentRetention != endpointconfig.ContentRetentionMetadata {
+		t.Fatalf("loaded ContentRetention = %q, want metadata", loaded.ContentRetention)
+	}
+	// An explicit log path overrides the saved value.
+	overridden := loadOrDefault(true, logPath)
+	if overridden.LogPath != logPath {
+		t.Fatalf("override LogPath = %q, want %q", overridden.LogPath, logPath)
+	}
+}
+
+func TestSnapshotAndRestoreFileRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte("original"), 0640); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	snap := snapshotFile(path)
+	if !snap.Existed || string(snap.Data) != "original" {
+		t.Fatalf("snapshot did not capture existing file: %#v", snap)
+	}
+
+	if err := os.WriteFile(path, []byte("mutated"), 0640); err != nil {
+		t.Fatalf("mutate file: %v", err)
+	}
+	restoreFile(path, snap)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
+	if string(data) != "original" {
+		t.Fatalf("restoreFile did not restore content: %q", string(data))
+	}
+
+	// A snapshot of a missing file restores by removing the file.
+	missing := snapshotFile(filepath.Join(dir, "absent.json"))
+	if missing.Existed {
+		t.Fatal("snapshot of missing file should not report Existed")
+	}
+	restoreFile(path, missing)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("restoreFile of missing snapshot should remove file, stat err = %v", err)
+	}
+}
+
+func TestInstallRollbackTracksAndRestoresFiles(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "existing.json")
+	if err := os.WriteFile(existing, []byte("before"), 0640); err != nil {
+		t.Fatalf("write existing fixture: %v", err)
+	}
+	created := filepath.Join(dir, "created.json")
+
+	rollback := newInstallRollback(service.Manager{UserMode: true})
+	rollback.Track(existing)
+	rollback.Track(created)
+	rollback.Track("") // ignored
+	rollback.Track(existing) // de-duplicated
+
+	if err := os.WriteFile(existing, []byte("after"), 0640); err != nil {
+		t.Fatalf("mutate existing: %v", err)
+	}
+	if err := os.WriteFile(created, []byte("new"), 0640); err != nil {
+		t.Fatalf("write created: %v", err)
+	}
+
+	rollback.Rollback(Manifest{})
+
+	data, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatalf("read restored existing: %v", err)
+	}
+	if string(data) != "before" {
+		t.Fatalf("existing file not restored to original: %q", string(data))
+	}
+	if _, err := os.Stat(created); !os.IsNotExist(err) {
+		t.Fatalf("newly created file should be removed on rollback, stat err = %v", err)
+	}
+}
+
+func TestDestinationStatusAndInstallDestinationReportEnabledHEC(t *testing.T) {
+	cfg := endpointconfig.Config{
+		Destinations: &endpointconfig.Destinations{
+			SplunkHEC: &endpointconfig.SplunkHEC{
+				Enabled:    true,
+				Endpoint:   "https://splunk.example/services/collector",
+				Index:      "main",
+				Source:     "beacon",
+				Sourcetype: "beacon:endpoint",
+			},
+			FalconHEC: &endpointconfig.FalconHEC{
+				Enabled:  true,
+				Endpoint: "https://falcon.example/services/collector",
+			},
+		},
+	}
+
+	status := destinationStatus(cfg)
+	if !status.SplunkHEC.Configured || status.SplunkHEC.Endpoint != "https://splunk.example/services/collector" {
+		t.Fatalf("Splunk destination status not reported: %#v", status.SplunkHEC)
+	}
+	if !status.FalconHEC.Configured {
+		t.Fatalf("Falcon destination status not reported: %#v", status.FalconHEC)
+	}
+
+	info := installDestination(cfg)
+	if !strings.Contains(info.Type, "splunk_hec") || !strings.Contains(info.Type, "falcon_hec") {
+		t.Fatalf("installDestination type missing HEC destinations: %q", info.Type)
+	}
+	if !strings.Contains(info.Mode, "hec") {
+		t.Fatalf("installDestination mode missing hec: %q", info.Mode)
+	}
+
+	// With no destinations configured, status is empty and only local JSONL is reported.
+	empty := destinationStatus(endpointconfig.Config{})
+	if empty.SplunkHEC.Configured || empty.FalconHEC.Configured {
+		t.Fatalf("empty config should report no destinations: %#v", empty)
+	}
+	localOnly := installDestination(endpointconfig.Config{})
+	if localOnly.Type != "local_jsonl" {
+		t.Fatalf("installDestination with no HEC = %q, want local_jsonl", localOnly.Type)
+	}
+}
+
+func TestGetStatusAndResolveRuntimeLogReportRequestedConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logPath := filepath.Join(home, "runtime.jsonl")
+
+	source := ResolveRuntimeLog(true, logPath)
+	if source.EffectiveLogPath != logPath || source.Reason != "explicit runtime log path" {
+		t.Fatalf("ResolveRuntimeLog explicit path = %#v", source)
+	}
+
+	status := GetStatus(true, logPath)
+	if status.LogPath != logPath {
+		t.Fatalf("GetStatus LogPath = %q, want %q", status.LogPath, logPath)
+	}
+	if status.ConfigPath != endpointconfig.ConfigPath(true) {
+		t.Fatalf("GetStatus ConfigPath = %q, want %q", status.ConfigPath, endpointconfig.ConfigPath(true))
+	}
+	if status.Version == "" {
+		t.Fatal("GetStatus should populate Version")
+	}
 }

--- a/cli/beacon/internal/endpoint/service/service_test.go
+++ b/cli/beacon/internal/endpoint/service/service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -182,5 +183,60 @@ func TestManagerLoadReturnsBootoutFailureWhenReloadFails(t *testing.T) {
 	err := (Manager{UserMode: true}).Load()
 	if err == nil || !strings.Contains(err.Error(), "Boot-out failed") {
 		t.Fatalf("Load error = %v, want bootout failure", err)
+	}
+}
+
+func TestServiceDomainUserAndSystem(t *testing.T) {
+	if got, want := serviceDomain(false), "system"; got != want {
+		t.Fatalf("serviceDomain(system) = %q, want %q", got, want)
+	}
+	user := serviceDomain(true)
+	if !strings.HasPrefix(user, "gui/") {
+		t.Fatalf("serviceDomain(user) = %q, want gui/<uid> prefix", user)
+	}
+	if want := fmt.Sprintf("gui/%d", os.Getuid()); user != want {
+		t.Fatalf("serviceDomain(user) = %q, want %q", user, want)
+	}
+}
+
+func TestLoadAndUnloadAreNoOpsOffDarwin(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("non-darwin launchd contract")
+	}
+	manager := Manager{UserMode: true}
+	called := false
+	oldRun := runLaunchctlCommand
+	runLaunchctlCommand = func(args ...string) (string, error) {
+		called = true
+		return "", errors.New("launchctl should not run off darwin")
+	}
+	t.Cleanup(func() {
+		runLaunchctlCommand = oldRun
+	})
+
+	if err := manager.Load(); err != nil {
+		t.Fatalf("Load off darwin = %v, want nil", err)
+	}
+	if err := manager.Unload(); err != nil {
+		t.Fatalf("Unload off darwin = %v, want nil", err)
+	}
+	if called {
+		t.Fatal("launchctl was invoked off darwin")
+	}
+}
+
+func TestLaunchctlGuidance(t *testing.T) {
+	if got := launchctlGuidance("some unrelated launchctl output", "gui/501", UserLabel); got != "" {
+		t.Fatalf("guidance for unrelated output = %q, want empty", got)
+	}
+
+	withTarget := launchctlGuidance("Bootstrap failed: 5", "gui/501", UserLabel)
+	if !strings.Contains(withTarget, "launchctl bootout gui/501/"+UserLabel) {
+		t.Fatalf("guidance missing domain/label target: %q", withTarget)
+	}
+
+	fallback := launchctlGuidance("Input/output error", "", "")
+	if !strings.Contains(fallback, "the Beacon launchd job") {
+		t.Fatalf("guidance missing generic target fallback: %q", fallback)
 	}
 }


### PR DESCRIPTION
## Summary

Closes a gap in the `beacon` endpoint test suite: a test that failed on non-darwin hosts, plus low coverage on two critical packages.

### What changed
- **Fixed a broken cross-platform test.** `TestConfigureHarnessesAcceptsVSCode` hardcoded the macOS VS Code settings path (`Library/Application Support/Code/...`) and was not OS-gated, so it failed on Linux. It now derives the expected path from `harness.VSCodeUserSettingsPath()`, matching the per-OS resolution the product code already uses — so it passes on darwin, linux, and windows (per CLAUDE.md's gating guidance).
- **Raised coverage** on the two genuinely under-tested critical packages with deterministic, no-root/no-network tests:
  - **lifecycle: 27.8% → 53.1%** — `configureHarnesses` (claude branch), `sameCollectorPorts`, `loadOrDefault`, `snapshotFile`/`restoreFile`, the `installRollback` Track/Rollback flow, `destinationStatus`/`installDestination`, and `GetStatus`/`ResolveRuntimeLog`.
  - **service: 45.9% → 54.5%** — `serviceDomain`, the non-darwin no-op contract for `Load`/`Unload`, and `launchctlGuidance` branches.

The remaining uncovered code is macOS-only launchd/install logic, which stays covered by the existing darwin-gated tests. Both packages are race-clean.

### Verification
```
cd cli/beacon
go test ./internal/endpoint/lifecycle/... ./internal/endpoint/service/...   # pass
go test -race ./internal/endpoint/lifecycle/... ./internal/endpoint/service/...  # pass
go test -cover ./internal/endpoint/lifecycle/... ./internal/endpoint/service/...  # 53.1% / 54.5%
```
Test-only change; no product behavior is modified.

### Out of scope (flagged, not fixed)
The `hooks` package has the same class of Linux-only failure (`TestInstallFactoryUsesSystemConfigForSystemLog` — the embedded macOS Mach-O hooks binary can't run on Linux). It is pre-existing, unrelated to this change, and green in CI (which runs `go test ./...` on macOS). Can be addressed in a follow-up by gating the hooks tests for non-darwin.

https://claude.ai/code/session_01SiLKvW5gCan2jwm5Qk5uhC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiLKvW5gCan2jwm5Qk5uhC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no modifications to install, launchd, or harness configuration logic.
> 
> **Overview**
> **Test-only** changes to the beacon endpoint `lifecycle` and `service` packages—no product behavior changes.
> 
> The VS Code harness test no longer hardcodes the macOS `Library/Application Support/Code/...` path; it uses `harness.VSCodeUserSettingsPath()` so expectations match OS-specific resolution on Linux and Windows as well as darwin.
> 
> New lifecycle tests cover Claude harness configuration, collector port equality, config load/default/override, file snapshot/restore, install rollback tracking, HEC vs local destination reporting, and `GetStatus` / `ResolveRuntimeLog`. New service tests cover `serviceDomain` (system vs `gui/<uid>`), the non-darwin no-op contract for `Load`/`Unload` (no `launchctl`), and `launchctlGuidance` message branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aadb1a328671e91f1e3dc2ff4236ee2e5a8fb56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->