### PR TITLE
refactor(cmd): unify harness target normalization into one table

### DIFF
--- a/cli/beacon/cmd/endpoint_targets.go
+++ b/cli/beacon/cmd/endpoint_targets.go
@@ -17,41 +17,89 @@ type endpointTarget struct {
 	Kind endpointTargetKind
 }
 
-func normalizeEndpointTarget(name string) (endpointTarget, bool) {
+// harnessTarget is one row of the supported-harness registry. It is the single
+// source of truth for both normalizers:
+//
+//   - endpointAliases map a spelling to the harness in the combined endpoint
+//     namespace, classified by endpointKind (OTLP vs hook).
+//   - hookAliases map a spelling to the harness in the hook-only namespace.
+//
+// The two alias sets differ on purpose: in the hook-only namespace some OTLP
+// spellings are reinterpreted as their hook variant (for example "claude" and
+// "vscode"), and OTLP-only harnesses are not hook-addressable at all.
+type harnessTarget struct {
+	name            string
+	endpointKind    endpointTargetKind
+	endpointAliases []string
+	hookAliases     []string
+}
+
+// harnessTargets lists every supported runtime. Adding a harness is one row;
+// the lookup tables below are derived from it.
+var harnessTargets = []harnessTarget{
+	{name: "claude", endpointKind: endpointTargetOTLP, endpointAliases: []string{"claude", "claude-code"}, hookAliases: []string{"claude", "claude-code"}},
+	{name: "claude", endpointKind: endpointTargetHook, endpointAliases: []string{"claude-hooks"}, hookAliases: []string{"claude-hooks"}},
+	{name: "codex", endpointKind: endpointTargetOTLP, endpointAliases: []string{"codex", "codex-cli"}},
+	{name: "gemini", endpointKind: endpointTargetOTLP, endpointAliases: []string{"gemini", "gemini-cli"}},
+	{name: "vscode", endpointKind: endpointTargetOTLP, endpointAliases: []string{"vscode", "vs-code", "vscode-copilot"}, hookAliases: []string{"vscode", "vs-code"}},
+	{name: "cursor", endpointKind: endpointTargetHook, endpointAliases: []string{"cursor"}, hookAliases: []string{"cursor"}},
+	{name: "factory", endpointKind: endpointTargetHook, endpointAliases: []string{"factory", "droid"}, hookAliases: []string{"factory", "droid"}},
+	{name: "opencode", endpointKind: endpointTargetHook, endpointAliases: []string{"opencode"}, hookAliases: []string{"opencode"}},
+	{name: "grok", endpointKind: endpointTargetHook, endpointAliases: []string{"grok"}, hookAliases: []string{"grok"}},
+	{name: "hermes", endpointKind: endpointTargetHook, endpointAliases: []string{"hermes", "hermes-agent"}, hookAliases: []string{"hermes", "hermes-agent"}},
+	{name: "antigravity", endpointKind: endpointTargetHook, endpointAliases: []string{"antigravity", "antigravity-cli"}, hookAliases: []string{"antigravity", "antigravity-cli"}},
+	{name: "devin-cli", endpointKind: endpointTargetHook, endpointAliases: []string{"devin", "devin-cli"}, hookAliases: []string{"devin", "devin-cli"}},
+	{name: "devin-desktop", endpointKind: endpointTargetHook, endpointAliases: []string{"devin-desktop"}, hookAliases: []string{"devin-desktop"}},
+}
+
+var (
+	endpointTargetLookup = buildEndpointTargetLookup()
+	hookTargetLookup     = buildHookTargetLookup()
+)
+
+func buildEndpointTargetLookup() map[string]endpointTarget {
+	m := make(map[string]endpointTarget)
+	for _, t := range harnessTargets {
+		for _, alias := range t.endpointAliases {
+			m[alias] = endpointTarget{Name: t.name, Kind: t.endpointKind}
+		}
+	}
+	return m
+}
+
+func buildHookTargetLookup() map[string]string {
+	m := make(map[string]string)
+	for _, t := range harnessTargets {
+		for _, alias := range t.hookAliases {
+			m[alias] = t.name
+		}
+	}
+	return m
+}
+
+// normalizeHarnessKey canonicalizes a user-supplied harness spelling: trimmed,
+// lowercased, with underscores treated as hyphens.
+func normalizeHarnessKey(name string) string {
 	key := strings.ToLower(strings.TrimSpace(name))
-	key = strings.ReplaceAll(key, "_", "-")
-	switch key {
-	case "":
-		return endpointTarget{}, false
-	case "claude", "claude-code":
-		return endpointTarget{Name: "claude", Kind: endpointTargetOTLP}, true
-	case "codex", "codex-cli":
-		return endpointTarget{Name: "codex", Kind: endpointTargetOTLP}, true
-	case "gemini", "gemini-cli":
-		return endpointTarget{Name: "gemini", Kind: endpointTargetOTLP}, true
-	case "vscode", "vs-code", "vscode-copilot":
-		return endpointTarget{Name: "vscode", Kind: endpointTargetOTLP}, true
-	case "cursor":
-		return endpointTarget{Name: "cursor", Kind: endpointTargetHook}, true
-	case "claude-hooks":
-		return endpointTarget{Name: "claude", Kind: endpointTargetHook}, true
-	case "factory", "droid":
-		return endpointTarget{Name: "factory", Kind: endpointTargetHook}, true
-	case "opencode":
-		return endpointTarget{Name: "opencode", Kind: endpointTargetHook}, true
-	case "grok":
-		return endpointTarget{Name: "grok", Kind: endpointTargetHook}, true
-	case "hermes", "hermes-agent":
-		return endpointTarget{Name: "hermes", Kind: endpointTargetHook}, true
-	case "antigravity", "antigravity-cli":
-		return endpointTarget{Name: "antigravity", Kind: endpointTargetHook}, true
-	case "devin", "devin-cli":
-		return endpointTarget{Name: "devin-cli", Kind: endpointTargetHook}, true
-	case "devin-desktop":
-		return endpointTarget{Name: "devin-desktop", Kind: endpointTargetHook}, true
-	default:
+	return strings.ReplaceAll(key, "_", "-")
+}
+
+func normalizeEndpointTarget(name string) (endpointTarget, bool) {
+	key := normalizeHarnessKey(name)
+	if key == "" {
 		return endpointTarget{}, false
 	}
+	target, ok := endpointTargetLookup[key]
+	return target, ok
+}
+
+func normalizeHookTarget(name string) (string, bool) {
+	key := normalizeHarnessKey(name)
+	if key == "" {
+		return "", false
+	}
+	target, ok := hookTargetLookup[key]
+	return target, ok
 }
 
 func splitEndpointTargets(values []string) (otlp []string, hooks []string, err error) {
@@ -98,38 +146,4 @@ func canonicalHookTargets(values []string) ([]string, error) {
 		}
 	}
 	return targets, nil
-}
-
-func normalizeHookTarget(name string) (string, bool) {
-	key := strings.ToLower(strings.TrimSpace(name))
-	key = strings.ReplaceAll(key, "_", "-")
-	switch key {
-	case "":
-		return "", false
-	case "antigravity", "antigravity-cli":
-		return "antigravity", true
-	case "cursor":
-		return "cursor", true
-	case "claude", "claude-code":
-		return "claude", true
-	case "vscode", "vs-code":
-		return "vscode", true
-	case "factory", "droid":
-		return "factory", true
-	case "opencode":
-		return "opencode", true
-	case "grok":
-		return "grok", true
-	case "hermes", "hermes-agent":
-		return "hermes", true
-	case "devin", "devin-cli":
-		return "devin-cli", true
-	case "devin-desktop":
-		return "devin-desktop", true
-	default:
-		if target, ok := normalizeEndpointTarget(key); ok && target.Kind == endpointTargetHook {
-			return target.Name, true
-		}
-		return "", false
-	}
 }

--- a/cli/beacon/cmd/endpoint_targets_characterization_test.go
+++ b/cli/beacon/cmd/endpoint_targets_characterization_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import "testing"
+
+// These characterization tests pin the exact input→output mapping of the two
+// harness-target normalizers across every recognized alias (including the
+// underscore spellings) and the OTLP/Hook asymmetries, before the two switch
+// statements are collapsed into a single harness table. They guard against any
+// behavior drift during that refactor.
+
+func TestNormalizeEndpointTargetCharacterization(t *testing.T) {
+	type want struct {
+		name string
+		kind endpointTargetKind
+		ok   bool
+	}
+	cases := map[string]want{
+		// OTLP harnesses
+		"claude":         {"claude", endpointTargetOTLP, true},
+		"claude-code":    {"claude", endpointTargetOTLP, true},
+		"claude_code":    {"claude", endpointTargetOTLP, true},
+		"codex":          {"codex", endpointTargetOTLP, true},
+		"codex-cli":      {"codex", endpointTargetOTLP, true},
+		"gemini":         {"gemini", endpointTargetOTLP, true},
+		"gemini-cli":     {"gemini", endpointTargetOTLP, true},
+		"vscode":         {"vscode", endpointTargetOTLP, true},
+		"vs-code":        {"vscode", endpointTargetOTLP, true},
+		"vscode-copilot": {"vscode", endpointTargetOTLP, true},
+		// Hook harnesses
+		"cursor":          {"cursor", endpointTargetHook, true},
+		"claude-hooks":    {"claude", endpointTargetHook, true},
+		"factory":         {"factory", endpointTargetHook, true},
+		"droid":           {"factory", endpointTargetHook, true},
+		"opencode":        {"opencode", endpointTargetHook, true},
+		"grok":            {"grok", endpointTargetHook, true},
+		"hermes":          {"hermes", endpointTargetHook, true},
+		"hermes-agent":    {"hermes", endpointTargetHook, true},
+		"antigravity":     {"antigravity", endpointTargetHook, true},
+		"antigravity-cli": {"antigravity", endpointTargetHook, true},
+		"devin":           {"devin-cli", endpointTargetHook, true},
+		"devin-cli":       {"devin-cli", endpointTargetHook, true},
+		"devin-desktop":   {"devin-desktop", endpointTargetHook, true},
+		// Case/whitespace normalization
+		"  Claude_Code  ": {"claude", endpointTargetOTLP, true},
+		"DEVIN_DESKTOP":   {"devin-desktop", endpointTargetHook, true},
+		// Unsupported
+		"":              {"", "", false},
+		"unknown":       {"", "", false},
+		"vscode-hooks":  {"", "", false},
+		"claude-cowork": {"", "", false},
+	}
+	for in, w := range cases {
+		got, ok := normalizeEndpointTarget(in)
+		if ok != w.ok || got.Name != w.name || (ok && got.Kind != w.kind) {
+			t.Errorf("normalizeEndpointTarget(%q) = (%+v, %v), want ({Name:%q Kind:%q}, %v)",
+				in, got, ok, w.name, w.kind, w.ok)
+		}
+	}
+}
+
+func TestNormalizeHookTargetCharacterization(t *testing.T) {
+	type want struct {
+		name string
+		ok   bool
+	}
+	cases := map[string]want{
+		"antigravity":     {"antigravity", true},
+		"antigravity-cli": {"antigravity", true},
+		"antigravity_cli": {"antigravity", true},
+		"cursor":          {"cursor", true},
+		// claude is OTLP in the endpoint namespace but a hook in the hook namespace
+		"claude":        {"claude", true},
+		"claude-code":   {"claude", true},
+		"claude_code":   {"claude", true},
+		"claude-hooks":  {"claude", true},
+		"vscode":        {"vscode", true},
+		"vs-code":       {"vscode", true},
+		"vs_code":       {"vscode", true},
+		"factory":       {"factory", true},
+		"droid":         {"factory", true},
+		"opencode":      {"opencode", true},
+		"grok":          {"grok", true},
+		"hermes":        {"hermes", true},
+		"hermes-agent":  {"hermes", true},
+		"devin":         {"devin-cli", true},
+		"devin-cli":     {"devin-cli", true},
+		"devin-desktop": {"devin-desktop", true},
+		"DEVIN_DESKTOP": {"devin-desktop", true},
+		// OTLP-only harnesses are not hook-addressable
+		"codex":          {"", false},
+		"codex-cli":      {"", false},
+		"gemini":         {"", false},
+		"vscode-copilot": {"", false},
+		// Unsupported
+		"":        {"", false},
+		"unknown": {"", false},
+	}
+	for in, w := range cases {
+		got, ok := normalizeHookTarget(in)
+		if ok != w.ok || got != w.name {
+			t.Errorf("normalizeHookTarget(%q) = (%q, %v), want (%q, %v)", in, got, ok, w.name, w.ok)
+		}
+	}
+}


### PR DESCRIPTION
## Phase 2 of 3 — harness target table

Collapses the two overlapping switch statements in `cmd/endpoint_targets.go` (`normalizeEndpointTarget` and `normalizeHookTarget`) into a single `harnessTargets` registry. Each row declares the harness name, its endpoint-namespace kind and aliases, and its hook-namespace aliases; the two lookup maps are derived from that table. Branched off `main` after Phase 1 (#116) merged.

### Why
The two switches duplicated the hook-harness entries (cursor, factory, opencode, grok, hermes, devin, antigravity…) and had to be kept in sync by hand — `normalizeHookTarget` even fell through to `normalizeEndpointTarget`, showing they were really one dataset. Adding a runtime meant editing both. Now it's one table row.

### Behavior preserved exactly
The refactor keeps the deliberate OTLP/hook asymmetries:
- `claude` / `claude-code` and `vscode` / `vs-code` resolve to **OTLP** in the combined endpoint namespace, but to their **hook** variant in the hook-only namespace.
- `claude-hooks` resolves to the claude hook in both namespaces.
- OTLP-only harnesses (`codex`, `gemini`, `vscode-copilot`) remain non-hook-addressable.

### Verification
- New characterization tests (added first, as a safety net) pin every alias mapping — including underscore spellings and case/whitespace normalization — for **both** normalizers, and pass before and after the change.
- The existing `splitEndpointTargets` / `canonicalHookTargets` tests are unchanged and pass.
- `go vet ./cmd/`, the full `cmd` suite, and `gofmt` are clean.
- `beacon docs` output is byte-identical to baseline (no CLI surface change).

### Note on CI environment
As with #116, the pre-existing `embedded` / `hooks` / `harness` / `lifecycle` test failures in a Linux checkout (macOS `hooks.bin` placeholder) are unrelated to this change and reproduce on the baseline.

https://claude.ai/code/session_011RgMGykN4dt1PqphVehJN8

---
_Generated by [Claude Code](https://claude.ai/code/session_011RgMGykN4dt1PqphVehJN8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CLI refactor with characterization tests; endpoint install/repair still use the same normalization semantics.
> 
> **Overview**
> Replaces duplicated `switch`-based harness spelling logic in `endpoint_targets.go` with a single **`harnessTargets`** registry. Each row defines canonical name, endpoint-namespace kind/aliases, and hook-only aliases; **`endpointTargetLookup`** and **`hookTargetLookup`** are built from that table.
> 
> **`normalizeHarnessKey`** centralizes trim, lowercasing, and underscore→hyphen handling; **`normalizeEndpointTarget`** and **`normalizeHookTarget`** now map lookups only. Intentional OTLP vs hook asymmetries (e.g. `claude`/`vscode` in hook namespace, OTLP-only harnesses not hook-addressable) stay the same.
> 
> Adds **`endpoint_targets_characterization_test.go`** to pin every alias mapping for both normalizers before/after the refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6748cead2065f3d4a5ccd7cd72eec68d6ec51191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->