### PR TITLE
refactor(siempack): extract a shared content-pack builder

### DIFF
--- a/cli/beacon/internal/endpoint/cloudwatch/cloudwatch.go
+++ b/cli/beacon/internal/endpoint/cloudwatch/cloudwatch.go
@@ -2,7 +2,6 @@ package cloudwatch
 
 import (
 	"embed"
-	"fmt"
 	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -16,85 +15,40 @@ const (
 	DefaultOutputDir = "beacon-cloudwatch-pack"
 )
 
-type File struct {
-	Name            string
-	Content         string
-	TemplateLogPath bool
-	JSONEscape      bool
+const configAsset = "pack/vector.toml.tmpl"
+
+// File is the installable pack-file type, shared with siempack.
+type File = siempack.File
+
+var pack = siempack.Pack{
+	Label:            "cloudwatch",
+	FS:               packFS,
+	DefaultLogPath:   DefaultLogPath,
+	DefaultOutputDir: DefaultOutputDir,
+	Assets: []siempack.Asset{
+		{Source: "pack/README.md", Name: "README.md"},
+		{Source: "pack/sample-event.jsonl", Name: "sample-event.jsonl"},
+		{Source: configAsset, Name: "vector.toml", TemplateLogPath: true},
+	},
 }
 
-func readAsset(path string) (string, error) {
-	data, err := siempack.ReadFile(packFS, path)
-	if err != nil {
-		return "", fmt.Errorf("cloudwatch pack asset %q: %w", path, err)
-	}
-	return data, nil
-}
+// mustRead returns the embedded asset at path or panics. Retained for test use.
+func mustRead(path string) string { return pack.MustRead(path) }
 
-func mustRead(path string) string {
-	s, err := readAsset(path)
-	if err != nil {
-		panic(err.Error())
-	}
-	return s
-}
+// filesFromFS builds the file list from the supplied FS; tests use it to inject
+// read-error conditions.
+func filesFromFS(fsys fs.FS) ([]File, error) { return pack.WithFS(fsys).Files() }
 
+// configSnippetFromFS renders the Vector config using the supplied FS.
 func configSnippetFromFS(fsys fs.FS, logPath string) (string, error) {
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	content, err := siempack.ReadFile(fsys, "pack/vector.toml.tmpl")
-	if err != nil {
-		return "", fmt.Errorf("cloudwatch pack asset %q: %w", "pack/vector.toml.tmpl", err)
-	}
-	return siempack.RenderLogPath(content, logPath), nil
-}
-
-func filesFromFS(fsys fs.FS) ([]File, error) {
-	readme, err := siempack.ReadFile(fsys, "pack/README.md")
-	if err != nil {
-		return nil, fmt.Errorf("cloudwatch pack asset %q: %w", "pack/README.md", err)
-	}
-	sample, err := siempack.ReadFile(fsys, "pack/sample-event.jsonl")
-	if err != nil {
-		return nil, fmt.Errorf("cloudwatch pack asset %q: %w", "pack/sample-event.jsonl", err)
-	}
-	vector, err := siempack.ReadFile(fsys, "pack/vector.toml.tmpl")
-	if err != nil {
-		return nil, fmt.Errorf("cloudwatch pack asset %q: %w", "pack/vector.toml.tmpl", err)
-	}
-	return []File{
-		{Name: "README.md", Content: readme},
-		{Name: "sample-event.jsonl", Content: sample},
-		{Name: "vector.toml", Content: vector, TemplateLogPath: true},
-	}, nil
+	return pack.WithFS(fsys).Render(configAsset, logPath)
 }
 
 // ConfigSnippet returns a rendered Vector configuration for AWS CloudWatch Logs.
-func ConfigSnippet(logPath string) (string, error) {
-	return configSnippetFromFS(packFS, logPath)
-}
+func ConfigSnippet(logPath string) (string, error) { return pack.Render(configAsset, logPath) }
 
 // Files returns all pack files, propagating any embedded asset read error.
-func Files() ([]File, error) {
-	return filesFromFS(packFS)
-}
+func Files() ([]File, error) { return pack.Files() }
 
 // InstallPack writes the AWS CloudWatch Logs pack files to outputDir with logPath substituted.
-func InstallPack(outputDir, logPath string) error {
-	if outputDir == "" {
-		outputDir = DefaultOutputDir
-	}
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	files, err := filesFromFS(packFS)
-	if err != nil {
-		return err
-	}
-	sfiles := make([]siempack.File, 0, len(files))
-	for _, file := range files {
-		sfiles = append(sfiles, siempack.File(file))
-	}
-	return siempack.Install(outputDir, sfiles, logPath)
-}
+func InstallPack(outputDir, logPath string) error { return pack.Install(outputDir, logPath) }

--- a/cli/beacon/internal/endpoint/datadog/datadog.go
+++ b/cli/beacon/internal/endpoint/datadog/datadog.go
@@ -1,12 +1,9 @@
 package datadog
 
 import (
-	"embed"
-	"fmt"
 	"io/fs"
-	"os"
-	"path/filepath"
-	"strings"
+
+	"embed"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
 )
@@ -19,91 +16,41 @@ const (
 	DefaultOutputDir = "beacon-datadog-pack"
 )
 
-type File struct {
-	Name    string
-	Content string
+const configAsset = "pack/conf.yaml.tmpl"
+
+// File is the installable pack-file type, shared with siempack.
+type File = siempack.File
+
+var pack = siempack.Pack{
+	Label:            "datadog",
+	FS:               packFS,
+	DefaultLogPath:   DefaultLogPath,
+	DefaultOutputDir: DefaultOutputDir,
+	Assets: []siempack.Asset{
+		{Source: "pack/README.md", Name: "README.md"},
+		{Source: configAsset, Name: "conf.yaml", TemplateLogPath: true},
+		{Source: "pack/sample-event.jsonl", Name: "sample-event.jsonl"},
+	},
 }
 
-// readAsset reads an embedded asset by path and returns its contents or an error.
-func readAsset(path string) (string, error) {
-	data, err := packFS.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("datadog pack asset %q: %w", path, err)
-	}
-	return string(data), nil
-}
+// mustRead returns the embedded asset at path or panics. Retained for test use.
+func mustRead(path string) string { return pack.MustRead(path) }
 
-// mustRead returns the embedded asset at path or panics. Retained for test use
-// where the embedded FS is always present; all production code uses readAsset.
-func mustRead(path string) string {
-	s, err := readAsset(path)
-	if err != nil {
-		panic(err.Error())
-	}
-	return s
-}
+// filesFromFS builds the file list from the supplied FS; tests use it to inject
+// read-error conditions. Log-path substitution is deferred to InstallPack, so the
+// logPath argument is accepted for signature compatibility but unused here.
+func filesFromFS(fsys fs.FS, logPath string) ([]File, error) { return pack.WithFS(fsys).Files() }
 
 // configSnippetFromFS renders the Datadog Agent conf.yaml snippet using the supplied FS.
 func configSnippetFromFS(fsys fs.FS, logPath string) (string, error) {
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	content, err := siempack.ReadFile(fsys, "pack/conf.yaml.tmpl")
-	if err != nil {
-		return "", fmt.Errorf("datadog pack asset %q: %w", "pack/conf.yaml.tmpl", err)
-	}
-	return strings.ReplaceAll(content, "{{LOG_PATH}}", logPath), nil
-}
-
-// filesFromFS builds the full file list from the supplied FS, propagating any
-// read errors instead of panicking.
-func filesFromFS(fsys fs.FS, logPath string) ([]File, error) {
-	readme, err := siempack.ReadFile(fsys, "pack/README.md")
-	if err != nil {
-		return nil, fmt.Errorf("datadog pack asset %q: %w", "pack/README.md", err)
-	}
-	conf, err := configSnippetFromFS(fsys, logPath)
-	if err != nil {
-		return nil, err
-	}
-	sample, err := siempack.ReadFile(fsys, "pack/sample-event.jsonl")
-	if err != nil {
-		return nil, fmt.Errorf("datadog pack asset %q: %w", "pack/sample-event.jsonl", err)
-	}
-	return []File{
-		{Name: "README.md", Content: readme},
-		{Name: "conf.yaml", Content: conf},
-		{Name: "sample-event.jsonl", Content: sample},
-	}, nil
-}
-
-// Files returns all pack files rendered with DefaultLogPath, propagating any
-// embedded asset read error.
-func Files() ([]File, error) {
-	return filesFromFS(packFS, DefaultLogPath)
+	return pack.WithFS(fsys).Render(configAsset, logPath)
 }
 
 // ConfigSnippet returns the Datadog Agent conf.yaml snippet with logPath substituted.
-func ConfigSnippet(logPath string) (string, error) {
-	return configSnippetFromFS(packFS, logPath)
-}
+func ConfigSnippet(logPath string) (string, error) { return pack.Render(configAsset, logPath) }
+
+// Files returns all pack files, propagating any embedded asset read error.
+func Files() ([]File, error) { return pack.Files() }
 
 // InstallPack writes the pack files to outputDir with logPath substituted.
-func InstallPack(outputDir, logPath string) error {
-	if outputDir == "" {
-		outputDir = DefaultOutputDir
-	}
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return err
-	}
-	files, err := filesFromFS(packFS, logPath)
-	if err != nil {
-		return err
-	}
-	for _, file := range files {
-		if err := os.WriteFile(filepath.Join(outputDir, file.Name), []byte(file.Content), 0644); err != nil {
-			return err
-		}
-	}
-	return nil
-}
+func InstallPack(outputDir, logPath string) error { return pack.Install(outputDir, logPath) }

--- a/cli/beacon/internal/endpoint/gcs/gcs.go
+++ b/cli/beacon/internal/endpoint/gcs/gcs.go
@@ -2,7 +2,6 @@ package gcs
 
 import (
 	"embed"
-	"fmt"
 	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -16,98 +15,41 @@ const (
 	DefaultOutputDir = "beacon-gcs-pack"
 )
 
-type File struct {
-	Name            string
-	Content         string
-	TemplateLogPath bool
-	JSONEscape      bool
+const smokeTestAsset = "pack/gcs-upload-smoke-test.sh.tmpl"
+
+// File is the installable pack-file type, shared with siempack.
+type File = siempack.File
+
+var pack = siempack.Pack{
+	Label:            "gcs",
+	FS:               packFS,
+	DefaultLogPath:   DefaultLogPath,
+	DefaultOutputDir: DefaultOutputDir,
+	Assets: []siempack.Asset{
+		{Source: "pack/README.md", Name: "README.md"},
+		{Source: smokeTestAsset, Name: "gcs-upload-smoke-test.sh", TemplateLogPath: true},
+		{Source: "pack/sample-event.jsonl", Name: "sample-event.jsonl"},
+		{Source: "pack/vector.toml.tmpl", Name: "vector.toml", TemplateLogPath: true},
+	},
 }
 
-// readAsset reads an embedded asset using the module-level packFS and returns its
-// contents or an error.
-func readAsset(path string) (string, error) {
-	data, err := siempack.ReadFile(packFS, path)
-	if err != nil {
-		return "", fmt.Errorf("gcs pack asset %q: %w", path, err)
-	}
-	return data, nil
-}
+// mustRead returns the embedded asset at path or panics. Retained for test use.
+func mustRead(path string) string { return pack.MustRead(path) }
 
-// mustRead returns the embedded asset at path or panics. Retained for test use
-// where the embedded FS is always present; all production code uses readAsset.
-func mustRead(path string) string {
-	s, err := readAsset(path)
-	if err != nil {
-		panic(err.Error())
-	}
-	return s
-}
+// filesFromFS builds the file list from the supplied FS; tests use it to inject
+// read-error conditions.
+func filesFromFS(fsys fs.FS) ([]File, error) { return pack.WithFS(fsys).Files() }
 
 // uploadSmokeTestFromFS renders the GCS upload smoke-test script using the supplied FS.
 func uploadSmokeTestFromFS(fsys fs.FS, logPath string) (string, error) {
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	content, err := siempack.ReadFile(fsys, "pack/gcs-upload-smoke-test.sh.tmpl")
-	if err != nil {
-		return "", fmt.Errorf("gcs pack asset %q: %w", "pack/gcs-upload-smoke-test.sh.tmpl", err)
-	}
-	return siempack.RenderLogPath(content, logPath), nil
-}
-
-// filesFromFS builds the full file list from the supplied FS, propagating any
-// read errors instead of panicking. Template substitution of LOG_PATH is
-// deferred to siempack.Install via the TemplateLogPath field.
-func filesFromFS(fsys fs.FS) ([]File, error) {
-	readme, err := siempack.ReadFile(fsys, "pack/README.md")
-	if err != nil {
-		return nil, fmt.Errorf("gcs pack asset %q: %w", "pack/README.md", err)
-	}
-	smokeTest, err := siempack.ReadFile(fsys, "pack/gcs-upload-smoke-test.sh.tmpl")
-	if err != nil {
-		return nil, fmt.Errorf("gcs pack asset %q: %w", "pack/gcs-upload-smoke-test.sh.tmpl", err)
-	}
-	sample, err := siempack.ReadFile(fsys, "pack/sample-event.jsonl")
-	if err != nil {
-		return nil, fmt.Errorf("gcs pack asset %q: %w", "pack/sample-event.jsonl", err)
-	}
-	vector, err := siempack.ReadFile(fsys, "pack/vector.toml.tmpl")
-	if err != nil {
-		return nil, fmt.Errorf("gcs pack asset %q: %w", "pack/vector.toml.tmpl", err)
-	}
-	return []File{
-		{Name: "README.md", Content: readme},
-		{Name: "gcs-upload-smoke-test.sh", Content: smokeTest, TemplateLogPath: true},
-		{Name: "sample-event.jsonl", Content: sample},
-		{Name: "vector.toml", Content: vector, TemplateLogPath: true},
-	}, nil
+	return pack.WithFS(fsys).Render(smokeTestAsset, logPath)
 }
 
 // Files returns all pack files, propagating any embedded asset read error.
-func Files() ([]File, error) {
-	return filesFromFS(packFS)
-}
+func Files() ([]File, error) { return pack.Files() }
 
 // UploadSmokeTest returns the GCS upload smoke-test script with logPath substituted.
-func UploadSmokeTest(logPath string) (string, error) {
-	return uploadSmokeTestFromFS(packFS, logPath)
-}
+func UploadSmokeTest(logPath string) (string, error) { return pack.Render(smokeTestAsset, logPath) }
 
 // InstallPack writes the pack files to outputDir with logPath substituted.
-func InstallPack(outputDir, logPath string) error {
-	if outputDir == "" {
-		outputDir = DefaultOutputDir
-	}
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	files, err := filesFromFS(packFS)
-	if err != nil {
-		return err
-	}
-	sfiles := make([]siempack.File, 0, len(files))
-	for _, file := range files {
-		sfiles = append(sfiles, siempack.File(file))
-	}
-	return siempack.Install(outputDir, sfiles, logPath)
-}
+func InstallPack(outputDir, logPath string) error { return pack.Install(outputDir, logPath) }

--- a/cli/beacon/internal/endpoint/rapid7/rapid7.go
+++ b/cli/beacon/internal/endpoint/rapid7/rapid7.go
@@ -2,7 +2,6 @@ package rapid7
 
 import (
 	"embed"
-	"fmt"
 	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -16,98 +15,41 @@ const (
 	DefaultOutputDir = "beacon-rapid7-pack"
 )
 
-type File struct {
-	Name            string
-	Content         string
-	TemplateLogPath bool
-	JSONEscape      bool
+const smokeTestAsset = "pack/rapid7-upload-smoke-test.sh.tmpl"
+
+// File is the installable pack-file type, shared with siempack.
+type File = siempack.File
+
+var pack = siempack.Pack{
+	Label:            "rapid7",
+	FS:               packFS,
+	DefaultLogPath:   DefaultLogPath,
+	DefaultOutputDir: DefaultOutputDir,
+	Assets: []siempack.Asset{
+		{Source: "pack/README.md", Name: "README.md"},
+		{Source: smokeTestAsset, Name: "rapid7-upload-smoke-test.sh", TemplateLogPath: true},
+		{Source: "pack/sample-event.jsonl", Name: "sample-event.jsonl"},
+		{Source: "pack/vector.toml.tmpl", Name: "vector.toml", TemplateLogPath: true},
+	},
 }
 
-// readAsset reads an embedded asset using the module-level packFS and returns its
-// contents or an error.
-func readAsset(path string) (string, error) {
-	data, err := siempack.ReadFile(packFS, path)
-	if err != nil {
-		return "", fmt.Errorf("rapid7 pack asset %q: %w", path, err)
-	}
-	return data, nil
-}
+// mustRead returns the embedded asset at path or panics. Retained for test use.
+func mustRead(path string) string { return pack.MustRead(path) }
 
-// mustRead returns the embedded asset at path or panics. Retained for test use
-// where the embedded FS is always present; all production code uses readAsset.
-func mustRead(path string) string {
-	s, err := readAsset(path)
-	if err != nil {
-		panic(err.Error())
-	}
-	return s
-}
+// filesFromFS builds the file list from the supplied FS; tests use it to inject
+// read-error conditions.
+func filesFromFS(fsys fs.FS) ([]File, error) { return pack.WithFS(fsys).Files() }
 
 // uploadSmokeTestFromFS renders the Rapid7 upload smoke-test script using the supplied FS.
 func uploadSmokeTestFromFS(fsys fs.FS, logPath string) (string, error) {
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	content, err := siempack.ReadFile(fsys, "pack/rapid7-upload-smoke-test.sh.tmpl")
-	if err != nil {
-		return "", fmt.Errorf("rapid7 pack asset %q: %w", "pack/rapid7-upload-smoke-test.sh.tmpl", err)
-	}
-	return siempack.RenderLogPath(content, logPath), nil
-}
-
-// filesFromFS builds the full file list from the supplied FS, propagating any
-// read errors instead of panicking. Template substitution of LOG_PATH is
-// deferred to siempack.Install via the TemplateLogPath field.
-func filesFromFS(fsys fs.FS) ([]File, error) {
-	readme, err := siempack.ReadFile(fsys, "pack/README.md")
-	if err != nil {
-		return nil, fmt.Errorf("rapid7 pack asset %q: %w", "pack/README.md", err)
-	}
-	smokeTest, err := siempack.ReadFile(fsys, "pack/rapid7-upload-smoke-test.sh.tmpl")
-	if err != nil {
-		return nil, fmt.Errorf("rapid7 pack asset %q: %w", "pack/rapid7-upload-smoke-test.sh.tmpl", err)
-	}
-	sample, err := siempack.ReadFile(fsys, "pack/sample-event.jsonl")
-	if err != nil {
-		return nil, fmt.Errorf("rapid7 pack asset %q: %w", "pack/sample-event.jsonl", err)
-	}
-	vector, err := siempack.ReadFile(fsys, "pack/vector.toml.tmpl")
-	if err != nil {
-		return nil, fmt.Errorf("rapid7 pack asset %q: %w", "pack/vector.toml.tmpl", err)
-	}
-	return []File{
-		{Name: "README.md", Content: readme},
-		{Name: "rapid7-upload-smoke-test.sh", Content: smokeTest, TemplateLogPath: true},
-		{Name: "sample-event.jsonl", Content: sample},
-		{Name: "vector.toml", Content: vector, TemplateLogPath: true},
-	}, nil
+	return pack.WithFS(fsys).Render(smokeTestAsset, logPath)
 }
 
 // Files returns all pack files, propagating any embedded asset read error.
-func Files() ([]File, error) {
-	return filesFromFS(packFS)
-}
+func Files() ([]File, error) { return pack.Files() }
 
 // UploadSmokeTest returns the Rapid7 upload smoke-test script with logPath substituted.
-func UploadSmokeTest(logPath string) (string, error) {
-	return uploadSmokeTestFromFS(packFS, logPath)
-}
+func UploadSmokeTest(logPath string) (string, error) { return pack.Render(smokeTestAsset, logPath) }
 
 // InstallPack writes the pack files to outputDir with logPath substituted.
-func InstallPack(outputDir, logPath string) error {
-	if outputDir == "" {
-		outputDir = DefaultOutputDir
-	}
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	files, err := filesFromFS(packFS)
-	if err != nil {
-		return err
-	}
-	sfiles := make([]siempack.File, 0, len(files))
-	for _, file := range files {
-		sfiles = append(sfiles, siempack.File(file))
-	}
-	return siempack.Install(outputDir, sfiles, logPath)
-}
+func InstallPack(outputDir, logPath string) error { return pack.Install(outputDir, logPath) }

--- a/cli/beacon/internal/endpoint/s3/s3.go
+++ b/cli/beacon/internal/endpoint/s3/s3.go
@@ -2,7 +2,6 @@ package s3
 
 import (
 	"embed"
-	"fmt"
 	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -16,98 +15,41 @@ const (
 	DefaultOutputDir = "beacon-s3-pack"
 )
 
-type File struct {
-	Name            string
-	Content         string
-	TemplateLogPath bool
-	JSONEscape      bool
+const smokeTestAsset = "pack/s3-upload-smoke-test.sh.tmpl"
+
+// File is the installable pack-file type, shared with siempack.
+type File = siempack.File
+
+var pack = siempack.Pack{
+	Label:            "s3",
+	FS:               packFS,
+	DefaultLogPath:   DefaultLogPath,
+	DefaultOutputDir: DefaultOutputDir,
+	Assets: []siempack.Asset{
+		{Source: "pack/README.md", Name: "README.md"},
+		{Source: smokeTestAsset, Name: "s3-upload-smoke-test.sh", TemplateLogPath: true},
+		{Source: "pack/sample-event.jsonl", Name: "sample-event.jsonl"},
+		{Source: "pack/vector.toml.tmpl", Name: "vector.toml", TemplateLogPath: true},
+	},
 }
 
-// readAsset reads an embedded asset using the module-level packFS and returns its
-// contents or an error.
-func readAsset(path string) (string, error) {
-	data, err := siempack.ReadFile(packFS, path)
-	if err != nil {
-		return "", fmt.Errorf("s3 pack asset %q: %w", path, err)
-	}
-	return data, nil
-}
+// mustRead returns the embedded asset at path or panics. Retained for test use.
+func mustRead(path string) string { return pack.MustRead(path) }
 
-// mustRead returns the embedded asset at path or panics. Retained for test use
-// where the embedded FS is always present; all production code uses readAsset.
-func mustRead(path string) string {
-	s, err := readAsset(path)
-	if err != nil {
-		panic(err.Error())
-	}
-	return s
-}
+// filesFromFS builds the file list from the supplied FS; tests use it to inject
+// read-error conditions.
+func filesFromFS(fsys fs.FS) ([]File, error) { return pack.WithFS(fsys).Files() }
 
 // uploadSmokeTestFromFS renders the S3 upload smoke-test script using the supplied FS.
 func uploadSmokeTestFromFS(fsys fs.FS, logPath string) (string, error) {
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	content, err := siempack.ReadFile(fsys, "pack/s3-upload-smoke-test.sh.tmpl")
-	if err != nil {
-		return "", fmt.Errorf("s3 pack asset %q: %w", "pack/s3-upload-smoke-test.sh.tmpl", err)
-	}
-	return siempack.RenderLogPath(content, logPath), nil
-}
-
-// filesFromFS builds the full file list from the supplied FS, propagating any
-// read errors instead of panicking. Template substitution of LOG_PATH is
-// deferred to siempack.Install via the TemplateLogPath field.
-func filesFromFS(fsys fs.FS) ([]File, error) {
-	readme, err := siempack.ReadFile(fsys, "pack/README.md")
-	if err != nil {
-		return nil, fmt.Errorf("s3 pack asset %q: %w", "pack/README.md", err)
-	}
-	smokeTest, err := siempack.ReadFile(fsys, "pack/s3-upload-smoke-test.sh.tmpl")
-	if err != nil {
-		return nil, fmt.Errorf("s3 pack asset %q: %w", "pack/s3-upload-smoke-test.sh.tmpl", err)
-	}
-	sample, err := siempack.ReadFile(fsys, "pack/sample-event.jsonl")
-	if err != nil {
-		return nil, fmt.Errorf("s3 pack asset %q: %w", "pack/sample-event.jsonl", err)
-	}
-	vector, err := siempack.ReadFile(fsys, "pack/vector.toml.tmpl")
-	if err != nil {
-		return nil, fmt.Errorf("s3 pack asset %q: %w", "pack/vector.toml.tmpl", err)
-	}
-	return []File{
-		{Name: "README.md", Content: readme},
-		{Name: "s3-upload-smoke-test.sh", Content: smokeTest, TemplateLogPath: true},
-		{Name: "sample-event.jsonl", Content: sample},
-		{Name: "vector.toml", Content: vector, TemplateLogPath: true},
-	}, nil
+	return pack.WithFS(fsys).Render(smokeTestAsset, logPath)
 }
 
 // Files returns all pack files, propagating any embedded asset read error.
-func Files() ([]File, error) {
-	return filesFromFS(packFS)
-}
+func Files() ([]File, error) { return pack.Files() }
 
 // UploadSmokeTest returns the S3 upload smoke-test script with logPath substituted.
-func UploadSmokeTest(logPath string) (string, error) {
-	return uploadSmokeTestFromFS(packFS, logPath)
-}
+func UploadSmokeTest(logPath string) (string, error) { return pack.Render(smokeTestAsset, logPath) }
 
 // InstallPack writes the pack files to outputDir with logPath substituted.
-func InstallPack(outputDir, logPath string) error {
-	if outputDir == "" {
-		outputDir = DefaultOutputDir
-	}
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	files, err := filesFromFS(packFS)
-	if err != nil {
-		return err
-	}
-	sfiles := make([]siempack.File, 0, len(files))
-	for _, file := range files {
-		sfiles = append(sfiles, siempack.File(file))
-	}
-	return siempack.Install(outputDir, sfiles, logPath)
-}
+func InstallPack(outputDir, logPath string) error { return pack.Install(outputDir, logPath) }

--- a/cli/beacon/internal/endpoint/siempack/pack_test.go
+++ b/cli/beacon/internal/endpoint/siempack/pack_test.go
@@ -1,0 +1,109 @@
+package siempack
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+)
+
+func testPack() Pack {
+	return Pack{
+		Label:            "demo",
+		DefaultLogPath:   "/var/log/beacon-agent/runtime.jsonl",
+		DefaultOutputDir: "beacon-demo-pack",
+		FS: fstest.MapFS{
+			"pack/README.md":      {Data: []byte("readme")},
+			"pack/run.sh.tmpl":    {Data: []byte("log={{LOG_PATH}}\n")},
+			"pack/sample.jsonl":   {Data: []byte("{\"a\":1}\n")},
+			"pack/conf.json.tmpl": {Data: []byte("{\"path\":\"{{LOG_PATH}}\"}")},
+		},
+		Assets: []Asset{
+			{Source: "pack/README.md", Name: "README.md"},
+			{Source: "pack/run.sh.tmpl", Name: "run.sh", TemplateLogPath: true},
+			{Source: "pack/sample.jsonl", Name: "sample.jsonl"},
+			{Source: "pack/conf.json.tmpl", Name: "conf.json", TemplateLogPath: true, JSONEscape: true},
+		},
+	}
+}
+
+func TestPackFilesReturnsUnrenderedContentWithFlags(t *testing.T) {
+	files, err := testPack().Files()
+	if err != nil {
+		t.Fatalf("Files() error: %v", err)
+	}
+	if len(files) != 4 {
+		t.Fatalf("Files() returned %d files, want 4", len(files))
+	}
+	// run.sh keeps the token unrendered; substitution is deferred to Install.
+	if files[1].Name != "run.sh" || files[1].Content != "log={{LOG_PATH}}\n" || !files[1].TemplateLogPath {
+		t.Fatalf("run.sh entry = %+v", files[1])
+	}
+	if !files[3].JSONEscape {
+		t.Fatalf("conf.json should carry JSONEscape flag: %+v", files[3])
+	}
+}
+
+func TestPackRenderSubstitutesLogPathAndDefaults(t *testing.T) {
+	p := testPack()
+	got, err := p.Render("pack/run.sh.tmpl", "/custom/path.jsonl")
+	if err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	if got != "log=/custom/path.jsonl\n" {
+		t.Fatalf("Render = %q", got)
+	}
+	def, err := p.Render("pack/run.sh.tmpl", "")
+	if err != nil {
+		t.Fatalf("Render default error: %v", err)
+	}
+	if def != "log="+p.DefaultLogPath+"\n" {
+		t.Fatalf("Render with empty logPath = %q, want DefaultLogPath", def)
+	}
+}
+
+func TestPackInstallWritesRenderedFilesWithModes(t *testing.T) {
+	dir := t.TempDir()
+	if err := testPack().Install(dir, "/custom/path.jsonl"); err != nil {
+		t.Fatalf("Install error: %v", err)
+	}
+
+	run, err := os.ReadFile(filepath.Join(dir, "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(run) != "log=/custom/path.jsonl\n" {
+		t.Fatalf("installed run.sh = %q", run)
+	}
+	// .sh files are executable.
+	info, err := os.Stat(filepath.Join(dir, "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Fatalf("run.sh mode = %v, want 0755", info.Mode().Perm())
+	}
+
+	// JSON-escaped substitution keeps the surrounding JSON valid.
+	conf, err := os.ReadFile(filepath.Join(dir, "conf.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(conf) != "{\"path\":\"/custom/path.jsonl\"}" {
+		t.Fatalf("installed conf.json = %q", conf)
+	}
+}
+
+func TestPackReadAndMustReadWrapErrorsWithLabel(t *testing.T) {
+	p := testPack().WithFS(fstest.MapFS{})
+	_, err := p.Read("pack/README.md")
+	if err == nil {
+		t.Fatal("Read of missing asset should error")
+	}
+	defer func() {
+		if recover() == nil {
+			t.Fatal("MustRead of missing asset should panic")
+		}
+	}()
+	_ = p.MustRead("pack/README.md")
+}

--- a/cli/beacon/internal/endpoint/siempack/siempack.go
+++ b/cli/beacon/internal/endpoint/siempack/siempack.go
@@ -2,6 +2,7 @@ package siempack
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -61,4 +62,102 @@ func Mode(name string) os.FileMode {
 		return 0755
 	}
 	return 0644
+}
+
+// Asset describes one embedded pack file and how it maps into an installed pack.
+type Asset struct {
+	// Source is the path within the embedded FS, e.g. "pack/vector.toml.tmpl".
+	Source string
+	// Name is the output filename, e.g. "vector.toml".
+	Name string
+	// TemplateLogPath substitutes the runtime log path into the content on install.
+	TemplateLogPath bool
+	// JSONEscape escapes the substituted log path for embedding in a JSON string.
+	JSONEscape bool
+}
+
+// Pack is an embedded content pack for a single forwarding destination. It
+// centralizes the asset-read, file-list, render, and install boilerplate that
+// would otherwise be duplicated across destination packages.
+type Pack struct {
+	// Label prefixes asset-read error messages, e.g. "sumo".
+	Label            string
+	FS               fs.FS
+	DefaultLogPath   string
+	DefaultOutputDir string
+	Assets           []Asset
+}
+
+// WithFS returns a copy of the pack reading from fsys instead of p.FS. It lets
+// callers inject a test FS to exercise read-error paths.
+func (p Pack) WithFS(fsys fs.FS) Pack {
+	p.FS = fsys
+	return p
+}
+
+// Read returns the embedded asset at path, wrapping read errors with the label.
+func (p Pack) Read(path string) (string, error) {
+	content, err := ReadFile(p.FS, path)
+	if err != nil {
+		return "", fmt.Errorf("%s pack asset %q: %w", p.Label, path, err)
+	}
+	return content, nil
+}
+
+// MustRead returns the embedded asset at path or panics. Intended for test and
+// package-init use where the embedded FS is always present.
+func (p Pack) MustRead(path string) string {
+	content, err := p.Read(path)
+	if err != nil {
+		panic(err.Error())
+	}
+	return content
+}
+
+// Files reads every asset and returns the pack's files. Log-path substitution is
+// deferred to Install via the per-file TemplateLogPath flag.
+func (p Pack) Files() ([]File, error) {
+	files := make([]File, 0, len(p.Assets))
+	for _, a := range p.Assets {
+		content, err := p.Read(a.Source)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, File{
+			Name:            a.Name,
+			Content:         content,
+			TemplateLogPath: a.TemplateLogPath,
+			JSONEscape:      a.JSONEscape,
+		})
+	}
+	return files, nil
+}
+
+// Render reads a single template asset and substitutes logPath (defaulting to
+// DefaultLogPath). Used by print-config snippet helpers.
+func (p Pack) Render(assetPath, logPath string) (string, error) {
+	if logPath == "" {
+		logPath = p.DefaultLogPath
+	}
+	content, err := p.Read(assetPath)
+	if err != nil {
+		return "", err
+	}
+	return RenderLogPath(content, logPath), nil
+}
+
+// Install writes the pack files to outputDir (defaulting to DefaultOutputDir),
+// substituting logPath (defaulting to DefaultLogPath) into templated files.
+func (p Pack) Install(outputDir, logPath string) error {
+	if outputDir == "" {
+		outputDir = p.DefaultOutputDir
+	}
+	if logPath == "" {
+		logPath = p.DefaultLogPath
+	}
+	files, err := p.Files()
+	if err != nil {
+		return err
+	}
+	return Install(outputDir, files, logPath)
 }

--- a/cli/beacon/internal/endpoint/sumo/sumo.go
+++ b/cli/beacon/internal/endpoint/sumo/sumo.go
@@ -2,7 +2,6 @@ package sumo
 
 import (
 	"embed"
-	"fmt"
 	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -16,98 +15,41 @@ const (
 	DefaultOutputDir = "beacon-sumo-pack"
 )
 
-type File struct {
-	Name            string
-	Content         string
-	TemplateLogPath bool
-	JSONEscape      bool
+const smokeTestAsset = "pack/sumo-upload-smoke-test.sh.tmpl"
+
+// File is the installable pack-file type, shared with siempack.
+type File = siempack.File
+
+var pack = siempack.Pack{
+	Label:            "sumo",
+	FS:               packFS,
+	DefaultLogPath:   DefaultLogPath,
+	DefaultOutputDir: DefaultOutputDir,
+	Assets: []siempack.Asset{
+		{Source: "pack/README.md", Name: "README.md"},
+		{Source: smokeTestAsset, Name: "sumo-upload-smoke-test.sh", TemplateLogPath: true},
+		{Source: "pack/sample-event.jsonl", Name: "sample-event.jsonl"},
+		{Source: "pack/vector.toml.tmpl", Name: "vector.toml", TemplateLogPath: true},
+	},
 }
 
-// readAsset reads an embedded asset using the module-level packFS and returns its
-// contents or an error.
-func readAsset(path string) (string, error) {
-	data, err := siempack.ReadFile(packFS, path)
-	if err != nil {
-		return "", fmt.Errorf("sumo pack asset %q: %w", path, err)
-	}
-	return data, nil
-}
+// mustRead returns the embedded asset at path or panics. Retained for test use.
+func mustRead(path string) string { return pack.MustRead(path) }
 
-// mustRead returns the embedded asset at path or panics. Retained for test use
-// where the embedded FS is always present; all production code uses readAsset.
-func mustRead(path string) string {
-	s, err := readAsset(path)
-	if err != nil {
-		panic(err.Error())
-	}
-	return s
-}
+// filesFromFS builds the file list from the supplied FS; tests use it to inject
+// read-error conditions.
+func filesFromFS(fsys fs.FS) ([]File, error) { return pack.WithFS(fsys).Files() }
 
 // uploadSmokeTestFromFS renders the Sumo upload smoke-test script using the supplied FS.
 func uploadSmokeTestFromFS(fsys fs.FS, logPath string) (string, error) {
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	content, err := siempack.ReadFile(fsys, "pack/sumo-upload-smoke-test.sh.tmpl")
-	if err != nil {
-		return "", fmt.Errorf("sumo pack asset %q: %w", "pack/sumo-upload-smoke-test.sh.tmpl", err)
-	}
-	return siempack.RenderLogPath(content, logPath), nil
-}
-
-// filesFromFS builds the full file list from the supplied FS, propagating any
-// read errors instead of panicking. Template substitution of LOG_PATH is
-// deferred to siempack.Install via the TemplateLogPath field.
-func filesFromFS(fsys fs.FS) ([]File, error) {
-	readme, err := siempack.ReadFile(fsys, "pack/README.md")
-	if err != nil {
-		return nil, fmt.Errorf("sumo pack asset %q: %w", "pack/README.md", err)
-	}
-	smokeTest, err := siempack.ReadFile(fsys, "pack/sumo-upload-smoke-test.sh.tmpl")
-	if err != nil {
-		return nil, fmt.Errorf("sumo pack asset %q: %w", "pack/sumo-upload-smoke-test.sh.tmpl", err)
-	}
-	sample, err := siempack.ReadFile(fsys, "pack/sample-event.jsonl")
-	if err != nil {
-		return nil, fmt.Errorf("sumo pack asset %q: %w", "pack/sample-event.jsonl", err)
-	}
-	vector, err := siempack.ReadFile(fsys, "pack/vector.toml.tmpl")
-	if err != nil {
-		return nil, fmt.Errorf("sumo pack asset %q: %w", "pack/vector.toml.tmpl", err)
-	}
-	return []File{
-		{Name: "README.md", Content: readme},
-		{Name: "sumo-upload-smoke-test.sh", Content: smokeTest, TemplateLogPath: true},
-		{Name: "sample-event.jsonl", Content: sample},
-		{Name: "vector.toml", Content: vector, TemplateLogPath: true},
-	}, nil
+	return pack.WithFS(fsys).Render(smokeTestAsset, logPath)
 }
 
 // Files returns all pack files, propagating any embedded asset read error.
-func Files() ([]File, error) {
-	return filesFromFS(packFS)
-}
+func Files() ([]File, error) { return pack.Files() }
 
 // UploadSmokeTest returns the Sumo upload smoke-test script with logPath substituted.
-func UploadSmokeTest(logPath string) (string, error) {
-	return uploadSmokeTestFromFS(packFS, logPath)
-}
+func UploadSmokeTest(logPath string) (string, error) { return pack.Render(smokeTestAsset, logPath) }
 
 // InstallPack writes the pack files to outputDir with logPath substituted.
-func InstallPack(outputDir, logPath string) error {
-	if outputDir == "" {
-		outputDir = DefaultOutputDir
-	}
-	if logPath == "" {
-		logPath = DefaultLogPath
-	}
-	files, err := filesFromFS(packFS)
-	if err != nil {
-		return err
-	}
-	sfiles := make([]siempack.File, 0, len(files))
-	for _, file := range files {
-		sfiles = append(sfiles, siempack.File(file))
-	}
-	return siempack.Install(outputDir, sfiles, logPath)
-}
+func InstallPack(outputDir, logPath string) error { return pack.Install(outputDir, logPath) }


### PR DESCRIPTION
## Package-side destination dedup (#1 from the post-Phase-3 backlog)

Adds `siempack.Pack` (+ `siempack.Asset`) to centralize the embedded-asset read, file-list, render, and install boilerplate that was copy-pasted across the destination content-pack packages. Each pack is now a small manifest — label, embed FS, default log path/output dir, and an asset→file list — and the public `Files` / `InstallPack` / `ConfigSnippet` / `UploadSmokeTest` functions delegate to the shared helper. This complements the Phase-1 cmd-side destination registry: the package side is now data-driven too.

### What changed
- **`siempack.go`**: new `Pack`/`Asset` types with `Read`/`MustRead`/`WithFS`/`Files`/`Render`/`Install` methods (built on the existing `Install`/`RenderLogPath`/`Mode` primitives).
- Converted **datadog, sumo, rapid7, s3, gcs, cloudwatch** to the builder — each drops from ~110 to ~55 lines. **Net −485 / +362 lines** (the +362 includes the new shared builder and its tests).
- Left **sentinel** (computed KQL/DCR content, not a pure asset manifest), **wazuh**, and **elastic** bespoke.

### Behavior preserved
- Each package keeps its **public API** and the **internal test seams** (`mustRead`, `filesFromFS`, `*FromFS`) as thin delegations, so every existing package test passes unchanged — including install-output content, snippet rendering, read-error propagation (injected FS), and default-log-path paths.
- datadog moves from eager-render + a local write loop to the shared deferred-render install; on-disk output is identical (verified by its existing `InstallPack` test that reads `conf.yaml` back).
- New `siempack.Pack` unit tests (`pack_test.go`) cover Files/Render/Install/Read incl. `.sh` exec mode and JSON-escaped substitution.
- `go test ./...` (minus the pre-existing macOS-`hooks.bin` env failures), `-race` on the affected packages, `go vet`, `gofmt`, and the cmd destination characterization tests all pass; **`beacon docs` is byte-identical** to baseline.

### Note on CI environment
As with the earlier PRs, the `embedded`/`hooks`/`harness`/`lifecycle` failures on Linux (macOS `hooks.bin` placeholder) are pre-existing and unrelated to this change.

https://claude.ai/code/session_011RgMGykN4dt1PqphVehJN8

---
_Generated by [Claude Code](https://claude.ai/code/session_011RgMGykN4dt1PqphVehJN8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install/snippet output paths for multiple forwarding destinations; behavior is intended to be identical but datadog’s install path changed implementation.
> 
> **Overview**
> Introduces **`siempack.Pack`** and **`siempack.Asset`** so embedded SIEM destination packs are declared as manifests (label, embed FS, defaults, asset list) instead of duplicating read/list/render/install logic in each package.
> 
> **cloudwatch**, **datadog**, **sumo**, **rapid7**, **s3**, and **gcs** are converted to thin wrappers: `File` aliases `siempack.File`, and `Files` / `InstallPack` / `ConfigSnippet` / smoke-test helpers delegate to `pack.Files()`, `pack.Install()`, and `pack.Render()`. Test seams (`mustRead`, `filesFromFS`, `*FromFS`) remain as delegations to `WithFS` for injected FS errors.
> 
> **Datadog** drops its custom install write loop and eager `Files()` rendering with `DefaultLogPath`; install now uses shared deferred `{{LOG_PATH}}` substitution like the other packs. New **`pack_test.go`** exercises unrendered `Files()`, `Render` defaults, install modes (`.sh` 0755), and JSON-escaped paths.
> 
> Sentinel, wazuh, and elastic are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c27fc1c94233e347b3092303f4f5b238122e4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->