### PR TITLE
refactor(harness): extract shared executable-detection helper

### DIFF
--- a/cli/beacon/internal/endpoint/harness/copilot.go
+++ b/cli/beacon/internal/endpoint/harness/copilot.go
@@ -3,7 +3,6 @@ package harness
 import (
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -14,12 +13,7 @@ func DiscoverCopilotCLI() Harness {
 
 func discoverCopilotCLI(expectedEndpoint string) Harness {
 	h := Harness{Name: "copilot_cli", DisplayName: "GitHub Copilot CLI", Capability: "otel_env"}
-	path, err := exec.LookPath("copilot")
-	if err == nil {
-		h.Detected = true
-		h.ExecutablePath = path
-		h.Version = commandVersion(path)
-	}
+	detectExecutable(&h, "copilot")
 	home, _ := os.UserHomeDir()
 	if !h.Detected && fileExists(filepath.Join(home, ".copilot", "config.json")) {
 		h.Detected = true

--- a/cli/beacon/internal/endpoint/harness/gemini.go
+++ b/cli/beacon/internal/endpoint/harness/gemini.go
@@ -4,19 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
 
 func DiscoverGemini() Harness {
 	h := Harness{Name: "gemini_cli", DisplayName: "Gemini CLI", Capability: "otel_config"}
-	path, err := exec.LookPath("gemini")
-	if err == nil {
-		h.Detected = true
-		h.ExecutablePath = path
-		h.Version = commandVersion(path)
-	}
+	detectExecutable(&h, "gemini")
 	home, _ := os.UserHomeDir()
 	h.ConfigPath = filepath.Join(home, ".gemini", "settings.json")
 	if fileExists(h.ConfigPath) {

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -66,15 +66,7 @@ func DiscoverAll() []Harness {
 
 func DiscoverAntigravity() Harness {
 	h := Harness{Name: "antigravity_cli", DisplayName: "Antigravity CLI", Capability: "hooks"}
-	for _, name := range []string{"antigravity", "antigravity-cli"} {
-		path, err := exec.LookPath(name)
-		if err == nil {
-			h.Detected = true
-			h.ExecutablePath = path
-			h.Version = commandVersion(path)
-			break
-		}
-	}
+	detectExecutable(&h, "antigravity", "antigravity-cli")
 	home, _ := os.UserHomeDir()
 	userConfig := filepath.Join(home, ".gemini", "config", "hooks.json")
 	projectConfig := filepath.Join(".agents", "hooks.json")
@@ -98,12 +90,7 @@ func DiscoverAntigravity() Harness {
 
 func DiscoverClaude() Harness {
 	h := Harness{Name: "claude_code", DisplayName: "Claude Code", Capability: "otel_env"}
-	path, err := exec.LookPath("claude")
-	if err == nil {
-		h.Detected = true
-		h.ExecutablePath = path
-		h.Version = commandVersion(path)
-	}
+	detectExecutable(&h, "claude")
 	home, _ := os.UserHomeDir()
 	userConfig := filepath.Join(home, ".claude", "settings.json")
 	managedConfig := "/Library/Application Support/ClaudeCode/managed-settings.json"
@@ -130,12 +117,7 @@ func DiscoverClaude() Harness {
 
 func DiscoverCodex() Harness {
 	h := Harness{Name: "codex_cli", DisplayName: "Codex CLI", Capability: "otel_config"}
-	path, err := exec.LookPath("codex")
-	if err == nil {
-		h.Detected = true
-		h.ExecutablePath = path
-		h.Version = commandVersion(path)
-	}
+	detectExecutable(&h, "codex")
 	home, _ := os.UserHomeDir()
 	h.ConfigPath = filepath.Join(home, ".codex", "config.toml")
 	if fileExists(h.ConfigPath) {
@@ -151,12 +133,7 @@ func DiscoverCodex() Harness {
 
 func DiscoverFactory() Harness {
 	h := Harness{Name: "factory", DisplayName: "Factory Droid", Capability: "otel_env"}
-	path, err := exec.LookPath("droid")
-	if err == nil {
-		h.Detected = true
-		h.ExecutablePath = path
-		h.Version = commandVersion(path)
-	}
+	detectExecutable(&h, "droid")
 	home, _ := os.UserHomeDir()
 	h.ConfigPath = factoryProfilePath(home)
 	if fileExists(h.ConfigPath) {
@@ -172,12 +149,7 @@ func DiscoverFactory() Harness {
 
 func DiscoverOpenCode() Harness {
 	h := Harness{Name: "opencode", DisplayName: "opencode", Capability: "plugin"}
-	path, err := exec.LookPath("opencode")
-	if err == nil {
-		h.Detected = true
-		h.ExecutablePath = path
-		h.Version = commandVersion(path)
-	}
+	detectExecutable(&h, "opencode")
 	home, _ := os.UserHomeDir()
 	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts")
 	h.ConfigPath = pluginPath
@@ -202,12 +174,7 @@ func DiscoverOpenCode() Harness {
 
 func DiscoverHermes() Harness {
 	h := Harness{Name: "hermes", DisplayName: "Hermes Agent", Capability: "hooks"}
-	path, err := exec.LookPath("hermes")
-	if err == nil {
-		h.Detected = true
-		h.ExecutablePath = path
-		h.Version = commandVersion(path)
-	}
+	detectExecutable(&h, "hermes")
 	home, _ := os.UserHomeDir()
 	h.ConfigPath = filepath.Join(home, ".hermes", "config.yaml")
 	if !h.Detected && dirExists(filepath.Join(home, ".hermes")) {
@@ -226,12 +193,7 @@ func DiscoverHermes() Harness {
 
 func DiscoverCursor() Harness {
 	h := Harness{Name: "cursor", DisplayName: "Cursor", Capability: "hooks"}
-	path, err := exec.LookPath("cursor")
-	if err == nil {
-		h.Detected = true
-		h.ExecutablePath = path
-		h.Version = commandVersion(path)
-	}
+	detectExecutable(&h, "cursor")
 	home, _ := os.UserHomeDir()
 	h.ConfigPath = filepath.Join(home, ".cursor", "hooks.json")
 	if !h.Detected && dirExists(filepath.Join(home, ".cursor")) {
@@ -255,12 +217,7 @@ func DiscoverCursor() Harness {
 
 func DiscoverDevin() Harness {
 	h := Harness{Name: "devin-cli", DisplayName: "Devin CLI", Capability: "hooks"}
-	path, err := exec.LookPath("devin")
-	if err == nil {
-		h.Detected = true
-		h.ExecutablePath = path
-		h.Version = commandVersion(path)
-	}
+	detectExecutable(&h, "devin")
 	home, _ := os.UserHomeDir()
 	userConfig := filepath.Join(home, ".config", "devin", "config.json")
 	projectConfig := filepath.Join(".devin", "hooks.v1.json")
@@ -722,6 +679,21 @@ func factoryProfilePath(home string) string {
 		return filepath.Join(home, ".bash_profile")
 	default:
 		return filepath.Join(home, ".profile")
+	}
+}
+
+// detectExecutable looks up each candidate command name on PATH and, on the
+// first match, marks the harness detected and records its executable path and
+// version. Names are tried in order.
+func detectExecutable(h *Harness, names ...string) {
+	for _, name := range names {
+		path, err := exec.LookPath(name)
+		if err == nil {
+			h.Detected = true
+			h.ExecutablePath = path
+			h.Version = commandVersion(path)
+			return
+		}
 	}
 }
 

--- a/cli/beacon/internal/endpoint/harness/vscode.go
+++ b/cli/beacon/internal/endpoint/harness/vscode.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -28,11 +27,7 @@ func DiscoverVSCode() Harness {
 
 func discoverVSCode(expectedEndpoint string) Harness {
 	h := Harness{Name: VSCodeName, DisplayName: "VS Code", Capability: "otel_hooks"}
-	if path, err := exec.LookPath("code"); err == nil {
-		h.Detected = true
-		h.ExecutablePath = path
-		h.Version = commandVersion(path)
-	}
+	detectExecutable(&h, "code")
 	settingsPath, err := VSCodeUserSettingsPath()
 	if err == nil {
 		h.ConfigPath = settingsPath


### PR DESCRIPTION
## Harness cleanup — Part A of #4 (executable-detection helper)

The PATH-lookup block that sets `Detected` / `ExecutablePath` / `Version` was copy-pasted across ~11 `Discover*` functions. This extracts it into a single helper and calls it from each:

```go
func detectExecutable(h *Harness, names ...string) {
	for _, name := range names {
		if path, err := exec.LookPath(name); err == nil {
			h.Detected = true
			h.ExecutablePath = path
			h.Version = commandVersion(path)
			return
		}
	}
}
```

It handles all three shapes that existed: single-name lookups (claude, codex, gemini, factory, opencode, hermes, cursor, devin, copilot), the multi-name Antigravity case (`"antigravity"`, `"antigravity-cli"`), and VS Code's `"code"`.

**−45 net lines**, no behavior change.

### Scope
This is deliberately just the low-risk deduplication. The larger piece of #4 — a harness **definition registry** to replace the three hand-maintained enumerations (`DiscoverAll`, `ValidateConfigured`, and `lifecycle.configureHarnesses`) — is intentionally left for a separate follow-up PR so this stays small and obviously safe. The per-harness discovery/status/configure bodies are unchanged (they're genuine per-harness logic, not boilerplate).

### Verification
- All harness discovery / configure / status tests pass unchanged (they directly exercise the detection behavior).
- The one failing test in this package (`TestConfigureVSCodePreservesSettingsAndDisablesContentCaptureByDefault`) was verified to **fail identically on the baseline** — it's the pre-existing macOS-`hooks.bin` env issue, not introduced here.
- `go vet`, `gofmt`, `-race` clean; **`beacon docs` byte-identical** to baseline; no new failures anywhere in the module.

https://claude.ai/code/session_011RgMGykN4dt1PqphVehJN8

---
_Generated by [Claude Code](https://claude.ai/code/session_011RgMGykN4dt1PqphVehJN8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor of discovery-only PATH lookups; telemetry/configure paths are untouched and existing harness tests still cover behavior.
> 
> **Overview**
> Extracts repeated PATH lookup logic from many `Discover*` harness functions into a shared **`detectExecutable`** helper in `harness.go`, which tries candidate command names in order and sets `Detected`, `ExecutablePath`, and `Version` via `commandVersion`.
> 
> **Copilot**, **Gemini**, **VS Code**, and multiple discoverers in **`harness.go`** (Claude, Codex, Factory, OpenCode, Hermes, Cursor, Devin, Antigravity with two names) now call that helper instead of inline `exec.LookPath` blocks. Redundant **`os/exec`** imports are dropped from the smaller harness files.
> 
> Per-harness config/telemetry status logic is unchanged; this is deduplication only (~45 fewer lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b3ffa06dc89f5b81de3e2e2f7621b39730a961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->