### PR TITLE
Finish ci telemetry exports

### DIFF
--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -93,10 +93,11 @@ Validate an existing CI artifact explicitly:
   --min-events 1
 ```
 
-Captured events carry the GitHub Actions run context (`run.repository`,
-`run.branch`, `run.run_id`, `run.run_attempt`, `run.job`, `run.event_name`, and
-`run.pr_number` on pull-request events) so they can be correlated per-workflow
-and per-PR downstream.
+Captured events carry the GitHub Actions run context (`origin`, `run.provider`,
+`run.repository`, `run.branch`, `run.run_id`, `run.run_attempt`, `run.workflow`,
+`run.job`, `run.event_name`, `run.commit`, `run.actor`, and `run.pr_number` on
+pull-request events) so they can be correlated per-workflow and per-PR
+downstream.
 
 Upload the log from GitHub Actions for customer-controlled retention:
 
@@ -113,10 +114,10 @@ Upload the log from GitHub Actions for customer-controlled retention:
 ```
 
 Upload only the `runtime.jsonl` file (as above), not the whole
-`${{ runner.temp }}/beacon` directory: when forwarding is configured the
-job-scoped `otelcol.yaml` in that directory contains the SIEM token. Beacon
-writes that file with `0600` permissions, but excluding it from the artifact
-keeps the credential off the uploaded path entirely.
+`${{ runner.temp }}/beacon` directory. When forwarding is configured, Beacon
+keeps the SIEM token in the runner environment and writes only collector
+environment references into `otelcol.yaml`; excluding the collector config from
+artifacts still avoids exposing forwarding endpoints or local collector details.
 
 ### Forwarding to a customer-managed SIEM
 

--- a/cli/beacon/internal/ci/harness.go
+++ b/cli/beacon/internal/ci/harness.go
@@ -2,9 +2,11 @@ package ci
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
 )
 
 func ClaudeEnv(base []string, endpoint string, retention endpointconfig.ContentRetention) []string {
@@ -23,6 +25,61 @@ func ClaudeEnv(base []string, endpoint string, retention endpointconfig.ContentR
 		env["OTEL_LOG_USER_PROMPTS"] = "1"
 	}
 	return flattenEnv(env)
+}
+
+func WithCIResourceAttributes(base []string, run *schema.RunInfo) []string {
+	attrs := RunResourceAttributes(run)
+	if attrs == "" {
+		return base
+	}
+	env := envMap(base)
+	if existing := strings.TrimSpace(env["OTEL_RESOURCE_ATTRIBUTES"]); existing != "" {
+		env["OTEL_RESOURCE_ATTRIBUTES"] = existing + "," + attrs
+	} else {
+		env["OTEL_RESOURCE_ATTRIBUTES"] = attrs
+	}
+	return flattenEnv(env)
+}
+
+func RunResourceAttributes(run *schema.RunInfo) string {
+	if run == nil {
+		return ""
+	}
+	fields := []struct {
+		key   string
+		value string
+	}{
+		{schema.AttributeOrigin, string(schema.OriginCI)},
+		{schema.AttributeRunProvider, run.Provider},
+		{schema.AttributeRunID, run.RunID},
+		{schema.AttributeRunAttempt, run.RunAttempt},
+		{schema.AttributeRunWorkflow, run.Workflow},
+		{schema.AttributeRunJob, run.Job},
+		{schema.AttributeRunEventName, run.EventName},
+		{schema.AttributeRunCommit, run.Commit},
+		{schema.AttributeRunRepository, run.Repository},
+		{schema.AttributeRunBranch, run.Branch},
+		{schema.AttributeRunPR, run.PR},
+		{schema.AttributeRunPRNumber, run.PRNumber},
+		{schema.AttributeRunActor, run.Actor},
+	}
+	attrs := make([]string, 0, len(fields)+1)
+	for _, field := range fields {
+		if strings.TrimSpace(field.value) == "" {
+			continue
+		}
+		attrs = append(attrs, field.key+"="+percentEncodeResourceValue(field.value))
+	}
+	if run.Ephemeral {
+		attrs = append(attrs, schema.AttributeRunEphemeral+"=true")
+	}
+	return strings.Join(attrs, ",")
+}
+
+func percentEncodeResourceValue(value string) string {
+	// OTEL_RESOURCE_ATTRIBUTES uses W3C Baggage-style percent encoding. QueryEscape
+	// escapes delimiters such as comma and equals; spaces must remain percent-encoded.
+	return strings.ReplaceAll(url.QueryEscape(value), "+", "%20")
 }
 
 func envMap(values []string) map[string]string {

--- a/cli/beacon/internal/ci/session.go
+++ b/cli/beacon/internal/ci/session.go
@@ -243,7 +243,7 @@ func (s *Session) RunChild(ctx context.Context, args []string, stdout, stderr io
 	}
 	cmd := childCommandContext(ctx, args[0], args[1:]...)
 	cmd.Dir = s.WorkDir
-	env := append(ClaudeEnv(os.Environ(), s.GRPCEndpoint, s.cfg.ContentRetention),
+	env := append(WithCIResourceAttributes(ClaudeEnv(os.Environ(), s.GRPCEndpoint, s.cfg.ContentRetention), s.Run),
 		"BEACON_CI_BASE_DIR="+s.BaseDir,
 		"BEACON_CI_CONFIG_PATH="+s.ConfigPath,
 		"BEACON_CI_LOG_PATH="+s.LogPath,

--- a/cli/beacon/internal/ci/session_test.go
+++ b/cli/beacon/internal/ci/session_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
 )
 
 func TestProvisionUsesRunnerTempAndWritesCollectorConfig(t *testing.T) {
@@ -102,12 +103,25 @@ func TestRunChildInjectsClaudeEnvAndBeaconPaths(t *testing.T) {
 	dir := t.TempDir()
 	output := filepath.Join(dir, "env.txt")
 	child := fakeExecutable(t, "child", "#!/bin/sh\nenv > \"$1\"\n")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=custom")
 	session := &Session{
 		BaseDir:      dir,
 		ConfigPath:   filepath.Join(dir, "otelcol.yaml"),
 		LogPath:      filepath.Join(dir, "runtime.jsonl"),
 		GRPCEndpoint: "http://127.0.0.1:4317",
 		cfg:          endpointconfig.Default(true, filepath.Join(dir, "runtime.jsonl")),
+		Run: &schema.RunInfo{
+			Provider:   "github_actions",
+			RunID:      "123",
+			RunAttempt: "2",
+			Workflow:   "CI / build, smoke",
+			Job:        "telemetry",
+			EventName:  "pull_request",
+			Repository: "asymptote-labs/agent-beacon",
+			Branch:     "feature/ci telemetry",
+			PRNumber:   "12",
+			Ephemeral:  true,
+		},
 	}
 	exitCode, err := session.RunChild(context.Background(), []string{child, output}, nil, nil)
 	if err != nil {
@@ -134,6 +148,33 @@ func TestRunChildInjectsClaudeEnvAndBeaconPaths(t *testing.T) {
 			t.Fatalf("child env missing %q:\n%s", want, env)
 		}
 	}
+	resourceAttrs := envVarValue(env, "OTEL_RESOURCE_ATTRIBUTES")
+	for _, want := range []string{
+		"service.name=custom",
+		"beacon.origin=ci",
+		"beacon.run.provider=github_actions",
+		"beacon.run.run_id=123",
+		"beacon.run.workflow=CI%20%2F%20build%2C%20smoke",
+		"beacon.run.branch=feature%2Fci%20telemetry",
+		"beacon.run.ephemeral=true",
+	} {
+		if !strings.Contains(resourceAttrs, want) {
+			t.Fatalf("OTEL_RESOURCE_ATTRIBUTES missing %q: %q", want, resourceAttrs)
+		}
+	}
+	if !strings.HasPrefix(resourceAttrs, "service.name=custom,beacon.origin=ci,") {
+		t.Fatalf("OTEL_RESOURCE_ATTRIBUTES should preserve existing attributes first: %q", resourceAttrs)
+	}
+}
+
+func envVarValue(env, key string) string {
+	prefix := key + "="
+	for _, line := range strings.Split(env, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	return ""
 }
 
 func TestDetectRunInfoPullRequest(t *testing.T) {

--- a/cli/beacon/internal/endpoint/schema/event.go
+++ b/cli/beacon/internal/endpoint/schema/event.go
@@ -28,6 +28,23 @@ const (
 	OriginCI    = asymptotetrace.OriginCI
 )
 
+const (
+	AttributeOrigin        = asymptotetrace.AttributeOrigin
+	AttributeRunProvider   = asymptotetrace.AttributeRunProvider
+	AttributeRunID         = asymptotetrace.AttributeRunID
+	AttributeRunAttempt    = asymptotetrace.AttributeRunAttempt
+	AttributeRunWorkflow   = asymptotetrace.AttributeRunWorkflow
+	AttributeRunJob        = asymptotetrace.AttributeRunJob
+	AttributeRunEventName  = asymptotetrace.AttributeRunEventName
+	AttributeRunCommit     = asymptotetrace.AttributeRunCommit
+	AttributeRunRepository = asymptotetrace.AttributeRunRepository
+	AttributeRunBranch     = asymptotetrace.AttributeRunBranch
+	AttributeRunPR         = asymptotetrace.AttributeRunPR
+	AttributeRunPRNumber   = asymptotetrace.AttributeRunPRNumber
+	AttributeRunActor      = asymptotetrace.AttributeRunActor
+	AttributeRunEphemeral  = asymptotetrace.AttributeRunEphemeral
+)
+
 type EventInfo = asymptotetrace.EventInfo
 type EndpointInfo = asymptotetrace.EndpointInfo
 type UserInfo = asymptotetrace.UserInfo

--- a/collector-builder/exporter/beaconjsonexporter/exporter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -165,6 +166,74 @@ func TestConsumeLogsWritesBeaconJSONL(t *testing.T) {
 	}
 	if event.Command == nil || event.Command.Command != "kubectl get pods" {
 		t.Fatalf("command missing from event: %#v", event.Command)
+	}
+}
+
+func TestConsumeLogsMapsCIRunResourceAttributes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:             path,
+		MaxEventBytes:    defaultMaxEventBytes,
+		RotateBytes:      defaultRotateBytes,
+		RedactSecrets:    true,
+		ContentRetention: "metadata",
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	resourceAttrs := rl.Resource().Attributes()
+	resourceAttrs.PutStr("service.name", "claude-code")
+	resourceAttrs.PutStr("repository", "local/repo")
+	resourceAttrs.PutStr("branch", "local-branch")
+	resourceAttrs.PutStr(asymptotetrace.AttributeOrigin, string(asymptotetrace.OriginCI))
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunProvider, "github_actions")
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunID, "123")
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunAttempt, "2")
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunWorkflow, "CI / build, smoke")
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunJob, "telemetry")
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunEventName, "pull_request")
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunCommit, "deadbeef")
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunRepository, "asymptote-labs/agent-beacon")
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunBranch, "feature/ci telemetry")
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunPR, "refs/pull/12/merge")
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunPRNumber, "12")
+	resourceAttrs.PutStr(asymptotetrace.AttributeRunActor, "octocat")
+	resourceAttrs.PutBool(asymptotetrace.AttributeRunEphemeral, true)
+	rec := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	rec.Body().SetStr("ci telemetry event")
+	rec.Attributes().PutStr("beacon.event.action", "tool.invoked")
+
+	if err := exp.consumeLogs(context.Background(), logs); err != nil {
+		t.Fatalf("consumeLogs returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime log: %v", err)
+	}
+	var event beaconEvent
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &event); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	if event.Origin != asymptotetrace.OriginCI {
+		t.Fatalf("Origin = %q, want ci", event.Origin)
+	}
+	if event.Run == nil {
+		t.Fatal("Run missing from event")
+	}
+	if event.Run.Provider != "github_actions" || event.Run.RunID != "123" || event.Run.Workflow != "CI / build, smoke" || !event.Run.Ephemeral {
+		t.Fatalf("unexpected run context: %#v", event.Run)
+	}
+	if event.Run.Repository != "asymptote-labs/agent-beacon" || event.Run.Branch != "feature/ci telemetry" {
+		t.Fatalf("run repository/branch = %q/%q", event.Run.Repository, event.Run.Branch)
+	}
+	if event.Repository != "local/repo" || event.Branch != "local-branch" {
+		t.Fatalf("top-level repository/branch = %q/%q", event.Repository, event.Branch)
+	}
+	if event.Run.PR != "refs/pull/12/merge" || event.Run.PRNumber != "12" || event.Run.Actor != "octocat" {
+		t.Fatalf("pull request context missing: %#v", event.Run)
 	}
 }
 

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -3,9 +3,11 @@ package beaconevent
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptotetrace"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -394,6 +396,7 @@ func (c Converter) EventFromMetric(resourceAttrs map[string]interface{}, metric 
 }
 
 func (c Converter) PopulateCommon(event *Event, attrs map[string]interface{}) {
+	populateRunContext(event, attrs)
 	event.Model = FirstString(attrs, "gen_ai.request.model", "gen_ai.response.model", "model", "ai.model")
 	event.Repository = FirstString(attrs, "vcs.repository.url", "repository", "repo.path", "workspace.repository")
 	event.Branch = FirstString(attrs, "vcs.branch.name", "git.branch", "branch")
@@ -445,6 +448,33 @@ func (c Converter) PopulateCommon(event *Event, attrs map[string]interface{}) {
 		}
 	}
 	event.Content = &ContentInfo{Retention: c.opts.ContentRetention, Included: c.opts.ContentRetention != "metadata", Redacted: c.opts.ContentRetention == "redacted"}
+}
+
+func populateRunContext(event *Event, attrs map[string]interface{}) {
+	if FirstString(attrs, asymptotetrace.AttributeOrigin) == string(asymptotetrace.OriginCI) {
+		event.Origin = asymptotetrace.OriginCI
+	}
+	run := RunInfo{
+		Provider:   FirstString(attrs, asymptotetrace.AttributeRunProvider),
+		RunID:      FirstString(attrs, asymptotetrace.AttributeRunID),
+		RunAttempt: FirstString(attrs, asymptotetrace.AttributeRunAttempt),
+		Workflow:   FirstString(attrs, asymptotetrace.AttributeRunWorkflow),
+		Job:        FirstString(attrs, asymptotetrace.AttributeRunJob),
+		EventName:  FirstString(attrs, asymptotetrace.AttributeRunEventName),
+		Commit:     FirstString(attrs, asymptotetrace.AttributeRunCommit),
+		Repository: FirstString(attrs, asymptotetrace.AttributeRunRepository),
+		Branch:     FirstString(attrs, asymptotetrace.AttributeRunBranch),
+		PR:         FirstString(attrs, asymptotetrace.AttributeRunPR),
+		PRNumber:   FirstString(attrs, asymptotetrace.AttributeRunPRNumber),
+		Actor:      FirstString(attrs, asymptotetrace.AttributeRunActor),
+	}
+	if ephemeral, ok := BoolAttr(attrs, asymptotetrace.AttributeRunEphemeral); ok {
+		run.Ephemeral = ephemeral
+	}
+	if run.Provider == "" && run.RunID == "" && run.RunAttempt == "" && run.Workflow == "" && run.Job == "" && run.EventName == "" && run.Commit == "" && run.Repository == "" && run.Branch == "" && run.PR == "" && run.PRNumber == "" && run.Actor == "" && !run.Ephemeral {
+		return
+	}
+	event.Run = &run
 }
 
 func (c Converter) RawPayload(attrs map[string]interface{}, extra map[string]interface{}) map[string]interface{} {
@@ -517,6 +547,21 @@ func Int64Attr(attrs map[string]interface{}, keys ...string) (int64, bool) {
 		}
 	}
 	return 0, false
+}
+
+func BoolAttr(attrs map[string]interface{}, keys ...string) (bool, bool) {
+	for _, key := range keys {
+		switch typed := attrs[key].(type) {
+		case bool:
+			return typed, true
+		case string:
+			value, err := strconv.ParseBool(strings.TrimSpace(typed))
+			if err == nil {
+				return value, true
+			}
+		}
+	}
+	return false, false
 }
 
 func Timestamp(ts time.Time) time.Time {

--- a/pkg/asymptotetrace/event.go
+++ b/pkg/asymptotetrace/event.go
@@ -31,6 +31,23 @@ const (
 	OriginCI    Origin = "ci"
 )
 
+const (
+	AttributeOrigin        = "beacon.origin"
+	AttributeRunProvider   = "beacon.run.provider"
+	AttributeRunID         = "beacon.run.run_id"
+	AttributeRunAttempt    = "beacon.run.run_attempt"
+	AttributeRunWorkflow   = "beacon.run.workflow"
+	AttributeRunJob        = "beacon.run.job"
+	AttributeRunEventName  = "beacon.run.event_name"
+	AttributeRunCommit     = "beacon.run.commit"
+	AttributeRunRepository = "beacon.run.repository"
+	AttributeRunBranch     = "beacon.run.branch"
+	AttributeRunPR         = "beacon.run.pr"
+	AttributeRunPRNumber   = "beacon.run.pr_number"
+	AttributeRunActor      = "beacon.run.actor"
+	AttributeRunEphemeral  = "beacon.run.ephemeral"
+)
+
 type EventInfo struct {
 	Kind     string `json:"kind"`
 	Action   string `json:"action"`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive telemetry metadata and exporter mapping with tests; no auth or persistence behavior changes beyond clearer CI correlation fields.
> 
> **Overview**
> CI telemetry now stamps **GitHub Actions (and generic CI) run metadata** onto Claude’s OTLP export and carries it through to normalized JSONL events.
> 
> `beacon ci exec` merges detected run info into the child’s **`OTEL_RESOURCE_ATTRIBUTES`** (preserving any existing values, with W3C-style percent-encoding for delimiters). Shared **`beacon.run.*`** attribute names live in `pkg/asymptotetrace` and are re-exported from the CLI schema. The **beaconjsonexporter** maps those resource attributes into **`origin: ci`** and a structured **`run`** block on each event, without overwriting top-level repo/branch from other OTEL attrs.
> 
> Docs now list the expanded run fields on captured events and clarify that SIEM tokens stay in the runner environment (collector config uses env refs), so artifact guidance focuses on **`runtime.jsonl`** rather than implying the token is written into `otelcol.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ff51e7167ce066f2f547381823913c75eebf17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->