### PR TITLE
Add sample upload for uploading telemetry

### DIFF
--- a/examples/github-actions/gcs-upload-telemetry.yml
+++ b/examples/github-actions/gcs-upload-telemetry.yml
@@ -1,0 +1,45 @@
+# Reference workflow for testing Agent Beacon CI Telemetry with direct GCS
+# upload. Copy this file to .github/workflows/ in a test repository and update
+# the bucket, workload identity provider, service account, and action ref.
+#
+# This file lives under examples/ (not .github/workflows/) so it is a reference
+# only and does not run in this repository.
+
+name: Test Agent Beacon GCS upload
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  beacon-gcs-upload:
+    runs-on: ubuntu-latest
+    env:
+      BEACON_CI_GCS_BUCKET: ${{ vars.BEACON_CI_GCS_BUCKET }}
+      BEACON_CI_GCS_PREFIX: github-actions/test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Install gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run Agent Beacon with GCS upload
+        uses: asymptote-labs/agent-beacon@v0.0.45
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          command: claude --print "Say hello from Agent Beacon CI telemetry"
+          upload: gcs
+          upload-artifact: "true"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only example workflow under examples/ with no runtime impact on this repository.
> 
> **Overview**
> Adds a **reference** GitHub Actions workflow at `examples/github-actions/gcs-upload-telemetry.yml` for exercising Agent Beacon CI telemetry with **direct GCS upload** (`upload: gcs`).
> 
> The workflow is **manual** (`workflow_dispatch` only) and is documented as copy-paste into a test repo’s `.github/workflows/`—it does not run from `examples/`. It wires **Workload Identity** GCP auth, `gcloud`, Claude Code, then runs `asymptote-labs/agent-beacon@v0.0.45` with bucket/prefix env vars, Anthropic API key, and `upload-artifact: "true"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e70538ac21a75c248826ef2d8fb17e91b954cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->