### PR TITLE
Add Asymptote Observe SDK scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,31 @@ on:
       - main
 
 jobs:
+  typescript-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: packages/asymptote-observe-js/package-lock.json
+      - name: Install SDK dependencies
+        working-directory: packages/asymptote-observe-js
+        run: npm ci
+      - name: Test SDK
+        working-directory: packages/asymptote-observe-js
+        run: npm test
+      - name: Type-check SDK
+        working-directory: packages/asymptote-observe-js
+        run: npm run check
+      - name: Build SDK
+        working-directory: packages/asymptote-observe-js
+        run: npm run build
+      - name: Validate SDK package contents
+        working-directory: packages/asymptote-observe-js
+        run: npm run pack:dry-run
+
   go-test:
     runs-on: macos-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 .env
 .env.*
 
+# JavaScript dependencies and build outputs
+node_modules/
+packages/*/node_modules/
+
 # Go build outputs
 *.test
 coverage.out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Beacon Endpoint Agent is a local-only endpoint telemetry agent for AI runtimes. 
 - `cli/beacon`: public `beacon` CLI and endpoint runtime.
 - `cli/beacon-hooks`: hook adapter invoked by Cursor and other supported runtimes.
 - `collector-builder`: OpenTelemetry Collector distribution and Beacon JSONL exporter.
+- `packages/asymptote-observe-js`: TypeScript SDK for cloud agent telemetry that exports Beacon-compatible OpenTelemetry spans.
 - `packaging`: macOS packaging and deployment assets.
 
 Do not recreate or depend on removed `asymptote` mirror trees. Keep new work focused on the Beacon paths above.
@@ -21,6 +22,7 @@ Do not recreate or depend on removed `asymptote` mirror trees. Keep new work foc
 - Do not add broad runtime enforcement unless explicitly requested. Current control behavior is limited to hook-native approvals/denials exposed by supported agent runtimes.
 - Keep direct destination support scoped to local JSONL/Wazuh unless explicitly requested. Elastic support is a file-tailing pack over local JSONL; Beacon itself must not store Elastic credentials or require a hosted Elastic dependency.
 - Beacon writes retained prompt text, command output, raw tool inputs, raw OTLP attributes, and raw diffs to local or customer-controlled logs, subject to local redaction and size limits where supported.
+- The Asymptote Observe TypeScript SDK may default to the hosted `/v1/observe` endpoint as an opt-in cloud SDK contract. Beacon endpoint execution stays local-only/no-network.
 
 ## Telemetry Scope
 
@@ -30,6 +32,7 @@ Supported runtime surfaces today:
 - Cursor hook telemetry for sessions, prompt submission, tool use, command execution, MCP-like tool activity, approval decisions, and file edits where hook payloads expose those fields.
 - Claude Cowork admin-configured OpenTelemetry setup guidance and local validation.
 - `beaconjson` OpenTelemetry Collector exporter that converts OTLP logs, traces, metrics, and resource attributes into Beacon endpoint JSONL.
+- Asymptote Observe TypeScript SDK instrumentation for cloud applications, starting from OpenTelemetry/OpenLLMetry patterns and `observe()` wrappers.
 - Elasticsearch/Filebeat content pack generation for forwarding local Beacon JSONL into customer-managed Elastic deployments or the bundled loopback-only development stack.
 - A local-only dashboard served by `beacon endpoint dashboard`, bound to loopback by default and backed by the runtime JSONL log.
 
@@ -82,6 +85,16 @@ cd collector-builder/exporter/beaconjsonexporter
 go test ./...
 ```
 
+Run TypeScript SDK checks:
+
+```bash
+cd packages/asymptote-observe-js
+npm test
+npm run check
+npm run build
+npm run pack:dry-run
+```
+
 Run the local dashboard during manual testing:
 
 ```bash
@@ -116,7 +129,8 @@ Run the release gates before publishing:
 cd cli/beacon && go test ./...
 cd ../beacon-hooks && go test ./...
 cd ../../collector-builder/exporter/beaconjsonexporter && go test ./...
-cd ../../..
+cd ../../../packages/asymptote-observe-js && npm test && npm run check && npm run build && npm run pack:dry-run
+cd ../..
 sh packaging/macos/test-endpoint-scripts.sh
 ```
 

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -447,7 +447,7 @@ func (c Converter) PopulateCommon(event *Event, attrs map[string]interface{}) {
 		}
 	}
 	if event.Event.Category == "prompt" {
-		if text := FirstNonEmpty(FirstTextAttr(attrs, "gen_ai.prompt", "prompt", "user_prompt", "input.prompt", "copilot_chat.user_request"), FirstMessageText(event.GenAI)); text != "" {
+		if text := FirstNonEmpty(FirstTextAttr(attrs, "beacon.prompt.text", "gen_ai.prompt", "prompt", "user_prompt", "input.prompt", "copilot_chat.user_request"), FirstMessageText(event.GenAI)); text != "" {
 			event.Prompt = &PromptInfo{Text: text}
 		}
 	}
@@ -671,7 +671,12 @@ func MCPFromAttrs(attrs map[string]interface{}) *MCPInfo {
 }
 
 func populateRunContext(event *Event, attrs map[string]interface{}) {
-	if FirstString(attrs, asymptoteobserve.AttributeOrigin) == string(asymptoteobserve.OriginCI) {
+	switch FirstString(attrs, asymptoteobserve.AttributeOrigin) {
+	case string(asymptoteobserve.OriginLocal):
+		event.Origin = asymptoteobserve.OriginLocal
+	case string(asymptoteobserve.OriginCloud):
+		event.Origin = asymptoteobserve.OriginCloud
+	case string(asymptoteobserve.OriginCI):
 		event.Origin = asymptoteobserve.OriginCI
 	}
 	run := RunInfo{

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
@@ -1,0 +1,67 @@
+package beaconevent
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestEventsFromTracesNormalizesObserveSDKSpan(t *testing.T) {
+	traces := ptrace.NewTraces()
+	resourceSpans := traces.ResourceSpans().AppendEmpty()
+	resourceAttrs := resourceSpans.Resource().Attributes()
+	resourceAttrs.PutStr("beacon.origin", "cloud")
+	resourceAttrs.PutStr("beacon.harness.name", "asymptote_observe")
+	resourceAttrs.PutStr("service.name", "agent-api")
+
+	scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
+	scopeSpans.Scope().SetName("asymptote-observe")
+	span := scopeSpans.Spans().AppendEmpty()
+	span.SetName("agent.plan")
+	span.SetKind(ptrace.SpanKindClient)
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(1700000000, 0).UTC()))
+	attrs := span.Attributes()
+	attrs.PutStr("beacon.event.action", "prompt.submitted")
+	attrs.PutStr("beacon.event.category", "prompt")
+	attrs.PutStr("beacon.prompt.text", "summarize this deployment")
+	attrs.PutStr("gen_ai.provider.name", "openai")
+	attrs.PutStr("gen_ai.operation.name", "chat")
+	attrs.PutStr("gen_ai.request.model", "gpt-4o-mini")
+	attrs.PutInt("gen_ai.usage.input_tokens", 12)
+	attrs.PutInt("gen_ai.usage.output_tokens", 34)
+
+	events := NewConverter(Options{}).EventsFromTraces(traces)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	event := events[0]
+	if event.Origin != "cloud" {
+		t.Fatalf("origin = %q, want cloud", event.Origin)
+	}
+	if event.Harness.Name != "asymptote_observe" {
+		t.Fatalf("harness = %q, want asymptote_observe", event.Harness.Name)
+	}
+	if event.Event.Action != "prompt.submitted" {
+		t.Fatalf("action = %q, want prompt.submitted", event.Event.Action)
+	}
+	if event.Event.Category != "prompt" {
+		t.Fatalf("category = %q, want prompt", event.Event.Category)
+	}
+	if event.Prompt == nil || event.Prompt.Text != "summarize this deployment" {
+		t.Fatalf("prompt = %#v, want captured prompt text", event.Prompt)
+	}
+	if event.GenAI == nil || event.GenAI.Provider == nil || event.GenAI.Provider.Name != "openai" {
+		t.Fatalf("gen_ai provider = %#v, want openai", event.GenAI)
+	}
+	if event.GenAI.Request == nil || event.GenAI.Request.Model != "gpt-4o-mini" {
+		t.Fatalf("gen_ai request = %#v, want model", event.GenAI.Request)
+	}
+	if event.GenAI.Usage == nil || event.GenAI.Usage.InputTokens == nil || *event.GenAI.Usage.InputTokens != 12 {
+		t.Fatalf("gen_ai usage input = %#v, want 12", event.GenAI.Usage)
+	}
+	if event.GenAI.Usage.OutputTokens == nil || *event.GenAI.Usage.OutputTokens != 34 {
+		t.Fatalf("gen_ai usage output = %#v, want 34", event.GenAI.Usage)
+	}
+}

--- a/packages/asymptote-observe-js/README.md
+++ b/packages/asymptote-observe-js/README.md
@@ -1,0 +1,142 @@
+# Asymptote Observe TypeScript SDK
+
+Asymptote Observe instruments cloud-hosted agent apps and exports OpenTelemetry
+spans that remain compatible with Beacon's normalized JSONL event schema.
+
+## Hosted Asymptote Observe
+
+```bash
+npm install @asymptote-labs/observe
+export ASYMPTOTE_OBSERVE_API_KEY=...
+```
+
+```typescript
+import { AsymptoteObserve } from "@asymptote-labs/observe";
+
+AsymptoteObserve.initialize({
+  apiKey: process.env.ASYMPTOTE_OBSERVE_API_KEY,
+});
+```
+
+Hosted Observe contract:
+
+- Transport: OpenTelemetry over HTTP.
+- Default base URL: `https://api.asymptotelabs.ai`.
+- Observe path: `/v1/observe` is appended when the endpoint does not already include it.
+- Auth: `authorization: Bearer <ASYMPTOTE_OBSERVE_API_KEY>`.
+- Override base URL with `ASYMPTOTE_OBSERVE_BASE_URL` or `initialize({ baseUrl })`.
+
+The TypeScript SDK preserves this hosted contract, but this repository does not
+implement the managed ingest service. Use `baseUrl` with a local stub in tests.
+
+## Local Or Customer-Managed Observe Export
+
+```typescript
+import { AsymptoteObserve } from "@asymptote-labs/observe";
+
+AsymptoteObserve.initialize({
+  otlpEndpoint: process.env.ASYMPTOTE_OBSERVE_ENDPOINT,
+});
+```
+
+The SDK appends `/v1/observe` when the endpoint does not already include it.
+Cloud spans carry `beacon.origin=cloud` and the compatibility
+attributes documented in `docs/asymptote-observe-sdk.md`.
+
+Endpoint precedence:
+
+1. `initialize({ otlpEndpoint })`
+2. `ASYMPTOTE_OBSERVE_ENDPOINT`
+3. `OTEL_EXPORTER_OTLP_ENDPOINT`
+4. hosted `baseUrl` when an API key is present
+
+Beacon endpoint installs remain local-first and never require hosted credentials.
+
+## Automatic AI Instrumentation
+
+Asymptote Observe follows an OpenTelemetry-first pattern: initialize once
+as early as possible, then use existing OpenLLMetry instrumentations for common
+provider SDKs.
+
+```typescript
+import { AsymptoteObserve } from "@asymptote-labs/observe";
+
+AsymptoteObserve.initialize({
+  apiKey: process.env.ASYMPTOTE_OBSERVE_API_KEY,
+});
+```
+
+By default the SDK enables OpenAI and Anthropic OpenLLMetry instrumentations.
+Disable or configure them if needed:
+
+```typescript
+AsymptoteObserve.initialize({
+  apiKey: process.env.ASYMPTOTE_OBSERVE_API_KEY,
+  instrumentationOptions: {
+    openAI: { traceContent: true },
+    anthropic: false,
+  },
+});
+```
+
+If your app already owns OpenTelemetry setup, use
+`AsymptoteObserve.instrumentations()` with that provider instead of calling
+`initialize()` twice.
+
+## Vercel AI SDK
+
+```typescript
+import { registerTelemetry } from "ai";
+import { OpenTelemetry } from "@ai-sdk/otel";
+import { AsymptoteObserve } from "@asymptote-labs/observe";
+
+AsymptoteObserve.initialize();
+
+registerTelemetry(new OpenTelemetry({
+  tracer: AsymptoteObserve.getTracer(),
+}));
+```
+
+## Claude Agent SDK
+
+```typescript
+import { query as originalQuery } from "@anthropic-ai/claude-agent-sdk";
+import { AsymptoteObserve } from "@asymptote-labs/observe";
+
+AsymptoteObserve.initialize();
+
+const query = AsymptoteObserve.wrapClaudeAgentQuery(originalQuery);
+```
+
+For the first SDK release, prefer provider-level Anthropic/OpenLLMetry
+instrumentation or `observe()` around the agent entry point. Custom Claude Agent
+SDK hooks are deferred until those paths leave important telemetry gaps.
+
+## Custom Agent Steps
+
+```typescript
+const plan = AsymptoteObserve.observe(
+  {
+    name: "agent.plan",
+    attributes: {
+      "beacon.harness.name": "custom_agent",
+      "beacon.event.action": "tool.invoked",
+    },
+  },
+  async (input: string) => {
+    return runPlanner(input);
+  },
+);
+```
+
+Call `AsymptoteObserve.flush()` before short-lived scripts exit, or
+`AsymptoteObserve.shutdown()` when the process owns the provider lifecycle.
+
+## Beta Support Matrix
+
+- OpenAI SDK: OpenLLMetry instrumentation enabled by default.
+- Anthropic SDK: OpenLLMetry instrumentation enabled by default.
+- Vercel AI SDK: register `@ai-sdk/otel` with `AsymptoteObserve.getTracer()`.
+- Claude Agent SDK: wrap query functions with `wrapClaudeAgentQuery()` or use `observe()`.
+- Custom orchestration: wrap functions with `observe()`.
+- Custom Claude hook and OpenAI Agents tracing adapters are intentionally deferred.

--- a/packages/asymptote-observe-js/package-lock.json
+++ b/packages/asymptote-observe-js/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.102.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
         "@opentelemetry/instrumentation": "^0.218.0",
@@ -21,6 +20,7 @@
         "@traceloop/instrumentation-openai": "^0.27.0"
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.102.0",
         "@types/node": "^25.9.2",
         "typescript": "^6.0.3",
         "vitest": "^4.1.8"
@@ -33,6 +33,7 @@
       "version": "0.102.0",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.102.0.tgz",
       "integrity": "sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
@@ -54,6 +55,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -435,9 +437,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -455,9 +454,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -475,9 +471,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -495,9 +488,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -515,9 +505,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -535,9 +522,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -628,6 +612,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -1122,6 +1107,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/fdir": {
@@ -1221,6 +1207,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -1373,9 +1360,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1397,9 +1381,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1421,9 +1402,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1445,9 +1423,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1716,6 +1691,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
@@ -1789,6 +1765,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tslib": {

--- a/packages/asymptote-observe-js/package-lock.json
+++ b/packages/asymptote-observe-js/package-lock.json
@@ -1,0 +1,2007 @@
+{
+  "name": "@asymptote-labs/observe",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@asymptote-labs/observe",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.102.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+        "@opentelemetry/instrumentation": "^0.218.0",
+        "@opentelemetry/resources": "^2.7.1",
+        "@opentelemetry/sdk-trace-base": "^2.7.1",
+        "@opentelemetry/sdk-trace-node": "^2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.41.1",
+        "@traceloop/instrumentation-anthropic": "^0.27.0",
+        "@traceloop/instrumentation-openai": "^0.27.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.9.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.102.0.tgz",
+      "integrity": "sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
+      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
+      "integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz",
+      "integrity": "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.7.1",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@traceloop/ai-semantic-conventions": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/ai-semantic-conventions/-/ai-semantic-conventions-0.27.0.tgz",
+      "integrity": "sha512-kT/0ftxCHIRDW7DZ4uip1qRBv3hvOqqTkPJUNnjPSIW1Tie7Pe5N8aeVUGEzjz32eTS7vRdO/CUws8Shr5f6yA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/semantic-conventions": "^1.40.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@traceloop/instrumentation-anthropic": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-anthropic/-/instrumentation-anthropic-0.27.0.tgz",
+      "integrity": "sha512-9ya3GxvTFdgA4sJjuPz7RCQh7jQlCxaOJzXSibT6CX+L2zP/6nJBJhgjT4jiLU0D1+JKOEIfArTsEduJ/Uvzow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.203.0",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@traceloop/ai-semantic-conventions": "0.27.0",
+        "@traceloop/instrumentation-utils": "0.27.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@traceloop/instrumentation-anthropic/node_modules/@opentelemetry/api-logs": {
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
+      "integrity": "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@traceloop/instrumentation-anthropic/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.203.0.tgz",
+      "integrity": "sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.203.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@traceloop/instrumentation-anthropic/node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "license": "MIT"
+    },
+    "node_modules/@traceloop/instrumentation-anthropic/node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/@traceloop/instrumentation-anthropic/node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@traceloop/instrumentation-openai": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-openai/-/instrumentation-openai-0.27.0.tgz",
+      "integrity": "sha512-tZhyYsxZvJV+Kif/3A7F1rNx5SHSinLg/1Q54+9izrH+kA9c/Bcx3W+Qe2n3sWWRUnFzd71P/2JryYq1MGCccQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/instrumentation": "^0.203.0",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@traceloop/ai-semantic-conventions": "0.27.0",
+        "@traceloop/instrumentation-utils": "0.27.0",
+        "js-tiktoken": "^1.0.20",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@traceloop/instrumentation-openai/node_modules/@opentelemetry/api-logs": {
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
+      "integrity": "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@traceloop/instrumentation-openai/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.203.0.tgz",
+      "integrity": "sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.203.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@traceloop/instrumentation-openai/node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "license": "MIT"
+    },
+    "node_modules/@traceloop/instrumentation-openai/node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/@traceloop/instrumentation-openai/node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@traceloop/instrumentation-utils": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-utils/-/instrumentation-utils-0.27.0.tgz",
+      "integrity": "sha512-MUwSd1YRjj+XtYM0v29uCjAfLRUSTiDlNarH3x4D4lv0r3YiCudDiPaw8IT3XpBWvDKPjeLDZlgno+wfk8/UQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/asymptote-observe-js/package.json
+++ b/packages/asymptote-observe-js/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@asymptote-labs/observe",
+  "version": "0.0.0",
+  "description": "Asymptote Observe TypeScript SDK for Beacon-compatible agent telemetry",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/asymptote-labs/agent-beacon.git",
+    "directory": "packages/asymptote-observe-js"
+  },
+  "keywords": [
+    "asymptote",
+    "observe",
+    "beacon",
+    "opentelemetry",
+    "agents",
+    "llm",
+    "ai"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "npm run clean && tsc -p tsconfig.build.json",
+    "check": "tsc -p tsconfig.json --noEmit",
+    "clean": "rm -rf dist",
+    "pack:dry-run": "npm pack --dry-run",
+    "prepack": "npm run build",
+    "test": "vitest run",
+    "test:unit": "vitest run src"
+  },
+  "sideEffects": false,
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.102.0",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+    "@opentelemetry/instrumentation": "^0.218.0",
+    "@opentelemetry/resources": "^2.7.1",
+    "@opentelemetry/sdk-trace-base": "^2.7.1",
+    "@opentelemetry/sdk-trace-node": "^2.7.1",
+    "@opentelemetry/semantic-conventions": "^1.41.1",
+    "@traceloop/instrumentation-anthropic": "^0.27.0",
+    "@traceloop/instrumentation-openai": "^0.27.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/asymptote-observe-js/package.json
+++ b/packages/asymptote-observe-js/package.json
@@ -48,7 +48,6 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.102.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
     "@opentelemetry/instrumentation": "^0.218.0",
@@ -60,6 +59,7 @@
     "@traceloop/instrumentation-openai": "^0.27.0"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.102.0",
     "@types/node": "^25.9.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"

--- a/packages/asymptote-observe-js/src/constants.ts
+++ b/packages/asymptote-observe-js/src/constants.ts
@@ -1,0 +1,36 @@
+export const BEACON_VENDOR = "beacon";
+export const BEACON_PRODUCT = "endpoint-agent";
+export const BEACON_SCHEMA_VERSION = "1.0";
+
+export const ATTR_BEACON_ORIGIN = "beacon.origin";
+export const ATTR_BEACON_HARNESS_NAME = "beacon.harness.name";
+export const ATTR_BEACON_EVENT_ACTION = "beacon.event.action";
+export const ATTR_BEACON_EVENT_CATEGORY = "beacon.event.category";
+
+export const ATTR_BEACON_SESSION_ID = "beacon.session.id";
+export const ATTR_BEACON_SESSION_WORKING_DIRECTORY = "beacon.session.working_directory";
+
+export const ATTR_BEACON_TOOL_NAME = "beacon.tool.name";
+export const ATTR_BEACON_TOOL_COMMAND = "beacon.tool.command";
+export const ATTR_BEACON_TOOL_PATH = "beacon.tool.path";
+
+export const ATTR_BEACON_COMMAND = "beacon.command";
+export const ATTR_BEACON_COMMAND_EXIT_CODE = "beacon.command.exit_code";
+export const ATTR_BEACON_COMMAND_DURATION_MS = "beacon.command.duration_ms";
+
+export const ATTR_BEACON_FILE_PATH = "beacon.file.path";
+export const ATTR_BEACON_FILE_OPERATION = "beacon.file.operation";
+export const ATTR_BEACON_FILE_LANGUAGE = "beacon.file.language";
+
+export const ATTR_BEACON_MCP_SERVER = "beacon.mcp.server";
+export const ATTR_BEACON_MCP_TOOL = "beacon.mcp.tool";
+
+export const ATTR_BEACON_APPROVAL_DECISION = "beacon.approval.decision";
+export const ATTR_BEACON_APPROVAL_REASON = "beacon.approval.reason";
+
+export const ATTR_BEACON_PROMPT_TEXT = "beacon.prompt.text";
+export const ATTR_BEACON_CONTENT_RETENTION = "beacon.content.retention";
+
+export const ATTR_ASYMPTOTE_INTEGRATION_NAME = "asymptote.observe.integration.name";
+export const ATTR_ASYMPTOTE_INTEGRATION_VERSION = "asymptote.observe.integration.version";
+export const ATTR_ASYMPTOTE_SDK_MODE = "asymptote.observe.sdk.mode";

--- a/packages/asymptote-observe-js/src/index.test.ts
+++ b/packages/asymptote-observe-js/src/index.test.ts
@@ -1,0 +1,327 @@
+import { SpanStatusCode } from "@opentelemetry/api";
+import { InMemorySpanExporter } from "@opentelemetry/sdk-trace-base";
+import { createServer, type IncomingMessage } from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ATTR_ASYMPTOTE_SDK_MODE,
+  ATTR_BEACON_EVENT_ACTION,
+  ATTR_BEACON_EVENT_CATEGORY,
+  ATTR_BEACON_HARNESS_NAME,
+  ATTR_BEACON_ORIGIN,
+  ATTR_BEACON_PROMPT_TEXT,
+  AsymptoteObserve,
+  flush,
+  getTracer,
+  initialize,
+  initializeAsymptoteInstrumentations,
+  isInitialized,
+  observe,
+  resolveExporterConfig,
+  shutdown,
+  wrapClaudeAgentQuery,
+} from "./index.js";
+
+const envKeys = [
+  "ASYMPTOTE_OBSERVE_API_KEY",
+  "ASYMPTOTE_OBSERVE_BASE_URL",
+  "ASYMPTOTE_OBSERVE_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+];
+
+describe("resolveExporterConfig", () => {
+  beforeEach(() => {
+    clearEnv();
+  });
+
+  afterEach(() => {
+    clearEnv();
+  });
+
+  it("resolves hosted config from api key and default base URL", () => {
+    const config = resolveExporterConfig({ apiKey: "test-key" });
+
+    expect(config.mode).toBe("hosted");
+    expect(config.observeUrl).toBe("https://api.asymptotelabs.ai/v1/observe");
+    expect(config.headers.authorization).toBe("Bearer test-key");
+  });
+
+  it("resolves hosted config from env", () => {
+    process.env.ASYMPTOTE_OBSERVE_API_KEY = "env-key";
+    process.env.ASYMPTOTE_OBSERVE_BASE_URL = "https://observe.example";
+
+    const config = resolveExporterConfig();
+
+    expect(config.mode).toBe("hosted");
+    expect(config.observeUrl).toBe("https://observe.example/v1/observe");
+    expect(config.headers.authorization).toBe("Bearer env-key");
+  });
+
+  it("resolves explicit Observe endpoint config without api key", () => {
+    const config = resolveExporterConfig({ otlpEndpoint: "http://127.0.0.1:4318" });
+
+    expect(config.mode).toBe("otlp");
+    expect(config.observeUrl).toBe("http://127.0.0.1:4318/v1/observe");
+    expect(config.headers.authorization).toBeUndefined();
+  });
+
+  it("prefers Observe endpoint env over generic OTLP endpoint env", () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://127.0.0.1:4318";
+    process.env.ASYMPTOTE_OBSERVE_ENDPOINT = "http://127.0.0.1:9999/v1/observe";
+
+    const config = resolveExporterConfig();
+
+    expect(config.mode).toBe("otlp");
+    expect(config.observeUrl).toBe("http://127.0.0.1:9999/v1/observe");
+  });
+
+  it("throws when neither hosted credentials nor explicit OTLP are configured", () => {
+    expect(() => resolveExporterConfig()).toThrow(/ASYMPTOTE_OBSERVE_API_KEY/);
+  });
+
+  it("allows custom mode when default exporter is disabled", () => {
+    const config = resolveExporterConfig({ disableDefaultExporter: true });
+
+    expect(config.mode).toBe("custom");
+    expect(config.observeUrl).toBeUndefined();
+  });
+});
+
+describe("Asymptote Observe SDK", () => {
+  beforeEach(() => {
+    clearEnv();
+  });
+
+  afterEach(async () => {
+    await shutdown();
+    clearEnv();
+  });
+
+  it("initializes with a custom exporter and exports observe spans", async () => {
+    const exporter = new InMemorySpanExporter();
+    initialize({ spanExporter: exporter, disableDefaultExporter: true, disableBatch: true });
+
+    const wrapped = observe(
+      {
+        name: "agent.plan",
+        attributes: {
+          [ATTR_BEACON_HARNESS_NAME]: "custom_agent",
+          [ATTR_BEACON_EVENT_ACTION]: "tool.invoked",
+        },
+      },
+      (value: string) => value.toUpperCase(),
+    );
+
+    expect(wrapped("ship it")).toBe("SHIP IT");
+    await flush();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("agent.plan");
+    expect(spans[0].attributes[ATTR_BEACON_HARNESS_NAME]).toBe("custom_agent");
+    expect(spans[0].attributes[ATTR_BEACON_EVENT_ACTION]).toBe("tool.invoked");
+    expect(spans[0].attributes["asymptote.observe.input.count"]).toBe(1);
+    expect(spans[0].attributes["asymptote.observe.output.type"]).toBe("string");
+  });
+
+  it("respects observe input/output suppression", async () => {
+    const exporter = new InMemorySpanExporter();
+    initialize({ spanExporter: exporter, disableDefaultExporter: true, disableBatch: true });
+
+    const wrapped = observe({ name: "agent.redacted", ignoreInput: true, ignoreOutput: true }, () => "secret");
+
+    wrapped();
+    await flush();
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span.attributes["asymptote.observe.input.count"]).toBeUndefined();
+    expect(span.attributes["asymptote.observe.output.type"]).toBeUndefined();
+  });
+
+  it("records errors and ends failed observe spans", async () => {
+    const exporter = new InMemorySpanExporter();
+    initialize({ spanExporter: exporter, disableDefaultExporter: true, disableBatch: true });
+
+    const wrapped = observe({ name: "agent.fail" }, () => {
+      throw new Error("boom");
+    });
+
+    expect(() => wrapped()).toThrow("boom");
+    await flush();
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span.status.code).toBe(SpanStatusCode.ERROR);
+    expect(span.status.message).toBe("boom");
+  });
+
+  it("rejects conflicting reinitialization", () => {
+    initialize({ disableDefaultExporter: true });
+
+    expect(isInitialized()).toBe(true);
+    expect(() => initialize({ disableDefaultExporter: true })).toThrow(/already initialized/);
+  });
+
+  it("creates OpenLLMetry instrumentations", () => {
+    const instrumentations = initializeAsymptoteInstrumentations();
+
+    expect(instrumentations.map(instrumentation => instrumentation.instrumentationName)).toEqual(
+      expect.arrayContaining([
+        "@traceloop/instrumentation-openai",
+        "@traceloop/instrumentation-anthropic",
+      ]),
+    );
+    instrumentations.forEach(instrumentation => instrumentation.disable());
+  });
+
+  it("allows disabling individual auto-instrumentations", () => {
+    const instrumentations = initializeAsymptoteInstrumentations({ anthropic: false });
+
+    expect(instrumentations.map(instrumentation => instrumentation.instrumentationName)).toEqual([
+      "@traceloop/instrumentation-openai",
+    ]);
+    instrumentations.forEach(instrumentation => instrumentation.disable());
+  });
+
+  it("wraps Claude Agent query functions with Beacon-compatible prompt spans", async () => {
+    const exporter = new InMemorySpanExporter();
+    initialize({ spanExporter: exporter, disableDefaultExporter: true, disableBatch: true });
+    const query = wrapClaudeAgentQuery(async (prompt: string) => ({ ok: true, prompt }));
+
+    await expect(query("explain memoization")).resolves.toEqual({ ok: true, prompt: "explain memoization" });
+    await flush();
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span.name).toBe("claude_agent_sdk.query");
+    expect(span.attributes[ATTR_BEACON_ORIGIN]).toBe("cloud");
+    expect(span.attributes[ATTR_BEACON_HARNESS_NAME]).toBe("claude_agent_sdk");
+    expect(span.attributes[ATTR_BEACON_EVENT_ACTION]).toBe("prompt.submitted");
+    expect(span.attributes[ATTR_BEACON_EVENT_CATEGORY]).toBe("prompt");
+    expect(span.attributes[ATTR_BEACON_PROMPT_TEXT]).toBe("explain memoization");
+  });
+
+  it("keeps Claude async iterable spans open until consumed", async () => {
+    const exporter = new InMemorySpanExporter();
+    initialize({ spanExporter: exporter, disableDefaultExporter: true, disableBatch: true });
+    const query = wrapClaudeAgentQuery(async function* (_prompt: string) {
+      yield { type: "message", text: "one" };
+      yield { type: "message", text: "two" };
+    });
+
+    const messages = [];
+    for await (const message of query("stream please")) {
+      messages.push(message);
+    }
+    await flush();
+
+    expect(messages).toHaveLength(2);
+    expect(exporter.getFinishedSpans()).toHaveLength(1);
+  });
+
+  it("provides a tracer compatible with Vercel-style telemetry hooks", async () => {
+    const exporter = new InMemorySpanExporter();
+    initialize({ spanExporter: exporter, disableDefaultExporter: true, disableBatch: true });
+
+    await fakeGenerateText({
+      experimental_telemetry: {
+        isEnabled: true,
+        tracer: AsymptoteObserve.getTracer(),
+      },
+    });
+    await flush();
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span.name).toBe("ai.generateText");
+    expect(span.attributes[ATTR_BEACON_HARNESS_NAME]).toBe("vercel_ai_sdk");
+    expect(span.attributes[ATTR_BEACON_EVENT_ACTION]).toBe("prompt.submitted");
+  });
+
+  it("exports OTLP over HTTP with hosted auth headers", async () => {
+    const requests: CapturedRequest[] = [];
+    const server = createServer(async (req, res) => {
+      requests.push({
+        method: req.method ?? "",
+        url: req.url ?? "",
+        authorization: req.headers.authorization,
+        body: await readRequestBody(req),
+      });
+      res.statusCode = 200;
+      res.end();
+    });
+    await listen(server);
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("unexpected server address");
+      }
+      initialize({
+        apiKey: "hosted-key",
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        disableBatch: true,
+      });
+
+      const traced = observe({ name: "agent.http" }, () => "ok");
+      traced();
+      await flush();
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0].method).toBe("POST");
+      expect(requests[0].url).toBe("/v1/observe");
+      expect(requests[0].authorization).toBe("Bearer hosted-key");
+      expect(requests[0].body.length).toBeGreaterThan(0);
+    } finally {
+      await close(server);
+    }
+  });
+});
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  authorization: string | undefined;
+  body: Buffer;
+}
+
+function clearEnv(): void {
+  for (const key of envKeys) {
+    delete process.env[key];
+  }
+}
+
+async function fakeGenerateText(options: { experimental_telemetry?: { isEnabled?: boolean; tracer?: ReturnType<typeof getTracer> } }): Promise<void> {
+  if (!options.experimental_telemetry?.isEnabled || !options.experimental_telemetry.tracer) {
+    return;
+  }
+  options.experimental_telemetry.tracer.startActiveSpan(
+    "ai.generateText",
+    {
+      attributes: {
+        [ATTR_BEACON_HARNESS_NAME]: "vercel_ai_sdk",
+        [ATTR_BEACON_EVENT_ACTION]: "prompt.submitted",
+      },
+    },
+    span => {
+      span.end();
+    },
+  );
+}
+
+function readRequestBody(req: IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", chunk => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function listen(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise(resolve => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}
+
+function close(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close(error => (error ? reject(error) : resolve()));
+  });
+}

--- a/packages/asymptote-observe-js/src/index.test.ts
+++ b/packages/asymptote-observe-js/src/index.test.ts
@@ -4,7 +4,6 @@ import { createServer, type IncomingMessage } from "node:http";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
-  ATTR_ASYMPTOTE_SDK_MODE,
   ATTR_BEACON_EVENT_ACTION,
   ATTR_BEACON_EVENT_CATEGORY,
   ATTR_BEACON_HARNESS_NAME,
@@ -63,6 +62,22 @@ describe("resolveExporterConfig", () => {
     expect(config.mode).toBe("otlp");
     expect(config.observeUrl).toBe("http://127.0.0.1:4318/v1/observe");
     expect(config.headers.authorization).toBeUndefined();
+  });
+
+  it("normalizes explicit OTLP traces endpoints to the Observe path", () => {
+    const config = resolveExporterConfig({ otlpEndpoint: "http://127.0.0.1:4318/v1/traces" });
+
+    expect(config.mode).toBe("otlp");
+    expect(config.observeUrl).toBe("http://127.0.0.1:4318/v1/observe");
+  });
+
+  it("normalizes generic OTLP endpoint env when it includes the traces path", () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://127.0.0.1:4318/v1/traces/";
+
+    const config = resolveExporterConfig();
+
+    expect(config.mode).toBe("otlp");
+    expect(config.observeUrl).toBe("http://127.0.0.1:4318/v1/observe");
   });
 
   it("prefers Observe endpoint env over generic OTLP endpoint env", () => {
@@ -159,6 +174,26 @@ describe("Asymptote Observe SDK", () => {
 
     expect(isInitialized()).toBe(true);
     expect(() => initialize({ disableDefaultExporter: true })).toThrow(/already initialized/);
+  });
+
+  it("does not wrap Claude Agent query twice when initialized again with instrumented modules", async () => {
+    const exporter = new InMemorySpanExporter();
+    const claudeAgentSDK = {
+      query: async (prompt: string) => ({ ok: true, prompt }),
+    };
+    initialize({
+      spanExporter: exporter,
+      disableDefaultExporter: true,
+      disableBatch: true,
+      instrumentModules: { claudeAgentSDK },
+    });
+
+    initialize({ instrumentModules: { claudeAgentSDK } });
+
+    await expect(claudeAgentSDK.query("explain tracing")).resolves.toEqual({ ok: true, prompt: "explain tracing" });
+    await flush();
+
+    expect(exporter.getFinishedSpans().filter(span => span.name === "claude_agent_sdk.query")).toHaveLength(1);
   });
 
   it("creates OpenLLMetry instrumentations", () => {

--- a/packages/asymptote-observe-js/src/index.ts
+++ b/packages/asymptote-observe-js/src/index.ts
@@ -1,0 +1,472 @@
+import {
+  SpanKind,
+  SpanStatusCode,
+  context,
+  trace,
+  type Attributes,
+  type Span,
+  type SpanOptions,
+  type Tracer,
+} from "@opentelemetry/api";
+import {
+  registerInstrumentations,
+  type Instrumentation,
+} from "@opentelemetry/instrumentation";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import {
+  BatchSpanProcessor,
+  SimpleSpanProcessor,
+  type SpanExporter,
+  type SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import {
+  AnthropicInstrumentation,
+  type AnthropicInstrumentationConfig,
+} from "@traceloop/instrumentation-anthropic";
+import {
+  OpenAIInstrumentation,
+  type OpenAIInstrumentationConfig,
+} from "@traceloop/instrumentation-openai";
+
+import {
+  ATTR_ASYMPTOTE_SDK_MODE,
+  ATTR_BEACON_EVENT_ACTION,
+  ATTR_BEACON_EVENT_CATEGORY,
+  ATTR_BEACON_HARNESS_NAME,
+  ATTR_BEACON_ORIGIN,
+  ATTR_BEACON_PROMPT_TEXT,
+  ATTR_BEACON_SESSION_ID,
+} from "./constants.js";
+
+export * from "./constants.js";
+
+const DEFAULT_HOSTED_BASE_URL = "https://api.asymptotelabs.ai";
+const DEFAULT_OBSERVE_PATH = "/v1/observe";
+const DEFAULT_TRACER_NAME = "asymptote-observe";
+const DEFAULT_SERVICE_NAME = "asymptote-observe-app";
+const SDK_VERSION = "0.0.0";
+
+export type ExportMode = "hosted" | "otlp" | "custom";
+
+export interface InstrumentModules {
+  Anthropic?: unknown;
+  OpenAI?: unknown;
+  anthropic?: unknown;
+  claudeAgentSDK?: { query?: unknown };
+  claudeAgentSdk?: { query?: unknown };
+  openAI?: unknown;
+  openai?: unknown;
+  [name: string]: unknown;
+}
+
+export interface InitializeOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  otlpEndpoint?: string;
+  headers?: Record<string, string>;
+  serviceName?: string;
+  resourceAttributes?: Attributes;
+  instrumentModules?: InstrumentModules;
+  disableInstrumentations?: boolean;
+  instrumentationOptions?: AsymptoteInstrumentationOptions;
+  spanProcessor?: SpanProcessor;
+  spanProcessors?: SpanProcessor[];
+  spanExporter?: SpanExporter;
+  disableDefaultExporter?: boolean;
+  disableBatch?: boolean;
+  traceExportTimeoutMillis?: number;
+  maxExportBatchSize?: number;
+}
+
+export interface ResolvedExporterConfig {
+  observeUrl?: string;
+  headers: Record<string, string>;
+  mode: ExportMode;
+}
+
+export interface ObserveOptions {
+  name: string;
+  spanKind?: SpanKind;
+  attributes?: Attributes;
+  ignoreInput?: boolean;
+  ignoreOutput?: boolean;
+}
+
+export interface AsymptoteInstrumentationOptions {
+  anthropic?: boolean | AnthropicInstrumentationConfig;
+  instrumentModules?: InstrumentModules;
+  openAI?: boolean | OpenAIInstrumentationConfig;
+  traceContent?: boolean;
+}
+
+interface SDKState {
+  instrumentations: Instrumentation[];
+  provider: NodeTracerProvider;
+  mode: ExportMode;
+  observeUrl?: string;
+}
+
+let state: SDKState | undefined;
+
+export class AsymptoteObserve {
+  static initialize(options: InitializeOptions = {}): void {
+    initialize(options);
+  }
+
+  static getTracer(name?: string, version?: string): Tracer {
+    return getTracer(name, version);
+  }
+
+  static observe<T extends (...args: any[]) => any>(options: ObserveOptions, fn: T): T {
+    return observe(options, fn);
+  }
+
+  static patch(modules: InstrumentModules): void {
+    patch(modules);
+  }
+
+  static instrumentations(options: AsymptoteInstrumentationOptions = {}): Instrumentation[] {
+    return initializeAsymptoteInstrumentations(options);
+  }
+
+  static wrapClaudeAgentQuery<T extends (...args: any[]) => any>(originalQuery: T): T {
+    return wrapClaudeAgentQuery(originalQuery);
+  }
+
+  static async flush(): Promise<void> {
+    await flush();
+  }
+
+  static async shutdown(): Promise<void> {
+    await shutdown();
+  }
+}
+
+export function initialize(options: InitializeOptions = {}): void {
+  if (state) {
+    if (options.instrumentModules) {
+      patch(options.instrumentModules);
+      return;
+    }
+    throw new Error("Asymptote Observe is already initialized; call shutdown() before reinitializing with new options");
+  }
+
+  const resolved = resolveExporterConfig(options);
+  const instrumentations = options.disableInstrumentations
+    ? []
+    : initializeAsymptoteInstrumentations(options.instrumentationOptions ?? {});
+  const processors = [
+    ...(options.spanProcessors ?? []),
+    ...(options.spanProcessor ? [options.spanProcessor] : []),
+  ];
+  if (options.spanExporter) {
+    processors.push(makeSpanProcessor(options.spanExporter, options));
+  }
+  if (!options.disableDefaultExporter) {
+    if (!resolved.observeUrl) {
+      throw new Error("Asymptote Observe default exporter requires an Observe endpoint");
+    }
+    processors.push(
+      makeSpanProcessor(
+        new OTLPTraceExporter({
+          url: resolved.observeUrl,
+          headers: resolved.headers,
+        }),
+        options,
+      ),
+    );
+  }
+
+  const provider = new NodeTracerProvider({
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: options.serviceName ?? process.env.OTEL_SERVICE_NAME ?? DEFAULT_SERVICE_NAME,
+      "telemetry.sdk.name": "asymptote-observe-js",
+      "telemetry.sdk.version": SDK_VERSION,
+      [ATTR_BEACON_ORIGIN]: "cloud",
+      [ATTR_BEACON_HARNESS_NAME]: "asymptote_observe",
+      [ATTR_ASYMPTOTE_SDK_MODE]: resolved.mode,
+      ...(options.resourceAttributes ?? {}),
+    }),
+    spanProcessors: processors,
+  });
+  provider.register();
+  if (instrumentations.length > 0) {
+    registerInstrumentations({ instrumentations });
+  }
+  state = { instrumentations, provider, mode: resolved.mode, observeUrl: resolved.observeUrl };
+
+  if (options.instrumentModules) {
+    patch(options.instrumentModules);
+  }
+}
+
+export function getTracer(name = DEFAULT_TRACER_NAME, version = SDK_VERSION): Tracer {
+  if (state) {
+    return state.provider.getTracer(name, version);
+  }
+  return trace.getTracer(name, version);
+}
+
+export function observe<T extends (...args: any[]) => any>(options: ObserveOptions, fn: T): T {
+  return function observed(this: unknown, ...args: Parameters<T>): ReturnType<T> {
+    const tracer = getTracer();
+    const span = tracer.startSpan(options.name, {
+      kind: options.spanKind ?? SpanKind.INTERNAL,
+      attributes: {
+        [ATTR_BEACON_HARNESS_NAME]: "asymptote_observe",
+        ...(options.attributes ?? {}),
+      },
+    });
+    if (!options.ignoreInput) {
+      span.setAttribute("asymptote.observe.input.count", args.length);
+    }
+    return context.with(trace.setSpan(context.active(), span), () => {
+      try {
+        const result = fn.apply(this, args);
+        return finishResult(result, span, options) as ReturnType<T>;
+      } catch (error) {
+        endSpanWithError(span, error);
+        throw error;
+      }
+    });
+  } as T;
+}
+
+export function patch(modules: InstrumentModules): void {
+  if (!modules || Object.keys(modules).length === 0) {
+    throw new Error("AsymptoteObserve.patch requires at least one module");
+  }
+  patchOpenLLMetryModules(modules);
+  patchClaudeAgentSDK(modules.claudeAgentSDK ?? modules.claudeAgentSdk);
+}
+
+export function initializeAsymptoteInstrumentations(options: AsymptoteInstrumentationOptions = {}): Instrumentation[] {
+  const instrumentations: Instrumentation[] = [];
+  const traceContent = options.traceContent;
+  if (options.openAI !== false) {
+    const config = typeof options.openAI === "object" ? options.openAI : {};
+    instrumentations.push(
+      new OpenAIInstrumentation({
+        traceContent,
+        ...config,
+      }) as unknown as Instrumentation,
+    );
+  }
+  if (options.anthropic !== false) {
+    const config = typeof options.anthropic === "object" ? options.anthropic : {};
+    instrumentations.push(
+      new AnthropicInstrumentation({
+        traceContent,
+        ...config,
+      }) as unknown as Instrumentation,
+    );
+  }
+  if (options.instrumentModules) {
+    manuallyInstrumentModules(instrumentations, options.instrumentModules);
+  }
+  return instrumentations;
+}
+
+export function wrapClaudeAgentQuery<T extends (...args: any[]) => any>(originalQuery: T): T {
+  return function asymptoteClaudeAgentQuery(this: unknown, ...args: Parameters<T>): ReturnType<T> {
+    const tracer = getTracer();
+    const span = tracer.startSpan("claude_agent_sdk.query", {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        [ATTR_BEACON_ORIGIN]: "cloud",
+        [ATTR_BEACON_HARNESS_NAME]: "claude_agent_sdk",
+        [ATTR_BEACON_EVENT_ACTION]: "prompt.submitted",
+        [ATTR_BEACON_EVENT_CATEGORY]: "prompt",
+        [ATTR_BEACON_PROMPT_TEXT]: firstStringArg(args),
+      },
+    });
+    return context.with(trace.setSpan(context.active(), span), () => {
+      try {
+        const result = originalQuery.apply(this, args);
+        return finishResult(result, span) as ReturnType<T>;
+      } catch (error) {
+        endSpanWithError(span, error);
+        throw error;
+      }
+    });
+  } as T;
+}
+
+export function startActiveSpan<T>(name: string, fn: (span: Span) => T, options: SpanOptions = {}): T {
+  const tracer = getTracer();
+  return tracer.startActiveSpan(name, options, span => {
+    try {
+      const result = fn(span);
+      return finishResult(result, span) as T;
+    } catch (error) {
+      endSpanWithError(span, error);
+      throw error;
+    }
+  });
+}
+
+export async function flush(): Promise<void> {
+  await state?.provider.forceFlush();
+}
+
+export async function shutdown(): Promise<void> {
+  state?.instrumentations.forEach(instrumentation => instrumentation.disable());
+  await state?.provider.shutdown();
+  state = undefined;
+}
+
+export function isInitialized(): boolean {
+  return Boolean(state);
+}
+
+export function resolveExporterConfig(options: InitializeOptions = {}): ResolvedExporterConfig {
+  const explicitEndpoint = options.otlpEndpoint ?? process.env.ASYMPTOTE_OBSERVE_ENDPOINT ?? process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  const apiKey = options.apiKey ?? process.env.ASYMPTOTE_OBSERVE_API_KEY;
+  const baseUrl = options.baseUrl ?? process.env.ASYMPTOTE_OBSERVE_BASE_URL ?? DEFAULT_HOSTED_BASE_URL;
+  const mode: ExportMode = options.disableDefaultExporter ? "custom" : explicitEndpoint ? "otlp" : apiKey ? "hosted" : "custom";
+
+  if (mode === "custom" && !options.disableDefaultExporter && !explicitEndpoint) {
+    throw new Error("Asymptote Observe requires ASYMPTOTE_OBSERVE_API_KEY for hosted ingest or OTEL_EXPORTER_OTLP_ENDPOINT for explicit OTLP export");
+  }
+
+  const observeUrl = options.disableDefaultExporter ? undefined : explicitEndpoint ? observeURL(explicitEndpoint) : observeURL(baseUrl);
+  const headers: Record<string, string> = { ...(options.headers ?? {}) };
+  if (apiKey && !headers.authorization && !headers.Authorization) {
+    headers.authorization = `Bearer ${apiKey}`;
+  }
+  return { observeUrl, headers, mode };
+}
+
+function makeSpanProcessor(exporter: SpanExporter, options: InitializeOptions): SpanProcessor {
+  return options.disableBatch
+    ? new SimpleSpanProcessor(exporter)
+    : new BatchSpanProcessor(exporter, {
+        exportTimeoutMillis: options.traceExportTimeoutMillis,
+        maxExportBatchSize: options.maxExportBatchSize,
+      });
+}
+
+function observeURL(endpoint: string): string {
+  const trimmed = endpoint.replace(/\/+$/, "");
+  if (trimmed.endsWith(DEFAULT_OBSERVE_PATH)) {
+    return trimmed;
+  }
+  return `${trimmed}${DEFAULT_OBSERVE_PATH}`;
+}
+
+function patchOpenLLMetryModules(modules: InstrumentModules): void {
+  const instrumentations = state?.instrumentations.length
+    ? state.instrumentations
+    : initializeAsymptoteInstrumentations();
+  manuallyInstrumentModules(instrumentations, modules);
+}
+
+function manuallyInstrumentModules(instrumentations: Instrumentation[], modules: InstrumentModules): void {
+  const openAIModule = modules.OpenAI ?? modules.openAI ?? modules.openai;
+  const anthropicModule = modules.Anthropic ?? modules.anthropic;
+  for (const instrumentation of instrumentations) {
+    const maybeManual = instrumentation as Instrumentation & {
+      manuallyInstrument?: (moduleValue: unknown) => void;
+    };
+    const instrumentationName = instrumentation.instrumentationName.toLowerCase();
+    if (openAIModule && instrumentationName.includes("openai")) {
+      maybeManual.manuallyInstrument?.(openAIModule);
+    }
+    if (anthropicModule && instrumentationName.includes("anthropic")) {
+      maybeManual.manuallyInstrument?.(anthropicModule);
+    }
+  }
+}
+
+function patchClaudeAgentSDK(moduleValue: unknown): void {
+  if (!moduleValue || typeof moduleValue !== "object") {
+    return;
+  }
+  const target = moduleValue as { query?: unknown };
+  if (typeof target.query !== "function") {
+    return;
+  }
+  try {
+    target.query = wrapClaudeAgentQuery(target.query as (...args: any[]) => any);
+  } catch {
+    // ESM namespace exports may be read-only; callers can wrap explicitly.
+  }
+}
+
+function finishResult<T>(result: T, span: Span, options?: ObserveOptions): unknown {
+  if (isPromiseLike(result)) {
+    return result.then(
+      value => {
+        if (!options?.ignoreOutput) {
+          span.setAttribute("asymptote.observe.output.type", typeof value);
+        }
+        span.setStatus({ code: SpanStatusCode.OK });
+        span.end();
+        return value;
+      },
+      error => {
+        endSpanWithError(span, error);
+        throw error;
+      },
+    );
+  }
+  if (isAsyncIterable(result)) {
+    return finishAsyncIterable(result, span);
+  }
+  if (!options?.ignoreOutput) {
+    span.setAttribute("asymptote.observe.output.type", typeof result);
+  }
+  span.setStatus({ code: SpanStatusCode.OK });
+  span.end();
+  return result;
+}
+
+async function* finishAsyncIterable(iterable: AsyncIterable<unknown>, span: Span): AsyncGenerator<unknown> {
+  try {
+    for await (const item of iterable) {
+      yield item;
+    }
+    span.setStatus({ code: SpanStatusCode.OK });
+  } catch (error) {
+    endSpanWithError(span, error);
+    throw error;
+  } finally {
+    span.end();
+  }
+}
+
+function endSpanWithError(span: Span, error: unknown): void {
+  if (error instanceof Error) {
+    span.recordException(error);
+    span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+  } else {
+    span.setStatus({ code: SpanStatusCode.ERROR, message: String(error) });
+  }
+  span.end();
+}
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return Boolean(value && typeof (value as Promise<unknown>).then === "function");
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return Boolean(value && typeof (value as AsyncIterable<unknown>)[Symbol.asyncIterator] === "function");
+}
+
+function firstStringArg(args: unknown[]): string {
+  for (const arg of args) {
+    if (typeof arg === "string" && arg.trim() !== "") {
+      return arg;
+    }
+    if (arg && typeof arg === "object") {
+      const maybePrompt = (arg as { prompt?: unknown; input?: unknown; query?: unknown }).prompt ?? (arg as { input?: unknown }).input ?? (arg as { query?: unknown }).query;
+      if (typeof maybePrompt === "string" && maybePrompt.trim() !== "") {
+        return maybePrompt;
+      }
+    }
+  }
+  return "";
+}

--- a/packages/asymptote-observe-js/src/index.ts
+++ b/packages/asymptote-observe-js/src/index.ts
@@ -430,11 +430,10 @@ async function* finishAsyncIterable(iterable: AsyncIterable<unknown>, span: Span
       yield item;
     }
     span.setStatus({ code: SpanStatusCode.OK });
+    span.end();
   } catch (error) {
     endSpanWithError(span, error);
     throw error;
-  } finally {
-    span.end();
   }
 }
 

--- a/packages/asymptote-observe-js/src/index.ts
+++ b/packages/asymptote-observe-js/src/index.ts
@@ -105,6 +105,7 @@ export interface AsymptoteInstrumentationOptions {
 
 interface SDKState {
   instrumentations: Instrumentation[];
+  instrumentationsDisabled: boolean;
   provider: NodeTracerProvider;
   mode: ExportMode;
   observeUrl?: string;
@@ -201,7 +202,7 @@ export function initialize(options: InitializeOptions = {}): void {
   if (instrumentations.length > 0) {
     registerInstrumentations({ instrumentations });
   }
-  state = { instrumentations, provider, mode: resolved.mode, observeUrl: resolved.observeUrl };
+  state = { instrumentations, instrumentationsDisabled: !!options.disableInstrumentations, provider, mode: resolved.mode, observeUrl: resolved.observeUrl };
 
   if (options.instrumentModules) {
     try {
@@ -385,6 +386,9 @@ function observeURL(endpoint: string): string {
 }
 
 function patchOpenLLMetryModules(modules: InstrumentModules): void {
+  if (state?.instrumentationsDisabled) {
+    return;
+  }
   let instrumentations: Instrumentation[];
   if (state?.instrumentations.length) {
     instrumentations = state.instrumentations;

--- a/packages/asymptote-observe-js/src/index.ts
+++ b/packages/asymptote-observe-js/src/index.ts
@@ -165,7 +165,7 @@ export function initialize(options: InitializeOptions = {}): void {
   if (options.spanExporter) {
     processors.push(makeSpanProcessor(options.spanExporter, options));
   }
-  if (!options.disableDefaultExporter) {
+  if (!options.disableDefaultExporter && !options.spanExporter) {
     if (!resolved.observeUrl) {
       throw new Error("Asymptote Observe default exporter requires an Observe endpoint");
     }
@@ -326,13 +326,14 @@ export function resolveExporterConfig(options: InitializeOptions = {}): Resolved
   const explicitEndpoint = options.otlpEndpoint ?? process.env.ASYMPTOTE_OBSERVE_ENDPOINT ?? process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
   const apiKey = options.apiKey ?? process.env.ASYMPTOTE_OBSERVE_API_KEY;
   const baseUrl = options.baseUrl ?? process.env.ASYMPTOTE_OBSERVE_BASE_URL ?? DEFAULT_HOSTED_BASE_URL;
-  const mode: ExportMode = options.disableDefaultExporter ? "custom" : explicitEndpoint ? "otlp" : apiKey ? "hosted" : "custom";
+  const skipDefault = !!(options.disableDefaultExporter || options.spanExporter);
+  const mode: ExportMode = skipDefault ? "custom" : explicitEndpoint ? "otlp" : apiKey ? "hosted" : "custom";
 
-  if (mode === "custom" && !options.disableDefaultExporter && !explicitEndpoint) {
+  if (mode === "custom" && !skipDefault && !explicitEndpoint) {
     throw new Error("Asymptote Observe requires ASYMPTOTE_OBSERVE_API_KEY for hosted ingest or OTEL_EXPORTER_OTLP_ENDPOINT for explicit OTLP export");
   }
 
-  const observeUrl = options.disableDefaultExporter ? undefined : explicitEndpoint ? observeURL(explicitEndpoint) : observeURL(baseUrl);
+  const observeUrl = skipDefault ? undefined : explicitEndpoint ? observeURL(explicitEndpoint) : observeURL(baseUrl);
   const headers: Record<string, string> = { ...(options.headers ?? {}) };
   if (apiKey && !headers.authorization && !headers.Authorization) {
     headers.authorization = `Bearer ${apiKey}`;
@@ -358,9 +359,15 @@ function observeURL(endpoint: string): string {
 }
 
 function patchOpenLLMetryModules(modules: InstrumentModules): void {
-  const instrumentations = state?.instrumentations.length
-    ? state.instrumentations
-    : initializeAsymptoteInstrumentations();
+  let instrumentations: Instrumentation[];
+  if (state?.instrumentations.length) {
+    instrumentations = state.instrumentations;
+  } else {
+    instrumentations = initializeAsymptoteInstrumentations();
+    if (state) {
+      state.instrumentations = instrumentations;
+    }
+  }
   manuallyInstrumentModules(instrumentations, modules);
 }
 

--- a/packages/asymptote-observe-js/src/index.ts
+++ b/packages/asymptote-observe-js/src/index.ts
@@ -38,16 +38,17 @@ import {
   ATTR_BEACON_HARNESS_NAME,
   ATTR_BEACON_ORIGIN,
   ATTR_BEACON_PROMPT_TEXT,
-  ATTR_BEACON_SESSION_ID,
 } from "./constants.js";
 
 export * from "./constants.js";
 
 const DEFAULT_HOSTED_BASE_URL = "https://api.asymptotelabs.ai";
 const DEFAULT_OBSERVE_PATH = "/v1/observe";
+const DEFAULT_OTLP_TRACES_PATH = "/v1/traces";
 const DEFAULT_TRACER_NAME = "asymptote-observe";
 const DEFAULT_SERVICE_NAME = "asymptote-observe-app";
 const SDK_VERSION = "0.0.0";
+const CLAUDE_AGENT_QUERY_WRAPPED = Symbol.for("@asymptote-labs/observe.claude-agent-query-wrapped");
 
 export type ExportMode = "hosted" | "otlp" | "custom";
 
@@ -108,6 +109,10 @@ interface SDKState {
   mode: ExportMode;
   observeUrl?: string;
 }
+
+type ClaudeAgentQueryFunction<T extends (...args: any[]) => any = (...args: any[]) => any> = T & {
+  [CLAUDE_AGENT_QUERY_WRAPPED]?: true;
+};
 
 let state: SDKState | undefined;
 
@@ -271,7 +276,10 @@ export function initializeAsymptoteInstrumentations(options: AsymptoteInstrument
 }
 
 export function wrapClaudeAgentQuery<T extends (...args: any[]) => any>(originalQuery: T): T {
-  return function asymptoteClaudeAgentQuery(this: unknown, ...args: Parameters<T>): ReturnType<T> {
+  if ((originalQuery as ClaudeAgentQueryFunction<T>)[CLAUDE_AGENT_QUERY_WRAPPED]) {
+    return originalQuery;
+  }
+  const wrapped = function asymptoteClaudeAgentQuery(this: unknown, ...args: Parameters<T>): ReturnType<T> {
     const tracer = getTracer();
     const span = tracer.startSpan("claude_agent_sdk.query", {
       kind: SpanKind.CLIENT,
@@ -292,7 +300,11 @@ export function wrapClaudeAgentQuery<T extends (...args: any[]) => any>(original
         throw error;
       }
     });
-  } as T;
+  } as ClaudeAgentQueryFunction<T>;
+  Object.defineProperty(wrapped, CLAUDE_AGENT_QUERY_WRAPPED, {
+    value: true,
+  });
+  return wrapped;
 }
 
 export function startActiveSpan<T>(name: string, fn: (span: Span) => T, options: SpanOptions = {}): T {
@@ -351,9 +363,16 @@ function makeSpanProcessor(exporter: SpanExporter, options: InitializeOptions): 
 }
 
 function observeURL(endpoint: string): string {
-  const trimmed = endpoint.replace(/\/+$/, "");
+  let end = endpoint.length;
+  while (end > 0 && endpoint.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  const trimmed = endpoint.slice(0, end);
   if (trimmed.endsWith(DEFAULT_OBSERVE_PATH)) {
     return trimmed;
+  }
+  if (trimmed.endsWith(DEFAULT_OTLP_TRACES_PATH)) {
+    return `${trimmed.slice(0, -DEFAULT_OTLP_TRACES_PATH.length)}${DEFAULT_OBSERVE_PATH}`;
   }
   return `${trimmed}${DEFAULT_OBSERVE_PATH}`;
 }

--- a/packages/asymptote-observe-js/src/index.ts
+++ b/packages/asymptote-observe-js/src/index.ts
@@ -204,7 +204,14 @@ export function initialize(options: InitializeOptions = {}): void {
   state = { instrumentations, provider, mode: resolved.mode, observeUrl: resolved.observeUrl };
 
   if (options.instrumentModules) {
-    patch(options.instrumentModules);
+    try {
+      patch(options.instrumentModules);
+    } catch (error) {
+      instrumentations.forEach(i => i.disable());
+      provider.shutdown().catch(() => {});
+      state = undefined;
+      throw error;
+    }
   }
 }
 

--- a/packages/asymptote-observe-js/tsconfig.build.json
+++ b/packages/asymptote-observe-js/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/asymptote-observe-js/tsconfig.json
+++ b/packages/asymptote-observe-js/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New opt-in cloud telemetry path may export prompts and API keys via env; beaconjson origin/prompt mapping changes affect how OTLP traces become JSONL events.
> 
> **Overview**
> Introduces **`@asymptote-labs/observe`** under `packages/asymptote-observe-js`: an OpenTelemetry-based SDK for cloud agent apps that exports spans to hosted or custom **`/v1/observe`** endpoints (API key or OTLP env/config), with **`observe()`** wrappers, default OpenLLMetry for OpenAI/Anthropic, and **`wrapClaudeAgentQuery()`** for Beacon-style prompt attributes.
> 
> **Beacon JSONL exporter** updates map **`beacon.origin`** for local/cloud/CI (not only CI), prefer **`beacon.prompt.text`** when building prompt events, and add a trace normalization test for Observe SDK spans.
> 
> **Repo plumbing:** a CI **`typescript-sdk`** job (test, typecheck, build, pack dry-run), **`node_modules`** gitignore, and **CLAUDE.md** / README docs for the SDK and release gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef8f9f15c093735c861c230d744dc2c9347bdfca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->