### PR TITLE
Require cloud run ID before upload

### DIFF
--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
@@ -74,7 +74,7 @@ func ConfigFromEnv() Config {
 		Prefix:         strings.Trim(strings.TrimSpace(os.Getenv("BEACON_CLOUD_GCS_PREFIX")), "/"),
 		CredentialsB64: strings.TrimSpace(os.Getenv("BEACON_CLOUD_GCS_CREDENTIALS_B64")),
 		Provider:       firstEnvDefault("claude_code_web", "BEACON_RUN_PROVIDER"),
-		RunID:          resolveRunID(statePath),
+		RunID:          resolveRunID(),
 		UserID:         firstEnvDefault("unknown", "BEACON_CLOUD_USER_ID_HASH", "BEACON_CLOUD_USER_ID"),
 		Repository:     firstEnv("BEACON_RUN_REPOSITORY"),
 		GCSEndpoint:    firstEnvDefault(defaultGCSEndpoint, "BEACON_CLOUD_GCS_ENDPOINT"),
@@ -93,7 +93,7 @@ func ResetFromEnv() error {
 	if err := preserveExistingLog(cfg); err != nil {
 		return err
 	}
-	for _, path := range []string{cfg.LogPath + ".lock", cfg.StatePath, cfg.StatePath + ".run-id"} {
+	for _, path := range []string{cfg.LogPath + ".lock", cfg.StatePath} {
 		if path == "" {
 			continue
 		}
@@ -106,6 +106,9 @@ func ResetFromEnv() error {
 
 func Upload(ctx context.Context, cfg Config, force bool) error {
 	if strings.TrimSpace(cfg.Bucket) == "" || strings.TrimSpace(cfg.CredentialsB64) == "" {
+		return nil
+	}
+	if strings.TrimSpace(cfg.RunID) == "" {
 		return nil
 	}
 	if cfg.LogPath == "" {
@@ -388,25 +391,8 @@ func preserveExistingLog(cfg Config) error {
 	return nil
 }
 
-func resolveRunID(statePath string) string {
-	if runID := firstEnv("BEACON_RUN_ID", "CLAUDE_CODE_REMOTE_SESSION_ID"); runID != "" {
-		return runID
-	}
-	return stableFallbackRunID(statePath)
-}
-
-func stableFallbackRunID(statePath string) string {
-	path := statePath + ".run-id"
-	if data, err := os.ReadFile(path); err == nil {
-		if value := strings.TrimSpace(string(data)); value != "" {
-			return value
-		}
-	}
-	value := fmt.Sprintf("manual-%d", time.Now().UTC().UnixNano())
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err == nil {
-		_ = os.WriteFile(path, []byte(value+"\n"), 0644)
-	}
-	return value
+func resolveRunID() string {
+	return firstEnv("BEACON_RUN_ID", "CLAUDE_CODE_REMOTE_SESSION_ID")
 }
 
 func cleanKeyParts(value string) []string {

--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
@@ -45,7 +45,7 @@ func TestResetFromEnvRemovesCloudRuntimeFiles(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "runtime.jsonl")
 	statePath := filepath.Join(dir, "state.json")
-	for _, path := range []string{logPath, logPath + ".lock", statePath, statePath + ".run-id"} {
+	for _, path := range []string{logPath, logPath + ".lock", statePath} {
 		if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
 			t.Fatalf("write %s: %v", path, err)
 		}
@@ -57,7 +57,7 @@ func TestResetFromEnvRemovesCloudRuntimeFiles(t *testing.T) {
 	if err := ResetFromEnv(); err != nil {
 		t.Fatalf("ResetFromEnv returned error: %v", err)
 	}
-	for _, path := range []string{logPath, logPath + ".lock", statePath, statePath + ".run-id"} {
+	for _, path := range []string{logPath, logPath + ".lock", statePath} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("%s still exists, stat err=%v", path, err)
 		}
@@ -129,23 +129,25 @@ func TestUploadSendsJSONLToGCS(t *testing.T) {
 	}
 }
 
-func TestStableFallbackRunIDReusesGeneratedValue(t *testing.T) {
-	statePath := filepath.Join(t.TempDir(), "shuttle-state.json")
-	first := stableFallbackRunID(statePath)
-	second := stableFallbackRunID(statePath)
-	if first == "" || second == "" || first != second {
-		t.Fatalf("fallback run id not stable: first=%q second=%q", first, second)
+func TestResolveRunIDUsesOnlyEnvironment(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_REMOTE_SESSION_ID", "cse_env")
+	if got := resolveRunID(); got != "cse_env" {
+		t.Fatalf("resolveRunID = %q, want cse_env", got)
 	}
 }
 
-func TestResolveRunIDPrefersEnvironmentWithoutFallbackSideEffect(t *testing.T) {
-	statePath := filepath.Join(t.TempDir(), "shuttle-state.json")
-	t.Setenv("CLAUDE_CODE_REMOTE_SESSION_ID", "cse_env")
-	if got := resolveRunID(statePath); got != "cse_env" {
-		t.Fatalf("resolveRunID = %q, want cse_env", got)
+func TestUploadNoopsWithoutRunID(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	if err := os.WriteFile(logPath, []byte("{}\n"), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
 	}
-	if _, err := os.Stat(statePath + ".run-id"); !os.IsNotExist(err) {
-		t.Fatalf("fallback run-id file should not be created when env run id exists: %v", err)
+	cfg := Config{
+		LogPath:        logPath,
+		Bucket:         "bucket",
+		CredentialsB64: "invalid-but-should-not-be-read",
+	}
+	if err := Upload(context.Background(), cfg, true); err != nil {
+		t.Fatalf("Upload returned error: %v", err)
 	}
 }
 

--- a/cli/beacon-hooks/internal/logging/endpoint_event_test.go
+++ b/cli/beacon-hooks/internal/logging/endpoint_event_test.go
@@ -103,43 +103,30 @@ func TestEndpointEventPrefersCloudUserHash(t *testing.T) {
 	}
 }
 
-func TestEndpointEventUsesStableFallbackCloudRunID(t *testing.T) {
+func TestEndpointEventDoesNotInventCloudRunID(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "runtime.jsonl")
-	statePath := filepath.Join(dir, "shuttle-state.json")
 	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
 	t.Setenv("BEACON_ORIGIN", "cloud")
 	t.Setenv("BEACON_RUN_PROVIDER", "claude_code_web")
 	t.Setenv("BEACON_CLOUD_GCS_BUCKET", "bucket")
 	t.Setenv("BEACON_CLOUD_GCS_CREDENTIALS_B64", "credentials")
-	t.Setenv("BEACON_CLOUD_SHUTTLE_STATE", statePath)
 
 	logger := NewLoggerForPlatform("session-start", "claude")
 	if err := logger.EndpointEvent("session.started", "session", "info", "Session started", nil); err != nil {
-		t.Fatalf("EndpointEvent returned error: %v", err)
-	}
-	if err := logger.EndpointEvent("tool.completed", "tool", "info", "Done", nil); err != nil {
 		t.Fatalf("EndpointEvent returned error: %v", err)
 	}
 	data, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read endpoint log: %v", err)
 	}
-	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("lines = %d, want 2", len(lines))
+	var event map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &event); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
 	}
-	var first, second map[string]interface{}
-	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
-		t.Fatalf("unmarshal first event: %v", err)
-	}
-	if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {
-		t.Fatalf("unmarshal second event: %v", err)
-	}
-	firstRunID := first["run"].(map[string]interface{})["run_id"]
-	secondRunID := second["run"].(map[string]interface{})["run_id"]
-	if firstRunID == "" || firstRunID != secondRunID {
-		t.Fatalf("fallback run IDs = %q and %q, want same non-empty value", firstRunID, secondRunID)
+	run := event["run"].(map[string]interface{})
+	if _, ok := run["run_id"]; ok {
+		t.Fatalf("run_id should be omitted when provider did not expose a run id: %#v", run)
 	}
 }
 

--- a/cli/beacon-hooks/internal/logging/logging.go
+++ b/cli/beacon-hooks/internal/logging/logging.go
@@ -164,8 +164,6 @@ func cloudRunFields() map[string]interface{} {
 	}
 	if runID := firstEnv("BEACON_RUN_ID", "CLAUDE_CODE_REMOTE_SESSION_ID"); runID != "" {
 		run["run_id"] = runID
-	} else if runID := fallbackCloudRunID(); runID != "" {
-		run["run_id"] = runID
 	}
 	if attempt := firstEnv("BEACON_RUN_ATTEMPT"); attempt != "" {
 		run["run_attempt"] = attempt
@@ -212,30 +210,6 @@ func firstEnv(keys ...string) string {
 		}
 	}
 	return ""
-}
-
-func fallbackCloudRunID() string {
-	if firstEnv("BEACON_ORIGIN") != "cloud" {
-		return ""
-	}
-	if firstEnv("BEACON_CLOUD_GCS_BUCKET") == "" || firstEnv("BEACON_CLOUD_GCS_CREDENTIALS_B64") == "" {
-		return ""
-	}
-	statePath := firstEnv("BEACON_CLOUD_SHUTTLE_STATE")
-	if statePath == "" {
-		statePath = "/tmp/beacon/shuttle-state.json"
-	}
-	path := statePath + ".run-id"
-	if data, err := os.ReadFile(path); err == nil {
-		if value := strings.TrimSpace(string(data)); value != "" {
-			return value
-		}
-	}
-	value := fmt.Sprintf("manual-%d", time.Now().UTC().UnixNano())
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err == nil {
-		_ = os.WriteFile(path, []byte(value+"\n"), 0644)
-	}
-	return value
 }
 
 func writeEndpointJSON(path string, event map[string]interface{}) error {


### PR DESCRIPTION
## Summary
- Stop inventing `manual-*` cloud run IDs for GCS uploads when Claude has not exposed `CLAUDE_CODE_REMOTE_SESSION_ID` yet.
- Keep local JSONL capture working while skipping GCS upload until a real provider run ID is available.
- Remove fallback run ID metadata from Beacon events so object paths and event contents stay aligned.

## Test plan
- `cd cli/beacon-hooks && go test ./...`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when cloud traces upload and how run_id appears in events; early sessions without `CLAUDE_CODE_REMOTE_SESSION_ID` may delay GCS uploads until the ID is available.
> 
> **Overview**
> Removes **synthetic `manual-*` cloud run IDs** so GCS uploads and endpoint telemetry only use provider-supplied IDs (`BEACON_RUN_ID` or `CLAUDE_CODE_REMOTE_SESSION_ID`).
> 
> **Cloud shuttle:** `resolveRunID` no longer reads or writes `statePath + ".run-id"`. `Upload` returns early when `RunID` is empty (local JSONL can still grow; no GCS call). `ResetFromEnv` no longer deletes the `.run-id` sidecar.
> 
> **Logging:** `cloudRunFields` drops `fallbackCloudRunID`; events omit `run.run_id` until the env exposes a real ID, matching upload object paths that require a real `run_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38886a64194bdafc07adcb574b2b2dc39df61471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->