### PR TITLE
Add release instructions

### DIFF
--- a/.github/workflows/npm-publish-sdk.yml
+++ b/.github/workflows/npm-publish-sdk.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - sdk-js-v*
 
+concurrency:
+  group: npm-publish-sdk-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   id-token: write
@@ -19,11 +23,33 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-          cache: npm
-          cache-dependency-path: packages/asymptote-sdk-js/package-lock.json
+      - name: Verify npm supports trusted publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --version
+          npm_version="$(npm --version)"
+          echo "npm ${npm_version}"
+          IFS=. read -r npm_major npm_minor _ <<<"${npm_version}"
+          if [ "${npm_major}" -lt 11 ] || { [ "${npm_major}" -eq 11 ] && [ "${npm_minor}" -lt 5 ]; }; then
+            echo "npm ${npm_version} does not support trusted publishing"
+            exit 1
+          fi
       - name: Install SDK dependencies
         working-directory: packages/asymptote-sdk-js
         run: npm ci
+      - name: Verify tag matches SDK version
+        if: startsWith(github.ref, 'refs/tags/')
+        working-directory: packages/asymptote-sdk-js
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#sdk-js-v}"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$pkg_version" ]; then
+            echo "Tag version ($tag) does not match package.json version ($pkg_version)"
+            exit 1
+          fi
       - name: Test SDK
         working-directory: packages/asymptote-sdk-js
         run: npm test
@@ -38,4 +64,4 @@ jobs:
         run: npm run pack:smoke
       - name: Publish SDK to npm
         working-directory: packages/asymptote-sdk-js
-        run: npm publish --access public --provenance
+        run: npm publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,46 @@ Clean up the temporary worktree after verification:
 git worktree remove --force .tmp/release-<tag>
 ```
 
+### TypeScript SDK Release
+
+Publish `@asymptote/sdk` from GitHub Actions instead of a local shell when
+possible so npm provenance remains enabled.
+
+Before tagging:
+
+```bash
+cd packages/asymptote-sdk-js
+npm test
+npm run check
+npm run pack:dry-run
+```
+
+Publish with an annotated SDK tag that matches `package.json` exactly:
+
+```bash
+git tag -a sdk-js-v<version> -m "sdk-js-v<version>"
+git push origin sdk-js-v<version>
+gh run list --workflow npm-publish-sdk.yml --limit 5
+```
+
+The `.github/workflows/npm-publish-sdk.yml` workflow validates that the pushed
+`sdk-js-v<version>` tag matches `packages/asymptote-sdk-js/package.json`, reruns
+the SDK checks, and publishes to npm with provenance.
+
+Trusted publishing must be configured in npm for this repository/workflow before
+the first CI publish. If trusted publishing is unavailable and the maintainer
+explicitly requests a local fallback, disable provenance for that one publish
+instead of changing the package defaults.
+
+Use these npm trusted publisher values:
+
+- Package: `@asymptote/sdk`
+- Publisher: GitHub Actions
+- Organization or owner: `asymptote-labs`
+- Repository: `agent-beacon`
+- Workflow filename: `npm-publish-sdk.yml`
+- Environment: leave unset unless the workflow is updated to declare one
+
 ## Implementation Notes
 
 - Prefer deterministic tests that use `t.TempDir()`, `t.Setenv("HOME", ...)`, fake binaries, and free local ports.

--- a/packages/asymptote-sdk-js/package-lock.json
+++ b/packages/asymptote-sdk-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asymptote/sdk",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asymptote/sdk",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",

--- a/packages/asymptote-sdk-js/package.json
+++ b/packages/asymptote-sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asymptote/sdk",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Asymptote TypeScript SDK for Observe agent telemetry",
   "type": "module",
   "license": "MIT",

--- a/packages/asymptote-sdk-js/src/index.ts
+++ b/packages/asymptote-sdk-js/src/index.ts
@@ -394,7 +394,7 @@ function readSDKVersion(): string {
   } catch {
     // Keep tracing usable in unusual bundler/test environments where package.json is unavailable.
   }
-  return "0.0.0";
+  return "0.1.0";
 }
 
 function patchOpenLLMetryModules(modules: InstrumentModules): void {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are release automation, documentation, and version metadata; no runtime Beacon or SDK API behavior changes beyond the version bump.
> 
> **Overview**
> Bumps **`@asymptote/sdk`** from `0.0.0` to **`0.1.0`** (including lockfile and the fallback in `readSDKVersion()`).
> 
> **`npm-publish-sdk.yml`** is tightened for trusted publishing: workflow **concurrency** per ref, drops setup-node **npm cache**, adds a gate that **npm ≥ 11.5** is required, and on tag pushes **fails if `sdk-js-v*` doesn’t match `package.json`**. Publish is now plain **`npm publish`** (provenance via `publishConfig` + OIDC) instead of explicit `--access public --provenance`.
> 
> **`CLAUDE.md`** adds a **TypeScript SDK release** section: pre-tag checks, `sdk-js-v<version>` tagging, CI workflow behavior, and npm trusted-publisher settings for GitHub Actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7036a8d5b58ef8e1317b1ef9dcc4ff69e219f572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->