### PR TITLE
Update readme hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,18 +103,18 @@ CI, and cloud surfaces.
 
 | Harness | Collection path | Telemetry coverage |
 | --- | --- | --- |
-| CI agent telemetry | Temporary local collector through `beacon ci exec` or `beacon ci start` / `beacon ci finish` | Supported agent prompt, tool, command, file, and run context where emitted during the job |
+| [CI agent telemetry](https://docs.asymptotelabs.ai/supported-runtimes-claude-code-ci) | Temporary local collector through `beacon ci exec` or `beacon ci start` / `beacon ci finish` | Supported agent prompt, tool, command, file, and run context where emitted during the job |
 
 #### Cloud Agents
 
 | Cloud surface | Collection path | Telemetry coverage |
 | --- | --- | --- |
-| Claude Code Cloud Agents | Cloud sandbox hooks with GCS upload | Session, prompt, tool, command, file, and lifecycle telemetry where Claude Code cloud hook payloads expose it |
-| Cursor Cloud Agents | Cloud sandbox hooks with GCS upload | Tool, shell command, file, subagent, and compaction telemetry where Cursor cloud hook payloads expose it |
-| Anthropic | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported Anthropic model call spans, errors, and OpenTelemetry attributes |
-| Claude Agent SDK | Query wrapper through `Observe.wrapClaudeAgentQuery()` | Query root spans with Beacon-compatible prompt attributes |
-| OpenAI | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported OpenAI model call spans, errors, and OpenTelemetry attributes |
-| Vercel AI SDK | Tracer handoff through `experimental_telemetry` | AI SDK model call and tool spans where telemetry is enabled |
+| [Claude Code Cloud Agents](https://docs.asymptotelabs.ai/claude-code-cloud-agents) | Cloud sandbox hooks with GCS upload | Session, prompt, tool, command, file, and lifecycle telemetry where Claude Code cloud hook payloads expose it |
+| [Cursor Cloud Agents](https://docs.asymptotelabs.ai/cursor-cloud-agents) | Cloud sandbox hooks with GCS upload | Tool, shell command, file, subagent, and compaction telemetry where Cursor cloud hook payloads expose it |
+| [Anthropic](https://docs.asymptotelabs.ai/sdk/integrations-anthropic) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported Anthropic model call spans, errors, and OpenTelemetry attributes |
+| [Claude Agent SDK](https://docs.asymptotelabs.ai/sdk/integrations-claude-agent-sdk) | Query wrapper through `Observe.wrapClaudeAgentQuery()` | Query root spans with Beacon-compatible prompt attributes |
+| [OpenAI](https://docs.asymptotelabs.ai/sdk/integrations-openai) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported OpenAI model call spans, errors, and OpenTelemetry attributes |
+| [Vercel AI SDK](https://docs.asymptotelabs.ai/sdk/integrations-vercel-ai-sdk) | Tracer handoff through `experimental_telemetry` | AI SDK model call and tool spans where telemetry is enabled |
 
 ### Output Destinations
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only hyperlink updates in README with no runtime or configuration impact.
> 
> **Overview**
> Adds **docs.asymptotelabs.ai** links on harness names in the **CI Agents** and **Cloud Agents** support tables so readers can jump straight to the matching runtime/integration pages.
> 
> **CI Agents:** `CI agent telemetry` now links to the Claude Code CI runtime doc.
> 
> **Cloud Agents:** Each row label (Claude Code Cloud Agents, Cursor Cloud Agents, Anthropic, Claude Agent SDK, OpenAI, Vercel AI SDK) is linked to its cloud-agent or SDK integration doc. Collection paths and telemetry columns are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47bae4bc78d1e8fc11410792bf5c74e45023ddab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->