### PR TITLE
Add cursor config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "image": "ubuntu-22.04",
+  "install": "./.cursor/install.sh",
+  "start": "./.cursor/start.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Installing Beacon Cursor Cloud hooks..."
+
+BEACON_HOME="${BEACON_HOME:-/tmp/beacon}"
+BEACON_BIN_DIR="$BEACON_HOME/bin"
+BEACON_LOG_PATH="${BEACON_CLOUD_LOG_PATH:-$BEACON_HOME/runtime.jsonl}"
+REPO_ROOT="${BEACON_CLOUD_REPO_DIR:-${CURSOR_PROJECT_DIR:-$(pwd)}}"
+
+mkdir -p "$BEACON_BIN_DIR" "$BEACON_HOME/logs"
+
+install_from_release() {
+  local version="$1"
+  local os="linux"
+  local arch
+
+  case "$(uname -m)" in
+    x86_64|amd64) arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *) echo "unsupported arch $(uname -m)" >&2; return 1 ;;
+  esac
+
+  local archive="beacon_${version#v}_${os}_${arch}.tar.gz"
+  local base="https://github.com/asymptote-labs/agent-beacon/releases/download/${version}"
+
+  curl -fsSL "${base}/${archive}" -o "$BEACON_HOME/${archive}"
+  tar -xzf "$BEACON_HOME/${archive}" -C "$BEACON_BIN_DIR"
+}
+
+install_go() {
+  if command -v go >/dev/null 2>&1; then
+    return
+  fi
+
+  local go_version="${BEACON_GO_VERSION:-1.24.4}"
+  local arch
+
+  case "$(uname -m)" in
+    x86_64|amd64) arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *) echo "unsupported arch $(uname -m)" >&2; return 1 ;;
+  esac
+
+  local tarball="go${go_version}.linux-${arch}.tar.gz"
+  mkdir -p "$BEACON_HOME/go-toolchain"
+  curl -fsSL "https://go.dev/dl/${tarball}" -o "$BEACON_HOME/${tarball}"
+  tar -xzf "$BEACON_HOME/${tarball}" -C "$BEACON_HOME/go-toolchain"
+  export PATH="$BEACON_HOME/go-toolchain/go/bin:$PATH"
+}
+
+build_from_source() {
+  install_go
+  (cd "$REPO_ROOT/cli/beacon" && go build -o "$BEACON_BIN_DIR/beacon" .)
+  (cd "$REPO_ROOT/cli/beacon-hooks" && go build -o "$BEACON_BIN_DIR/beacon-hooks" .)
+}
+
+if [ -n "${BEACON_VERSION:-}" ]; then
+  install_from_release "$BEACON_VERSION"
+else
+  build_from_source
+fi
+
+chmod +x "$BEACON_BIN_DIR/beacon" "$BEACON_BIN_DIR/beacon-hooks"
+
+mkdir -p "$REPO_ROOT/.cursor"
+"$BEACON_BIN_DIR/beacon" cloud cursor install-hooks \
+  --binary-path "$BEACON_BIN_DIR/beacon-hooks" \
+  --log-path "$BEACON_LOG_PATH" \
+  --hooks-json "$REPO_ROOT/.cursor/hooks.json"
+
+echo ".cursor/hooks.json" >> "$REPO_ROOT/.git/info/exclude" 2>/dev/null || true
+echo "Beacon Cursor Cloud hooks installed at $REPO_ROOT/.cursor/hooks.json"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BEACON_HOME="${BEACON_HOME:-/tmp/beacon}"
+BEACON_LOG_PATH="${BEACON_CLOUD_LOG_PATH:-$BEACON_HOME/runtime.jsonl}"
+
+mkdir -p "$(dirname "$BEACON_LOG_PATH")"
+
+if [ -n "${BEACON_CLOUD_GCS_BUCKET:-}" ] && [ -n "${BEACON_CLOUD_GCS_CREDENTIALS_B64:-}" ]; then
+  echo "Beacon Cloud GCS forwarding is configured for bucket: $BEACON_CLOUD_GCS_BUCKET"
+else
+  echo "Beacon Cloud GCS forwarding is not active; set BEACON_CLOUD_GCS_BUCKET and BEACON_CLOUD_GCS_CREDENTIALS_B64 to enable uploads."
+fi
+
+echo "Beacon runtime log path: $BEACON_LOG_PATH"

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -62,19 +62,30 @@ BEACON_RUN_EPHEMERAL=true
 BEACON_CLOUD_USER_ID_HASH=<stable-user-or-test-id>
 ```
 
-Then generate the setup script for a Beacon release and paste it into the
-provider's cloud setup field:
+For Cursor Cloud Agents, keep the repository-owned setup in `.cursor/`:
+
+```text
+.cursor/environment.json
+.cursor/install.sh
+.cursor/start.sh
+```
+
+The install script builds the current branch by default, or downloads a release
+when `BEACON_VERSION` is set, then merges Beacon commands into
+`.cursor/hooks.json` during environment setup.
+
+For Claude Code on the web, generate the setup script for a Beacon release and
+paste it into the provider's cloud setup field:
 
 ```bash
 ./beacon cloud claude-web print-setup --version vX.Y.Z
-./beacon cloud cursor print-setup --version vX.Y.Z
 ```
 
 The setup script installs `beacon-hooks` into the cloud sandbox and uploads a
 browser-viewable `/tmp/beacon/runtime.jsonl` snapshot to GCS. Claude web writes
-`.claude/settings.local.json` inside the sandbox clone. Cursor cloud merges
-Beacon commands into project-level `.cursor/hooks.json` because Cursor cloud
-only runs repository project hooks.
+`.claude/settings.local.json` inside the sandbox clone. Cursor cloud uses
+`.cursor/environment.json` to install Beacon and generate project-level
+`.cursor/hooks.json` because Cursor cloud only runs repository project hooks.
 
 ```text
 <prefix>/provider=claude_code_web/user_id=<id>/run_id=<claude-session-id>/runtime.jsonl


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dev-environment and documentation only; install script downloads/builds tooling and writes local hook config, with no production runtime or auth changes.
> 
> **Overview**
> Adds **repository-owned Cursor Cloud Agent bootstrap** under `.cursor/` so Beacon installs automatically when the cloud environment starts, instead of relying on a pasted `beacon cloud cursor print-setup` script.
> 
> `environment.json` points Cursor at **ubuntu-22.04** and runs `install.sh` / `start.sh`. **Install** either downloads a release when `BEACON_VERSION` is set or builds `beacon` and `beacon-hooks` from the repo (installing Go if needed), then runs `beacon cloud cursor install-hooks` to merge Beacon into `.cursor/hooks.json` and excludes that file from git via `.git/info/exclude`. **Start** ensures the runtime log directory exists and logs whether GCS forwarding env vars are set.
> 
> `cli/beacon/README.md` now documents this `.cursor/` layout as the Cursor Cloud path and drops `print-setup` from the Cursor quick-start (Claude web still uses `print-setup`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25c28d92da977efffdced4f308450f52e626303f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->