### PR TITLE
Add safe-mode for cursor hooks

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -63,11 +63,24 @@ fi
 
 chmod +x "$BEACON_BIN_DIR/beacon" "$BEACON_BIN_DIR/beacon-hooks"
 
+if [ ! -d "$REPO_ROOT" ] || [ ! -d "$REPO_ROOT/.git" ]; then
+  echo "Beacon Cursor Cloud setup could not find a git repository at REPO_ROOT=$REPO_ROOT" >&2
+  echo "Set BEACON_CLOUD_REPO_DIR or CURSOR_PROJECT_DIR to the cloned repository root." >&2
+  exit 1
+fi
+
 mkdir -p "$REPO_ROOT/.cursor"
-"$BEACON_BIN_DIR/beacon" cloud cursor install-hooks \
-  --binary-path "$BEACON_BIN_DIR/beacon-hooks" \
-  --log-path "$BEACON_LOG_PATH" \
+hook_args=(
+  cloud cursor install-hooks
+  --binary-path "$BEACON_BIN_DIR/beacon-hooks"
+  --log-path "$BEACON_LOG_PATH"
   --hooks-json "$REPO_ROOT/.cursor/hooks.json"
+)
+if [ "${BEACON_CURSOR_CLOUD_FULL_HOOKS:-0}" != "1" ]; then
+  hook_args+=(--safe-hooks)
+fi
+
+"$BEACON_BIN_DIR/beacon" "${hook_args[@]}"
 
 echo ".cursor/hooks.json" >> "$REPO_ROOT/.git/info/exclude" 2>/dev/null || true
 echo "Beacon Cursor Cloud hooks installed at $REPO_ROOT/.cursor/hooks.json"

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -72,7 +72,9 @@ For Cursor Cloud Agents, keep the repository-owned setup in `.cursor/`:
 
 The install script builds the current branch by default, or downloads a release
 when `BEACON_VERSION` is set, then merges Beacon commands into
-`.cursor/hooks.json` during environment setup.
+`.cursor/hooks.json` during environment setup. It defaults to safe hook coverage
+while testing forwarding and skips shell/edit-specific hooks; set
+`BEACON_CURSOR_CLOUD_FULL_HOOKS=1` to enable the full Cursor Cloud hook set.
 
 For Claude Code on the web, generate the setup script for a Beacon release and
 paste it into the provider's cloud setup field:

--- a/cli/beacon/cmd/cloud.go
+++ b/cli/beacon/cmd/cloud.go
@@ -27,6 +27,7 @@ var cloudOpts struct {
 	printOnly      bool
 	apply          bool
 	printEnv       bool
+	safeHooks      bool
 }
 
 var cloudCmd = &cobra.Command{
@@ -84,6 +85,7 @@ var cloudCursorPrintHooksCmd = &cobra.Command{
 		rendered, err := endpointhooks.RenderCursorCloudHooks(endpointhooks.CursorCloudOptions{
 			BinaryPath: cloudOpts.binaryPath,
 			LogPath:    defaultCloudLogPath(cloudOpts.logPath),
+			SafeHooks:  cloudOpts.safeHooks,
 		})
 		if err != nil {
 			return err
@@ -111,6 +113,7 @@ var cloudCursorInstallHooksCmd = &cobra.Command{
 		return endpointhooks.InstallCursorCloudHooksJSON(path, endpointhooks.CursorCloudOptions{
 			BinaryPath: cloudOpts.binaryPath,
 			LogPath:    defaultCloudLogPath(cloudOpts.logPath),
+			SafeHooks:  cloudOpts.safeHooks,
 		})
 	},
 }
@@ -157,9 +160,11 @@ func init() {
 	cloudClaudeWebPrintSetupCmd.Flags().StringVar(&cloudOpts.version, "version", "", "Beacon release tag to download, such as v0.0.50")
 	cloudCursorPrintHooksCmd.Flags().StringVar(&cloudOpts.binaryPath, "binary-path", "", "Path to beacon-hooks inside the cloud sandbox")
 	cloudCursorPrintHooksCmd.Flags().StringVar(&cloudOpts.logPath, "log-path", "/tmp/beacon/runtime.jsonl", "Cloud sandbox runtime JSONL path")
+	cloudCursorPrintHooksCmd.Flags().BoolVar(&cloudOpts.safeHooks, "safe-hooks", false, "Skip Cursor cloud shell/edit-specific hooks while testing telemetry forwarding")
 	cloudCursorInstallHooksCmd.Flags().StringVar(&cloudOpts.binaryPath, "binary-path", "", "Path to beacon-hooks inside the cloud sandbox")
 	cloudCursorInstallHooksCmd.Flags().StringVar(&cloudOpts.logPath, "log-path", "/tmp/beacon/runtime.jsonl", "Cloud sandbox runtime JSONL path")
 	cloudCursorInstallHooksCmd.Flags().StringVar(&cloudOpts.hooksJSONPath, "hooks-json", filepath.Join(".cursor", "hooks.json"), "Path to the project-level Cursor hooks.json")
+	cloudCursorInstallHooksCmd.Flags().BoolVar(&cloudOpts.safeHooks, "safe-hooks", false, "Skip Cursor cloud shell/edit-specific hooks while testing telemetry forwarding")
 	cloudCursorPrintSetupCmd.Flags().StringVar(&cloudOpts.version, "version", "", "Beacon release tag to download, such as v0.0.50")
 
 	cloudGCSSetupCmd.Flags().StringVar(&cloudOpts.project, "project", "", "Google Cloud project ID")

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -61,6 +61,33 @@ func TestRenderCursorCloudHooks(t *testing.T) {
 	}
 }
 
+func TestRenderCursorCloudSafeHooks(t *testing.T) {
+	got, err := endpointhooks.RenderCursorCloudHooks(endpointhooks.CursorCloudOptions{
+		BinaryPath: "/tmp/beacon/bin/beacon-hooks",
+		LogPath:    "/tmp/beacon/runtime.jsonl",
+		SafeHooks:  true,
+	})
+	if err != nil {
+		t.Fatalf("render cursor cloud hooks: %v", err)
+	}
+	for _, want := range []string{
+		`"beforeReadFile"`,
+		`"preToolUse"`,
+		`"postToolUse"`,
+		`"subagentStart"`,
+		`"preCompact"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered safe hooks missing %q:\n%s", want, got)
+		}
+	}
+	for _, skipped := range []string{`"beforeShellExecution"`, `"afterShellExecution"`, `"afterFileEdit"`} {
+		if strings.Contains(got, skipped) {
+			t.Fatalf("rendered safe hooks should not contain %q:\n%s", skipped, got)
+		}
+	}
+}
+
 func TestRenderCursorCloudSetupInstallsHooks(t *testing.T) {
 	got := renderCursorCloudSetup("v0.0.50")
 	for _, want := range []string{

--- a/cli/beacon/internal/endpoint/hooks/cursor.go
+++ b/cli/beacon/internal/endpoint/hooks/cursor.go
@@ -34,6 +34,7 @@ type CursorOptions struct {
 type CursorCloudOptions struct {
 	BinaryPath string
 	LogPath    string
+	SafeHooks  bool
 }
 
 type CursorStatus struct {
@@ -146,20 +147,13 @@ func CursorCloudHookRefs(opts CursorCloudOptions) map[string][]HookRef {
 		opts.LogPath = "/tmp/beacon/runtime.jsonl"
 	}
 	prefix := cursorCloudCommandPrefix(opts.BinaryPath, opts.LogPath)
-	return map[string][]HookRef{
+	refs := map[string][]HookRef{
 		"preToolUse":         {{Command: prefix + " pre-tool"}},
 		"postToolUse":        {{Command: prefix + " post-tool"}},
 		"postToolUseFailure": {{Command: prefix + " post-tool"}},
-		"beforeShellExecution": {
-			{Command: prefix + " pre-tool"},
-		},
-		"afterShellExecution": {
-			{Command: prefix + " post-tool"},
-		},
 		"beforeReadFile": {
 			{Command: prefix + " pre-tool"},
 		},
-		"afterFileEdit": {{Command: prefix + " post-tool"}},
 		"subagentStart": {
 			{Command: prefix + " subagent-start"},
 		},
@@ -170,6 +164,12 @@ func CursorCloudHookRefs(opts CursorCloudOptions) map[string][]HookRef {
 			{Command: prefix + " cursor-event"},
 		},
 	}
+	if !opts.SafeHooks {
+		refs["beforeShellExecution"] = []HookRef{{Command: prefix + " pre-tool"}}
+		refs["afterShellExecution"] = []HookRef{{Command: prefix + " post-tool"}}
+		refs["afterFileEdit"] = []HookRef{{Command: prefix + " post-tool"}}
+	}
+	return refs
 }
 
 func cursorCloudCommandPrefix(binaryPath, logPath string) string {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scope is cloud hook generation and install scripting only; default installs capture less telemetry until full hooks are opted in.
> 
> **Overview**
> Adds a **safe hooks** path for Cursor Cloud Beacon setup so telemetry can be validated without registering shell- and file-edit-specific Cursor hooks.
> 
> `CursorCloudHookRefs` now takes `SafeHooks`; when enabled it omits `beforeShellExecution`, `afterShellExecution`, and `afterFileEdit` while keeping tool, read, subagent, and compaction hooks. `beacon cloud cursor print-hooks` and `install-hooks` expose `--safe-hooks`, and `.cursor/install.sh` passes it by default unless `BEACON_CURSOR_CLOUD_FULL_HOOKS=1`. The install script also fails fast if `REPO_ROOT` is not a git checkout, with guidance to set `BEACON_CLOUD_REPO_DIR` or `CURSOR_PROJECT_DIR`.
> 
> Docs and tests cover the reduced hook set and the new default for cloud installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b480282692388b7a46262a88a8f87dda2f878f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->