### PR TITLE
Fix loom link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@
 ## What is Agent Beacon
 
 <div align="center">
-  <iframe src="https://www.loom.com/embed/b39038879dc24b10af9e603ad4e03fb6?t=0s" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="width: 100%; max-width: 860px; height: 484px;"></iframe>
+  <a href="https://www.loom.com/share/b39038879dc24b10af9e603ad4e03fb6?t=0s">
+    <img src="https://cdn.loom.com/sessions/thumbnails/b39038879dc24b10af9e603ad4e03fb6-with-play.gif" alt="Watch the Agent Beacon overview" width="860">
+  </a>
 </div>
 
 Agent Beacon is the world's first [open-source telemetry layer](https://justindsouza.substack.com/p/introducing-beacon-endpoint-telemetry) for AI agents wherever they run: locally, in CI, or in the cloud.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Replaces the embedded Loom **iframe** in the README “What is Agent Beacon” section with a **clickable thumbnail** (Loom CDN play GIF) that opens the same Loom share URL.
> 
> This fixes README rendering on GitHub, where iframes often fail or are stripped, while keeping the overview video one click away.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8113e4777db7694cbc90dfd358127be0a419b07c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->