### PR TITLE
Fix Cursor Cloud telemetry run IDs

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -76,7 +76,7 @@ hook_args=(
   --log-path "$BEACON_LOG_PATH"
   --hooks-json "$REPO_ROOT/.cursor/hooks.json"
 )
-if [ "${BEACON_CURSOR_CLOUD_FULL_HOOKS:-0}" != "1" ]; then
+if [ "${BEACON_CURSOR_CLOUD_SAFE_HOOKS:-0}" = "1" ]; then
   hook_args+=(--safe-hooks)
 fi
 

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -18,6 +18,7 @@ func emitHookEvent(logger *logging.Logger, action, category, severity, message s
 	if fields == nil {
 		fields = map[string]interface{}{}
 	}
+	seedCursorCloudRunID(input)
 	if platformFlag == "grok" {
 		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"grok": input})
 	}
@@ -56,6 +57,15 @@ func uploadCloudTelemetry(logger *logging.Logger, force bool) {
 func isCursorCloudMode() bool {
 	return strings.TrimSpace(os.Getenv("BEACON_ORIGIN")) == "cloud" &&
 		strings.TrimSpace(os.Getenv("BEACON_RUN_PROVIDER")) == "cursor_cloud"
+}
+
+func seedCursorCloudRunID(input map[string]interface{}) {
+	if platformFlag != "cursor" || !isCursorCloudMode() || strings.TrimSpace(os.Getenv("BEACON_RUN_ID")) != "" {
+		return
+	}
+	if runID := getFirstStr(input, "conversation_id", "parent_conversation_id"); runID != "" {
+		_ = os.Setenv("BEACON_RUN_ID", runID)
+	}
 }
 
 func maybeUploadCursorCloudTelemetry(logger *logging.Logger) {

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -84,6 +84,7 @@ func runPostTool(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	seedCursorCloudRunID(input)
 	recordLocalEdit(params, logger)
 	maybeUploadCursorCloudTelemetry(logger)
 	outputJSON(emptyResponse)
@@ -354,10 +355,10 @@ func emitCursorPostHookObserved(logger *logging.Logger, input map[string]interfa
 		return true
 	case "postToolUse":
 		toolName := strings.ToLower(getFirstStr(input, "tool_name", "toolName"))
-		if toolName == "shell" || strings.Contains(toolName, "terminal") {
-			// Only suppress when afterShellExecution is also registered (cloud setups).
-			// Desktop/project installs wire shell activity only through postToolUse.
-			if isCursorCloudMode() {
+		if isCursorCloudMode() {
+			// Cloud setups also register dedicated read/shell hooks, so avoid
+			// emitting a second generic postToolUse event for the same action.
+			if toolName == "read" || toolName == "shell" || strings.Contains(toolName, "terminal") {
 				return true
 			}
 		}

--- a/cli/beacon-hooks/cmd/post_tool_test.go
+++ b/cli/beacon-hooks/cmd/post_tool_test.go
@@ -114,6 +114,61 @@ func TestRunPostToolEmitsCursorAfterShellExecution(t *testing.T) {
 	}
 }
 
+func TestRunPostToolSuppressesCursorCloudReadPostToolDuplicate(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_ORIGIN", "cloud")
+	t.Setenv("BEACON_RUN_PROVIDER", "cursor_cloud")
+
+	out := runHookWithInput(t, runPostTool, map[string]interface{}{
+		"conversation_id": "conv-read",
+		"hook_event_name": "postToolUse",
+		"tool_name":       "Read",
+		"tool_input": map[string]interface{}{
+			"path": "/repo/README.md",
+		},
+	})
+	if len(out) != 0 {
+		t.Fatalf("post-tool response = %#v, want empty response", out)
+	}
+	assertNoEndpointLog(t, logPath)
+}
+
+func TestRunPostToolSeedsCursorCloudRunIDForAfterFileEdit(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_ORIGIN", "cloud")
+	t.Setenv("BEACON_RUN_PROVIDER", "cursor_cloud")
+	t.Setenv("BEACON_RUN_ID", "")
+
+	out := runHookWithInput(t, runPostTool, map[string]interface{}{
+		"conversation_id": "conv-edit",
+		"hook_event_name": "afterFileEdit",
+		"file_path":       "/repo/main.go",
+		"edits": []interface{}{
+			map[string]interface{}{
+				"old_string": "package main\n",
+				"new_string": "package main\n\nfunc main() {}\n",
+			},
+		},
+	})
+	if len(out) != 0 {
+		t.Fatalf("post-tool response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "file.modified" {
+		t.Fatalf("event.action = %q, want file.modified", action)
+	}
+	if runID := event["run"].(map[string]interface{})["run_id"]; runID != "conv-edit" {
+		t.Fatalf("run.run_id = %q, want conv-edit", runID)
+	}
+}
+
 func TestRunPostToolEmitsCursorPostToolFailure(t *testing.T) {
 	setupHookConfigDirs(t)
 	platformFlag = "cursor"

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -62,6 +62,7 @@ func TestRunPreToolEmitsCursorBeforeShellExecution(t *testing.T) {
 	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
 	t.Setenv("BEACON_ORIGIN", "cloud")
 	t.Setenv("BEACON_RUN_PROVIDER", "cursor_cloud")
+	t.Setenv("BEACON_RUN_ID", "")
 
 	out := runHookWithInput(t, runPreTool, map[string]interface{}{
 		"conversation_id": "conv-shell",
@@ -87,6 +88,9 @@ func TestRunPreToolEmitsCursorBeforeShellExecution(t *testing.T) {
 	}
 	if provider := event["run"].(map[string]interface{})["provider"]; provider != "cursor_cloud" {
 		t.Fatalf("run.provider = %q, want cursor_cloud", provider)
+	}
+	if runID := event["run"].(map[string]interface{})["run_id"]; runID != "conv-shell" {
+		t.Fatalf("run.run_id = %q, want conv-shell", runID)
 	}
 }
 

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -46,6 +46,7 @@ func TestRenderCursorCloudHooks(t *testing.T) {
 		`"subagentStart"`,
 		`"subagentStop"`,
 		`"preCompact"`,
+		`"matcher": "Write|Edit|MultiEdit|Delete|Grep|Glob|MCP|Task"`,
 		`BEACON_ORIGIN=cloud`,
 		`BEACON_RUN_PROVIDER=cursor_cloud`,
 		`'/tmp/beacon/bin/beacon-hooks' --platform cursor`,

--- a/cli/beacon/internal/endpoint/hooks/cursor.go
+++ b/cli/beacon/internal/endpoint/hooks/cursor.go
@@ -148,7 +148,7 @@ func CursorCloudHookRefs(opts CursorCloudOptions) map[string][]HookRef {
 	}
 	prefix := cursorCloudCommandPrefix(opts.BinaryPath, opts.LogPath)
 	refs := map[string][]HookRef{
-		"preToolUse":         {{Command: prefix + " pre-tool"}},
+		"preToolUse":         {{Command: prefix + " pre-tool", Matcher: "Write|Edit|MultiEdit|Delete|Grep|Glob|MCP|Task"}},
 		"postToolUse":        {{Command: prefix + " post-tool"}},
 		"postToolUseFailure": {{Command: prefix + " post-tool"}},
 		"beforeReadFile": {


### PR DESCRIPTION
## Summary
- Use Cursor Cloud `conversation_id` as the default Beacon `run.run_id` when `BEACON_RUN_ID` is not set.
- Reduce duplicate Cursor Cloud hook events for read and shell activity while preserving supported cloud hook coverage.
- Align the checked-in Cursor cloud install helper with the generated full-hook setup by making safe hooks opt-in.

## Test plan
- `cd cli/beacon-hooks && go test ./cmd`
- `cd cli/beacon && go test ./cmd`
- IDE lints checked for edited files


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Cursor Cloud hook wiring and telemetry correlation; mis-seeding or over-suppression could affect run grouping or event completeness, but scope is limited to cloud cursor hooks with new tests.
> 
> **Overview**
> Fixes **Cursor Cloud** telemetry so endpoint events get a stable **`run.run_id`** and duplicate hook noise is reduced.
> 
> When **`BEACON_RUN_ID`** is unset in cloud mode, hooks now seed it from **`conversation_id`** (or **`parent_conversation_id`**) via **`seedCursorCloudRunID`**, called from **`emitHookEvent`** and before file-edit handling in **`post-tool`**.
> 
> **`postToolUse`** no longer emits a second event for **read** and **shell/terminal** tools in Cursor Cloud, since dedicated read/shell hooks already cover those actions. Cloud **`preToolUse`** is scoped with matcher **`Write|Edit|MultiEdit|Delete|Grep|Glob|MCP|Task`** so read/shell traffic stays on the dedicated hooks.
> 
> **`.cursor/install.sh`** flips safe-hooks behavior: full cloud hook setup is the default; **`BEACON_CURSOR_CLOUD_SAFE_HOOKS=1`** opts into **`--safe-hooks`** (replacing the old opt-out **`BEACON_CURSOR_CLOUD_FULL_HOOKS`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02beeef1af96f949e1eadea9787976f66d86948a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->