### PR TITLE
Require committed Cursor Cloud hooks

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,50 @@
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor post-tool"
+      }
+    ],
+    "afterShellExecution": [
+      {
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor post-tool"
+      }
+    ],
+    "beforeReadFile": [
+      {
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor pre-tool"
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor pre-tool"
+      }
+    ],
+    "postToolUse": [
+      {
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor post-tool"
+      }
+    ],
+    "postToolUseFailure": [
+      {
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor post-tool"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor cursor-event"
+      }
+    ],
+    "subagentStart": [
+      {
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor subagent-start"
+      }
+    ],
+    "subagentStop": [
+      {
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor subagent-stop"
+      }
+    ]
+  }
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Installing Beacon Cursor Cloud hooks..."
+echo "Installing Beacon Cursor Cloud binaries..."
 
 BEACON_HOME="${BEACON_HOME:-/tmp/beacon}"
 BEACON_BIN_DIR="$BEACON_HOME/bin"
-BEACON_LOG_PATH="${BEACON_CLOUD_LOG_PATH:-$BEACON_HOME/runtime.jsonl}"
 REPO_ROOT="${BEACON_CLOUD_REPO_DIR:-${CURSOR_PROJECT_DIR:-$(pwd)}}"
 
 mkdir -p "$BEACON_BIN_DIR" "$BEACON_HOME/logs"
@@ -69,18 +68,10 @@ if [ ! -d "$REPO_ROOT" ] || [ ! -d "$REPO_ROOT/.git" ]; then
   exit 1
 fi
 
-mkdir -p "$REPO_ROOT/.cursor"
-hook_args=(
-  cloud cursor install-hooks
-  --binary-path "$BEACON_BIN_DIR/beacon-hooks"
-  --log-path "$BEACON_LOG_PATH"
-  --hooks-json "$REPO_ROOT/.cursor/hooks.json"
-)
-if [ "${BEACON_CURSOR_CLOUD_SAFE_HOOKS:-0}" = "1" ]; then
-  hook_args+=(--safe-hooks)
+if [ ! -f "$REPO_ROOT/.cursor/hooks.json" ]; then
+  echo "Beacon Cursor Cloud project hooks were not found at $REPO_ROOT/.cursor/hooks.json" >&2
+  echo "Commit .cursor/hooks.json before starting Cursor Cloud Agents." >&2
+  echo "Generate it with: beacon cloud cursor print-hooks --binary-path $BEACON_BIN_DIR/beacon-hooks --log-path $BEACON_HOME/runtime.jsonl > .cursor/hooks.json" >&2
 fi
 
-"$BEACON_BIN_DIR/beacon" "${hook_args[@]}"
-
-echo ".cursor/hooks.json" >> "$REPO_ROOT/.git/info/exclude" 2>/dev/null || true
-echo "Beacon Cursor Cloud hooks installed at $REPO_ROOT/.cursor/hooks.json"
+echo "Beacon Cursor Cloud binaries installed in $BEACON_BIN_DIR"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -72,6 +72,7 @@ if [ ! -f "$REPO_ROOT/.cursor/hooks.json" ]; then
   echo "Beacon Cursor Cloud project hooks were not found at $REPO_ROOT/.cursor/hooks.json" >&2
   echo "Commit .cursor/hooks.json before starting Cursor Cloud Agents." >&2
   echo "Generate it with: beacon cloud cursor print-hooks --binary-path $BEACON_BIN_DIR/beacon-hooks --log-path $BEACON_HOME/runtime.jsonl > .cursor/hooks.json" >&2
+  exit 1
 fi
 
 echo "Beacon Cursor Cloud binaries installed in $BEACON_BIN_DIR"

--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ CI, and cloud surfaces.
 | [OpenAI](https://docs.asymptotelabs.ai/sdk/integrations-openai) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported OpenAI model call spans, errors, and OpenTelemetry attributes |
 | [Vercel AI SDK](https://docs.asymptotelabs.ai/sdk/integrations-vercel-ai-sdk) | Tracer handoff through `experimental_telemetry` | AI SDK model call and tool spans where telemetry is enabled |
 
+Cursor Cloud Agents load project hooks from `.cursor/hooks.json` at task start.
+For reliable Cursor Cloud telemetry, commit the generated project hooks to the
+target repository and use the cloud setup script only to install Beacon binaries
+under `/tmp/beacon/bin`. Generate the project hook file locally with:
+
+```bash
+mkdir -p .cursor
+beacon cloud cursor print-hooks \
+  --binary-path /tmp/beacon/bin/beacon-hooks \
+  --log-path /tmp/beacon/runtime.jsonl > .cursor/hooks.json
+```
+
 ### Output Destinations
 
 Agent Beacon writes endpoint telemetry to local JSONL by default and supports

--- a/cli/beacon/cmd/cloud.go
+++ b/cli/beacon/cmd/cloud.go
@@ -20,7 +20,6 @@ var cloudOpts struct {
 	version        string
 	project        string
 	bucket         string
-	hooksJSONPath  string
 	location       string
 	prefix         string
 	serviceAccount string
@@ -95,32 +94,9 @@ var cloudCursorPrintHooksCmd = &cobra.Command{
 	},
 }
 
-var cloudCursorInstallHooksCmd = &cobra.Command{
-	Use:          "install-hooks",
-	Short:        "Merge Beacon hooks into project-level Cursor cloud hook settings",
-	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if strings.TrimSpace(cloudOpts.binaryPath) == "" {
-			return fmt.Errorf("--binary-path is required")
-		}
-		path := strings.TrimSpace(cloudOpts.hooksJSONPath)
-		if path == "" {
-			path = filepath.Join(".cursor", "hooks.json")
-		}
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-			return err
-		}
-		return endpointhooks.InstallCursorCloudHooksJSON(path, endpointhooks.CursorCloudOptions{
-			BinaryPath: cloudOpts.binaryPath,
-			LogPath:    defaultCloudLogPath(cloudOpts.logPath),
-			SafeHooks:  cloudOpts.safeHooks,
-		})
-	},
-}
-
 var cloudCursorPrintSetupCmd = &cobra.Command{
 	Use:          "print-setup",
-	Short:        "Print a Cursor cloud agent environment setup script",
+	Short:        "Print a Cursor cloud agent binary setup script",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if strings.TrimSpace(cloudOpts.version) == "" {
@@ -151,7 +127,6 @@ func init() {
 	cloudClaudeWebCmd.AddCommand(cloudClaudeWebPrintHooksCmd)
 	cloudClaudeWebCmd.AddCommand(cloudClaudeWebPrintSetupCmd)
 	cloudCursorCmd.AddCommand(cloudCursorPrintHooksCmd)
-	cloudCursorCmd.AddCommand(cloudCursorInstallHooksCmd)
 	cloudCursorCmd.AddCommand(cloudCursorPrintSetupCmd)
 	cloudGCSCmd.AddCommand(cloudGCSSetupCmd)
 
@@ -161,10 +136,6 @@ func init() {
 	cloudCursorPrintHooksCmd.Flags().StringVar(&cloudOpts.binaryPath, "binary-path", "", "Path to beacon-hooks inside the cloud sandbox")
 	cloudCursorPrintHooksCmd.Flags().StringVar(&cloudOpts.logPath, "log-path", "/tmp/beacon/runtime.jsonl", "Cloud sandbox runtime JSONL path")
 	cloudCursorPrintHooksCmd.Flags().BoolVar(&cloudOpts.safeHooks, "safe-hooks", false, "Skip Cursor cloud shell/edit-specific hooks while testing telemetry forwarding")
-	cloudCursorInstallHooksCmd.Flags().StringVar(&cloudOpts.binaryPath, "binary-path", "", "Path to beacon-hooks inside the cloud sandbox")
-	cloudCursorInstallHooksCmd.Flags().StringVar(&cloudOpts.logPath, "log-path", "/tmp/beacon/runtime.jsonl", "Cloud sandbox runtime JSONL path")
-	cloudCursorInstallHooksCmd.Flags().StringVar(&cloudOpts.hooksJSONPath, "hooks-json", filepath.Join(".cursor", "hooks.json"), "Path to the project-level Cursor hooks.json")
-	cloudCursorInstallHooksCmd.Flags().BoolVar(&cloudOpts.safeHooks, "safe-hooks", false, "Skip Cursor cloud shell/edit-specific hooks while testing telemetry forwarding")
 	cloudCursorPrintSetupCmd.Flags().StringVar(&cloudOpts.version, "version", "", "Beacon release tag to download, such as v0.0.50")
 
 	cloudGCSSetupCmd.Flags().StringVar(&cloudOpts.project, "project", "", "Google Cloud project ID")
@@ -284,26 +255,9 @@ curl -fsSL "${BASE}/${ARCHIVE}" -o "/tmp/beacon/${ARCHIVE}"
 tar -xzf "/tmp/beacon/${ARCHIVE}" -C /tmp/beacon/bin
 chmod +x /tmp/beacon/bin/beacon /tmp/beacon/bin/beacon-hooks 2>/dev/null || true
 
-REPO_ROOT="${BEACON_CLOUD_REPO_DIR:-${CURSOR_PROJECT_DIR:-}}"
-if [ -z "$REPO_ROOT" ]; then
-  REPO_ROOT="$(pwd)"
-fi
-if [ -z "$REPO_ROOT" ] || [ ! -d "$REPO_ROOT" ]; then
-  echo "Could not find Cursor cloud repo root" >&2
-  exit 1
-fi
-
-mkdir -p "$REPO_ROOT/.cursor"
-cat >> "$REPO_ROOT/.git/info/exclude" <<'EOF'
-.cursor/hooks.json
-EOF
-cd "$REPO_ROOT"
-/tmp/beacon/bin/beacon cloud cursor install-hooks \
-  --binary-path /tmp/beacon/bin/beacon-hooks \
-  --log-path /tmp/beacon/runtime.jsonl \
-  --hooks-json "$REPO_ROOT/.cursor/hooks.json"
-
-echo "Beacon hooks installed at $REPO_ROOT/.cursor/hooks.json"
+echo "Beacon binaries installed in /tmp/beacon/bin"
+echo "Commit a project-level .cursor/hooks.json before starting Cursor Cloud Agents:"
+echo "  beacon cloud cursor print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .cursor/hooks.json"
 `, version)
 }
 

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -12,7 +12,6 @@ func TestCloudCommandsRegistered(t *testing.T) {
 		{"cloud", "claude-web", "print-hooks"},
 		{"cloud", "claude-web", "print-setup"},
 		{"cloud", "cursor", "print-hooks"},
-		{"cloud", "cursor", "install-hooks"},
 		{"cloud", "cursor", "print-setup"},
 		{"cloud", "gcs", "setup"},
 	} {
@@ -36,7 +35,6 @@ func TestRenderCursorCloudHooks(t *testing.T) {
 	}
 	for _, want := range []string{
 		`"version": 1`,
-		`"preToolUse"`,
 		`"postToolUse"`,
 		`"postToolUseFailure"`,
 		`"beforeShellExecution"`,
@@ -46,7 +44,6 @@ func TestRenderCursorCloudHooks(t *testing.T) {
 		`"subagentStart"`,
 		`"subagentStop"`,
 		`"preCompact"`,
-		`"matcher": "Write|Edit|MultiEdit|Delete|Grep|Glob|MCP|Task"`,
 		`BEACON_ORIGIN=cloud`,
 		`BEACON_RUN_PROVIDER=cursor_cloud`,
 		`'/tmp/beacon/bin/beacon-hooks' --platform cursor`,
@@ -55,7 +52,7 @@ func TestRenderCursorCloudHooks(t *testing.T) {
 			t.Fatalf("rendered hooks missing %q:\n%s", want, got)
 		}
 	}
-	for _, unsupported := range []string{`"sessionStart"`, `"sessionEnd"`, `"beforeSubmitPrompt"`, `"stop"`} {
+	for _, unsupported := range []string{`"preToolUse"`, `"sessionStart"`, `"sessionEnd"`, `"beforeSubmitPrompt"`, `"stop"`} {
 		if strings.Contains(got, unsupported) {
 			t.Fatalf("rendered cursor cloud hooks should not contain %q:\n%s", unsupported, got)
 		}
@@ -73,7 +70,6 @@ func TestRenderCursorCloudSafeHooks(t *testing.T) {
 	}
 	for _, want := range []string{
 		`"beforeReadFile"`,
-		`"preToolUse"`,
 		`"postToolUse"`,
 		`"subagentStart"`,
 		`"preCompact"`,
@@ -87,23 +83,27 @@ func TestRenderCursorCloudSafeHooks(t *testing.T) {
 			t.Fatalf("rendered safe hooks should not contain %q:\n%s", skipped, got)
 		}
 	}
+	if strings.Contains(got, `"preToolUse"`) {
+		t.Fatalf("rendered safe hooks should not contain broad preToolUse:\n%s", got)
+	}
 }
 
-func TestRenderCursorCloudSetupInstallsHooks(t *testing.T) {
+func TestRenderCursorCloudSetupInstallsBinariesOnly(t *testing.T) {
 	got := renderCursorCloudSetup("v0.0.50")
 	for _, want := range []string{
 		`BEACON_VERSION="v0.0.50"`,
-		`REPO_ROOT="${BEACON_CLOUD_REPO_DIR:-${CURSOR_PROJECT_DIR:-}}"`,
-		`.cursor/hooks.json`,
-		`beacon cloud cursor install-hooks`,
-		`--hooks-json "$REPO_ROOT/.cursor/hooks.json"`,
+		`tar -xzf "/tmp/beacon/${ARCHIVE}" -C /tmp/beacon/bin`,
+		`Beacon binaries installed in /tmp/beacon/bin`,
+		`beacon cloud cursor print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .cursor/hooks.json`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("rendered setup missing %q:\n%s", want, got)
 		}
 	}
-	if strings.Contains(got, `> "$REPO_ROOT/.cursor/hooks.json"`) {
-		t.Fatalf("cursor setup should merge hooks instead of overwriting hooks.json:\n%s", got)
+	for _, forbidden := range []string{`beacon cloud cursor install-hooks`, `--hooks-json`, `.git/info/exclude`} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("cursor setup should not rewrite project hooks with %q:\n%s", forbidden, got)
+		}
 	}
 }
 

--- a/cli/beacon/internal/endpoint/hooks/cursor.go
+++ b/cli/beacon/internal/endpoint/hooks/cursor.go
@@ -111,25 +111,6 @@ func installCursorHooksJSON(path, binaryPath, logPath, configPath string) error 
 	return os.WriteFile(path, data, 0644)
 }
 
-func InstallCursorCloudHooksJSON(path string, opts CursorCloudOptions) error {
-	hooksJSON, err := readHooksJSON(path)
-	if err != nil {
-		return err
-	}
-	for hookName, refs := range CursorCloudHookRefs(opts) {
-		merged := hooksJSON.Hooks[hookName]
-		for _, ref := range refs {
-			merged = mergeEndpointHook(merged, ref)
-		}
-		hooksJSON.Hooks[hookName] = merged
-	}
-	data, err := json.MarshalIndent(hooksJSON, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(path, data, 0644)
-}
-
 func RenderCursorCloudHooks(opts CursorCloudOptions) (string, error) {
 	hooksJSON := HooksJSON{
 		Version: 1,
@@ -148,7 +129,6 @@ func CursorCloudHookRefs(opts CursorCloudOptions) map[string][]HookRef {
 	}
 	prefix := cursorCloudCommandPrefix(opts.BinaryPath, opts.LogPath)
 	refs := map[string][]HookRef{
-		"preToolUse":         {{Command: prefix + " pre-tool", Matcher: "Write|Edit|MultiEdit|Delete|Grep|Glob|MCP|Task"}},
 		"postToolUse":        {{Command: prefix + " post-tool"}},
 		"postToolUseFailure": {{Command: prefix + " post-tool"}},
 		"beforeReadFile": {

--- a/cli/beacon/internal/endpoint/hooks/cursor_test.go
+++ b/cli/beacon/internal/endpoint/hooks/cursor_test.go
@@ -153,67 +153,6 @@ func TestInstallCursorHooksJSONDoesNotReplaceUserCommandWithBeaconEnvOnly(t *tes
 	}
 }
 
-func TestInstallCursorCloudHooksJSONPreservesNonBeaconHooks(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "hooks.json")
-	existing := `{"version":1,"hooks":{"preToolUse":[{"command":"echo keep"}],"sessionStart":[{"command":"echo local-only"}]}}`
-	if err := os.WriteFile(path, []byte(existing), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := InstallCursorCloudHooksJSON(path, CursorCloudOptions{
-		BinaryPath: "/tmp/beacon-hooks",
-		LogPath:    "/tmp/runtime.jsonl",
-	}); err != nil {
-		t.Fatalf("InstallCursorCloudHooksJSON returned error: %v", err)
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read hooks.json: %v", err)
-	}
-	text := string(data)
-	for _, want := range []string{
-		"echo keep",
-		"echo local-only",
-		"BEACON_ORIGIN=cloud",
-		"BEACON_RUN_PROVIDER=cursor_cloud",
-		"beforeShellExecution",
-		"preCompact",
-	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("merged cursor cloud hooks missing %q:\n%s", want, text)
-		}
-	}
-	if strings.Contains(text, `"sessionEnd"`) || strings.Contains(text, `"beforeSubmitPrompt"`) {
-		t.Fatalf("cursor cloud install should not add unsupported cloud hooks:\n%s", text)
-	}
-}
-
-func TestInstallCursorCloudHooksJSONReplacesExistingBeaconHook(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "hooks.json")
-	existing := `{"version":1,"hooks":{"preToolUse":[{"command":"BEACON_ENDPOINT_MODE=1 old-beacon-hooks --platform cursor pre-tool"},{"command":"echo keep"}]}}`
-	if err := os.WriteFile(path, []byte(existing), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := InstallCursorCloudHooksJSON(path, CursorCloudOptions{
-		BinaryPath: "/tmp/new-beacon-hooks",
-		LogPath:    "/tmp/runtime.jsonl",
-	}); err != nil {
-		t.Fatalf("InstallCursorCloudHooksJSON returned error: %v", err)
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read hooks.json: %v", err)
-	}
-	text := string(data)
-	if strings.Contains(text, "old-beacon-hooks") {
-		t.Fatalf("old Beacon hook was not replaced:\n%s", text)
-	}
-	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "/tmp/new-beacon-hooks") {
-		t.Fatalf("merged hook config missing kept or new hook:\n%s", text)
-	}
-}
-
 func TestInstallCursorWithUnknownLevelFailsBeforeWritingTarget(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary
- Remove `beacon cloud cursor install-hooks` so Cursor Cloud setup no longer mutates `.cursor/hooks.json` inside the VM.
- Make `print-setup` install binaries only and document `print-hooks` as the committed project hook generation path.
- Drop broad Cursor Cloud `preToolUse` generation to keep project hooks conservative.

## Test plan
- `cd cli/beacon && go test ./cmd ./internal/endpoint/hooks`
- IDE lints checked for edited files


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Cursor Cloud onboarding and removes install-hooks merge behavior, which can break setups that relied on VM-time hook installation until repos commit the new hooks file.
> 
> **Overview**
> Cursor Cloud telemetry now expects a **committed** `.cursor/hooks.json` in the repo instead of rewriting hooks inside the cloud VM.
> 
> The **`beacon cloud cursor install-hooks`** command and **`InstallCursorCloudHooksJSON`** merge path are removed. **`print-setup`** / **`.cursor/install.sh`** only install binaries under `/tmp/beacon/bin` and **fail** if `.cursor/hooks.json` is missing, with instructions to generate it via **`beacon cloud cursor print-hooks`**. A sample committed hooks file is added, and the README documents the commit-first workflow.
> 
> Generated cloud hooks no longer include broad **`preToolUse`** (with tool matcher); tests were updated to match binaries-only setup and the slimmer hook set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d427543b3591cea9c926c5afa7ddb17d991ab7da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->