### PR TITLE
Token Usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Supported runtime surfaces today:
 - Asymptote Observe TypeScript SDK instrumentation for cloud applications, starting from OpenTelemetry/OpenLLMetry patterns and `observe()` wrappers.
 - Elasticsearch/Filebeat content pack generation for forwarding local Beacon JSONL into customer-managed Elastic deployments or the bundled loopback-only development stack.
 - A local-only dashboard served by `beacon endpoint dashboard`, bound to loopback by default and backed by the runtime JSONL log.
+- Token usage and runtime-reported cost capture across spans, logs, and metric datapoints, normalized into `gen_ai.usage`, with attribution rollups served by the dashboard token view (`/api/tokens`) and the `beacon endpoint tokens` report command for local and CI logs.
 
 Current non-goals unless explicitly requested:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,8 @@ Use these npm trusted publisher values:
 - Avoid tests that require root, real `launchctl` service changes, Wazuh, a live collector, or external network access.
 - For macOS-only behavior, gate tests with `runtime.GOOS == "darwin"` or assert the non-Darwin contract explicitly.
 - Keep endpoint event schema fields stable: `vendor`, `product`, `schema_version`, required event fields, and Wazuh-compatible JSONL output are release contracts.
-- Preserve optional event fields for agent-native metadata (`session`, `tool`, `file`, `command`, `mcp`, `approval`, `content`, `model`, `repository`, and `branch`) without changing existing required field semantics.
+- Preserve optional event fields for agent-native metadata (`session`, `trace`, `tool`, `file`, `command`, `mcp`, `approval`, `content`, `model`, `repository`, and `branch`) without changing existing required field semantics.
+- Keep `gen_ai.usage` as the single canonical token-usage representation: normalize all runtime token telemetry (span attributes, metric datapoints, legacy `llm.usage.*` aliases) into it, mirror OTel GenAI semconv JSON names exactly, and never add parallel or per-harness token fields. `gen_ai.usage.cost_usd` carries runtime-reported cost only; do not derive cost from local pricing tables.
 - When adding a new signal, include stable identifiers/counts/hashes alongside any retained raw content, and route raw fields through redaction, sanitization, truncation, and event-size controls.
 - Keep the dashboard read-only. It should inspect local status and JSONL events but must not mutate endpoint configuration or telemetry.
 - Keep the release readiness guidance in `README.md` up to date when install, packaging, collector, or dashboard behavior changes.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,15 @@ through standard MDM workflows.
 Beacon includes a local, read-only dashboard for validating endpoint activity
 without a hosted backend. The overview screen summarizes recent runtime events
 and collection status, while log search helps teams inspect normalized event
-records during rollout, testing, and investigations.
+records during rollout, testing, and investigations. The token usage screen
+breaks captured token telemetry down by model, session (with per-step
+drilldown), CI run, and harness, including context-window utilization and
+runtime-reported cost.
+
+For scripted or CI reporting, `beacon endpoint tokens` prints the same token
+usage rollups as text or JSON from any runtime JSONL log, for example
+`beacon endpoint tokens --log-path "$BEACON_CI_LOG_PATH" --json` after a CI
+session.
 
 Beacon writes endpoint activity to a stable local `runtime.jsonl` file. The
 active file rotates at 10 MiB with five numbered local archives, keeping the

--- a/cli/beacon/cmd/endpoint_tokens.go
+++ b/cli/beacon/cmd/endpoint_tokens.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/dashboard"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/tokens"
+)
+
+var endpointTokensOpts struct {
+	userMode   bool
+	systemMode bool
+	logPath    string
+	jsonOutput bool
+	since      string
+	until      string
+	session    string
+	model      string
+	harness    string
+	repository string
+	runID      string
+	bucket     string
+	top        int
+}
+
+var endpointTokensCmd = &cobra.Command{
+	Use:          "tokens",
+	Short:        "Report token usage and attribution from the endpoint runtime log",
+	SilenceUsage: true,
+	RunE:         runEndpointTokens,
+}
+
+func runEndpointTokens(cmd *cobra.Command, args []string) error {
+	userMode := endpointTokensOpts.userMode
+	if endpointTokensOpts.systemMode {
+		userMode = false
+	}
+	runtimeLog := lifecycle.ResolveRuntimeLog(userMode, endpointTokensOpts.logPath)
+	query := dashboard.EventQuery{
+		NoLimit:    true,
+		Session:    endpointTokensOpts.session,
+		Model:      endpointTokensOpts.model,
+		Harness:    endpointTokensOpts.harness,
+		Repository: endpointTokensOpts.repository,
+	}
+	if since := strings.TrimSpace(endpointTokensOpts.since); since != "" {
+		parsed, err := time.Parse(time.RFC3339, since)
+		if err != nil {
+			return err
+		}
+		query.Since = parsed
+	}
+	if until := strings.TrimSpace(endpointTokensOpts.until); until != "" {
+		parsed, err := time.Parse(time.RFC3339, until)
+		if err != nil {
+			return err
+		}
+		query.Until = parsed
+	}
+	result, err := dashboard.ReadEvents(runtimeLog.EffectiveLogPath, query)
+	if err != nil {
+		return err
+	}
+	events := make([]schema.Event, 0, len(result.Events))
+	for _, record := range result.Events {
+		if runID := strings.TrimSpace(endpointTokensOpts.runID); runID != "" {
+			if record.Event.Run == nil || record.Event.Run.RunID != runID {
+				continue
+			}
+		}
+		events = append(events, record.Event)
+	}
+	opts := tokens.Options{
+		SessionID: endpointTokensOpts.session,
+		TopLimit:  endpointTokensOpts.top,
+	}
+	if bucket := strings.TrimSpace(endpointTokensOpts.bucket); bucket != "" {
+		parsed, err := time.ParseDuration(bucket)
+		if err != nil {
+			return err
+		}
+		opts.BucketSize = parsed
+	}
+	report := tokens.Aggregate(events, opts)
+	out := cmd.OutOrStdout()
+	if endpointTokensOpts.jsonOutput {
+		encoder := json.NewEncoder(out)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
+	}
+	tokens.RenderText(out, report)
+	return nil
+}
+
+func init() {
+	endpointCmd.AddCommand(endpointTokensCmd)
+	endpointTokensCmd.Flags().BoolVar(&endpointTokensOpts.userMode, "user", true, "Use per-user endpoint paths")
+	endpointTokensCmd.Flags().BoolVar(&endpointTokensOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
+	endpointTokensCmd.Flags().StringVar(&endpointTokensOpts.logPath, "log-path", "", "Runtime JSONL log path (defaults to the endpoint runtime log; in CI point at the session log)")
+	endpointTokensCmd.Flags().BoolVar(&endpointTokensOpts.jsonOutput, "json", false, "Print the token usage report as JSON")
+	endpointTokensCmd.Flags().StringVar(&endpointTokensOpts.since, "since", "", "Only include events at or after this RFC3339 timestamp")
+	endpointTokensCmd.Flags().StringVar(&endpointTokensOpts.until, "until", "", "Only include events at or before this RFC3339 timestamp")
+	endpointTokensCmd.Flags().StringVar(&endpointTokensOpts.session, "session", "", "Filter to one session and include per-step detail")
+	endpointTokensCmd.Flags().StringVar(&endpointTokensOpts.model, "model", "", "Filter by model name")
+	endpointTokensCmd.Flags().StringVar(&endpointTokensOpts.harness, "harness", "", "Filter by harness name")
+	endpointTokensCmd.Flags().StringVar(&endpointTokensOpts.repository, "repository", "", "Filter by repository")
+	endpointTokensCmd.Flags().StringVar(&endpointTokensOpts.runID, "run-id", "", "Filter by CI run id")
+	endpointTokensCmd.Flags().StringVar(&endpointTokensOpts.bucket, "bucket", "", "Time-series bucket size (for example 1h or 15m)")
+	endpointTokensCmd.Flags().IntVar(&endpointTokensOpts.top, "top", 0, "Limit each grouping to the top N entries (0 keeps all)")
+}

--- a/cli/beacon/cmd/endpoint_tokens.go
+++ b/cli/beacon/cmd/endpoint_tokens.go
@@ -81,7 +81,10 @@ func runEndpointTokens(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		if runID != "" {
-			if record.Event.Run == nil || record.Event.Run.RunID != runID {
+			// Accept either the bare run id or the composite provider/run_id
+			// key shown in the BY RUN rollup.
+			run := record.Event.Run
+			if run == nil || (run.RunID != runID && tokens.RunKey(run.Provider, run.RunID) != runID) {
 				continue
 			}
 		}

--- a/cli/beacon/cmd/endpoint_tokens.go
+++ b/cli/beacon/cmd/endpoint_tokens.go
@@ -67,13 +67,20 @@ func runEndpointTokens(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	// ReadEvents returns events newest-first; feed Aggregate oldest-first so
-	// cumulative metric series resolve in chronological (append) order even
-	// when a batch of datapoints shares the same second-resolution timestamp.
+	// Feed Aggregate in chronological (append) order so cumulative metric
+	// series resolve correctly when a batch of datapoints shares the same
+	// second-resolution timestamp.
+	dashboard.SortRecordsAppendOrder(result.Events)
+	session := strings.TrimSpace(endpointTokensOpts.session)
+	runID := strings.TrimSpace(endpointTokensOpts.runID)
 	events := make([]schema.Event, 0, len(result.Events))
-	for i := len(result.Events) - 1; i >= 0; i-- {
-		record := result.Events[i]
-		if runID := strings.TrimSpace(endpointTokensOpts.runID); runID != "" {
+	for _, record := range result.Events {
+		// Exact session match keeps totals/grouping consistent with the
+		// per-step drilldown, which matches the session id exactly.
+		if session != "" && (record.Event.Session == nil || record.Event.Session.ID != session) {
+			continue
+		}
+		if runID != "" {
 			if record.Event.Run == nil || record.Event.Run.RunID != runID {
 				continue
 			}

--- a/cli/beacon/cmd/endpoint_tokens.go
+++ b/cli/beacon/cmd/endpoint_tokens.go
@@ -67,8 +67,12 @@ func runEndpointTokens(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// ReadEvents returns events newest-first; feed Aggregate oldest-first so
+	// cumulative metric series resolve in chronological (append) order even
+	// when a batch of datapoints shares the same second-resolution timestamp.
 	events := make([]schema.Event, 0, len(result.Events))
-	for _, record := range result.Events {
+	for i := len(result.Events) - 1; i >= 0; i-- {
+		record := result.Events[i]
 		if runID := strings.TrimSpace(endpointTokensOpts.runID); runID != "" {
 			if record.Event.Run == nil || record.Event.Run.RunID != runID {
 				continue

--- a/cli/beacon/cmd/endpoint_tokens.go
+++ b/cli/beacon/cmd/endpoint_tokens.go
@@ -75,9 +75,10 @@ func runEndpointTokens(cmd *cobra.Command, args []string) error {
 	runID := strings.TrimSpace(endpointTokensOpts.runID)
 	events := make([]schema.Event, 0, len(result.Events))
 	for _, record := range result.Events {
-		// Exact session match keeps totals/grouping consistent with the
-		// per-step drilldown, which matches the session id exactly.
-		if session != "" && (record.Event.Session == nil || record.Event.Session.ID != session) {
+		// Match the session case-insensitively (consistent with the
+		// case-insensitive event query) so totals/grouping stay aligned with
+		// the per-step drilldown.
+		if session != "" && (record.Event.Session == nil || !strings.EqualFold(record.Event.Session.ID, session)) {
 			continue
 		}
 		if runID != "" {

--- a/cli/beacon/cmd/endpoint_tokens_test.go
+++ b/cli/beacon/cmd/endpoint_tokens_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/tokens"
+)
+
+func TestEndpointTokensCommandRegistered(t *testing.T) {
+	cmd, _, err := endpointCmd.Find([]string{"tokens"})
+	if err != nil {
+		t.Fatalf("Find tokens returned error: %v", err)
+	}
+	if cmd == nil || cmd.Use != "tokens" {
+		t.Fatalf("tokens command not registered: %#v", cmd)
+	}
+	for _, flag := range []string{"log-path", "json", "since", "until", "session", "model", "harness", "repository", "run-id", "bucket", "top"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Fatalf("tokens command missing --%s flag", flag)
+		}
+	}
+}
+
+func writeTokensFixtureLog(t *testing.T) string {
+	t.Helper()
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	lines := []string{
+		`{"timestamp":"2026-06-11T10:00:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"token.usage","category":"metric"},"severity":"info","endpoint":{"os":"darwin"},"harness":{"name":"claude_code"},"session":{"id":"session-1"},"model":"claude-sonnet-4-5","gen_ai":{"usage":{"input_tokens":100}},"message":"claude_code.token.usage","raw":{"metric_name":"claude_code.token.usage","metric_temporality":"Delta"}}`,
+		`{"timestamp":"2026-06-11T10:00:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"token.usage","category":"metric"},"severity":"info","endpoint":{"os":"darwin"},"harness":{"name":"claude_code"},"session":{"id":"session-1"},"model":"claude-sonnet-4-5","gen_ai":{"usage":{"output_tokens":40}},"message":"claude_code.token.usage","raw":{"metric_name":"claude_code.token.usage","metric_temporality":"Delta"}}`,
+		`{"timestamp":"2026-06-11T10:05:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"cost.usage","category":"metric"},"severity":"info","endpoint":{"os":"darwin"},"harness":{"name":"claude_code"},"session":{"id":"session-1"},"model":"claude-sonnet-4-5","run":{"provider":"github_actions","run_id":"777"},"gen_ai":{"usage":{"cost_usd":0.5}},"message":"claude_code.cost.usage","raw":{"metric_name":"claude_code.cost.usage","metric_temporality":"Delta"}}`,
+	}
+	if err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatalf("write fixture log: %v", err)
+	}
+	return logPath
+}
+
+func runTokensCommand(t *testing.T, args ...string) string {
+	t.Helper()
+	endpointTokensOpts = struct {
+		userMode   bool
+		systemMode bool
+		logPath    string
+		jsonOutput bool
+		since      string
+		until      string
+		session    string
+		model      string
+		harness    string
+		repository string
+		runID      string
+		bucket     string
+		top        int
+	}{userMode: true}
+	if err := endpointTokensCmd.Flags().Parse(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	var out bytes.Buffer
+	endpointTokensCmd.SetOut(&out)
+	defer endpointTokensCmd.SetOut(nil)
+	if err := runEndpointTokens(endpointTokensCmd, nil); err != nil {
+		t.Fatalf("runEndpointTokens returned error: %v", err)
+	}
+	return out.String()
+}
+
+func TestEndpointTokensTextReport(t *testing.T) {
+	logPath := writeTokensFixtureLog(t)
+	output := runTokensCommand(t, "--log-path", logPath)
+	for _, want := range []string{
+		"3 of 3 events carry usage",
+		"claude-sonnet-4-5",
+		"session-1",
+		"claude_code",
+		"github_actions/777",
+		"0.5000",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("text report missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestEndpointTokensJSONReport(t *testing.T) {
+	logPath := writeTokensFixtureLog(t)
+	output := runTokensCommand(t, "--log-path", logPath, "--json", "--session", "session-1")
+	var report tokens.Report
+	if err := json.Unmarshal([]byte(output), &report); err != nil {
+		t.Fatalf("unmarshal JSON report: %v\n%s", err, output)
+	}
+	if report.Totals.InputTokens != 100 || report.Totals.OutputTokens != 40 || report.Totals.CostUSD != 0.5 {
+		t.Fatalf("totals = %#v", report.Totals)
+	}
+	if len(report.ByRun) != 1 || report.ByRun[0].Key != "github_actions/777" {
+		t.Fatalf("by_run = %#v", report.ByRun)
+	}
+	if report.SessionDetail == nil || report.SessionDetail.SessionID != "session-1" || len(report.SessionDetail.Steps) != 3 {
+		t.Fatalf("session detail = %#v", report.SessionDetail)
+	}
+}
+
+func TestEndpointTokensEmptyLogSucceeds(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	output := runTokensCommand(t, "--log-path", logPath)
+	if !strings.Contains(output, "0 of 0 events carry usage") {
+		t.Fatalf("empty report = %q", output)
+	}
+}

--- a/cli/beacon/cmd/endpoint_tokens_test.go
+++ b/cli/beacon/cmd/endpoint_tokens_test.go
@@ -104,6 +104,25 @@ func TestEndpointTokensJSONReport(t *testing.T) {
 	}
 }
 
+func TestEndpointTokensRunIDFilterAcceptsBareAndCompositeKeys(t *testing.T) {
+	logPath := writeTokensFixtureLog(t)
+	// The BY RUN rollup labels this run "github_actions/777"; both that
+	// composite key and the bare run id must select the run's usage.
+	for _, runID := range []string{"777", "github_actions/777"} {
+		output := runTokensCommand(t, "--log-path", logPath, "--json", "--run-id", runID)
+		var report tokens.Report
+		if err := json.Unmarshal([]byte(output), &report); err != nil {
+			t.Fatalf("unmarshal JSON report for %q: %v\n%s", runID, err, output)
+		}
+		if len(report.ByRun) != 1 || report.ByRun[0].Key != "github_actions/777" {
+			t.Fatalf("--run-id %q by_run = %#v, want the github_actions/777 run", runID, report.ByRun)
+		}
+		if report.Totals.CostUSD != 0.5 {
+			t.Fatalf("--run-id %q totals = %#v, want the run's cost", runID, report.Totals)
+		}
+	}
+}
+
 func TestEndpointTokensEmptyLogSucceeds(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
 	output := runTokensCommand(t, "--log-path", logPath)

--- a/cli/beacon/internal/ci/harness.go
+++ b/cli/beacon/internal/ci/harness.go
@@ -30,6 +30,9 @@ func ClaudeEnv(base []string, endpoint string) []string {
 	env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
 	env["OTEL_LOGS_EXPORTER"] = "otlp"
 	env["OTEL_METRICS_EXPORTER"] = "otlp"
+	// Delta temporality keeps token usage counters per-interval so downstream
+	// aggregation can sum datapoints without deduping cumulative series.
+	env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = "delta"
 	env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc"
 	env["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
 	delete(env, "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT")

--- a/cli/beacon/internal/ci/harness_test.go
+++ b/cli/beacon/internal/ci/harness_test.go
@@ -12,6 +12,7 @@ func TestClaudeEnvIncludesPromptLogging(t *testing.T) {
 	for _, want := range []string{
 		"CLAUDE_CODE_ENABLE_TELEMETRY=1",
 		"OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317",
+		"OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta",
 		"OTEL_LOG_USER_PROMPTS=1",
 	} {
 		if !strings.Contains(env, want) {

--- a/cli/beacon/internal/endpoint/dashboard/events.go
+++ b/cli/beacon/internal/endpoint/dashboard/events.go
@@ -83,6 +83,27 @@ func ReadEvents(path string, query EventQuery) (EventResult, error) {
 	return result, nil
 }
 
+// SortRecordsAppendOrder orders records oldest-first in log append order: by
+// timestamp, then older archives before the live log, then by numeric line.
+// Token aggregation needs this because runtime timestamps are second-resolution
+// (a batch of cumulative datapoints shares a timestamp) and the cumulative
+// dedup relies on append order; the newest-first ReadEvents sort breaks ties on
+// lexicographic line IDs, which mis-orders line-9 vs line-10 within a second.
+func SortRecordsAppendOrder(records []EventRecord) {
+	sort.SliceStable(records, func(i, j int) bool {
+		if !records[i].Parsed.Equal(records[j].Parsed) {
+			return records[i].Parsed.Before(records[j].Parsed)
+		}
+		ai, li, _ := parseRecordID(records[i].ID)
+		aj, lj, _ := parseRecordID(records[j].ID)
+		if ai != aj {
+			// Higher archive index is an older rotation, so it comes first.
+			return ai > aj
+		}
+		return li < lj
+	})
+}
+
 func readEventsFromSource(source eventSource, query EventQuery, result *EventResult, limit int) error {
 	file, err := os.Open(source.path)
 	if err != nil {

--- a/cli/beacon/internal/endpoint/dashboard/events.go
+++ b/cli/beacon/internal/endpoint/dashboard/events.go
@@ -42,6 +42,7 @@ type EventQuery struct {
 	Category   string
 	Repository string
 	Session    string
+	Trace      string
 	File       string
 	Command    string
 	MCP        string
@@ -317,6 +318,11 @@ func matchesQuery(record EventRecord, query EventQuery) bool {
 			return false
 		}
 	}
+	if query.Trace != "" {
+		if event.Trace == nil || (!containsFold(event.Trace.ID, query.Trace) && !containsFold(event.Trace.SpanID, query.Trace) && !containsFold(event.Trace.ParentSpanID, query.Trace)) {
+			return false
+		}
+	}
 	if query.File != "" {
 		if event.File == nil || !containsFold(event.File.Path, query.File) {
 			return false
@@ -440,6 +446,9 @@ func searchFields(record EventRecord) []string {
 	if event.Session != nil {
 		fields = append(fields, event.Session.ID, event.Session.WorkingDirectory)
 	}
+	if event.Trace != nil {
+		fields = append(fields, event.Trace.ID, event.Trace.SpanID, event.Trace.ParentSpanID)
+	}
 	if event.Tool != nil {
 		fields = append(fields, event.Tool.Name, event.Tool.Command, event.Tool.Path)
 	}
@@ -503,6 +512,7 @@ func activeFilters(query EventQuery) map[string]string {
 	add("category", query.Category)
 	add("repository", query.Repository)
 	add("session", query.Session)
+	add("trace", query.Trace)
 	add("file", query.File)
 	add("command", query.Command)
 	add("mcp", query.MCP)

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -110,9 +110,10 @@ func Handler(opts Options) (http.Handler, error) {
 		session := strings.TrimSpace(query.Session)
 		events := make([]schema.Event, 0, len(result.Events))
 		for _, record := range result.Events {
-			// Exact session match keeps totals/grouping consistent with the
-			// per-step drilldown, which matches the session id exactly.
-			if session != "" && (record.Event.Session == nil || record.Event.Session.ID != session) {
+			// Match the session case-insensitively (consistent with the
+			// case-insensitive event query) so totals/grouping stay aligned
+			// with the per-step drilldown.
+			if session != "" && (record.Event.Session == nil || !strings.EqualFold(record.Event.Session.ID, session)) {
 				continue
 			}
 			events = append(events, record.Event)

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -103,9 +103,12 @@ func Handler(opts Options) (http.Handler, error) {
 			writeError(w, http.StatusInternalServerError, err)
 			return
 		}
+		// ReadEvents returns events newest-first; feed Aggregate oldest-first so
+		// cumulative metric series resolve in chronological (append) order even
+		// when a batch of datapoints shares the same second-resolution timestamp.
 		events := make([]schema.Event, 0, len(result.Events))
-		for _, record := range result.Events {
-			events = append(events, record.Event)
+		for i := len(result.Events) - 1; i >= 0; i-- {
+			events = append(events, result.Events[i].Event)
 		}
 		writeJSON(w, tokens.Aggregate(events, tokenOptions(r)))
 	})

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -103,12 +103,19 @@ func Handler(opts Options) (http.Handler, error) {
 			writeError(w, http.StatusInternalServerError, err)
 			return
 		}
-		// ReadEvents returns events newest-first; feed Aggregate oldest-first so
-		// cumulative metric series resolve in chronological (append) order even
-		// when a batch of datapoints shares the same second-resolution timestamp.
+		// Feed Aggregate in chronological (append) order so cumulative metric
+		// series resolve correctly when a batch of datapoints shares the same
+		// second-resolution timestamp.
+		SortRecordsAppendOrder(result.Events)
+		session := strings.TrimSpace(query.Session)
 		events := make([]schema.Event, 0, len(result.Events))
-		for i := len(result.Events) - 1; i >= 0; i-- {
-			events = append(events, result.Events[i].Event)
+		for _, record := range result.Events {
+			// Exact session match keeps totals/grouping consistent with the
+			// per-step drilldown, which matches the session id exactly.
+			if session != "" && (record.Event.Session == nil || record.Event.Session.ID != session) {
+				continue
+			}
+			events = append(events, record.Event)
 		}
 		writeJSON(w, tokens.Aggregate(events, tokenOptions(r)))
 	})

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/tokens"
 )
 
 const DefaultAddr = "127.0.0.1:8765"
@@ -87,6 +89,25 @@ func Handler(opts Options) (http.Handler, error) {
 			return
 		}
 		writeJSON(w, events)
+	})
+	mux.HandleFunc("/api/tokens", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			methodNotAllowed(w)
+			return
+		}
+		// Token rollups need the full matching log, not the latest page.
+		query := parseQuery(r, maxEventLimit)
+		query.NoLimit = true
+		result, err := ReadEvents(opts.LogPath, query)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err)
+			return
+		}
+		events := make([]schema.Event, 0, len(result.Events))
+		for _, record := range result.Events {
+			events = append(events, record.Event)
+		}
+		writeJSON(w, tokens.Aggregate(events, tokenOptions(r)))
 	})
 	mux.HandleFunc("/api/event", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -176,6 +197,7 @@ func parseQuery(r *http.Request, fallbackLimit int) EventQuery {
 		Category:   q.Get("category"),
 		Repository: q.Get("repository"),
 		Session:    q.Get("session"),
+		Trace:      q.Get("trace"),
 		File:       q.Get("file"),
 		Command:    q.Get("command"),
 		MCP:        q.Get("mcp"),
@@ -196,6 +218,20 @@ func parseQuery(r *http.Request, fallbackLimit int) EventQuery {
 		}
 	}
 	return query
+}
+
+func tokenOptions(r *http.Request) tokens.Options {
+	q := r.URL.Query()
+	opts := tokens.Options{SessionID: q.Get("session")}
+	if bucket := q.Get("bucket"); bucket != "" {
+		if parsed, err := time.ParseDuration(bucket); err == nil && parsed > 0 {
+			opts.BucketSize = parsed
+		}
+	}
+	if top, err := strconv.Atoi(q.Get("top")); err == nil && top > 0 {
+		opts.TopLimit = top
+	}
+	return opts
 }
 
 func writeJSON(w http.ResponseWriter, value interface{}) {

--- a/cli/beacon/internal/endpoint/dashboard/server_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/server_test.go
@@ -145,6 +145,73 @@ func TestTokensEndpointDedupesCumulativeSameSecondDatapoints(t *testing.T) {
 
 func itoa(v int64) string { return strconv.FormatInt(v, 10) }
 
+// TestTokensEndpointDedupesManySameSecondDatapoints uses more than nine
+// cumulative datapoints in the same second so line numbers reach two digits.
+// ReadEvents breaks same-timestamp ties on lexicographic line IDs (line-9 >
+// line-10), so the token path must reorder by numeric append order or the
+// cumulative dedup scrambles and inflates totals.
+func TestTokensEndpointDedupesManySameSecondDatapoints(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	var lines []string
+	for k := int64(1); k <= 12; k++ {
+		// Cumulative input k*100 -> per-interval delta of 100 each -> 1200 total.
+		lines = append(lines, `{"timestamp":"2026-06-11T10:00:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"token.usage","category":"metric"},"severity":"info","endpoint":{"os":"linux"},"harness":{"name":"claude_code"},"session":{"id":"s1"},"model":"claude-sonnet-4-5","gen_ai":{"usage":{"input_tokens":`+itoa(k*100)+`}},"message":"claude_code.token.usage","raw":{"metric_name":"claude_code.token.usage","metric_temporality":"Cumulative"}}`)
+	}
+	if err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatalf("write fixture log: %v", err)
+	}
+	handler, err := Handler(Options{UserMode: true, LogPath: logPath})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/tokens", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var report tokens.Report
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("unmarshal tokens report: %v", err)
+	}
+	if report.Totals.InputTokens != 1200 {
+		t.Fatalf("cumulative input tokens = %d, want 1200", report.Totals.InputTokens)
+	}
+}
+
+// TestTokensEndpointSessionFilterIsExact guards against substring session
+// matching: filtering session-1 must not fold in session-10's usage.
+func TestTokensEndpointSessionFilterIsExact(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	mk := func(session string, input int64) string {
+		return `{"timestamp":"2026-06-11T10:00:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"token.usage","category":"metric"},"severity":"info","endpoint":{"os":"linux"},"harness":{"name":"claude_code"},"session":{"id":"` + session + `"},"model":"claude-sonnet-4-5","gen_ai":{"usage":{"input_tokens":` + itoa(input) + `}},"message":"claude_code.token.usage","raw":{"metric_name":"claude_code.token.usage","metric_temporality":"Delta"}}`
+	}
+	lines := []string{mk("session-1", 100), mk("session-10", 999)}
+	if err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatalf("write fixture log: %v", err)
+	}
+	handler, err := Handler(Options{UserMode: true, LogPath: logPath})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/tokens?session=session-1", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var report tokens.Report
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("unmarshal tokens report: %v", err)
+	}
+	if report.Totals.InputTokens != 100 {
+		t.Fatalf("session-1 totals = %d, want 100 (session-10 must not fold in)", report.Totals.InputTokens)
+	}
+	if report.SessionDetail == nil || report.SessionDetail.Usage.InputTokens != 100 {
+		t.Fatalf("session detail = %#v, want exact session-1 usage", report.SessionDetail)
+	}
+}
+
 func TestStaticDashboardPagesServe(t *testing.T) {
 	handler, err := Handler(Options{UserMode: true, LogPath: filepath.Join(t.TempDir(), "runtime.jsonl")})
 	if err != nil {

--- a/cli/beacon/internal/endpoint/dashboard/server_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/server_test.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/tokens"
 )
 
 func TestStatusUsesExplicitRuntimeLogPath(t *testing.T) {
@@ -35,6 +38,69 @@ func TestStatusUsesExplicitRuntimeLogPath(t *testing.T) {
 	}
 }
 
+func TestTokensEndpointAggregatesUsage(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	lines := []string{
+		// Claude Code metric datapoint events (delta temporality).
+		`{"timestamp":"2026-06-11T10:00:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"token.usage","category":"metric"},"severity":"info","endpoint":{"os":"darwin"},"harness":{"name":"claude_code"},"session":{"id":"local-session"},"model":"claude-sonnet-4-5","gen_ai":{"usage":{"input_tokens":100}},"message":"claude_code.token.usage","raw":{"metric_name":"claude_code.token.usage","metric_temporality":"Delta"}}`,
+		`{"timestamp":"2026-06-11T10:00:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"token.usage","category":"metric"},"severity":"info","endpoint":{"os":"darwin"},"harness":{"name":"claude_code"},"session":{"id":"local-session"},"model":"claude-sonnet-4-5","gen_ai":{"usage":{"output_tokens":40}},"message":"claude_code.token.usage","raw":{"metric_name":"claude_code.token.usage","metric_temporality":"Delta"}}`,
+		`{"timestamp":"2026-06-11T10:05:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"cost.usage","category":"metric"},"severity":"info","endpoint":{"os":"darwin"},"harness":{"name":"claude_code"},"session":{"id":"local-session"},"model":"claude-sonnet-4-5","gen_ai":{"usage":{"cost_usd":0.5}},"message":"claude_code.cost.usage","raw":{"metric_name":"claude_code.cost.usage","metric_temporality":"Delta"}}`,
+		// Cloud SDK span usage with trace identity.
+		`{"timestamp":"2026-06-11T11:00:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"tool.invoked","category":"tool"},"severity":"info","endpoint":{"os":"linux"},"harness":{"name":"asymptote_observe"},"origin":"cloud","session":{"id":"cloud-session"},"trace":{"id":"trace-1","span_id":"span-1"},"model":"gpt-4o-mini","gen_ai":{"usage":{"input_tokens":60,"output_tokens":20}},"message":"agent.step"}`,
+	}
+	if err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatalf("write fixture log: %v", err)
+	}
+	handler, err := Handler(Options{UserMode: true, LogPath: logPath})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tokens?bucket=1h", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var report tokens.Report
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("unmarshal tokens report: %v", err)
+	}
+	if report.Totals.InputTokens != 160 || report.Totals.OutputTokens != 60 || report.Totals.CostUSD != 0.5 {
+		t.Fatalf("totals = %#v", report.Totals)
+	}
+	if len(report.ByModel) != 2 || report.ByModel[0].Key != "claude-sonnet-4-5" {
+		t.Fatalf("by_model = %#v", report.ByModel)
+	}
+	if len(report.BySession) != 2 {
+		t.Fatalf("by_session = %#v", report.BySession)
+	}
+	if len(report.Series) != 2 {
+		t.Fatalf("series = %#v", report.Series)
+	}
+
+	// Session filter plus per-step detail for the cloud session.
+	req = httptest.NewRequest(http.MethodGet, "/api/tokens?session=cloud-session", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	report = tokens.Report{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("unmarshal session tokens report: %v", err)
+	}
+	if report.Totals.InputTokens != 60 {
+		t.Fatalf("session totals = %#v", report.Totals)
+	}
+	if report.SessionDetail == nil || report.SessionDetail.SessionID != "cloud-session" || len(report.SessionDetail.Steps) != 1 {
+		t.Fatalf("session detail = %#v", report.SessionDetail)
+	}
+	if report.SessionDetail.Steps[0].SpanID != "span-1" || report.SessionDetail.Steps[0].Usage.InputTokens != 60 {
+		t.Fatalf("session step = %#v", report.SessionDetail.Steps[0])
+	}
+}
+
 func TestStaticDashboardPagesServe(t *testing.T) {
 	handler, err := Handler(Options{UserMode: true, LogPath: filepath.Join(t.TempDir(), "runtime.jsonl")})
 	if err != nil {
@@ -47,6 +113,7 @@ func TestStaticDashboardPagesServe(t *testing.T) {
 	}{
 		{path: "/", want: "Beacon Endpoint Log Search"},
 		{path: "/overview.html", want: "Beacon Endpoint Security Overview"},
+		{path: "/tokens.html", want: "Beacon Endpoint Token Usage"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.path, func(t *testing.T) {

--- a/cli/beacon/internal/endpoint/dashboard/server_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -100,6 +101,49 @@ func TestTokensEndpointAggregatesUsage(t *testing.T) {
 		t.Fatalf("session step = %#v", report.SessionDetail.Steps[0])
 	}
 }
+
+// TestTokensEndpointDedupesCumulativeSameSecondDatapoints reproduces a real
+// Claude Code export: a batch of cumulative token.usage datapoints written to
+// the log within the same second. ReadEvents returns events newest-first, so
+// the token endpoint must still feed Aggregate in chronological order or the
+// cumulative dedup misreads each step-down as a counter reset and sums the raw
+// cumulative values instead of the per-interval deltas.
+func TestTokensEndpointDedupesCumulativeSameSecondDatapoints(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	mk := func(ts string, cumulative int64) string {
+		return `{"timestamp":"` + ts + `","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"token.usage","category":"metric"},"severity":"info","endpoint":{"os":"linux"},"harness":{"name":"claude_code"},"session":{"id":"s1"},"model":"claude-sonnet-4-5","gen_ai":{"usage":{"input_tokens":` +
+			itoa(cumulative) + `}},"message":"claude_code.token.usage","raw":{"metric_name":"claude_code.token.usage","metric_temporality":"Cumulative"}}`
+	}
+	// Append order is chronological; all three share the same second.
+	lines := []string{
+		mk("2026-06-11T10:00:00Z", 1200),
+		mk("2026-06-11T10:00:00Z", 2700),
+		mk("2026-06-11T10:00:00Z", 4500),
+	}
+	if err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatalf("write fixture log: %v", err)
+	}
+	handler, err := Handler(Options{UserMode: true, LogPath: logPath})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/tokens", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var report tokens.Report
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("unmarshal tokens report: %v", err)
+	}
+	// Deltas 1200, 1500, 1800 -> 4500. Raw (broken) sum would be 8400.
+	if report.Totals.InputTokens != 4500 {
+		t.Fatalf("cumulative input tokens = %d, want 4500 (raw over-count is 8400)", report.Totals.InputTokens)
+	}
+}
+
+func itoa(v int64) string { return strconv.FormatInt(v, 10) }
 
 func TestStaticDashboardPagesServe(t *testing.T) {
 	handler, err := Handler(Options{UserMode: true, LogPath: filepath.Join(t.TempDir(), "runtime.jsonl")})

--- a/cli/beacon/internal/endpoint/dashboard/server_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/server_test.go
@@ -212,6 +212,38 @@ func TestTokensEndpointSessionFilterIsExact(t *testing.T) {
 	}
 }
 
+// TestTokensEndpointSessionFilterIsCaseInsensitive guards the token session
+// filter against case mismatches: the event query matches sessions
+// case-insensitively, so the post-filter and drilldown must too, or a
+// differently-cased filter value returns zero usage for matching events.
+func TestTokensEndpointSessionFilterIsCaseInsensitive(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	line := `{"timestamp":"2026-06-11T10:00:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"token.usage","category":"metric"},"severity":"info","endpoint":{"os":"linux"},"harness":{"name":"claude_code"},"session":{"id":"Session-ABC"},"model":"claude-sonnet-4-5","gen_ai":{"usage":{"input_tokens":123}},"message":"claude_code.token.usage","raw":{"metric_name":"claude_code.token.usage","metric_temporality":"Delta"}}`
+	if err := os.WriteFile(logPath, []byte(line+"\n"), 0644); err != nil {
+		t.Fatalf("write fixture log: %v", err)
+	}
+	handler, err := Handler(Options{UserMode: true, LogPath: logPath})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/tokens?session=session-abc", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var report tokens.Report
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("unmarshal tokens report: %v", err)
+	}
+	if report.Totals.InputTokens != 123 {
+		t.Fatalf("totals = %d, want 123 for case-insensitive session match", report.Totals.InputTokens)
+	}
+	if report.SessionDetail == nil || report.SessionDetail.Usage.InputTokens != 123 {
+		t.Fatalf("session detail = %#v, want case-insensitive match", report.SessionDetail)
+	}
+}
+
 func TestStaticDashboardPagesServe(t *testing.T) {
 	handler, err := Handler(Options{UserMode: true, LogPath: filepath.Join(t.TempDir(), "runtime.jsonl")})
 	if err != nil {

--- a/cli/beacon/internal/endpoint/dashboard/static/app.js
+++ b/cli/beacon/internal/endpoint/dashboard/static/app.js
@@ -12,6 +12,7 @@ const state = {
 const $ = (selector) => document.querySelector(selector);
 const $$ = (selector) => Array.from(document.querySelectorAll(selector));
 const isOverviewPage = document.body.dataset.page === "overview";
+const isTokensPage = document.body.dataset.page === "tokens";
 const formFields = [
   "q",
   "harness",
@@ -714,7 +715,157 @@ function clearSearch() {
   clearFields();
 }
 
-$("#refresh")?.addEventListener("click", () => load().catch(console.error));
+async function loadTokens() {
+  const params = new URLSearchParams(window.location.search);
+  const tokenParams = new URLSearchParams({ bucket: "1h" });
+  const session = (params.get("session") || "").trim();
+  if (session) tokenParams.set("session", session);
+  try {
+    const [status, report] = await Promise.all([
+      getJSON("/api/status"),
+      getJSON(`/api/tokens?${tokenParams.toString()}`),
+    ]);
+    state.status = status;
+    state.error = null;
+    renderTokensPage(report, session);
+  } catch (err) {
+    state.error = err;
+    setText("#token-meta", `Failed to load token usage: ${err.message}`);
+  }
+}
+
+function renderTokensPage(report, session) {
+  setText("#log-path", state.status?.log_path || "Runtime log unavailable");
+  setText("#token-meta", `${report.events_with_usage} of ${report.total_events} events carry usage`);
+  renderTokenCards(report.totals || {});
+  renderUtilizationRows(report.utilization || []);
+  renderUsageGroupRows("#token-models", report.by_model || [], "model");
+  renderUsageGroupRows("#token-sessions", report.by_session || [], "session");
+  renderUsageGroupRows("#token-runs", report.by_run || []);
+  renderUsageGroupRows("#token-harnesses", report.by_harness || []);
+  renderSessionDetail(report.session_detail, session);
+}
+
+function renderTokenCards(totals) {
+  if (!$("#token-cards")) return;
+  const cards = [
+    { label: "Input Tokens", value: formatTokens(totals.input_tokens) },
+    { label: "Output Tokens", value: formatTokens(totals.output_tokens) },
+    { label: "Cache Read", value: formatTokens(totals.cache_read_input_tokens) },
+    { label: "Cache Creation", value: formatTokens(totals.cache_creation_input_tokens) },
+    { label: "Reasoning", value: formatTokens(totals.reasoning_output_tokens) },
+    { label: "Cost (USD)", value: totals.cost_usd ? totals.cost_usd.toFixed(4) : "-", hint: "runtime-reported only" },
+  ];
+  $("#token-cards").innerHTML = cards
+    .map((card) => `
+      <div class="card">
+        <span class="muted">${escapeHTML(card.label)}</span>
+        <span class="value">${escapeHTML(card.value)}</span>
+        ${card.hint ? `<span class="muted">${escapeHTML(card.hint)}</span>` : ""}
+      </div>
+    `)
+    .join("");
+}
+
+function renderUtilizationRows(utilization) {
+  const tbody = $("#token-utilization");
+  if (!tbody) return;
+  if (!utilization.length) {
+    tbody.innerHTML = `<tr><td colspan="7" class="muted">No usage with input tokens captured yet.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = utilization
+    .map((item) => `
+      <tr>
+        <td class="mono">${escapeHTML(item.model)}</td>
+        <td>${item.context_window ? formatTokens(item.context_window) : `<span class="muted">unknown</span>`}</td>
+        <td>${escapeHTML(item.calls)}</td>
+        <td>${formatTokens(item.max_input_tokens)}</td>
+        <td>${formatRatio(item.max_ratio, item.context_window)}</td>
+        <td>${formatRatio(item.p95_ratio, item.context_window)}</td>
+        <td>${item.near_limit_calls ? badge(`${item.near_limit_calls} near limit`, "badge-warn") : ""}</td>
+      </tr>
+    `)
+    .join("");
+}
+
+function renderUsageGroupRows(selector, groups, filterKey) {
+  const tbody = $(selector);
+  if (!tbody) return;
+  if (!groups.length) {
+    tbody.innerHTML = `<tr><td colspan="8" class="muted">No usage captured yet.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = groups
+    .map((group) => `
+      <tr ${filterKey === "session" ? `class="row-link" data-token-session="${escapeHTML(group.key)}"` : ""}>
+        <td class="mono">${escapeHTML(group.key)}</td>
+        ${usageCells(group.usage)}
+      </tr>
+    `)
+    .join("");
+  $$(`${selector} [data-token-session]`).forEach((row) => {
+    row.addEventListener("click", () => {
+      const params = new URLSearchParams(window.location.search);
+      params.set("session", row.dataset.tokenSession);
+      window.location.search = params.toString();
+    });
+  });
+}
+
+function renderSessionDetail(detail, session) {
+  const panel = $("#token-session-panel");
+  if (!panel) return;
+  if (!detail || !session) {
+    panel.hidden = true;
+    return;
+  }
+  panel.hidden = false;
+  setText("#token-session-title", `Session ${detail.session_id}`);
+  const rows = [];
+  const walk = (steps, depth) => {
+    for (const step of steps || []) {
+      const label = step.name || step.action || step.span_id || "step";
+      rows.push(`
+        <tr>
+          <td><span class="mono">${"&nbsp;".repeat(depth * 4)}${escapeHTML(label)}</span></td>
+          <td class="mono">${escapeHTML(step.model || "")}</td>
+          ${usageCells(step.usage, { events: false })}
+        </tr>
+      `);
+      walk(step.children, depth + 1);
+    }
+  };
+  walk(detail.steps, 0);
+  $("#token-session-detail").innerHTML = rows.length
+    ? rows.join("")
+    : `<tr><td colspan="8" class="muted">No usage-bearing steps in this session.</td></tr>`;
+}
+
+function usageCells(usage = {}, { events = true } = {}) {
+  const cells = [
+    formatTokens(usage.input_tokens),
+    formatTokens(usage.output_tokens),
+    formatTokens(usage.cache_read_input_tokens),
+    formatTokens(usage.cache_creation_input_tokens),
+    formatTokens(usage.reasoning_output_tokens),
+    usage.cost_usd ? usage.cost_usd.toFixed(4) : "-",
+  ];
+  if (events) cells.push(String(usage.events ?? 0));
+  return cells.map((value) => `<td>${escapeHTML(value)}</td>`).join("");
+}
+
+function formatTokens(value) {
+  if (!value) return "0";
+  return Number(value).toLocaleString();
+}
+
+function formatRatio(ratio, contextWindow) {
+  if (!contextWindow) return "-";
+  return `${(ratio * 100).toFixed(1)}%`;
+}
+
+$("#refresh")?.addEventListener("click", () => (isTokensPage ? loadTokens() : load()).catch(console.error));
 $("#filters")?.addEventListener("submit", (event) => {
   event.preventDefault();
   load({ updateLocation: true }).catch(console.error);
@@ -726,9 +877,14 @@ $$("[data-preset]").forEach((button) => {
   button.addEventListener("click", () => applyPreset(button.dataset.preset));
 });
 
-hydrateFiltersFromURL();
-load().catch(console.error);
-setInterval(() => load({ mode: "poll" }).catch(console.error), 10000);
+if (isTokensPage) {
+  loadTokens().catch(console.error);
+  setInterval(() => loadTokens().catch(console.error), 15000);
+} else {
+  hydrateFiltersFromURL();
+  load().catch(console.error);
+  setInterval(() => load({ mode: "poll" }).catch(console.error), 10000);
+}
 
 function setText(selector, value) {
   const element = $(selector);

--- a/cli/beacon/internal/endpoint/dashboard/static/index.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/index.html
@@ -15,6 +15,7 @@
       <nav class="nav-toggle" aria-label="Dashboard navigation">
         <a class="active" href="/" aria-current="page">Log Search</a>
         <a href="/overview.html">Security Overview</a>
+        <a href="/tokens.html">Token Usage</a>
       </nav>
       <button id="refresh">Refresh</button>
     </header>

--- a/cli/beacon/internal/endpoint/dashboard/static/overview.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/overview.html
@@ -15,6 +15,7 @@
       <nav class="nav-toggle" aria-label="Dashboard navigation">
         <a href="/">Log Search</a>
         <a class="active" href="/overview.html" aria-current="page">Security Overview</a>
+        <a href="/tokens.html">Token Usage</a>
       </nav>
       <button id="refresh">Refresh</button>
     </header>

--- a/cli/beacon/internal/endpoint/dashboard/static/styles.css
+++ b/cli/beacon/internal/endpoint/dashboard/static/styles.css
@@ -616,3 +616,11 @@ pre {
     padding: 1rem;
   }
 }
+
+.row-link {
+  cursor: pointer;
+}
+
+.row-link:hover {
+  background: rgba(125, 211, 252, 0.08);
+}

--- a/cli/beacon/internal/endpoint/dashboard/static/tokens.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/tokens.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Beacon Endpoint Token Usage</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body data-page="tokens">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Local-only</p>
+        <h1>Beacon Endpoint Token Usage</h1>
+      </div>
+      <nav class="nav-toggle" aria-label="Dashboard navigation">
+        <a href="/">Log Search</a>
+        <a href="/overview.html">Security Overview</a>
+        <a class="active" href="/tokens.html" aria-current="page">Token Usage</a>
+      </nav>
+      <button id="refresh">Refresh</button>
+    </header>
+
+    <main>
+      <section class="panel status-panel">
+        <div>
+          <h2>Endpoint</h2>
+          <p id="log-path" class="muted">Loading runtime log...</p>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-head overview-head">
+          <div>
+            <h2>Token Totals</h2>
+            <p class="muted">Prompt, completion, cache, reasoning, and runtime-reported cost across all captured telemetry.</p>
+          </div>
+          <div id="token-meta" class="muted"></div>
+        </div>
+        <div class="cards" id="token-cards"></div>
+      </section>
+
+      <section class="panel">
+        <h2>Context Window Utilization</h2>
+        <p class="muted">Input plus cache tokens per call against each model's context window. Unknown models show raw input tokens.</p>
+        <table>
+          <thead>
+            <tr><th>Model</th><th>Window</th><th>Calls</th><th>Max Input</th><th>Max</th><th>P95</th><th>Near Limit</th></tr>
+          </thead>
+          <tbody id="token-utilization"></tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <h2>By Model</h2>
+        <table>
+          <thead>
+            <tr><th>Model</th><th>Input</th><th>Output</th><th>Cache Read</th><th>Cache Create</th><th>Reasoning</th><th>Cost USD</th><th>Events</th></tr>
+          </thead>
+          <tbody id="token-models"></tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <h2>By Session</h2>
+        <p class="muted">Select a session to inspect per-step usage.</p>
+        <table>
+          <thead>
+            <tr><th>Session</th><th>Input</th><th>Output</th><th>Cache Read</th><th>Cache Create</th><th>Reasoning</th><th>Cost USD</th><th>Events</th></tr>
+          </thead>
+          <tbody id="token-sessions"></tbody>
+        </table>
+      </section>
+
+      <section class="panel" id="token-session-panel" hidden>
+        <h2 id="token-session-title">Session Detail</h2>
+        <table>
+          <thead>
+            <tr><th>Step</th><th>Model</th><th>Input</th><th>Output</th><th>Cache Read</th><th>Cache Create</th><th>Reasoning</th><th>Cost USD</th></tr>
+          </thead>
+          <tbody id="token-session-detail"></tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <h2>By CI Run</h2>
+        <table>
+          <thead>
+            <tr><th>Run</th><th>Input</th><th>Output</th><th>Cache Read</th><th>Cache Create</th><th>Reasoning</th><th>Cost USD</th><th>Events</th></tr>
+          </thead>
+          <tbody id="token-runs"></tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <h2>By Harness</h2>
+        <table>
+          <thead>
+            <tr><th>Harness</th><th>Input</th><th>Output</th><th>Cache Read</th><th>Cache Create</th><th>Reasoning</th><th>Cost USD</th><th>Events</th></tr>
+          </thead>
+          <tbody id="token-harnesses"></tbody>
+        </table>
+      </section>
+    </main>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -306,6 +306,9 @@ func ConfigureClaude(opts ConfigureOptions) (string, error) {
 	env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
 	env["OTEL_LOGS_EXPORTER"] = "otlp"
 	env["OTEL_METRICS_EXPORTER"] = "otlp"
+	// Delta temporality keeps token usage counters per-interval so downstream
+	// aggregation can sum datapoints without deduping cumulative series.
+	env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = "delta"
 	env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc"
 	env["OTEL_EXPORTER_OTLP_ENDPOINT"] = opts.Endpoint
 	env["OTEL_LOG_USER_PROMPTS"] = "1"

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -66,9 +66,10 @@ func TestConfigureClaudeWritesTelemetryEnvAndBackup(t *testing.T) {
 		"CLAUDE_CODE_ENABLE_TELEMETRY": "1",
 		"OTEL_LOGS_EXPORTER":           "otlp",
 		"OTEL_METRICS_EXPORTER":        "otlp",
-		"OTEL_EXPORTER_OTLP_PROTOCOL":  "grpc",
-		"OTEL_EXPORTER_OTLP_ENDPOINT":  "http://127.0.0.1:4317",
-		"OTEL_LOG_USER_PROMPTS":        "1",
+		"OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "delta",
+		"OTEL_EXPORTER_OTLP_PROTOCOL":                       "grpc",
+		"OTEL_EXPORTER_OTLP_ENDPOINT":                       "http://127.0.0.1:4317",
+		"OTEL_LOG_USER_PROMPTS":                             "1",
 	} {
 		if got := env[key]; got != want {
 			t.Fatalf("env[%s] = %q, want %q; env=%#v", key, got, want, env)

--- a/cli/beacon/internal/endpoint/schema/event.go
+++ b/cli/beacon/internal/endpoint/schema/event.go
@@ -48,6 +48,7 @@ type EndpointInfo = asymptoteobserve.EndpointInfo
 type UserInfo = asymptoteobserve.UserInfo
 type HarnessInfo = asymptoteobserve.HarnessInfo
 type SessionInfo = asymptoteobserve.SessionInfo
+type TraceInfo = asymptoteobserve.TraceInfo
 type RunInfo = asymptoteobserve.RunInfo
 type ToolInfo = asymptoteobserve.ToolInfo
 type FileInfo = asymptoteobserve.FileInfo

--- a/cli/beacon/internal/endpoint/tokens/contextwindow.go
+++ b/cli/beacon/internal/endpoint/tokens/contextwindow.go
@@ -1,0 +1,53 @@
+package tokens
+
+import "strings"
+
+// contextWindows maps normalized model-name prefixes to context window sizes
+// in tokens. Longest prefix wins. The table is a best-effort static snapshot;
+// unknown models simply report raw input tokens without a utilization ratio.
+var contextWindows = []struct {
+	prefix string
+	tokens int64
+}{
+	{"claude", 200000},
+	{"gpt-5", 400000},
+	{"gpt-4.1", 1047576},
+	{"gpt-4o", 128000},
+	{"gpt-4-turbo", 128000},
+	{"gpt-4", 8192},
+	{"gpt-3.5", 16385},
+	{"o1", 200000},
+	{"o3", 200000},
+	{"o4", 200000},
+	{"gemini-1.5-pro", 2097152},
+	{"gemini-1.5-flash", 1048576},
+	{"gemini-2", 1048576},
+	{"gemini-3", 1048576},
+}
+
+// ContextWindow returns the context window size for a model name, matching
+// provider-prefixed and date-suffixed variants such as
+// "anthropic/claude-sonnet-4-5" or "gpt-4o-2024-08-06".
+func ContextWindow(model string) (int64, bool) {
+	normalized := normalizeModel(model)
+	if normalized == "" {
+		return 0, false
+	}
+	best := int64(0)
+	bestLen := -1
+	for _, entry := range contextWindows {
+		if strings.HasPrefix(normalized, entry.prefix) && len(entry.prefix) > bestLen {
+			best = entry.tokens
+			bestLen = len(entry.prefix)
+		}
+	}
+	return best, bestLen >= 0
+}
+
+func normalizeModel(model string) string {
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	if idx := strings.LastIndex(normalized, "/"); idx >= 0 {
+		normalized = normalized[idx+1:]
+	}
+	return normalized
+}

--- a/cli/beacon/internal/endpoint/tokens/contextwindow_test.go
+++ b/cli/beacon/internal/endpoint/tokens/contextwindow_test.go
@@ -1,0 +1,34 @@
+package tokens
+
+import "testing"
+
+func TestContextWindowMatchesModelVariants(t *testing.T) {
+	tests := []struct {
+		model string
+		want  int64
+		known bool
+	}{
+		{"claude-sonnet-4-5", 200000, true},
+		{"anthropic/claude-3-5-sonnet-20241022", 200000, true},
+		{"gpt-4o-2024-08-06", 128000, true},
+		{"gpt-4o-mini", 128000, true},
+		{"gpt-4.1-mini", 1047576, true},
+		{"gpt-4-turbo", 128000, true},
+		{"gpt-4", 8192, true},
+		{"gpt-5-mini", 400000, true},
+		{"o1-preview", 200000, true},
+		{"gemini-1.5-pro-latest", 2097152, true},
+		{"gemini-2.0-flash", 1048576, true},
+		{"GPT-4O", 128000, true},
+		{"experimental-model", 0, false},
+		{"", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			got, known := ContextWindow(tt.model)
+			if got != tt.want || known != tt.known {
+				t.Fatalf("ContextWindow(%q) = %d/%v, want %d/%v", tt.model, got, known, tt.want, tt.known)
+			}
+		})
+	}
+}

--- a/cli/beacon/internal/endpoint/tokens/report.go
+++ b/cli/beacon/internal/endpoint/tokens/report.go
@@ -1,0 +1,120 @@
+package tokens
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+// RenderText writes a human-readable token usage report.
+func RenderText(w io.Writer, report Report) {
+	fmt.Fprintf(w, "Token usage report (%d of %d events carry usage)\n\n", report.EventsWithUsage, report.TotalEvents)
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "TOTALS\tINPUT\tOUTPUT\tCACHE READ\tCACHE CREATE\tREASONING\tCOST USD\tEVENTS")
+	writeUsageRow(tw, "", report.Totals)
+	tw.Flush()
+
+	writeGroups(w, "BY MODEL", report.ByModel)
+	writeGroups(w, "BY SESSION", report.BySession)
+	writeGroups(w, "BY HARNESS", report.ByHarness)
+	writeGroups(w, "BY REPOSITORY", report.ByRepository)
+	writeGroups(w, "BY RUN", report.ByRun)
+
+	if len(report.Utilization) > 0 {
+		fmt.Fprintln(w)
+		tw = tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "CONTEXT UTILIZATION\tWINDOW\tCALLS\tMAX INPUT\tMAX\tP95\tNEAR LIMIT")
+		for _, u := range report.Utilization {
+			window := "unknown"
+			maxRatio, p95Ratio := "-", "-"
+			if u.ContextWindow > 0 {
+				window = fmt.Sprintf("%d", u.ContextWindow)
+				maxRatio = fmt.Sprintf("%.1f%%", u.MaxRatio*100)
+				p95Ratio = fmt.Sprintf("%.1f%%", u.P95Ratio*100)
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%s\t%s\t%d\n", u.Model, window, u.Calls, u.MaxInputTokens, maxRatio, p95Ratio, u.NearLimitCalls)
+		}
+		tw.Flush()
+	}
+
+	if len(report.Series) > 0 {
+		fmt.Fprintln(w)
+		tw = tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "BUCKET\tINPUT\tOUTPUT\tCACHE READ\tCACHE CREATE\tREASONING\tCOST USD\tEVENTS")
+		for _, bucket := range report.Series {
+			writeUsageRow(tw, bucket.Start, bucket.Usage)
+		}
+		tw.Flush()
+	}
+
+	if report.SessionDetail != nil {
+		fmt.Fprintf(w, "\nSESSION %s\n", report.SessionDetail.SessionID)
+		tw = tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "STEP\tMODEL\tINPUT\tOUTPUT\tCACHE READ\tCACHE CREATE\tREASONING\tCOST USD")
+		for _, step := range report.SessionDetail.Steps {
+			writeStepRows(tw, step, 0)
+		}
+		tw.Flush()
+	}
+}
+
+func writeGroups(w io.Writer, title string, groups []Group) {
+	if len(groups) == 0 {
+		return
+	}
+	fmt.Fprintln(w)
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	fmt.Fprintf(tw, "%s\tINPUT\tOUTPUT\tCACHE READ\tCACHE CREATE\tREASONING\tCOST USD\tEVENTS\n", title)
+	for _, group := range groups {
+		writeUsageRow(tw, group.Key, group.Usage)
+	}
+	tw.Flush()
+}
+
+func writeUsageRow(w io.Writer, key string, usage Usage) {
+	if key == "" {
+		key = "total"
+	}
+	fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t%d\t%s\t%d\n",
+		key,
+		usage.InputTokens,
+		usage.OutputTokens,
+		usage.CacheReadInputTokens,
+		usage.CacheCreationInputTokens,
+		usage.ReasoningOutputTokens,
+		formatCost(usage.CostUSD),
+		usage.Events,
+	)
+}
+
+func writeStepRows(w io.Writer, step *Step, depth int) {
+	label := strings.TrimSpace(step.Name)
+	if label == "" {
+		label = step.Action
+	}
+	if label == "" {
+		label = step.SpanID
+	}
+	fmt.Fprintf(w, "%s%s\t%s\t%d\t%d\t%d\t%d\t%d\t%s\n",
+		strings.Repeat("  ", depth),
+		label,
+		step.Model,
+		step.Usage.InputTokens,
+		step.Usage.OutputTokens,
+		step.Usage.CacheReadInputTokens,
+		step.Usage.CacheCreationInputTokens,
+		step.Usage.ReasoningOutputTokens,
+		formatCost(step.Usage.CostUSD),
+	)
+	for _, child := range step.Children {
+		writeStepRows(w, child, depth+1)
+	}
+}
+
+func formatCost(cost float64) string {
+	if cost == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.4f", cost)
+}

--- a/cli/beacon/internal/endpoint/tokens/tokens.go
+++ b/cli/beacon/internal/endpoint/tokens/tokens.go
@@ -1,0 +1,483 @@
+// Package tokens aggregates token usage and runtime-reported cost from
+// Beacon endpoint JSONL events into attribution rollups: totals, per-model,
+// per-session, per-harness, per-repository, per-CI-run, time series,
+// context-window utilization, and per-step session detail.
+package tokens
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+)
+
+const defaultNearLimitRatio = 0.8
+
+// Usage sums the canonical gen_ai.usage fields across events. Field names
+// match the event schema so report consumers see one vocabulary.
+type Usage struct {
+	InputTokens              int64   `json:"input_tokens"`
+	OutputTokens             int64   `json:"output_tokens"`
+	CacheReadInputTokens     int64   `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64   `json:"cache_creation_input_tokens"`
+	ReasoningOutputTokens    int64   `json:"reasoning_output_tokens"`
+	CostUSD                  float64 `json:"cost_usd"`
+	Events                   int     `json:"events"`
+}
+
+func (u Usage) TotalTokens() int64 {
+	return u.InputTokens + u.OutputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
+}
+
+func (u *Usage) add(delta Usage) {
+	u.InputTokens += delta.InputTokens
+	u.OutputTokens += delta.OutputTokens
+	u.CacheReadInputTokens += delta.CacheReadInputTokens
+	u.CacheCreationInputTokens += delta.CacheCreationInputTokens
+	u.ReasoningOutputTokens += delta.ReasoningOutputTokens
+	u.CostUSD += delta.CostUSD
+	u.Events += delta.Events
+}
+
+type Group struct {
+	Key   string `json:"key"`
+	Usage Usage  `json:"usage"`
+}
+
+// Step is one usage-bearing event inside a session. Steps with span identity
+// nest under their parent span; steps without span identity stay flat in
+// time order.
+type Step struct {
+	Timestamp    string  `json:"timestamp,omitempty"`
+	Action       string  `json:"action,omitempty"`
+	Name         string  `json:"name,omitempty"`
+	Model        string  `json:"model,omitempty"`
+	TraceID      string  `json:"trace_id,omitempty"`
+	SpanID       string  `json:"span_id,omitempty"`
+	ParentSpanID string  `json:"parent_span_id,omitempty"`
+	Usage        Usage   `json:"usage"`
+	Children     []*Step `json:"children,omitempty"`
+}
+
+type SessionDetail struct {
+	SessionID string  `json:"session_id"`
+	Usage     Usage   `json:"usage"`
+	Steps     []*Step `json:"steps,omitempty"`
+}
+
+// ModelUtilization summarizes how close a model's calls run to its context
+// window. Utilization samples sum input, cache read, and cache creation
+// tokens per (harness, session, model, timestamp) group so Claude Code's
+// per-type metric datapoints recombine into one per-interval context size.
+type ModelUtilization struct {
+	Model          string  `json:"model"`
+	ContextWindow  int64   `json:"context_window,omitempty"`
+	Calls          int     `json:"calls"`
+	MaxInputTokens int64   `json:"max_input_tokens"`
+	MaxRatio       float64 `json:"max_ratio,omitempty"`
+	P95Ratio       float64 `json:"p95_ratio,omitempty"`
+	NearLimitCalls int     `json:"near_limit_calls,omitempty"`
+}
+
+type TimeBucket struct {
+	Start string `json:"start"`
+	Usage Usage  `json:"usage"`
+}
+
+type Options struct {
+	// BucketSize controls the time-series granularity. Zero disables the series.
+	BucketSize time.Duration
+	// NearLimitRatio marks utilization samples at or above this fraction of the
+	// model context window. Defaults to 0.8.
+	NearLimitRatio float64
+	// SessionID selects one session for per-step detail.
+	SessionID string
+	// TopLimit caps each group list (0 keeps all groups).
+	TopLimit int
+}
+
+type Report struct {
+	Totals          Usage              `json:"totals"`
+	ByModel         []Group            `json:"by_model,omitempty"`
+	BySession       []Group            `json:"by_session,omitempty"`
+	ByHarness       []Group            `json:"by_harness,omitempty"`
+	ByRepository    []Group            `json:"by_repository,omitempty"`
+	ByRun           []Group            `json:"by_run,omitempty"`
+	Utilization     []ModelUtilization `json:"utilization,omitempty"`
+	Series          []TimeBucket       `json:"series,omitempty"`
+	SessionDetail   *SessionDetail     `json:"session_detail,omitempty"`
+	EventsWithUsage int                `json:"events_with_usage"`
+	TotalEvents     int                `json:"total_events"`
+}
+
+// usageEvent is one usage-bearing event with its usage normalized to a delta
+// contribution and its attribution keys extracted.
+type usageEvent struct {
+	ts           time.Time
+	order        int
+	action       string
+	name         string
+	harness      string
+	session      string
+	model        string
+	repository   string
+	run          string
+	traceID      string
+	spanID       string
+	parentSpanID string
+	usage        Usage
+	cumulative   bool
+	metricName   string
+	seriesField  string
+	seriesValue  float64
+}
+
+// Aggregate builds a token usage report from endpoint events. Events from
+// cumulative metric series are converted to per-interval deltas (grouped by
+// harness, session, model, metric name, and usage field; counter resets fall
+// back to the raw value) so totals never double-count. Delta metrics and
+// span-level usage sum directly.
+func Aggregate(events []schema.Event, opts Options) Report {
+	if opts.NearLimitRatio <= 0 {
+		opts.NearLimitRatio = defaultNearLimitRatio
+	}
+	report := Report{TotalEvents: len(events)}
+	usageEvents := collectUsageEvents(events)
+	resolveCumulativeSeries(usageEvents)
+
+	byModel := map[string]*Usage{}
+	bySession := map[string]*Usage{}
+	byHarness := map[string]*Usage{}
+	byRepository := map[string]*Usage{}
+	byRun := map[string]*Usage{}
+	buckets := map[time.Time]*Usage{}
+	for _, ue := range usageEvents {
+		report.Totals.add(ue.usage)
+		addGroup(byModel, ue.model, ue.usage)
+		addGroup(bySession, ue.session, ue.usage)
+		addGroup(byHarness, ue.harness, ue.usage)
+		addGroup(byRepository, ue.repository, ue.usage)
+		addGroup(byRun, ue.run, ue.usage)
+		if opts.BucketSize > 0 && !ue.ts.IsZero() {
+			start := ue.ts.Truncate(opts.BucketSize)
+			if buckets[start] == nil {
+				buckets[start] = &Usage{}
+			}
+			buckets[start].add(ue.usage)
+		}
+	}
+	report.EventsWithUsage = len(usageEvents)
+	report.ByModel = sortedGroups(byModel, opts.TopLimit)
+	report.BySession = sortedGroups(bySession, opts.TopLimit)
+	report.ByHarness = sortedGroups(byHarness, opts.TopLimit)
+	report.ByRepository = sortedGroups(byRepository, opts.TopLimit)
+	report.ByRun = sortedGroups(byRun, opts.TopLimit)
+	report.Utilization = buildUtilization(usageEvents, opts.NearLimitRatio)
+	report.Series = sortedBuckets(buckets)
+	if session := strings.TrimSpace(opts.SessionID); session != "" {
+		report.SessionDetail = buildSessionDetail(usageEvents, session)
+	}
+	return report
+}
+
+func collectUsageEvents(events []schema.Event) []*usageEvent {
+	var out []*usageEvent
+	for i, event := range events {
+		if event.GenAI == nil || event.GenAI.Usage == nil {
+			continue
+		}
+		usage := event.GenAI.Usage
+		ue := &usageEvent{
+			order:      i,
+			action:     event.Event.Action,
+			name:       event.Message,
+			harness:    event.Harness.Name,
+			model:      event.Model,
+			repository: event.Repository,
+			usage:      Usage{Events: 1},
+		}
+		if ts, err := time.Parse(time.RFC3339, event.Timestamp); err == nil {
+			ue.ts = ts
+		}
+		if event.Session != nil {
+			ue.session = event.Session.ID
+		}
+		if event.Run != nil && (event.Run.Provider != "" || event.Run.RunID != "") {
+			ue.run = strings.TrimSuffix(event.Run.Provider+"/"+event.Run.RunID, "/")
+		}
+		if event.Trace != nil {
+			ue.traceID = event.Trace.ID
+			ue.spanID = event.Trace.SpanID
+			ue.parentSpanID = event.Trace.ParentSpanID
+		}
+		if usage.InputTokens != nil {
+			ue.usage.InputTokens = *usage.InputTokens
+		}
+		if usage.OutputTokens != nil {
+			ue.usage.OutputTokens = *usage.OutputTokens
+		}
+		if usage.CacheRead != nil && usage.CacheRead.InputTokens != nil {
+			ue.usage.CacheReadInputTokens = *usage.CacheRead.InputTokens
+		}
+		if usage.CacheCreation != nil && usage.CacheCreation.InputTokens != nil {
+			ue.usage.CacheCreationInputTokens = *usage.CacheCreation.InputTokens
+		}
+		if usage.Reasoning != nil && usage.Reasoning.OutputTokens != nil {
+			ue.usage.ReasoningOutputTokens = *usage.Reasoning.OutputTokens
+		}
+		if usage.CostUSD != nil {
+			ue.usage.CostUSD = *usage.CostUSD
+		}
+		if ue.usage.TotalTokens() == 0 && ue.usage.ReasoningOutputTokens == 0 && ue.usage.CostUSD == 0 {
+			continue
+		}
+		if event.Raw != nil {
+			if temporality, _ := event.Raw["metric_temporality"].(string); strings.EqualFold(temporality, "cumulative") {
+				ue.cumulative = true
+			}
+			ue.metricName, _ = event.Raw["metric_name"].(string)
+		}
+		out = append(out, ue)
+	}
+	return out
+}
+
+// resolveCumulativeSeries rewrites cumulative metric contributions into
+// per-interval deltas. Each cumulative series is identified by harness,
+// session, model, metric name, and the single usage field the datapoint set.
+func resolveCumulativeSeries(events []*usageEvent) {
+	series := map[string][]*usageEvent{}
+	for _, ue := range events {
+		if !ue.cumulative {
+			continue
+		}
+		field, value := dominantUsageField(ue.usage)
+		if field == "" {
+			continue
+		}
+		ue.seriesField = field
+		ue.seriesValue = value
+		key := strings.Join([]string{ue.harness, ue.session, ue.model, ue.metricName, field}, "\x00")
+		series[key] = append(series[key], ue)
+	}
+	for _, points := range series {
+		sort.SliceStable(points, func(i, j int) bool {
+			if points[i].ts.Equal(points[j].ts) {
+				return points[i].order < points[j].order
+			}
+			return points[i].ts.Before(points[j].ts)
+		})
+		previous := 0.0
+		for _, point := range points {
+			delta := point.seriesValue - previous
+			if delta < 0 {
+				// Counter reset: the raw value is the new interval's total.
+				delta = point.seriesValue
+			}
+			previous = point.seriesValue
+			setUsageField(&point.usage, point.seriesField, delta)
+		}
+	}
+}
+
+func dominantUsageField(u Usage) (string, float64) {
+	switch {
+	case u.CostUSD != 0:
+		return "cost_usd", u.CostUSD
+	case u.InputTokens != 0:
+		return "input_tokens", float64(u.InputTokens)
+	case u.OutputTokens != 0:
+		return "output_tokens", float64(u.OutputTokens)
+	case u.CacheReadInputTokens != 0:
+		return "cache_read_input_tokens", float64(u.CacheReadInputTokens)
+	case u.CacheCreationInputTokens != 0:
+		return "cache_creation_input_tokens", float64(u.CacheCreationInputTokens)
+	case u.ReasoningOutputTokens != 0:
+		return "reasoning_output_tokens", float64(u.ReasoningOutputTokens)
+	default:
+		return "", 0
+	}
+}
+
+func setUsageField(u *Usage, field string, value float64) {
+	switch field {
+	case "cost_usd":
+		u.CostUSD = value
+	case "input_tokens":
+		u.InputTokens = int64(value)
+	case "output_tokens":
+		u.OutputTokens = int64(value)
+	case "cache_read_input_tokens":
+		u.CacheReadInputTokens = int64(value)
+	case "cache_creation_input_tokens":
+		u.CacheCreationInputTokens = int64(value)
+	case "reasoning_output_tokens":
+		u.ReasoningOutputTokens = int64(value)
+	}
+}
+
+func addGroup(groups map[string]*Usage, key string, delta Usage) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return
+	}
+	if groups[key] == nil {
+		groups[key] = &Usage{}
+	}
+	groups[key].add(delta)
+}
+
+func sortedGroups(groups map[string]*Usage, limit int) []Group {
+	out := make([]Group, 0, len(groups))
+	for key, usage := range groups {
+		out = append(out, Group{Key: key, Usage: *usage})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		left, right := out[i].Usage.TotalTokens(), out[j].Usage.TotalTokens()
+		if left == right {
+			return out[i].Key < out[j].Key
+		}
+		return left > right
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func sortedBuckets(buckets map[time.Time]*Usage) []TimeBucket {
+	starts := make([]time.Time, 0, len(buckets))
+	for start := range buckets {
+		starts = append(starts, start)
+	}
+	sort.Slice(starts, func(i, j int) bool { return starts[i].Before(starts[j]) })
+	out := make([]TimeBucket, 0, len(starts))
+	for _, start := range starts {
+		out = append(out, TimeBucket{Start: start.UTC().Format(time.RFC3339), Usage: *buckets[start]})
+	}
+	return out
+}
+
+func buildUtilization(events []*usageEvent, nearLimitRatio float64) []ModelUtilization {
+	type sample struct{ inputTotal int64 }
+	samples := map[string]map[string]*sample{}
+	for _, ue := range events {
+		if ue.model == "" {
+			continue
+		}
+		inputTotal := ue.usage.InputTokens + ue.usage.CacheReadInputTokens + ue.usage.CacheCreationInputTokens
+		if inputTotal <= 0 {
+			continue
+		}
+		callKey := strings.Join([]string{ue.harness, ue.session, ue.ts.UTC().Format(time.RFC3339)}, "\x00")
+		if samples[ue.model] == nil {
+			samples[ue.model] = map[string]*sample{}
+		}
+		if samples[ue.model][callKey] == nil {
+			samples[ue.model][callKey] = &sample{}
+		}
+		samples[ue.model][callKey].inputTotal += inputTotal
+	}
+	out := make([]ModelUtilization, 0, len(samples))
+	for model, calls := range samples {
+		utilization := ModelUtilization{Model: model, Calls: len(calls)}
+		window, known := ContextWindow(model)
+		if known {
+			utilization.ContextWindow = window
+		}
+		ratios := make([]float64, 0, len(calls))
+		for _, call := range calls {
+			if call.inputTotal > utilization.MaxInputTokens {
+				utilization.MaxInputTokens = call.inputTotal
+			}
+			if !known {
+				continue
+			}
+			ratio := float64(call.inputTotal) / float64(window)
+			ratios = append(ratios, ratio)
+			if ratio >= nearLimitRatio {
+				utilization.NearLimitCalls++
+			}
+		}
+		if len(ratios) > 0 {
+			sort.Float64s(ratios)
+			utilization.MaxRatio = ratios[len(ratios)-1]
+			utilization.P95Ratio = percentile(ratios, 0.95)
+		}
+		out = append(out, utilization)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].MaxRatio == out[j].MaxRatio {
+			return out[i].Model < out[j].Model
+		}
+		return out[i].MaxRatio > out[j].MaxRatio
+	})
+	return out
+}
+
+// percentile reads the nearest-rank percentile from an ascending-sorted slice.
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	rank := int(float64(len(sorted))*p+0.999999) - 1
+	if rank < 0 {
+		rank = 0
+	}
+	if rank >= len(sorted) {
+		rank = len(sorted) - 1
+	}
+	return sorted[rank]
+}
+
+func buildSessionDetail(events []*usageEvent, sessionID string) *SessionDetail {
+	detail := &SessionDetail{SessionID: sessionID}
+	var ordered []*usageEvent
+	for _, ue := range events {
+		if ue.session != sessionID {
+			continue
+		}
+		detail.Usage.add(ue.usage)
+		ordered = append(ordered, ue)
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].ts.Equal(ordered[j].ts) {
+			return ordered[i].order < ordered[j].order
+		}
+		return ordered[i].ts.Before(ordered[j].ts)
+	})
+	steps := make([]*Step, 0, len(ordered))
+	bySpan := map[string]*Step{}
+	for _, ue := range ordered {
+		step := &Step{
+			Action:       ue.action,
+			Name:         ue.name,
+			Model:        ue.model,
+			TraceID:      ue.traceID,
+			SpanID:       ue.spanID,
+			ParentSpanID: ue.parentSpanID,
+			Usage:        ue.usage,
+		}
+		if !ue.ts.IsZero() {
+			step.Timestamp = ue.ts.UTC().Format(time.RFC3339)
+		}
+		steps = append(steps, step)
+		if step.SpanID != "" {
+			bySpan[step.SpanID] = step
+		}
+	}
+	for _, step := range steps {
+		if step.ParentSpanID == "" {
+			detail.Steps = append(detail.Steps, step)
+			continue
+		}
+		parent, ok := bySpan[step.ParentSpanID]
+		if !ok || parent == step {
+			detail.Steps = append(detail.Steps, step)
+			continue
+		}
+		parent.Children = append(parent.Children, step)
+	}
+	return detail
+}

--- a/cli/beacon/internal/endpoint/tokens/tokens.go
+++ b/cli/beacon/internal/endpoint/tokens/tokens.go
@@ -456,7 +456,9 @@ func buildSessionDetail(events []*usageEvent, sessionID string) *SessionDetail {
 	detail := &SessionDetail{SessionID: sessionID}
 	var ordered []*usageEvent
 	for _, ue := range events {
-		if ue.session != sessionID {
+		// Match case-insensitively to stay consistent with the case-insensitive
+		// session query the token callers use to select events.
+		if !strings.EqualFold(ue.session, sessionID) {
 			continue
 		}
 		detail.Usage.add(ue.usage)

--- a/cli/beacon/internal/endpoint/tokens/tokens.go
+++ b/cli/beacon/internal/endpoint/tokens/tokens.go
@@ -209,8 +209,15 @@ func collectUsageEvents(events []schema.Event) []*usageEvent {
 		if event.Session != nil {
 			ue.session = event.Session.ID
 		}
-		if event.Run != nil && (event.Run.Provider != "" || event.Run.RunID != "") {
-			ue.run = strings.TrimSuffix(event.Run.Provider+"/"+event.Run.RunID, "/")
+		if event.Run != nil {
+			switch {
+			case event.Run.Provider != "" && event.Run.RunID != "":
+				ue.run = event.Run.Provider + "/" + event.Run.RunID
+			case event.Run.Provider != "":
+				ue.run = event.Run.Provider
+			default:
+				ue.run = event.Run.RunID
+			}
 		}
 		if event.Trace != nil {
 			ue.traceID = event.Trace.ID

--- a/cli/beacon/internal/endpoint/tokens/tokens.go
+++ b/cli/beacon/internal/endpoint/tokens/tokens.go
@@ -210,14 +210,7 @@ func collectUsageEvents(events []schema.Event) []*usageEvent {
 			ue.session = event.Session.ID
 		}
 		if event.Run != nil {
-			switch {
-			case event.Run.Provider != "" && event.Run.RunID != "":
-				ue.run = event.Run.Provider + "/" + event.Run.RunID
-			case event.Run.Provider != "":
-				ue.run = event.Run.Provider
-			default:
-				ue.run = event.Run.RunID
-			}
+			ue.run = RunKey(event.Run.Provider, event.Run.RunID)
 		}
 		if event.Trace != nil {
 			ue.traceID = event.Trace.ID
@@ -327,6 +320,21 @@ func setUsageField(u *Usage, field string, value float64) {
 		u.CacheCreationInputTokens = int64(value)
 	case "reasoning_output_tokens":
 		u.ReasoningOutputTokens = int64(value)
+	}
+}
+
+// RunKey builds the CI run grouping key from a run's provider and id, joined as
+// "provider/run_id". It falls back to whichever part is set so an empty
+// provider never yields a leading slash. The same key labels the BY RUN rollup
+// and is accepted by the --run-id filter.
+func RunKey(provider, runID string) string {
+	switch {
+	case provider != "" && runID != "":
+		return provider + "/" + runID
+	case provider != "":
+		return provider
+	default:
+		return runID
 	}
 }
 

--- a/cli/beacon/internal/endpoint/tokens/tokens.go
+++ b/cli/beacon/internal/endpoint/tokens/tokens.go
@@ -138,6 +138,12 @@ type usageEvent struct {
 // harness, session, model, metric name, and usage field; counter resets fall
 // back to the raw value) so totals never double-count. Delta metrics and
 // span-level usage sum directly.
+//
+// Events should be supplied in chronological (log append) order. Runtime
+// timestamps are second-resolution, so a batch of cumulative datapoints from
+// one export commonly shares a timestamp; cumulative deduping then relies on
+// slice order to recover the emission sequence. Passing events newest-first
+// makes each cumulative step-down look like a counter reset and inflates totals.
 func Aggregate(events []schema.Event, opts Options) Report {
 	if opts.NearLimitRatio <= 0 {
 		opts.NearLimitRatio = defaultNearLimitRatio

--- a/cli/beacon/internal/endpoint/tokens/tokens_test.go
+++ b/cli/beacon/internal/endpoint/tokens/tokens_test.go
@@ -117,6 +117,19 @@ func TestAggregateAttributesCIRuns(t *testing.T) {
 	}
 }
 
+func TestAggregateRunKeyWithoutProvider(t *testing.T) {
+	events := []schema.Event{
+		usageEventFixture("2026-06-11T10:00:00Z", "claude_code", "s1", "claude-sonnet-4-5", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(7)
+			e.Run = &schema.RunInfo{RunID: "run-abc"} // provider empty
+		}),
+	}
+	report := Aggregate(events, Options{})
+	if len(report.ByRun) != 1 || report.ByRun[0].Key != "run-abc" {
+		t.Fatalf("by_run = %#v, want bare run id without leading slash", report.ByRun)
+	}
+}
+
 func TestAggregateBuildsSessionStepTree(t *testing.T) {
 	spanEvent := func(ts, span, parent string, input int64) schema.Event {
 		return usageEventFixture(ts, "asymptote_observe", "s1", "gpt-4o-mini", func(e *schema.Event) {

--- a/cli/beacon/internal/endpoint/tokens/tokens_test.go
+++ b/cli/beacon/internal/endpoint/tokens/tokens_test.go
@@ -1,0 +1,215 @@
+package tokens
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+)
+
+func usageEventFixture(ts, harness, session, model string, mutate func(*schema.Event)) schema.Event {
+	event := schema.Event{
+		Timestamp: ts,
+		Event:     schema.EventInfo{Kind: "agent_runtime", Action: "token.usage", Category: "metric"},
+		Harness:   schema.HarnessInfo{Name: harness},
+		Model:     model,
+		GenAI:     &schema.GenAIInfo{Usage: &schema.GenAIUsageInfo{}},
+	}
+	if session != "" {
+		event.Session = &schema.SessionInfo{ID: session}
+	}
+	if mutate != nil {
+		mutate(&event)
+	}
+	return event
+}
+
+func int64Ptr(v int64) *int64       { return &v }
+func float64Ptr(v float64) *float64 { return &v }
+
+func TestAggregateSumsDeltaUsageAcrossGroups(t *testing.T) {
+	events := []schema.Event{
+		usageEventFixture("2026-06-11T10:00:00Z", "claude_code", "s1", "claude-sonnet-4-5", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(100)
+			e.Repository = "github.com/acme/app"
+		}),
+		usageEventFixture("2026-06-11T10:00:00Z", "claude_code", "s1", "claude-sonnet-4-5", func(e *schema.Event) {
+			e.GenAI.Usage.OutputTokens = int64Ptr(40)
+		}),
+		usageEventFixture("2026-06-11T11:00:00Z", "asymptote_observe", "s2", "gpt-4o-mini", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(60)
+			e.GenAI.Usage.OutputTokens = int64Ptr(20)
+			e.GenAI.Usage.Reasoning = &schema.GenAIUsageReasoningInfo{OutputTokens: int64Ptr(5)}
+		}),
+		usageEventFixture("2026-06-11T11:30:00Z", "claude_code", "s1", "claude-sonnet-4-5", func(e *schema.Event) {
+			e.Event.Action = "cost.usage"
+			e.GenAI.Usage.CostUSD = float64Ptr(0.25)
+		}),
+		// Event without usage is counted in TotalEvents only.
+		{Timestamp: "2026-06-11T11:45:00Z", Event: schema.EventInfo{Action: "tool.invoked"}, Harness: schema.HarnessInfo{Name: "claude_code"}},
+	}
+
+	report := Aggregate(events, Options{BucketSize: time.Hour})
+	if report.TotalEvents != 5 || report.EventsWithUsage != 4 {
+		t.Fatalf("event counts = %d/%d, want 4/5", report.EventsWithUsage, report.TotalEvents)
+	}
+	if report.Totals.InputTokens != 160 || report.Totals.OutputTokens != 60 || report.Totals.ReasoningOutputTokens != 5 || report.Totals.CostUSD != 0.25 {
+		t.Fatalf("totals = %#v", report.Totals)
+	}
+	if len(report.ByModel) != 2 || report.ByModel[0].Key != "claude-sonnet-4-5" || report.ByModel[0].Usage.InputTokens != 100 || report.ByModel[0].Usage.CostUSD != 0.25 {
+		t.Fatalf("by_model = %#v", report.ByModel)
+	}
+	if len(report.BySession) != 2 || report.BySession[0].Key != "s1" {
+		t.Fatalf("by_session = %#v", report.BySession)
+	}
+	if len(report.ByHarness) != 2 || report.ByHarness[0].Key != "claude_code" {
+		t.Fatalf("by_harness = %#v", report.ByHarness)
+	}
+	if len(report.ByRepository) != 1 || report.ByRepository[0].Key != "github.com/acme/app" || report.ByRepository[0].Usage.InputTokens != 100 {
+		t.Fatalf("by_repository = %#v", report.ByRepository)
+	}
+	if len(report.Series) != 2 || report.Series[0].Start != "2026-06-11T10:00:00Z" || report.Series[0].Usage.InputTokens != 100 || report.Series[1].Usage.CostUSD != 0.25 {
+		t.Fatalf("series = %#v", report.Series)
+	}
+}
+
+func TestAggregateDedupesCumulativeSeries(t *testing.T) {
+	cumulative := func(ts string, value int64) schema.Event {
+		return usageEventFixture(ts, "claude_code", "s1", "claude-sonnet-4-5", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(value)
+			e.Raw = map[string]interface{}{
+				"metric_name":        "claude_code.token.usage",
+				"metric_temporality": "Cumulative",
+			}
+		})
+	}
+	events := []schema.Event{
+		cumulative("2026-06-11T10:00:00Z", 100),
+		cumulative("2026-06-11T10:01:00Z", 250),
+		cumulative("2026-06-11T10:02:00Z", 400),
+		// Counter reset: raw value becomes the interval contribution.
+		cumulative("2026-06-11T10:03:00Z", 50),
+	}
+
+	report := Aggregate(events, Options{})
+	if report.Totals.InputTokens != 450 {
+		t.Fatalf("cumulative input total = %d, want 450 (100+150+150+50)", report.Totals.InputTokens)
+	}
+}
+
+func TestAggregateAttributesCIRuns(t *testing.T) {
+	events := []schema.Event{
+		usageEventFixture("2026-06-11T10:00:00Z", "claude_code", "ci-1", "claude-sonnet-4-5", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(10)
+			e.Run = &schema.RunInfo{Provider: "github_actions", RunID: "12345"}
+		}),
+		usageEventFixture("2026-06-11T10:05:00Z", "claude_code", "ci-1", "claude-sonnet-4-5", func(e *schema.Event) {
+			e.GenAI.Usage.OutputTokens = int64Ptr(4)
+			e.Run = &schema.RunInfo{Provider: "github_actions", RunID: "12345"}
+		}),
+	}
+	report := Aggregate(events, Options{})
+	if len(report.ByRun) != 1 || report.ByRun[0].Key != "github_actions/12345" {
+		t.Fatalf("by_run = %#v", report.ByRun)
+	}
+	if report.ByRun[0].Usage.InputTokens != 10 || report.ByRun[0].Usage.OutputTokens != 4 {
+		t.Fatalf("by_run usage = %#v", report.ByRun[0].Usage)
+	}
+}
+
+func TestAggregateBuildsSessionStepTree(t *testing.T) {
+	spanEvent := func(ts, span, parent string, input int64) schema.Event {
+		return usageEventFixture(ts, "asymptote_observe", "s1", "gpt-4o-mini", func(e *schema.Event) {
+			e.Event.Action = "tool.invoked"
+			e.Message = "step-" + span
+			e.GenAI.Usage.InputTokens = int64Ptr(input)
+			e.Trace = &schema.TraceInfo{ID: "trace-1", SpanID: span, ParentSpanID: parent}
+		})
+	}
+	events := []schema.Event{
+		spanEvent("2026-06-11T10:00:00Z", "root", "", 100),
+		spanEvent("2026-06-11T10:00:05Z", "child-a", "root", 30),
+		spanEvent("2026-06-11T10:00:10Z", "child-b", "root", 20),
+		spanEvent("2026-06-11T10:00:15Z", "grandchild", "child-a", 10),
+		// Step without span identity stays flat at the top level.
+		usageEventFixture("2026-06-11T10:00:20Z", "claude_code", "s1", "claude-sonnet-4-5", func(e *schema.Event) {
+			e.GenAI.Usage.OutputTokens = int64Ptr(7)
+		}),
+	}
+
+	report := Aggregate(events, Options{SessionID: "s1"})
+	detail := report.SessionDetail
+	if detail == nil || detail.SessionID != "s1" {
+		t.Fatalf("session detail = %#v", detail)
+	}
+	if detail.Usage.InputTokens != 160 || detail.Usage.OutputTokens != 7 {
+		t.Fatalf("session usage = %#v", detail.Usage)
+	}
+	if len(detail.Steps) != 2 {
+		t.Fatalf("top-level steps = %d, want 2 (root + flat step): %#v", len(detail.Steps), detail.Steps)
+	}
+	root := detail.Steps[0]
+	if root.SpanID != "root" || len(root.Children) != 2 {
+		t.Fatalf("root step = %#v", root)
+	}
+	if root.Children[0].SpanID != "child-a" || len(root.Children[0].Children) != 1 || root.Children[0].Children[0].SpanID != "grandchild" {
+		t.Fatalf("child tree = %#v", root.Children)
+	}
+	if detail.Steps[1].SpanID != "" || detail.Steps[1].Usage.OutputTokens != 7 {
+		t.Fatalf("flat step = %#v", detail.Steps[1])
+	}
+}
+
+func TestAggregateUtilizationCombinesPerIntervalDataPoints(t *testing.T) {
+	// Claude Code reports one datapoint per token type at the same timestamp;
+	// utilization must recombine them into one context-size sample.
+	at := "2026-06-11T10:00:00Z"
+	events := []schema.Event{
+		usageEventFixture(at, "claude_code", "s1", "claude-sonnet-4-5", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(1000)
+		}),
+		usageEventFixture(at, "claude_code", "s1", "claude-sonnet-4-5", func(e *schema.Event) {
+			e.GenAI.Usage.CacheRead = &schema.GenAIUsageCacheReadInfo{InputTokens: int64Ptr(179000)}
+		}),
+		usageEventFixture(at, "claude_code", "s1", "claude-sonnet-4-5", func(e *schema.Event) {
+			e.GenAI.Usage.CacheCreation = &schema.GenAIUsageCacheCreationInfo{InputTokens: int64Ptr(5000)}
+		}),
+		usageEventFixture("2026-06-11T11:00:00Z", "asymptote_observe", "s2", "experimental-model", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(123)
+		}),
+	}
+
+	report := Aggregate(events, Options{})
+	if len(report.Utilization) != 2 {
+		t.Fatalf("utilization = %#v", report.Utilization)
+	}
+	claude := report.Utilization[0]
+	if claude.Model != "claude-sonnet-4-5" || claude.ContextWindow != 200000 || claude.Calls != 1 {
+		t.Fatalf("claude utilization = %#v", claude)
+	}
+	if claude.MaxInputTokens != 185000 || claude.MaxRatio != 0.925 || claude.NearLimitCalls != 1 {
+		t.Fatalf("claude utilization sample = %#v", claude)
+	}
+	unknown := report.Utilization[1]
+	if unknown.Model != "experimental-model" || unknown.ContextWindow != 0 || unknown.MaxRatio != 0 || unknown.MaxInputTokens != 123 {
+		t.Fatalf("unknown model utilization = %#v", unknown)
+	}
+}
+
+func TestAggregateTopLimitCapsGroups(t *testing.T) {
+	events := []schema.Event{
+		usageEventFixture("2026-06-11T10:00:00Z", "claude_code", "s1", "model-a", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(300)
+		}),
+		usageEventFixture("2026-06-11T10:01:00Z", "claude_code", "s2", "model-b", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(200)
+		}),
+		usageEventFixture("2026-06-11T10:02:00Z", "claude_code", "s3", "model-c", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(100)
+		}),
+	}
+	report := Aggregate(events, Options{TopLimit: 2})
+	if len(report.ByModel) != 2 || report.ByModel[0].Key != "model-a" || report.ByModel[1].Key != "model-b" {
+		t.Fatalf("by_model = %#v", report.ByModel)
+	}
+}

--- a/collector-builder/exporter/beaconjsonexporter/README.md
+++ b/collector-builder/exporter/beaconjsonexporter/README.md
@@ -20,6 +20,24 @@ Required behavior:
 - Redact common secrets and cap event size before writing.
 - Emit health failure events when write failures occur.
 
+Token and cost usage metrics:
+
+- Metrics named `gen_ai.client.token.usage` or ending in `.token.usage` or
+  `.cost.usage` (for example `claude_code.token.usage` and
+  `claude_code.cost.usage`) expand to one event per datapoint so the value,
+  token type, model, and session attributes survive into JSONL.
+- Token datapoints normalize into the canonical `gen_ai.usage` struct using
+  the `type`/`gen_ai.token.type` attribute (`input`, `output`, `cacheRead`,
+  `cacheCreation`, `reasoning`); cost datapoints map to
+  `gen_ai.usage.cost_usd`. Unknown token types keep the raw value in
+  `raw.metric_value` only.
+- Datapoint events use the datapoint timestamp and record
+  `raw.metric_temporality`, `raw.metric_monotonic`, `raw.metric_value`, and
+  (for histograms) `raw.metric_count` so downstream aggregation can dedupe
+  cumulative series.
+- All other metrics, and usage metrics without datapoints, keep the single
+  `metric.observed` event.
+
 Noise controls:
 
 - Generic process/runtime metrics are dropped by default unless

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -261,6 +261,12 @@ func (c Converter) EventFromLog(resourceAttrs map[string]interface{}, record plo
 	event := NewEvent(action, EventCategory(action, FirstString(attrs, "beacon.event.category", "event.category", "category")), Severity(record.SeverityText(), record.SeverityNumber().String()), HarnessName(attrs, message), ts)
 	event.Message = message
 	c.PopulateCommon(&event, attrs)
+	if !record.TraceID().IsEmpty() {
+		event.Trace = &TraceInfo{ID: record.TraceID().String()}
+		if !record.SpanID().IsEmpty() {
+			event.Trace.SpanID = record.SpanID().String()
+		}
+	}
 	event.Raw = c.RawPayload(attrs, map[string]interface{}{
 		"otel_signal": "logs",
 		"severity":    record.SeverityText(),
@@ -279,6 +285,15 @@ func (c Converter) EventFromSpan(resourceAttrs map[string]interface{}, span ptra
 	event := NewEvent(action, EventCategory(action, FirstString(attrs, "beacon.event.category", "event.category", "tool")), SpanSeverity(span.Status().Code().String()), HarnessName(attrs, message, span.Name()), Timestamp(span.StartTimestamp().AsTime()))
 	event.Message = message
 	c.PopulateCommon(&event, attrs)
+	if !span.TraceID().IsEmpty() {
+		event.Trace = &TraceInfo{ID: span.TraceID().String()}
+		if !span.SpanID().IsEmpty() {
+			event.Trace.SpanID = span.SpanID().String()
+		}
+		if !span.ParentSpanID().IsEmpty() {
+			event.Trace.ParentSpanID = span.ParentSpanID().String()
+		}
+	}
 	event.Raw = c.RawPayload(attrs, map[string]interface{}{
 		"otel_signal": "traces",
 		"span_name":   span.Name(),

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -623,19 +623,19 @@ func GenAIToolFromAttrs(attrs map[string]interface{}) *GenAIToolInfo {
 
 func GenAIUsageFromAttrs(attrs map[string]interface{}) *GenAIUsageInfo {
 	usage := &GenAIUsageInfo{}
-	if value, ok := IntAttr(attrs, "gen_ai.usage.cache_creation.input_tokens"); ok {
+	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_creation.input_tokens"); ok {
 		usage.CacheCreation = &GenAIUsageCacheCreationInfo{InputTokens: &value}
 	}
-	if value, ok := IntAttr(attrs, "gen_ai.usage.cache_read.input_tokens"); ok {
+	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_read.input_tokens"); ok {
 		usage.CacheRead = &GenAIUsageCacheReadInfo{InputTokens: &value}
 	}
-	if value, ok := IntAttr(attrs, "gen_ai.usage.input_tokens", "llm.usage.prompt_tokens", "gen_ai.usage.prompt_tokens"); ok {
+	if value, ok := Int64Attr(attrs, "gen_ai.usage.input_tokens", "llm.usage.prompt_tokens", "gen_ai.usage.prompt_tokens"); ok {
 		usage.InputTokens = &value
 	}
-	if value, ok := IntAttr(attrs, "gen_ai.usage.output_tokens", "llm.usage.completion_tokens", "gen_ai.usage.completion_tokens"); ok {
+	if value, ok := Int64Attr(attrs, "gen_ai.usage.output_tokens", "llm.usage.completion_tokens", "gen_ai.usage.completion_tokens"); ok {
 		usage.OutputTokens = &value
 	}
-	if value, ok := IntAttr(attrs, "gen_ai.usage.reasoning.output_tokens"); ok {
+	if value, ok := Int64Attr(attrs, "gen_ai.usage.reasoning.output_tokens"); ok {
 		usage.Reasoning = &GenAIUsageReasoningInfo{OutputTokens: &value}
 	}
 	if IsZeroJSON(usage) {

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -3,6 +3,7 @@ package beaconevent
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/url"
 	"sort"
 	"strconv"
@@ -106,7 +107,7 @@ func (c Converter) EventsFromMetrics(metrics pmetric.Metrics) []Event {
 				if ShouldDropMetric(resourceAttrs, metric.Name(), c.opts.IncludeRuntimeMetrics) {
 					continue
 				}
-				events = append(events, c.EventFromMetric(resourceAttrs, metric))
+				events = append(events, c.EventsFromMetric(resourceAttrs, metric)...)
 			}
 		}
 	}
@@ -406,6 +407,148 @@ func (c Converter) EventFromMetric(resourceAttrs map[string]interface{}, metric 
 		"metric_unit":        metric.Unit(),
 	})
 	return event
+}
+
+// IsTokenUsageMetric reports whether a metric carries token counts as
+// datapoint values, such as Claude Code's claude_code.token.usage counter or
+// the semconv gen_ai.client.token.usage histogram. Matching is deliberately
+// tight so unrelated metrics keep the generic metric.observed conversion.
+func IsTokenUsageMetric(name string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	return normalized == "gen_ai.client.token.usage" || strings.HasSuffix(normalized, ".token.usage")
+}
+
+// IsCostUsageMetric reports whether a metric carries runtime-reported cost as
+// datapoint values, such as Claude Code's claude_code.cost.usage counter.
+func IsCostUsageMetric(name string) bool {
+	return strings.HasSuffix(strings.ToLower(strings.TrimSpace(name)), ".cost.usage")
+}
+
+// EventsFromMetric expands token and cost usage metrics into one event per
+// datapoint so values and datapoint attributes (token type, model, session)
+// survive into JSONL. Other metrics, and usage metrics without datapoints,
+// keep the single metric.observed event.
+func (c Converter) EventsFromMetric(resourceAttrs map[string]interface{}, metric pmetric.Metric) []Event {
+	if IsTokenUsageMetric(metric.Name()) || IsCostUsageMetric(metric.Name()) {
+		if events := c.eventsFromUsageMetric(resourceAttrs, metric); len(events) > 0 {
+			return events
+		}
+	}
+	return []Event{c.EventFromMetric(resourceAttrs, metric)}
+}
+
+func (c Converter) eventsFromUsageMetric(resourceAttrs map[string]interface{}, metric pmetric.Metric) []Event {
+	var events []Event
+	switch metric.Type() {
+	case pmetric.MetricTypeSum:
+		sum := metric.Sum()
+		extra := map[string]interface{}{
+			"metric_type":        metric.Type().String(),
+			"metric_temporality": sum.AggregationTemporality().String(),
+			"metric_monotonic":   sum.IsMonotonic(),
+		}
+		for i := 0; i < sum.DataPoints().Len(); i++ {
+			dp := sum.DataPoints().At(i)
+			events = append(events, c.usageEventFromDataPoint(resourceAttrs, metric, dp.Attributes(), dp.Timestamp(), numberDataPointValue(dp), extra))
+		}
+	case pmetric.MetricTypeGauge:
+		gauge := metric.Gauge()
+		extra := map[string]interface{}{"metric_type": metric.Type().String()}
+		for i := 0; i < gauge.DataPoints().Len(); i++ {
+			dp := gauge.DataPoints().At(i)
+			events = append(events, c.usageEventFromDataPoint(resourceAttrs, metric, dp.Attributes(), dp.Timestamp(), numberDataPointValue(dp), extra))
+		}
+	case pmetric.MetricTypeHistogram:
+		histogram := metric.Histogram()
+		for i := 0; i < histogram.DataPoints().Len(); i++ {
+			dp := histogram.DataPoints().At(i)
+			if !dp.HasSum() {
+				continue
+			}
+			extra := map[string]interface{}{
+				"metric_type":        metric.Type().String(),
+				"metric_temporality": histogram.AggregationTemporality().String(),
+				"metric_count":       int64(dp.Count()),
+			}
+			events = append(events, c.usageEventFromDataPoint(resourceAttrs, metric, dp.Attributes(), dp.Timestamp(), dp.Sum(), extra))
+		}
+	}
+	return events
+}
+
+func numberDataPointValue(dp pmetric.NumberDataPoint) float64 {
+	if dp.ValueType() == pmetric.NumberDataPointValueTypeInt {
+		return float64(dp.IntValue())
+	}
+	return dp.DoubleValue()
+}
+
+func (c Converter) usageEventFromDataPoint(resourceAttrs map[string]interface{}, metric pmetric.Metric, dpAttrs pcommon.Map, ts pcommon.Timestamp, value float64, extra map[string]interface{}) Event {
+	attrs := MergeMaps(resourceAttrs, AttrsToMap(dpAttrs))
+	action := "token.usage"
+	if IsCostUsageMetric(metric.Name()) {
+		action = "cost.usage"
+	}
+	event := NewEvent(action, "metric", "info", HarnessName(attrs, metric.Name()), Timestamp(ts.AsTime()))
+	event.Message = metric.Name()
+	c.PopulateCommon(&event, attrs)
+	if action == "cost.usage" {
+		cost := value
+		if event.GenAI == nil {
+			event.GenAI = &GenAIInfo{}
+		}
+		if event.GenAI.Usage == nil {
+			event.GenAI.Usage = &GenAIUsageInfo{}
+		}
+		event.GenAI.Usage.CostUSD = &cost
+	} else {
+		ApplyTokenUsage(&event, FirstString(attrs, "type", "gen_ai.token.type"), int64(math.Round(value)))
+	}
+	rawExtra := map[string]interface{}{
+		"otel_signal":        "metrics",
+		"metric_name":        metric.Name(),
+		"metric_description": metric.Description(),
+		"metric_unit":        metric.Unit(),
+		"metric_value":       value,
+	}
+	for k, v := range extra {
+		rawExtra[k] = v
+	}
+	event.Raw = c.RawPayload(attrs, rawExtra)
+	return event
+}
+
+// ApplyTokenUsage merges a typed token count into the event's canonical
+// gen_ai.usage struct. Claude Code's cacheRead/cacheCreation token types
+// extend the semconv input/output enum. Unknown types only record the type
+// so the raw value stays inspectable without polluting usage totals.
+func ApplyTokenUsage(event *Event, tokenType string, value int64) {
+	if event.GenAI == nil {
+		event.GenAI = &GenAIInfo{}
+	}
+	if event.GenAI.Usage == nil {
+		event.GenAI.Usage = &GenAIUsageInfo{}
+	}
+	usage := event.GenAI.Usage
+	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(tokenType)), "_", "") {
+	case "input", "prompt":
+		usage.InputTokens = &value
+	case "output", "completion":
+		usage.OutputTokens = &value
+	case "cacheread":
+		usage.CacheRead = &GenAIUsageCacheReadInfo{InputTokens: &value}
+	case "cachecreation":
+		usage.CacheCreation = &GenAIUsageCacheCreationInfo{InputTokens: &value}
+	case "reasoning":
+		usage.Reasoning = &GenAIUsageReasoningInfo{OutputTokens: &value}
+	default:
+		if event.GenAI.Token == nil && tokenType != "" {
+			event.GenAI.Token = &GenAITokenInfo{Type: tokenType}
+		}
+	}
+	if tokenType != "" && event.GenAI.Token == nil {
+		event.GenAI.Token = &GenAITokenInfo{Type: tokenType}
+	}
 }
 
 func (c Converter) PopulateCommon(event *Event, attrs map[string]interface{}) {

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -557,10 +557,10 @@ func (c Converter) PopulateCommon(event *Event, attrs map[string]interface{}) {
 	event.Model = FirstString(attrs, "gen_ai.request.model", "gen_ai.response.model", "model", "ai.model")
 	event.Repository = FirstString(attrs, "vcs.repository.url", "repository", "repo.path", "workspace.repository")
 	event.Branch = FirstString(attrs, "vcs.branch.name", "git.branch", "branch")
-	if id := FirstString(attrs, "gen_ai.conversation.id", "copilot_chat.session_id", "copilot_chat.chat_session_id", "conversation.id", "conversation_id", "session.id"); id != "" || FirstString(attrs, "cwd", "working_directory", "workspace") != "" {
+	if id := FirstString(attrs, "gen_ai.conversation.id", "beacon.session.id", "copilot_chat.session_id", "copilot_chat.chat_session_id", "conversation.id", "conversation_id", "session.id"); id != "" || FirstString(attrs, "cwd", "working_directory", "workspace") != "" {
 		event.Session = &SessionInfo{
 			ID:               id,
-			WorkingDirectory: FirstString(attrs, "cwd", "working_directory", "process.command_args.cwd", "workspace"),
+			WorkingDirectory: FirstString(attrs, "cwd", "working_directory", "beacon.session.working_directory", "process.command_args.cwd", "workspace"),
 		}
 	}
 	if name := FirstString(attrs, "tool.name", "gen_ai.tool.name", "mcp.tool.name", "function_name", "tool_name"); name != "" || ToolCommandString(attrs) != "" {
@@ -781,10 +781,10 @@ func GenAIToolFromAttrs(attrs map[string]interface{}) *GenAIToolInfo {
 
 func GenAIUsageFromAttrs(attrs map[string]interface{}) *GenAIUsageInfo {
 	usage := &GenAIUsageInfo{}
-	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_creation.input_tokens"); ok {
+	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_creation.input_tokens", "gen_ai.usage.cache_creation_input_tokens"); ok {
 		usage.CacheCreation = &GenAIUsageCacheCreationInfo{InputTokens: &value}
 	}
-	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_read.input_tokens"); ok {
+	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_read.input_tokens", "gen_ai.usage.cache_read_input_tokens"); ok {
 		usage.CacheRead = &GenAIUsageCacheReadInfo{InputTokens: &value}
 	}
 	if value, ok := Int64Attr(attrs, "gen_ai.usage.input_tokens", "llm.usage.prompt_tokens", "gen_ai.usage.prompt_tokens"); ok {
@@ -795,6 +795,9 @@ func GenAIUsageFromAttrs(attrs map[string]interface{}) *GenAIUsageInfo {
 	}
 	if value, ok := Int64Attr(attrs, "gen_ai.usage.reasoning.output_tokens"); ok {
 		usage.Reasoning = &GenAIUsageReasoningInfo{OutputTokens: &value}
+	}
+	if value, ok := FloatAttr(attrs, "gen_ai.usage.cost"); ok {
+		usage.CostUSD = &value
 	}
 	if IsZeroJSON(usage) {
 		return nil

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -492,6 +492,13 @@ func (c Converter) usageEventFromDataPoint(resourceAttrs map[string]interface{},
 	event := NewEvent(action, "metric", "info", HarnessName(attrs, metric.Name()), Timestamp(ts.AsTime()))
 	event.Message = metric.Name()
 	c.PopulateCommon(&event, attrs)
+	// The datapoint value is the authoritative usage for this event. Drop any
+	// gen_ai.usage.* that PopulateCommon read from merged attributes so a stray
+	// usage attribute on the resource or datapoint cannot ride along on every
+	// expanded datapoint event and inflate aggregated totals.
+	if event.GenAI != nil {
+		event.GenAI.Usage = nil
+	}
 	if action == "cost.usage" {
 		cost := value
 		if event.GenAI == nil {
@@ -779,18 +786,23 @@ func GenAIToolFromAttrs(attrs map[string]interface{}) *GenAIToolInfo {
 	return tool
 }
 
+// GenAIUsageFromAttrs normalizes runtime token usage into the canonical
+// gen_ai.usage struct. Alongside the OTel GenAI and legacy llm.usage.* semconv
+// names it accepts Claude Code's bare claude_code.llm_request span attribute
+// names (input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+// so span-level usage and the per-step session drilldown carry real counts.
 func GenAIUsageFromAttrs(attrs map[string]interface{}) *GenAIUsageInfo {
 	usage := &GenAIUsageInfo{}
-	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_creation.input_tokens", "gen_ai.usage.cache_creation_input_tokens"); ok {
+	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_creation.input_tokens", "gen_ai.usage.cache_creation_input_tokens", "cache_creation_tokens"); ok {
 		usage.CacheCreation = &GenAIUsageCacheCreationInfo{InputTokens: &value}
 	}
-	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_read.input_tokens", "gen_ai.usage.cache_read_input_tokens"); ok {
+	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_read.input_tokens", "gen_ai.usage.cache_read_input_tokens", "cache_read_tokens"); ok {
 		usage.CacheRead = &GenAIUsageCacheReadInfo{InputTokens: &value}
 	}
-	if value, ok := Int64Attr(attrs, "gen_ai.usage.input_tokens", "llm.usage.prompt_tokens", "gen_ai.usage.prompt_tokens"); ok {
+	if value, ok := Int64Attr(attrs, "gen_ai.usage.input_tokens", "llm.usage.prompt_tokens", "gen_ai.usage.prompt_tokens", "input_tokens"); ok {
 		usage.InputTokens = &value
 	}
-	if value, ok := Int64Attr(attrs, "gen_ai.usage.output_tokens", "llm.usage.completion_tokens", "gen_ai.usage.completion_tokens"); ok {
+	if value, ok := Int64Attr(attrs, "gen_ai.usage.output_tokens", "llm.usage.completion_tokens", "gen_ai.usage.completion_tokens", "output_tokens"); ok {
 		usage.OutputTokens = &value
 	}
 	if value, ok := Int64Attr(attrs, "gen_ai.usage.reasoning.output_tokens"); ok {

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
@@ -388,6 +388,78 @@ func TestEventsFromMetricTokenUsageWithoutDataPointsFallsBack(t *testing.T) {
 	}
 }
 
+func TestGenAIUsageFromAttrsNormalizesAliases(t *testing.T) {
+	tests := []struct {
+		name  string
+		attrs map[string]interface{}
+		check func(t *testing.T, usage *GenAIUsageInfo)
+	}{
+		{
+			name:  "underscore cache read alias",
+			attrs: map[string]interface{}{"gen_ai.usage.cache_read_input_tokens": int64(90)},
+			check: func(t *testing.T, usage *GenAIUsageInfo) {
+				if usage.CacheRead == nil || usage.CacheRead.InputTokens == nil || *usage.CacheRead.InputTokens != 90 {
+					t.Fatalf("cache_read = %#v, want 90", usage.CacheRead)
+				}
+			},
+		},
+		{
+			name:  "underscore cache creation alias",
+			attrs: map[string]interface{}{"gen_ai.usage.cache_creation_input_tokens": int64(30)},
+			check: func(t *testing.T, usage *GenAIUsageInfo) {
+				if usage.CacheCreation == nil || usage.CacheCreation.InputTokens == nil || *usage.CacheCreation.InputTokens != 30 {
+					t.Fatalf("cache_creation = %#v, want 30", usage.CacheCreation)
+				}
+			},
+		},
+		{
+			name:  "runtime reported cost attribute",
+			attrs: map[string]interface{}{"gen_ai.usage.cost": 0.0123},
+			check: func(t *testing.T, usage *GenAIUsageInfo) {
+				if usage.CostUSD == nil || *usage.CostUSD != 0.0123 {
+					t.Fatalf("cost_usd = %#v, want 0.0123", usage.CostUSD)
+				}
+			},
+		},
+		{
+			name:  "semconv dotted names take precedence",
+			attrs: map[string]interface{}{"gen_ai.usage.cache_read.input_tokens": int64(7), "gen_ai.usage.cache_read_input_tokens": int64(99)},
+			check: func(t *testing.T, usage *GenAIUsageInfo) {
+				if usage.CacheRead == nil || usage.CacheRead.InputTokens == nil || *usage.CacheRead.InputTokens != 7 {
+					t.Fatalf("cache_read = %#v, want semconv value 7", usage.CacheRead)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usage := GenAIUsageFromAttrs(tt.attrs)
+			if usage == nil {
+				t.Fatalf("usage = nil, want populated usage")
+			}
+			tt.check(t, usage)
+		})
+	}
+}
+
+func TestPopulateCommonMapsBeaconSessionAttributes(t *testing.T) {
+	span, traces := newObserveSDKTraceSpan("agent.step")
+	span.Attributes().PutStr("beacon.session.id", "cloud-session-42")
+	span.Attributes().PutStr("beacon.session.working_directory", "/srv/agent")
+
+	events := NewConverter(Options{}).EventsFromTraces(traces)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	session := events[0].Session
+	if session == nil || session.ID != "cloud-session-42" {
+		t.Fatalf("session = %#v, want beacon.session.id mapped", session)
+	}
+	if session.WorkingDirectory != "/srv/agent" {
+		t.Fatalf("working directory = %q, want beacon.session.working_directory mapped", session.WorkingDirectory)
+	}
+}
+
 func newObserveSDKTraceSpan(name string) (ptrace.Span, ptrace.Traces) {
 	traces := ptrace.NewTraces()
 	resourceSpans := traces.ResourceSpans().AppendEmpty()

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -200,6 +201,190 @@ func TestEventFromLogCapturesTraceContext(t *testing.T) {
 	}
 	if trace.ParentSpanID != "" {
 		t.Fatalf("trace.parent_span_id = %q, want empty for logs", trace.ParentSpanID)
+	}
+}
+
+func TestEventsFromMetricsExpandsClaudeCodeTokenUsageDataPoints(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetrics.Resource().Attributes().PutStr("service.name", "claude-code")
+	metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("claude_code.token.usage")
+	metric.SetUnit("tokens")
+	sum := metric.SetEmptySum()
+	sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	sum.SetIsMonotonic(true)
+
+	ts := pcommon.NewTimestampFromTime(time.Unix(1700000100, 0).UTC())
+	for tokenType, value := range map[string]int64{
+		"input":         120,
+		"output":        45,
+		"cacheRead":     90,
+		"cacheCreation": 30,
+	} {
+		dp := sum.DataPoints().AppendEmpty()
+		dp.SetTimestamp(ts)
+		dp.SetIntValue(value)
+		dp.Attributes().PutStr("type", tokenType)
+		dp.Attributes().PutStr("model", "claude-sonnet-4-5")
+		dp.Attributes().PutStr("session.id", "session-123")
+	}
+
+	events := NewConverter(Options{}).EventsFromMetrics(metrics)
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events (one per datapoint), got %d", len(events))
+	}
+	got := map[string]int64{}
+	for _, event := range events {
+		if event.Event.Action != "token.usage" || event.Event.Category != "metric" {
+			t.Fatalf("event = %#v, want token.usage metric", event.Event)
+		}
+		if event.Harness.Name != "claude_code" {
+			t.Fatalf("harness = %q, want claude_code", event.Harness.Name)
+		}
+		if event.Model != "claude-sonnet-4-5" {
+			t.Fatalf("model = %q, want datapoint model attribute", event.Model)
+		}
+		if event.Session == nil || event.Session.ID != "session-123" {
+			t.Fatalf("session = %#v, want datapoint session attribute", event.Session)
+		}
+		if !event.ObservedAt.Equal(time.Unix(1700000100, 0).UTC()) {
+			t.Fatalf("timestamp = %v, want datapoint timestamp", event.ObservedAt)
+		}
+		if event.Raw["metric_temporality"] != "Delta" || event.Raw["metric_monotonic"] != true {
+			t.Fatalf("raw temporality = %#v, want Delta monotonic", event.Raw)
+		}
+		usage := event.GenAI.Usage
+		if usage == nil {
+			t.Fatalf("usage missing on event: %#v", event.GenAI)
+		}
+		switch {
+		case usage.InputTokens != nil:
+			got["input"] = *usage.InputTokens
+		case usage.OutputTokens != nil:
+			got["output"] = *usage.OutputTokens
+		case usage.CacheRead != nil && usage.CacheRead.InputTokens != nil:
+			got["cacheRead"] = *usage.CacheRead.InputTokens
+		case usage.CacheCreation != nil && usage.CacheCreation.InputTokens != nil:
+			got["cacheCreation"] = *usage.CacheCreation.InputTokens
+		default:
+			t.Fatalf("usage has no recognized token field: %#v", usage)
+		}
+	}
+	want := map[string]int64{"input": 120, "output": 45, "cacheRead": 90, "cacheCreation": 30}
+	for tokenType, value := range want {
+		if got[tokenType] != value {
+			t.Fatalf("token usage %s = %d, want %d (all: %#v)", tokenType, got[tokenType], value, got)
+		}
+	}
+}
+
+func TestEventsFromMetricsCapturesCostUsage(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetrics.Resource().Attributes().PutStr("service.name", "claude-code")
+	metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("claude_code.cost.usage")
+	metric.SetUnit("USD")
+	sum := metric.SetEmptySum()
+	sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	dp := sum.DataPoints().AppendEmpty()
+	dp.SetDoubleValue(0.42)
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(1700000200, 0).UTC()))
+	dp.Attributes().PutStr("model", "claude-sonnet-4-5")
+
+	events := NewConverter(Options{}).EventsFromMetrics(metrics)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	event := events[0]
+	if event.Event.Action != "cost.usage" {
+		t.Fatalf("action = %q, want cost.usage", event.Event.Action)
+	}
+	if event.GenAI == nil || event.GenAI.Usage == nil || event.GenAI.Usage.CostUSD == nil || *event.GenAI.Usage.CostUSD != 0.42 {
+		t.Fatalf("usage = %#v, want cost_usd 0.42", event.GenAI)
+	}
+	if event.Model != "claude-sonnet-4-5" {
+		t.Fatalf("model = %q, want datapoint model attribute", event.Model)
+	}
+	if event.Raw["metric_value"] != 0.42 || event.Raw["metric_unit"] != "USD" {
+		t.Fatalf("raw payload = %#v, want metric_value and unit", event.Raw)
+	}
+}
+
+func TestEventsFromMetricsCapturesTokenUsageHistogram(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetrics.Resource().Attributes().PutStr("beacon.harness.name", "asymptote_observe")
+	metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("gen_ai.client.token.usage")
+	histogram := metric.SetEmptyHistogram()
+	histogram.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	dp := histogram.DataPoints().AppendEmpty()
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(1700000300, 0).UTC()))
+	dp.SetCount(3)
+	dp.SetSum(456)
+	dp.Attributes().PutStr("gen_ai.token.type", "output")
+	dp.Attributes().PutStr("gen_ai.request.model", "gpt-4o-mini")
+
+	events := NewConverter(Options{}).EventsFromMetrics(metrics)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	event := events[0]
+	if event.GenAI == nil || event.GenAI.Usage == nil || event.GenAI.Usage.OutputTokens == nil || *event.GenAI.Usage.OutputTokens != 456 {
+		t.Fatalf("usage = %#v, want output 456", event.GenAI)
+	}
+	if event.Model != "gpt-4o-mini" {
+		t.Fatalf("model = %q, want gpt-4o-mini", event.Model)
+	}
+	if event.Raw["metric_count"] != int64(3) {
+		t.Fatalf("raw metric_count = %#v, want 3", event.Raw["metric_count"])
+	}
+}
+
+func TestEventsFromMetricsUnknownTokenTypeKeepsRawValueOnly(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetrics.Resource().Attributes().PutStr("service.name", "claude-code")
+	metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("claude_code.token.usage")
+	sum := metric.SetEmptySum()
+	sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	dp := sum.DataPoints().AppendEmpty()
+	dp.SetIntValue(7)
+	dp.Attributes().PutStr("type", "speculative")
+
+	events := NewConverter(Options{}).EventsFromMetrics(metrics)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	event := events[0]
+	usage := event.GenAI.Usage
+	if usage != nil && (usage.InputTokens != nil || usage.OutputTokens != nil || usage.CacheRead != nil || usage.CacheCreation != nil || usage.Reasoning != nil) {
+		t.Fatalf("unknown token type populated usage: %#v", usage)
+	}
+	if event.GenAI.Token == nil || event.GenAI.Token.Type != "speculative" {
+		t.Fatalf("token type = %#v, want speculative recorded", event.GenAI.Token)
+	}
+	if event.Raw["metric_value"] != float64(7) {
+		t.Fatalf("raw metric_value = %#v, want 7", event.Raw["metric_value"])
+	}
+}
+
+func TestEventsFromMetricTokenUsageWithoutDataPointsFallsBack(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetrics.Resource().Attributes().PutStr("service.name", "claude-code")
+	metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("claude_code.token.usage")
+
+	events := NewConverter(Options{}).EventsFromMetrics(metrics)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 fallback event, got %d", len(events))
+	}
+	if events[0].Event.Action != "metric.observed" {
+		t.Fatalf("action = %q, want metric.observed fallback", events[0].Event.Action)
 	}
 }
 

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
@@ -144,6 +144,46 @@ func TestEventsFromTracesNormalizesClaudeAgentSDKSpan(t *testing.T) {
 	}
 }
 
+func TestEventFromSpanNormalizesClaudeCodeLLMRequestUsage(t *testing.T) {
+	// Claude Code's claude_code.llm_request span records token usage under bare
+	// attribute names (input_tokens, output_tokens, cache_read_tokens,
+	// cache_creation_tokens), not the gen_ai.usage.* semconv names. These must
+	// normalize into the canonical gen_ai.usage so the per-step session
+	// drilldown and span-level attribution carry real usage.
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "claude-code")
+	span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName("claude_code.llm_request")
+	span.Attributes().PutStr("session.id", "session-span")
+	span.Attributes().PutStr("model", "claude-sonnet-4-5")
+	span.Attributes().PutInt("input_tokens", 1200)
+	span.Attributes().PutInt("output_tokens", 340)
+	span.Attributes().PutInt("cache_read_tokens", 8000)
+	span.Attributes().PutInt("cache_creation_tokens", 256)
+
+	events := NewConverter(Options{}).EventsFromTraces(traces)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	usage := events[0].GenAI.Usage
+	if usage == nil {
+		t.Fatalf("usage missing on span event: %#v", events[0].GenAI)
+	}
+	if usage.InputTokens == nil || *usage.InputTokens != 1200 {
+		t.Fatalf("input_tokens = %v, want 1200", usage.InputTokens)
+	}
+	if usage.OutputTokens == nil || *usage.OutputTokens != 340 {
+		t.Fatalf("output_tokens = %v, want 340", usage.OutputTokens)
+	}
+	if usage.CacheRead == nil || usage.CacheRead.InputTokens == nil || *usage.CacheRead.InputTokens != 8000 {
+		t.Fatalf("cache_read = %#v, want 8000", usage.CacheRead)
+	}
+	if usage.CacheCreation == nil || usage.CacheCreation.InputTokens == nil || *usage.CacheCreation.InputTokens != 256 {
+		t.Fatalf("cache_creation = %#v, want 256", usage.CacheCreation)
+	}
+}
+
 func TestEventFromSpanCapturesTraceIdentity(t *testing.T) {
 	span, traces := newObserveSDKTraceSpan("agent.step")
 	span.SetTraceID(pcommon.TraceID([16]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}))
@@ -275,6 +315,52 @@ func TestEventsFromMetricsExpandsClaudeCodeTokenUsageDataPoints(t *testing.T) {
 	for tokenType, value := range want {
 		if got[tokenType] != value {
 			t.Fatalf("token usage %s = %d, want %d (all: %#v)", tokenType, got[tokenType], value, got)
+		}
+	}
+}
+
+func TestEventsFromMetricsTokenUsageIgnoresStrayUsageAttributes(t *testing.T) {
+	// A token.usage datapoint event must carry only the value from its own
+	// datapoint, not gen_ai.usage.* attributes that happen to ride along on the
+	// resource or datapoint. Otherwise the stray field is attached to every
+	// expanded datapoint event and double-counted by tokens.Aggregate.
+	metrics := pmetric.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetrics.Resource().Attributes().PutStr("service.name", "claude-code")
+	// Stray usage attribute that overlaps the per-datapoint token type.
+	resourceMetrics.Resource().Attributes().PutInt("gen_ai.usage.input_tokens", 999)
+	metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("claude_code.token.usage")
+	metric.SetUnit("tokens")
+	sum := metric.SetEmptySum()
+	sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	sum.SetIsMonotonic(true)
+	ts := pcommon.NewTimestampFromTime(time.Unix(1700000200, 0).UTC())
+	for _, tokenType := range []string{"input", "output"} {
+		dp := sum.DataPoints().AppendEmpty()
+		dp.SetTimestamp(ts)
+		dp.SetIntValue(10)
+		dp.Attributes().PutStr("type", tokenType)
+	}
+
+	events := NewConverter(Options{}).EventsFromMetrics(metrics)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	for _, event := range events {
+		usage := event.GenAI.Usage
+		if usage == nil {
+			t.Fatalf("usage missing on event: %#v", event.GenAI)
+		}
+		if usage.OutputTokens != nil {
+			// The output datapoint event must not also carry the stray input.
+			if usage.InputTokens != nil {
+				t.Fatalf("output datapoint leaked input_tokens=%d from stray attribute", *usage.InputTokens)
+			}
+			continue
+		}
+		if usage.InputTokens == nil || *usage.InputTokens != 10 {
+			t.Fatalf("input datapoint = %#v, want input_tokens=10 from datapoint value", usage)
 		}
 	}
 }

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
@@ -1,12 +1,39 @@
 package beaconevent
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
+
+// Guards against the exporter Event mirror struct drifting from the shared
+// asymptoteobserve schema: new optional fields must survive JSON marshaling.
+func TestEventMirrorSerializesTraceAndUsageCost(t *testing.T) {
+	event := NewEvent("token.usage", "metric", "info", "claude_code", time.Unix(1700000000, 0).UTC())
+	event.Trace = &TraceInfo{ID: "0123456789abcdef0123456789abcdef", SpanID: "0123456789abcdef", ParentSpanID: "fedcba9876543210"}
+	cost := 0.0123
+	input := int64(120)
+	event.GenAI = &GenAIInfo{Usage: &GenAIUsageInfo{InputTokens: &input, CostUSD: &cost}}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`"trace":{"id":"0123456789abcdef0123456789abcdef","span_id":"0123456789abcdef","parent_span_id":"fedcba9876543210"}`,
+		`"cost_usd":0.0123`,
+		`"input_tokens":120`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("JSON missing %s: %s", want, text)
+		}
+	}
+}
 
 func TestEventsFromTracesNormalizesObserveSDKSpan(t *testing.T) {
 	span, traces := newObserveSDKTraceSpan("agent.plan")

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -139,6 +140,66 @@ func TestEventsFromTracesNormalizesClaudeAgentSDKSpan(t *testing.T) {
 	}
 	if event.Prompt == nil || event.Prompt.Text != "review this pull request" {
 		t.Fatalf("prompt = %#v, want captured prompt text", event.Prompt)
+	}
+}
+
+func TestEventFromSpanCapturesTraceIdentity(t *testing.T) {
+	span, traces := newObserveSDKTraceSpan("agent.step")
+	span.SetTraceID(pcommon.TraceID([16]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}))
+	span.SetSpanID(pcommon.SpanID([8]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}))
+	span.SetParentSpanID(pcommon.SpanID([8]byte{0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10}))
+
+	events := NewConverter(Options{}).EventsFromTraces(traces)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	trace := events[0].Trace
+	if trace == nil {
+		t.Fatalf("trace identity missing: %#v", events[0])
+	}
+	if trace.ID != "0123456789abcdef0123456789abcdef" {
+		t.Fatalf("trace.id = %q, want hex trace id", trace.ID)
+	}
+	if trace.SpanID != "0123456789abcdef" {
+		t.Fatalf("trace.span_id = %q, want hex span id", trace.SpanID)
+	}
+	if trace.ParentSpanID != "fedcba9876543210" {
+		t.Fatalf("trace.parent_span_id = %q, want hex parent span id", trace.ParentSpanID)
+	}
+}
+
+func TestEventFromSpanOmitsTraceWhenUnset(t *testing.T) {
+	_, traces := newObserveSDKTraceSpan("agent.step")
+
+	events := NewConverter(Options{}).EventsFromTraces(traces)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Trace != nil {
+		t.Fatalf("trace = %#v, want nil for span without trace identity", events[0].Trace)
+	}
+}
+
+func TestEventFromLogCapturesTraceContext(t *testing.T) {
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	record := scopeLogs.LogRecords().AppendEmpty()
+	record.Body().SetStr("model call completed")
+	record.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(1700000000, 0).UTC()))
+	record.SetTraceID(pcommon.TraceID([16]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}))
+	record.SetSpanID(pcommon.SpanID([8]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}))
+
+	events := NewConverter(Options{}).EventsFromLogs(logs)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	trace := events[0].Trace
+	if trace == nil || trace.ID != "0123456789abcdef0123456789abcdef" || trace.SpanID != "0123456789abcdef" {
+		t.Fatalf("trace = %#v, want log trace context", trace)
+	}
+	if trace.ParentSpanID != "" {
+		t.Fatalf("trace.parent_span_id = %q, want empty for logs", trace.ParentSpanID)
 	}
 }
 

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/event.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/event.go
@@ -17,6 +17,7 @@ type EndpointInfo = asymptoteobserve.EndpointInfo
 type UserInfo = asymptoteobserve.UserInfo
 type HarnessInfo = asymptoteobserve.HarnessInfo
 type SessionInfo = asymptoteobserve.SessionInfo
+type TraceInfo = asymptoteobserve.TraceInfo
 type RunInfo = asymptoteobserve.RunInfo
 type ToolInfo = asymptoteobserve.ToolInfo
 type FileInfo = asymptoteobserve.FileInfo
@@ -68,6 +69,7 @@ type Event struct {
 	Origin        asymptoteobserve.Origin           `json:"origin,omitempty"`
 	Run           *RunInfo                          `json:"run,omitempty"`
 	Session       *SessionInfo                      `json:"session,omitempty"`
+	Trace         *TraceInfo                        `json:"trace,omitempty"`
 	Tool          *ToolInfo                         `json:"tool,omitempty"`
 	File          *FileInfo                         `json:"file,omitempty"`
 	Command       *CommandInfo                      `json:"command,omitempty"`

--- a/packages/asymptote-sdk-js/README.md
+++ b/packages/asymptote-sdk-js/README.md
@@ -132,6 +132,31 @@ const plan = Observe.observe(
 Call `Observe.flush()` before short-lived scripts exit, or
 `Observe.shutdown()` when the process owns the provider lifecycle.
 
+## Token Usage Attribution
+
+The OpenLLMetry instrumentations record `gen_ai.usage.*` token counts on every
+supported model call, and the Beacon collector normalizes them into endpoint
+JSONL for the token usage dashboard and `beacon endpoint tokens` reports. Two
+notes:
+
+- Streaming responses report usage only after the stream is fully consumed;
+  abandoning a stream early can drop the final usage record for that call.
+- `traceContent` only controls prompt/completion text capture. Numeric token
+  usage is always recorded.
+
+To attribute usage to one agent session across spans, attach
+`Observe.sessionAttributes(sessionId)` to your spans or resource attributes:
+
+```typescript
+const handle = Observe.observe(
+  {
+    name: "agent.handle_request",
+    attributes: Observe.sessionAttributes(conversationId),
+  },
+  async (input: string) => runAgent(input),
+);
+```
+
 ## Beta Support Matrix
 
 - OpenAI SDK: OpenLLMetry instrumentation enabled by default.

--- a/packages/asymptote-sdk-js/src/index.test.ts
+++ b/packages/asymptote-sdk-js/src/index.test.ts
@@ -18,6 +18,7 @@ import {
   isInitialized,
   observe,
   resolveExporterConfig,
+  sessionAttributes,
   shutdown,
   wrapClaudeAgentQuery,
 } from "./index.js";
@@ -102,6 +103,27 @@ describe("resolveExporterConfig", () => {
 
     expect(config.mode).toBe("custom");
     expect(config.observeUrl).toBeUndefined();
+  });
+});
+
+describe("sessionAttributes", () => {
+  it("builds beacon and gen_ai session identity attributes", () => {
+    expect(sessionAttributes("session-42")).toEqual({
+      "beacon.session.id": "session-42",
+      "gen_ai.conversation.id": "session-42",
+    });
+  });
+
+  it("includes the working directory when provided", () => {
+    expect(sessionAttributes("session-42", "/srv/agent")).toEqual({
+      "beacon.session.id": "session-42",
+      "gen_ai.conversation.id": "session-42",
+      "beacon.session.working_directory": "/srv/agent",
+    });
+  });
+
+  it("is exposed on the Observe facade", () => {
+    expect(Observe.sessionAttributes("session-42")).toEqual(sessionAttributes("session-42"));
   });
 });
 

--- a/packages/asymptote-sdk-js/src/index.ts
+++ b/packages/asymptote-sdk-js/src/index.ts
@@ -41,6 +41,8 @@ import {
   ATTR_BEACON_HARNESS_NAME,
   ATTR_BEACON_ORIGIN,
   ATTR_BEACON_PROMPT_TEXT,
+  ATTR_BEACON_SESSION_ID,
+  ATTR_BEACON_SESSION_WORKING_DIRECTORY,
 } from "./constants.js";
 
 export * from "./constants.js";
@@ -134,6 +136,10 @@ export class Observe {
 
   static patch(modules: InstrumentModules): void {
     patch(modules);
+  }
+
+  static sessionAttributes(sessionId: string, workingDirectory?: string): Attributes {
+    return sessionAttributes(sessionId, workingDirectory);
   }
 
   static instrumentations(options: AsymptoteInstrumentationOptions = {}): Instrumentation[] {
@@ -248,6 +254,24 @@ export function observe<T extends (...args: any[]) => any>(options: ObserveOptio
       }
     });
   } as T;
+}
+
+/**
+ * Builds the span or resource attributes that attribute telemetry to one
+ * agent session for Beacon token usage rollups. Pass the result to
+ * `observe({ attributes: ... })`, `startActiveSpan`, or
+ * `initialize({ resourceAttributes: ... })` so every span in the session
+ * carries the same session identity.
+ */
+export function sessionAttributes(sessionId: string, workingDirectory?: string): Attributes {
+  const attributes: Attributes = {
+    [ATTR_BEACON_SESSION_ID]: sessionId,
+    "gen_ai.conversation.id": sessionId,
+  };
+  if (workingDirectory) {
+    attributes[ATTR_BEACON_SESSION_WORKING_DIRECTORY] = workingDirectory;
+  }
+  return attributes;
 }
 
 export function patch(modules: InstrumentModules): void {

--- a/pkg/asymptoteobserve/event.go
+++ b/pkg/asymptoteobserve/event.go
@@ -77,6 +77,12 @@ type SessionInfo struct {
 	WorkingDirectory string `json:"working_directory,omitempty"`
 }
 
+type TraceInfo struct {
+	ID           string `json:"id,omitempty"`
+	SpanID       string `json:"span_id,omitempty"`
+	ParentSpanID string `json:"parent_span_id,omitempty"`
+}
+
 type RunInfo struct {
 	Provider   string `json:"provider,omitempty"`
 	RunID      string `json:"run_id,omitempty"`
@@ -269,22 +275,27 @@ type GenAIToolInfo struct {
 }
 
 type GenAIUsageCacheCreationInfo struct {
-	InputTokens *int `json:"input_tokens,omitempty"`
+	InputTokens *int64 `json:"input_tokens,omitempty"`
 }
 
 type GenAIUsageCacheReadInfo struct {
-	InputTokens *int `json:"input_tokens,omitempty"`
+	InputTokens *int64 `json:"input_tokens,omitempty"`
 }
 
 type GenAIUsageReasoningInfo struct {
-	OutputTokens *int `json:"output_tokens,omitempty"`
+	OutputTokens *int64 `json:"output_tokens,omitempty"`
 }
 
+// GenAIUsageInfo mirrors the OpenTelemetry GenAI semconv usage attribute
+// names. Token counts are int64 to match OTLP integer values. CostUSD has no
+// semconv equivalent; it carries runtime-reported USD cost only (for example
+// Claude Code's cost metric) and is never derived from local pricing tables.
 type GenAIUsageInfo struct {
 	CacheCreation *GenAIUsageCacheCreationInfo `json:"cache_creation,omitempty"`
 	CacheRead     *GenAIUsageCacheReadInfo     `json:"cache_read,omitempty"`
-	InputTokens   *int                         `json:"input_tokens,omitempty"`
-	OutputTokens  *int                         `json:"output_tokens,omitempty"`
+	CostUSD       *float64                     `json:"cost_usd,omitempty"`
+	InputTokens   *int64                       `json:"input_tokens,omitempty"`
+	OutputTokens  *int64                       `json:"output_tokens,omitempty"`
 	Reasoning     *GenAIUsageReasoningInfo     `json:"reasoning,omitempty"`
 }
 
@@ -338,6 +349,7 @@ type Event struct {
 	Origin        Origin                 `json:"origin,omitempty"`
 	Run           *RunInfo               `json:"run,omitempty"`
 	Session       *SessionInfo           `json:"session,omitempty"`
+	Trace         *TraceInfo             `json:"trace,omitempty"`
 	Tool          *ToolInfo              `json:"tool,omitempty"`
 	File          *FileInfo              `json:"file,omitempty"`
 	Command       *CommandInfo           `json:"command,omitempty"`

--- a/pkg/asymptoteobserve/event_test.go
+++ b/pkg/asymptoteobserve/event_test.go
@@ -43,7 +43,7 @@ func TestNewEventSetsRequiredInvariants(t *testing.T) {
 	event.GenAI = &GenAIInfo{
 		Provider: &GenAIProviderInfo{Name: "openai"},
 		Request:  &GenAIRequestInfo{Model: "gpt-4o"},
-		Usage:    &GenAIUsageInfo{InputTokens: intPtr(10), OutputTokens: intPtr(20)},
+		Usage:    &GenAIUsageInfo{InputTokens: int64Ptr(10), OutputTokens: int64Ptr(20)},
 	}
 	if err := event.Validate(); err != nil {
 		t.Fatalf("Validate rejected optional telemetry fields: %v", err)
@@ -97,8 +97,63 @@ func TestValidateOriginValues(t *testing.T) {
 	}
 }
 
-func intPtr(value int) *int {
+func int64Ptr(value int64) *int64 {
 	return &value
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
+}
+
+func TestTraceAndUsageCostSerializeWithSemconvNames(t *testing.T) {
+	event := NewEvent(NewEventOptions{Action: "token.usage", Harness: HarnessInfo{Name: "claude_code"}})
+	event.Trace = &TraceInfo{ID: "0123456789abcdef0123456789abcdef", SpanID: "0123456789abcdef", ParentSpanID: "fedcba9876543210"}
+	event.GenAI = &GenAIInfo{
+		Usage: &GenAIUsageInfo{
+			InputTokens:   int64Ptr(120),
+			OutputTokens:  int64Ptr(45),
+			CacheCreation: &GenAIUsageCacheCreationInfo{InputTokens: int64Ptr(30)},
+			CacheRead:     &GenAIUsageCacheReadInfo{InputTokens: int64Ptr(90)},
+			Reasoning:     &GenAIUsageReasoningInfo{OutputTokens: int64Ptr(15)},
+			CostUSD:       float64Ptr(0.0123),
+		},
+	}
+	if err := event.Validate(); err != nil {
+		t.Fatalf("Validate rejected trace and usage fields: %v", err)
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`"trace":{"id":"0123456789abcdef0123456789abcdef","span_id":"0123456789abcdef","parent_span_id":"fedcba9876543210"}`,
+		`"input_tokens":120`,
+		`"output_tokens":45`,
+		`"cache_creation":{"input_tokens":30}`,
+		`"cache_read":{"input_tokens":90}`,
+		`"reasoning":{"output_tokens":15}`,
+		`"cost_usd":0.0123`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("JSON missing %s: %s", want, text)
+		}
+	}
+}
+
+func TestTraceAndUsageCostOmittedWhenUnset(t *testing.T) {
+	event := NewEvent(NewEventOptions{Action: "tool.invoked", Harness: HarnessInfo{Name: "cursor"}})
+	event.GenAI = &GenAIInfo{Usage: &GenAIUsageInfo{InputTokens: int64Ptr(1)}}
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	text := string(data)
+	for _, field := range []string{`"trace"`, `"cost_usd"`} {
+		if strings.Contains(text, field) {
+			t.Fatalf("unset additive field %s leaked into JSON: %s", field, text)
+		}
+	}
 }
 
 func TestRunAndOriginAreOmittedWhenUnset(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared event schema, collector metric expansion, and aggregation logic where cumulative-metric ordering bugs could inflate totals; behavior is heavily tested but affects a core JSONL contract.
> 
> **Overview**
> Adds end-to-end **token usage and runtime-reported cost** visibility: telemetry is normalized into canonical **`gen_ai.usage`** (plus optional **`trace`** identity), then rolled up for the local dashboard and CLI.
> 
> The **beaconjson exporter** expands token/cost OTLP metrics into per-datapoint events, maps types into `gen_ai.usage`, records metric temporality in `raw`, and enriches spans/logs with trace IDs and more usage attribute aliases (including Claude Code’s bare token field names). **Claude Code / CI harness** setup now prefers **delta** OTLP metrics temporality to simplify summing.
> 
> A new **`tokens`** package **`Aggregate`**s usage with cumulative-series dedup (chronological log order), groupings (model, session, harness, CI run, etc.), context-window utilization, and per-step session trees. The dashboard gains **`/api/tokens`**, **`tokens.html`**, and log **`trace`** search; **`beacon endpoint tokens`** mirrors the same report as text/JSON with filters.
> 
> **`@asymptote/sdk`** adds **`Observe.sessionAttributes()`** for session attribution. Docs and schema tests lock in **`cost_usd`**, **`TraceInfo`**, and the single canonical usage shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fcbbd897c8d2ba766c8d795ed0028a46f393c64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->