### PR TITLE
Add Codex cloud telemetry setup

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,74 @@
+{
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=codex_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform codex permission-request",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=codex_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform codex post-tool",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=codex_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform codex pre-tool",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=codex_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform codex cloud-reset",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": "startup|resume|clear|compact"
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=codex_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform codex cloud-upload",
+            "timeout": 45,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=codex_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform codex codex-prompt-submit",
+            "timeout": 30,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -130,19 +130,25 @@ beacon cloud cursor print-hooks \
 ```
 
 Codex Cloud Agents use user-level Codex configuration in the cloud sandbox.
-Generate the setup script locally, paste it into the Codex cloud environment
-setup step, and configure the Beacon cloud GCS environment variables:
+Generate and commit project-level Codex hooks before starting cloud tasks, then
+paste the setup script into the Codex cloud environment setup step and configure
+the Beacon cloud GCS environment variables:
 
 ```bash
+mkdir -p .codex
+beacon cloud codex print-hooks \
+  --binary-path /tmp/beacon/bin/beacon-hooks \
+  --log-path /tmp/beacon/runtime.jsonl > .codex/hooks.json
 beacon cloud codex print-setup --version vX.Y.Z
 ```
 
 The Codex setup script installs Beacon binaries under `/tmp/beacon/bin`, starts
 the local `beacon-otelcol` collector, writes `~/.codex/config.toml` with
-`log_user_prompt = true`, installs user-level Codex hooks in
-`~/.codex/hooks.json`, and uploads `/tmp/beacon/runtime.jsonl` snapshots to GCS.
-Codex agent internet access must allow `oauth2.googleapis.com`,
-`storage.googleapis.com`, `github.com`, and `*.githubusercontent.com`.
+`log_user_prompt = true` for follow-up runs where Codex reloads user config, and
+uploads `/tmp/beacon/runtime.jsonl` snapshots to GCS. Committed hooks provide
+the reliable first-turn prompt/tool/approval telemetry path. Codex agent
+internet access must allow `oauth2.googleapis.com`, `storage.googleapis.com`,
+`github.com`, and `*.githubusercontent.com`.
 
 ### Output Destinations
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ CI, and cloud surfaces.
 | --- | --- | --- |
 | [Claude Code Cloud Agents](https://docs.asymptotelabs.ai/claude-code-cloud-agents) | Cloud sandbox hooks with GCS upload | Session, prompt, tool, command, file, and lifecycle telemetry where Claude Code cloud hook payloads expose it |
 | [Cursor Cloud Agents](https://docs.asymptotelabs.ai/cursor-cloud-agents) | Cloud sandbox hooks with GCS upload | Tool, shell command, file, subagent, and compaction telemetry where Cursor cloud hook payloads expose it |
+| Codex Cloud Agents | Cloud sandbox Codex OTel plus hooks with GCS upload | Prompt, approval, tool, command, and session telemetry where Codex OTel and hooks expose it |
 | [Anthropic](https://docs.asymptotelabs.ai/sdk/integrations-anthropic) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported Anthropic model call spans, errors, and OpenTelemetry attributes |
 | [Claude Agent SDK](https://docs.asymptotelabs.ai/sdk/integrations-claude-agent-sdk) | Query wrapper through `Observe.wrapClaudeAgentQuery()` | Query root spans with Beacon-compatible prompt attributes |
 | [OpenAI](https://docs.asymptotelabs.ai/sdk/integrations-openai) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported OpenAI model call spans, errors, and OpenTelemetry attributes |
@@ -127,6 +128,21 @@ beacon cloud cursor print-hooks \
   --binary-path /tmp/beacon/bin/beacon-hooks \
   --log-path /tmp/beacon/runtime.jsonl > .cursor/hooks.json
 ```
+
+Codex Cloud Agents use user-level Codex configuration in the cloud sandbox.
+Generate the setup script locally, paste it into the Codex cloud environment
+setup step, and configure the Beacon cloud GCS environment variables:
+
+```bash
+beacon cloud codex print-setup --version vX.Y.Z
+```
+
+The Codex setup script installs Beacon binaries under `/tmp/beacon/bin`, starts
+the local `beacon-otelcol` collector, writes `~/.codex/config.toml` with
+`log_user_prompt = true`, installs user-level Codex hooks in
+`~/.codex/hooks.json`, and uploads `/tmp/beacon/runtime.jsonl` snapshots to GCS.
+Codex agent internet access must allow `oauth2.googleapis.com`,
+`storage.googleapis.com`, `github.com`, and `*.githubusercontent.com`.
 
 ### Output Destinations
 

--- a/cli/beacon-hooks/cmd/cloud.go
+++ b/cli/beacon-hooks/cmd/cloud.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/cloudshuttle"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
+)
+
+var cloudResetCmd = &cobra.Command{
+	Use:   "cloud-reset",
+	Short: "Reset cloud telemetry state at session start",
+	Run:   runCloudReset,
+}
+
+var cloudUploadCmd = &cobra.Command{
+	Use:   "cloud-upload",
+	Short: "Upload cloud telemetry runtime JSONL",
+	Run:   runCloudUpload,
+}
+
+var cloudWatchCmd = &cobra.Command{
+	Use:   "cloud-watch",
+	Short: "Periodically upload changed cloud telemetry",
+	Run:   runCloudWatch,
+}
+
+var codexPromptSubmitCmd = &cobra.Command{
+	Use:   "codex-prompt-submit",
+	Short: "Record Codex cloud prompt submission and upload telemetry",
+	Run:   runCodexPromptSubmit,
+}
+
+func init() {
+	rootCmd.AddCommand(cloudResetCmd)
+	rootCmd.AddCommand(cloudUploadCmd)
+	rootCmd.AddCommand(cloudWatchCmd)
+	rootCmd.AddCommand(codexPromptSubmitCmd)
+}
+
+func runCloudReset(cmd *cobra.Command, args []string) {
+	logger := logging.NewLoggerForPlatform("cloud-reset", platformFlag)
+	if input, ok := readOptionalStdinJSON(); ok {
+		seedCloudRunID(input)
+	}
+	if err := cloudshuttle.ResetFromEnv(); err != nil {
+		logger.Warn("Failed to reset cloud telemetry log", "error", err.Error())
+	}
+	outputJSON(emptyResponse)
+}
+
+func runCloudUpload(cmd *cobra.Command, args []string) {
+	logger := logging.NewLoggerForPlatform("cloud-upload", platformFlag)
+	if input, ok := readOptionalStdinJSON(); ok {
+		seedCloudRunID(input)
+	}
+	uploadCloudTelemetry(logger, true)
+	outputJSON(emptyResponse)
+}
+
+func runCloudWatch(cmd *cobra.Command, args []string) {
+	logger := logging.NewLoggerForPlatform("cloud-watch", platformFlag)
+	if err := cloudshuttle.Watch(context.Background(), 15*time.Second); err != nil {
+		logger.Warn("Cloud telemetry watcher stopped", "error", err.Error())
+	}
+}
+
+func runCodexPromptSubmit(cmd *cobra.Command, args []string) {
+	input, ok := readOptionalStdinJSON()
+	if !ok {
+		outputJSON(emptyResponse)
+		return
+	}
+	seedCloudRunID(input)
+	sessionID := resolveSessionID(input, platformFlag)
+	var logger *logging.Logger
+	if sessionID != "" {
+		logger = logging.NewSessionLogger("codex-prompt-submit", platformFlag, sessionID)
+	} else {
+		logger = logging.NewLoggerForPlatform("codex-prompt-submit", platformFlag)
+	}
+	fields := sessionFields(sessionID, input)
+	if prompt := getFirstStr(input, "prompt", "user_prompt", "prompt_text", "text", "input"); prompt != "" {
+		fields["prompt"] = map[string]interface{}{"text": prompt}
+	}
+	emitHookEvent(logger, "prompt.submitted", "prompt", "info", "Codex prompt submitted", input, fields)
+	uploadCloudTelemetry(logger, true)
+	outputJSON(emptyResponse)
+}
+
+func seedCloudRunID(input map[string]interface{}) {
+	sessionID := resolveSessionID(input, platformFlag)
+	if sessionID == "" {
+		return
+	}
+	if os.Getenv("BEACON_RUN_ID") == "" {
+		_ = os.Setenv("BEACON_RUN_ID", sessionID)
+	}
+	if os.Getenv("BEACON_CODEX_SESSION_ID") == "" {
+		_ = os.Setenv("BEACON_CODEX_SESSION_ID", sessionID)
+	}
+}
+
+func readOptionalStdinJSON() (map[string]interface{}, bool) {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return nil, false
+	}
+	if info.Mode()&os.ModeCharDevice != 0 {
+		return nil, false
+	}
+	input, err := readStdinJSON()
+	if err != nil {
+		return nil, false
+	}
+	return input, true
+}

--- a/cli/beacon-hooks/cmd/cloud_test.go
+++ b/cli/beacon-hooks/cmd/cloud_test.go
@@ -77,3 +77,32 @@ func TestRunCodexPromptSubmitEmitsCloudPromptEvent(t *testing.T) {
 		t.Fatalf("prompt.text = %q, want redacted prompt", prompt)
 	}
 }
+
+func TestRunCodexPreToolObservesWithoutDecisionResponse(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "codex"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_ORIGIN", "cloud")
+	t.Setenv("BEACON_RUN_PROVIDER", "codex_cloud")
+	t.Setenv("BEACON_RUN_EPHEMERAL", "true")
+
+	out := runHookWithInput(t, runPreTool, map[string]interface{}{
+		"session_id": "codex-session",
+		"tool_name":  "Bash",
+		"tool_input": map[string]interface{}{
+			"command": "pwd && ls",
+		},
+	})
+	if len(out) != 0 {
+		t.Fatalf("codex pre-tool response = %#v, want empty", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "approval.allowed" {
+		t.Fatalf("event.action = %q, want approval.allowed", action)
+	}
+	if command := event["command"].(map[string]interface{})["command"]; command != "pwd && ls" {
+		t.Fatalf("command = %q, want pwd && ls", command)
+	}
+}

--- a/cli/beacon-hooks/cmd/cloud_test.go
+++ b/cli/beacon-hooks/cmd/cloud_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCloudCommandsRegistered(t *testing.T) {
+	for _, name := range []string{"cloud-reset", "cloud-upload", "cloud-watch", "codex-prompt-submit"} {
+		cmd, _, err := rootCmd.Find([]string{name})
+		if err != nil {
+			t.Fatalf("Find %s returned error: %v", name, err)
+		}
+		if cmd == nil || cmd.Use != name {
+			t.Fatalf("command %s not registered: %#v", name, cmd)
+		}
+	}
+}
+
+func TestRunCloudResetRemovesRuntimeFiles(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "codex"
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "runtime.jsonl")
+	statePath := filepath.Join(dir, "state.json")
+	for _, path := range []string{logPath, logPath + ".lock", statePath} {
+		if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	t.Setenv("BEACON_ORIGIN", "cloud")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CLOUD_SHUTTLE_STATE", statePath)
+
+	out := runHookWithInput(t, runCloudReset, map[string]interface{}{"session_id": "codex-session"})
+	if len(out) != 0 {
+		t.Fatalf("cloud-reset response = %#v, want empty", out)
+	}
+	for _, path := range []string{logPath, logPath + ".lock", statePath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s still exists, stat err=%v", path, err)
+		}
+	}
+}
+
+func TestRunCodexPromptSubmitEmitsCloudPromptEvent(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "codex"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_ORIGIN", "cloud")
+	t.Setenv("BEACON_RUN_PROVIDER", "codex_cloud")
+	t.Setenv("BEACON_RUN_EPHEMERAL", "true")
+
+	out := runHookWithInput(t, runCodexPromptSubmit, map[string]interface{}{
+		"session_id": "codex-session",
+		"cwd":        "/repo",
+		"prompt":     "summarize token=codex-secret",
+		"model":      "gpt-5.1-codex",
+	})
+	if len(out) != 0 {
+		t.Fatalf("codex-prompt-submit response = %#v, want empty", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "prompt.submitted" {
+		t.Fatalf("event.action = %q, want prompt.submitted", action)
+	}
+	if provider := event["run"].(map[string]interface{})["provider"]; provider != "codex_cloud" {
+		t.Fatalf("run.provider = %q, want codex_cloud", provider)
+	}
+	if runID := event["run"].(map[string]interface{})["run_id"]; runID != "codex-session" {
+		t.Fatalf("run.run_id = %q, want codex-session", runID)
+	}
+	if prompt := event["prompt"].(map[string]interface{})["text"]; prompt != "summarize token=[REDACTED]" {
+		t.Fatalf("prompt.text = %q, want redacted prompt", prompt)
+	}
+}

--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -109,6 +109,9 @@ func preToolResponse() map[string]interface{} {
 	if platformFlag == "claude" || isDevinLikePlatform(platformFlag) || platformFlag == "hermes" || platformFlag == "vscode" {
 		return emptyResponse
 	}
+	if platformFlag == "codex" {
+		return emptyResponse
+	}
 	return allowResponse
 }
 

--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
@@ -67,14 +67,15 @@ type tokenResponse struct {
 
 func ConfigFromEnv() Config {
 	statePath := firstEnvDefault(defaultStatePath, "BEACON_CLOUD_SHUTTLE_STATE")
+	logPath := firstEnvDefault(defaultLogPath, "BEACON_CLOUD_LOG_PATH", "BEACON_ENDPOINT_LOG", "BEACON_LOG_PATH", "BEACON_RUNTIME_LOG")
 	return Config{
-		LogPath:        firstEnvDefault(defaultLogPath, "BEACON_CLOUD_LOG_PATH", "BEACON_ENDPOINT_LOG", "BEACON_LOG_PATH", "BEACON_RUNTIME_LOG"),
+		LogPath:        logPath,
 		StatePath:      statePath,
 		Bucket:         strings.TrimSpace(os.Getenv("BEACON_CLOUD_GCS_BUCKET")),
 		Prefix:         strings.Trim(strings.TrimSpace(os.Getenv("BEACON_CLOUD_GCS_PREFIX")), "/"),
 		CredentialsB64: strings.TrimSpace(os.Getenv("BEACON_CLOUD_GCS_CREDENTIALS_B64")),
 		Provider:       firstEnvDefault("claude_code_web", "BEACON_RUN_PROVIDER"),
-		RunID:          resolveRunID(),
+		RunID:          resolveRunIDFromLog(logPath),
 		UserID:         firstEnvDefault("unknown", "BEACON_CLOUD_USER_ID_HASH", "BEACON_CLOUD_USER_ID"),
 		Repository:     firstEnv("BEACON_RUN_REPOSITORY"),
 		GCSEndpoint:    firstEnvDefault(defaultGCSEndpoint, "BEACON_CLOUD_GCS_ENDPOINT"),
@@ -83,6 +84,30 @@ func ConfigFromEnv() Config {
 
 func MaybeUpload(ctx context.Context, force bool) error {
 	return Upload(ctx, ConfigFromEnv(), force)
+}
+
+func Watch(ctx context.Context, interval time.Duration) error {
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	if err := MaybeUpload(ctx, false); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return nil
+			}
+			return ctx.Err()
+		case <-ticker.C:
+			if err := MaybeUpload(ctx, false); err != nil {
+				return err
+			}
+		}
+	}
 }
 
 func ResetFromEnv() error {
@@ -131,7 +156,9 @@ func Upload(ctx context.Context, cfg Config, force bool) error {
 		return nil
 	}
 	if !force {
-		return nil
+		if st, err := readState(cfg.StatePath); err == nil && st.LastSize == info.Size() && st.LastObject == ObjectName(cfg) {
+			return nil
+		}
 	}
 	snapshot, cleanup, err := snapshotLog(cfg.LogPath)
 	if err != nil {
@@ -392,7 +419,74 @@ func preserveExistingLog(cfg Config) error {
 }
 
 func resolveRunID() string {
-	return firstEnv("BEACON_RUN_ID", "CLAUDE_CODE_REMOTE_SESSION_ID")
+	return firstEnv("BEACON_RUN_ID", "CLAUDE_CODE_REMOTE_SESSION_ID", "BEACON_CODEX_SESSION_ID")
+}
+
+func resolveRunIDFromLog(logPath string) string {
+	if runID := resolveRunID(); runID != "" {
+		return runID
+	}
+	return runIDFromRuntimeLog(logPath)
+}
+
+func runIDFromRuntimeLog(logPath string) string {
+	if strings.TrimSpace(logPath) == "" {
+		return ""
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return ""
+	}
+	var fallback string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var event map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+		if id := nestedString(event, "run", "run_id"); id != "" {
+			return id
+		}
+		if fallback == "" {
+			fallback = firstNestedString(event,
+				[]string{"session", "id"},
+				[]string{"gen_ai", "conversation", "id"},
+				[]string{"raw", "attributes", "session_id"},
+				[]string{"raw", "attributes", "conversation.id"},
+				[]string{"raw", "attributes", "conversation_id"},
+				[]string{"raw", "attributes", "gen_ai.conversation.id"},
+			)
+		}
+	}
+	return fallback
+}
+
+func firstNestedString(values map[string]interface{}, paths ...[]string) string {
+	for _, path := range paths {
+		if value := nestedString(values, path...); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func nestedString(values map[string]interface{}, path ...string) string {
+	var current interface{} = values
+	for _, key := range path {
+		next, ok := current.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current = next[key]
+	}
+	str, ok := current.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(str)
 }
 
 func cleanKeyParts(value string) []string {

--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
@@ -90,12 +90,15 @@ func Watch(ctx context.Context, interval time.Duration) error {
 	if interval <= 0 {
 		interval = 15 * time.Second
 	}
-	if err := MaybeUpload(ctx, false); err != nil {
-		return err
-	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
+		if err := MaybeUpload(ctx, false); err != nil && ctx.Err() != nil {
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return nil
+			}
+			return ctx.Err()
+		}
 		select {
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.Canceled) {
@@ -103,9 +106,6 @@ func Watch(ctx context.Context, interval time.Duration) error {
 			}
 			return ctx.Err()
 		case <-ticker.C:
-			if err := MaybeUpload(ctx, false); err != nil {
-				return err
-			}
 		}
 	}
 }

--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
@@ -14,7 +14,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestObjectNamePartitionsByProviderUserRepoAndRun(t *testing.T) {
@@ -39,6 +41,19 @@ func TestObjectNameUsesCursorCloudProvider(t *testing.T) {
 		RunID:    "manual-123",
 	})
 	want := "agent-traces/provider=cursor_cloud/user_id=user-1/run_id=manual-123/runtime.jsonl"
+	if got != want {
+		t.Fatalf("ObjectName = %q, want %q", got, want)
+	}
+}
+
+func TestObjectNameUsesCodexCloudProvider(t *testing.T) {
+	got := ObjectName(Config{
+		Prefix:   "agent-traces",
+		Provider: "codex_cloud",
+		UserID:   "user-1",
+		RunID:    "codex-session",
+	})
+	want := "agent-traces/provider=codex_cloud/user_id=user-1/run_id=codex-session/runtime.jsonl"
 	if got != want {
 		t.Fatalf("ObjectName = %q, want %q", got, want)
 	}
@@ -149,6 +164,79 @@ func TestResolveRunIDUsesOnlyEnvironment(t *testing.T) {
 	}
 }
 
+func TestResolveRunIDFromRuntimeLogUsesCodexSession(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	if err := os.WriteFile(logPath, []byte(`{"session":{"id":"codex-session"}}
+`), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	if got := resolveRunIDFromLog(logPath); got != "codex-session" {
+		t.Fatalf("resolveRunIDFromLog = %q, want codex-session", got)
+	}
+}
+
+func TestUploadSkipsUnchangedLogWhenNotForced(t *testing.T) {
+	key := mustRSAKey(t)
+	var uploads atomic.Int64
+	server := fakeGCSServer(t, key, &uploads, nil)
+	defer server.Close()
+
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	if err := os.WriteFile(logPath, []byte("{\"event\":\"ok\"}\n"), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	cfg := testUploadConfig(t, key, server.URL, logPath)
+	if err := Upload(context.Background(), cfg, false); err != nil {
+		t.Fatalf("first Upload returned error: %v", err)
+	}
+	if err := Upload(context.Background(), cfg, false); err != nil {
+		t.Fatalf("second Upload returned error: %v", err)
+	}
+	if got := uploads.Load(); got != 1 {
+		t.Fatalf("uploads after unchanged log = %d, want 1", got)
+	}
+	if err := os.WriteFile(logPath, []byte("{\"event\":\"ok\"}\n{\"event\":\"next\"}\n"), 0644); err != nil {
+		t.Fatalf("append log: %v", err)
+	}
+	if err := Upload(context.Background(), cfg, false); err != nil {
+		t.Fatalf("third Upload returned error: %v", err)
+	}
+	if got := uploads.Load(); got != 2 {
+		t.Fatalf("uploads after changed log = %d, want 2", got)
+	}
+}
+
+func TestWatchUploadsInitialLog(t *testing.T) {
+	key := mustRSAKey(t)
+	var uploads atomic.Int64
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server := fakeGCSServer(t, key, &uploads, nil)
+	defer server.Close()
+
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	if err := os.WriteFile(logPath, []byte("{\"event\":\"ok\"}\n"), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	cfg := testUploadConfig(t, key, server.URL, logPath)
+	t.Setenv("BEACON_ENDPOINT_LOG", cfg.LogPath)
+	t.Setenv("BEACON_CLOUD_SHUTTLE_STATE", cfg.StatePath)
+	t.Setenv("BEACON_CLOUD_GCS_BUCKET", cfg.Bucket)
+	t.Setenv("BEACON_CLOUD_GCS_PREFIX", cfg.Prefix)
+	t.Setenv("BEACON_CLOUD_GCS_CREDENTIALS_B64", cfg.CredentialsB64)
+	t.Setenv("BEACON_RUN_PROVIDER", cfg.Provider)
+	t.Setenv("BEACON_RUN_ID", cfg.RunID)
+	t.Setenv("BEACON_CLOUD_GCS_ENDPOINT", cfg.GCSEndpoint)
+
+	time.AfterFunc(20*time.Millisecond, cancel)
+	if err := Watch(ctx, time.Hour); err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	if got := uploads.Load(); got != 1 {
+		t.Fatalf("uploads = %d, want 1", got)
+	}
+}
+
 func TestUploadNoopsWithoutRunID(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
 	if err := os.WriteFile(logPath, []byte("{}\n"), 0644); err != nil {
@@ -162,6 +250,51 @@ func TestUploadNoopsWithoutRunID(t *testing.T) {
 	if err := Upload(context.Background(), cfg, true); err != nil {
 		t.Fatalf("Upload returned error: %v", err)
 	}
+}
+
+func testUploadConfig(t *testing.T, key *rsa.PrivateKey, endpoint, logPath string) Config {
+	t.Helper()
+	creds := serviceAccount{
+		ClientEmail: "beacon@example.iam.gserviceaccount.com",
+		PrivateKey:  pemKey(t, key),
+		TokenURI:    endpoint + "/token",
+	}
+	credsJSON, err := json.Marshal(creds)
+	if err != nil {
+		t.Fatalf("marshal creds: %v", err)
+	}
+	return Config{
+		LogPath:        logPath,
+		StatePath:      filepath.Join(t.TempDir(), "state.json"),
+		Bucket:         "bucket",
+		Prefix:         "prefix",
+		CredentialsB64: base64.StdEncoding.EncodeToString(credsJSON),
+		Provider:       "codex_cloud",
+		UserID:         "user",
+		RunID:          "run",
+		GCSEndpoint:    endpoint,
+	}
+}
+
+func fakeGCSServer(t *testing.T, key *rsa.PrivateKey, uploads *atomic.Int64, afterUpload func()) *httptest.Server {
+	t.Helper()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "test-token", "token_type": "Bearer", "expires_in": 3600})
+		default:
+			defer func() {
+				if afterUpload != nil {
+					go afterUpload()
+				}
+			}()
+			uploads.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	_ = key
+	return server
 }
 
 func mustRSAKey(t *testing.T) *rsa.PrivateKey {

--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
@@ -237,6 +237,36 @@ func TestWatchUploadsInitialLog(t *testing.T) {
 	}
 }
 
+func TestWatchContinuesAfterUploadError(t *testing.T) {
+	key := mustRSAKey(t)
+	var uploads atomic.Int64
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server := fakeFlakyGCSServer(t, key, &uploads, cancel)
+	defer server.Close()
+
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	if err := os.WriteFile(logPath, []byte("{\"event\":\"ok\"}\n"), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	cfg := testUploadConfig(t, key, server.URL, logPath)
+	t.Setenv("BEACON_ENDPOINT_LOG", cfg.LogPath)
+	t.Setenv("BEACON_CLOUD_SHUTTLE_STATE", cfg.StatePath)
+	t.Setenv("BEACON_CLOUD_GCS_BUCKET", cfg.Bucket)
+	t.Setenv("BEACON_CLOUD_GCS_PREFIX", cfg.Prefix)
+	t.Setenv("BEACON_CLOUD_GCS_CREDENTIALS_B64", cfg.CredentialsB64)
+	t.Setenv("BEACON_RUN_PROVIDER", cfg.Provider)
+	t.Setenv("BEACON_RUN_ID", cfg.RunID)
+	t.Setenv("BEACON_CLOUD_GCS_ENDPOINT", cfg.GCSEndpoint)
+
+	if err := Watch(ctx, 5*time.Millisecond); err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	if got := uploads.Load(); got < 2 {
+		t.Fatalf("uploads = %d, want retry after initial failure", got)
+	}
+}
+
 func TestUploadNoopsWithoutRunID(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
 	if err := os.WriteFile(logPath, []byte("{}\n"), 0644); err != nil {
@@ -291,6 +321,29 @@ func fakeGCSServer(t *testing.T, key *rsa.PrivateKey, uploads *atomic.Int64, aft
 			}()
 			uploads.Add(1)
 			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	_ = key
+	return server
+}
+
+func fakeFlakyGCSServer(t *testing.T, key *rsa.PrivateKey, uploads *atomic.Int64, cancel func()) *httptest.Server {
+	t.Helper()
+	var failed atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "test-token", "token_type": "Bearer", "expires_in": 3600})
+		default:
+			count := uploads.Add(1)
+			if !failed.Swap(true) {
+				http.Error(w, "temporary error", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			if count >= 2 {
+				time.AfterFunc(5*time.Millisecond, cancel)
+			}
 		}
 	}))
 	_ = key

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -86,17 +86,25 @@ paste it into the provider's cloud setup field:
 ```
 
 For Codex Cloud Agents, generate the setup script for a Beacon release and
-paste it into the Codex cloud environment setup script:
+paste it into the Codex cloud environment setup script. Also generate and commit
+project-level Codex hooks before starting cloud tasks:
 
 ```bash
+mkdir -p .codex
+./beacon cloud codex print-hooks \
+  --binary-path /tmp/beacon/bin/beacon-hooks \
+  --log-path /tmp/beacon/runtime.jsonl > .codex/hooks.json
 ./beacon cloud codex print-setup --version vX.Y.Z
 ```
 
 The Codex setup script installs `beacon`, `beacon-hooks`, and `beacon-otelcol`
 under `/tmp/beacon/bin`, starts a loopback OpenTelemetry collector, writes
-`~/.codex/config.toml` with `log_user_prompt = true`, writes user-level Codex
-hooks to `~/.codex/hooks.json`, and starts a periodic GCS uploader. Codex cloud
-agent internet access must allow `oauth2.googleapis.com`,
+`~/.codex/config.toml` with `log_user_prompt = true` for follow-up runs where
+Codex reloads user config, and starts a periodic GCS uploader. Committed
+`.codex/hooks.json` provides reliable first-turn prompt, tool, approval, and
+stop telemetry because setup-time user config writes may be too late for the
+current Codex agent process. Codex cloud agent internet access must allow
+`oauth2.googleapis.com`,
 `storage.googleapis.com`, `github.com`, and `*.githubusercontent.com`.
 
 The setup script installs `beacon-hooks` into the cloud sandbox and uploads a
@@ -104,8 +112,8 @@ browser-viewable `/tmp/beacon/runtime.jsonl` snapshot to GCS. Claude web writes
 `.claude/settings.local.json` inside the sandbox clone. Cursor cloud uses
 committed project-level `.cursor/hooks.json` because Cursor cloud may load hooks
 before the setup script creates files in the VM. Codex cloud uses native Codex
-OTel as the primary telemetry source and hooks for prompt upload/lifecycle
-resilience.
+hooks as the reliable self-serve telemetry source; Codex native OTel is enabled
+where user-level config is reloaded by the runtime.
 
 ```text
 <prefix>/provider=claude_code_web/user_id=<id>/run_id=<claude-session-id>/runtime.jsonl

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -38,8 +38,8 @@ configured.
 ## Cloud Agent Telemetry
 
 Use `beacon cloud` helpers to configure provider-managed cloud agent sandboxes.
-Claude Code on the web and Cursor cloud agents can forward Beacon JSONL to
-customer-managed GCS:
+Claude Code on the web, Cursor cloud agents, and Codex cloud agents can forward
+Beacon JSONL to customer-managed GCS:
 
 ```bash
 ./beacon cloud gcs setup \
@@ -57,24 +57,26 @@ values into the cloud agent environment. Also set:
 
 ```bash
 BEACON_ORIGIN=cloud
-BEACON_RUN_PROVIDER=claude_code_web # or cursor_cloud
+BEACON_RUN_PROVIDER=claude_code_web # or cursor_cloud or codex_cloud
 BEACON_RUN_EPHEMERAL=true
 BEACON_CLOUD_USER_ID_HASH=<stable-user-or-test-id>
 ```
 
-For Cursor Cloud Agents, keep the repository-owned setup in `.cursor/`:
+For Cursor Cloud Agents, generate and commit repository-owned project hooks
+before starting cloud tasks:
 
-```text
-.cursor/environment.json
-.cursor/install.sh
-.cursor/start.sh
+```bash
+mkdir -p .cursor
+./beacon cloud cursor print-hooks \
+  --binary-path /tmp/beacon/bin/beacon-hooks \
+  --log-path /tmp/beacon/runtime.jsonl > .cursor/hooks.json
 ```
 
-The install script builds the current branch by default, or downloads a release
-when `BEACON_VERSION` is set, then merges Beacon commands into
-`.cursor/hooks.json` during environment setup. It defaults to safe hook coverage
-while testing forwarding and skips shell/edit-specific hooks; set
-`BEACON_CURSOR_CLOUD_FULL_HOOKS=1` to enable the full Cursor Cloud hook set.
+Then paste the setup script into the Cursor cloud environment setup step:
+
+```bash
+./beacon cloud cursor print-setup --version vX.Y.Z
+```
 
 For Claude Code on the web, generate the setup script for a Beacon release and
 paste it into the provider's cloud setup field:
@@ -83,24 +85,52 @@ paste it into the provider's cloud setup field:
 ./beacon cloud claude-web print-setup --version vX.Y.Z
 ```
 
+For Codex Cloud Agents, generate the setup script for a Beacon release and
+paste it into the Codex cloud environment setup script:
+
+```bash
+./beacon cloud codex print-setup --version vX.Y.Z
+```
+
+The Codex setup script installs `beacon`, `beacon-hooks`, and `beacon-otelcol`
+under `/tmp/beacon/bin`, starts a loopback OpenTelemetry collector, writes
+`~/.codex/config.toml` with `log_user_prompt = true`, writes user-level Codex
+hooks to `~/.codex/hooks.json`, and starts a periodic GCS uploader. Codex cloud
+agent internet access must allow `oauth2.googleapis.com`,
+`storage.googleapis.com`, `github.com`, and `*.githubusercontent.com`.
+
 The setup script installs `beacon-hooks` into the cloud sandbox and uploads a
 browser-viewable `/tmp/beacon/runtime.jsonl` snapshot to GCS. Claude web writes
 `.claude/settings.local.json` inside the sandbox clone. Cursor cloud uses
-`.cursor/environment.json` to install Beacon and generate project-level
-`.cursor/hooks.json` because Cursor cloud only runs repository project hooks.
+committed project-level `.cursor/hooks.json` because Cursor cloud may load hooks
+before the setup script creates files in the VM. Codex cloud uses native Codex
+OTel as the primary telemetry source and hooks for prompt upload/lifecycle
+resilience.
 
 ```text
 <prefix>/provider=claude_code_web/user_id=<id>/run_id=<claude-session-id>/runtime.jsonl
 <prefix>/provider=cursor_cloud/user_id=<id>/run_id=<generated-or-explicit-run-id>/runtime.jsonl
+<prefix>/provider=codex_cloud/user_id=<id>/run_id=<codex-session-id>/runtime.jsonl
 ```
 
 Cloud network access must allow `oauth2.googleapis.com` and
 `storage.googleapis.com`. Cursor cloud currently supports command hooks for tool
 activity, shell execution, file reads and edits, subagents, and compaction
 events; it does not currently run session start, session end, prompt submit, or
-stop hooks in cloud agents. If you are testing unreleased Beacon changes, clone
-and build the feature branch in the setup script instead of using
+stop hooks in cloud agents. Codex cloud records retained user prompt text for
+prompt monitoring through `log_user_prompt = true`, subject to Beacon redaction
+and event-size limits. If you are testing unreleased Beacon changes, clone and
+build the feature branch in the setup script instead of using
 `print-setup --version`.
+
+Manual Codex cloud verification:
+
+```bash
+gcloud storage ls --recursive "gs://${BEACON_CLOUD_GCS_BUCKET}/${BEACON_CLOUD_GCS_PREFIX}/"
+gcloud storage cat "gs://${BEACON_CLOUD_GCS_BUCKET}/${BEACON_CLOUD_GCS_PREFIX}/provider=codex_cloud/user_id=<id>/run_id=<run-id>/runtime.jsonl" | head
+gcloud storage cat "gs://${BEACON_CLOUD_GCS_BUCKET}/${BEACON_CLOUD_GCS_PREFIX}/provider=codex_cloud/user_id=<id>/run_id=<run-id>/runtime.jsonl" \
+  | rg '"action":"prompt.submitted"|"action":"command.executed"|"action":"tool.invoked"|"provider":"codex_cloud"'
+```
 
 Add optional Falcon LogScale HEC forwarding during install or repair:
 

--- a/cli/beacon/cmd/cloud.go
+++ b/cli/beacon/cmd/cloud.go
@@ -44,6 +44,11 @@ var cloudCursorCmd = &cobra.Command{
 	Short: "Generate Cursor cloud agent telemetry setup",
 }
 
+var cloudCodexCmd = &cobra.Command{
+	Use:   "codex",
+	Short: "Generate Codex cloud agent telemetry setup",
+}
+
 var cloudClaudeWebPrintHooksCmd = &cobra.Command{
 	Use:          "print-hooks",
 	Short:        "Print project-level Claude hook settings for a cloud sandbox",
@@ -107,6 +112,32 @@ var cloudCursorPrintSetupCmd = &cobra.Command{
 	},
 }
 
+var cloudCodexPrintHooksCmd = &cobra.Command{
+	Use:          "print-hooks",
+	Short:        "Print user-level Codex hook settings for a cloud sandbox",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if strings.TrimSpace(cloudOpts.binaryPath) == "" {
+			return fmt.Errorf("--binary-path is required")
+		}
+		fmt.Print(renderCodexCloudHooks(cloudOpts.binaryPath, defaultCloudLogPath(cloudOpts.logPath)))
+		return nil
+	},
+}
+
+var cloudCodexPrintSetupCmd = &cobra.Command{
+	Use:          "print-setup",
+	Short:        "Print a Codex cloud agent telemetry setup script",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if strings.TrimSpace(cloudOpts.version) == "" {
+			return fmt.Errorf("--version is required")
+		}
+		fmt.Print(renderCodexCloudSetup(cloudOpts.version))
+		return nil
+	},
+}
+
 var cloudGCSCmd = &cobra.Command{
 	Use:   "gcs",
 	Short: "Configure GCS forwarding for cloud agent telemetry",
@@ -123,11 +154,14 @@ func init() {
 	rootCmd.AddCommand(cloudCmd)
 	cloudCmd.AddCommand(cloudClaudeWebCmd)
 	cloudCmd.AddCommand(cloudCursorCmd)
+	cloudCmd.AddCommand(cloudCodexCmd)
 	cloudCmd.AddCommand(cloudGCSCmd)
 	cloudClaudeWebCmd.AddCommand(cloudClaudeWebPrintHooksCmd)
 	cloudClaudeWebCmd.AddCommand(cloudClaudeWebPrintSetupCmd)
 	cloudCursorCmd.AddCommand(cloudCursorPrintHooksCmd)
 	cloudCursorCmd.AddCommand(cloudCursorPrintSetupCmd)
+	cloudCodexCmd.AddCommand(cloudCodexPrintHooksCmd)
+	cloudCodexCmd.AddCommand(cloudCodexPrintSetupCmd)
 	cloudGCSCmd.AddCommand(cloudGCSSetupCmd)
 
 	cloudClaudeWebPrintHooksCmd.Flags().StringVar(&cloudOpts.binaryPath, "binary-path", "", "Path to beacon-hooks inside the cloud sandbox")
@@ -137,6 +171,9 @@ func init() {
 	cloudCursorPrintHooksCmd.Flags().StringVar(&cloudOpts.logPath, "log-path", "/tmp/beacon/runtime.jsonl", "Cloud sandbox runtime JSONL path")
 	cloudCursorPrintHooksCmd.Flags().BoolVar(&cloudOpts.safeHooks, "safe-hooks", false, "Skip Cursor cloud shell/edit-specific hooks while testing telemetry forwarding")
 	cloudCursorPrintSetupCmd.Flags().StringVar(&cloudOpts.version, "version", "", "Beacon release tag to download, such as v0.0.50")
+	cloudCodexPrintHooksCmd.Flags().StringVar(&cloudOpts.binaryPath, "binary-path", "", "Path to beacon-hooks inside the cloud sandbox")
+	cloudCodexPrintHooksCmd.Flags().StringVar(&cloudOpts.logPath, "log-path", "/tmp/beacon/runtime.jsonl", "Cloud sandbox runtime JSONL path")
+	cloudCodexPrintSetupCmd.Flags().StringVar(&cloudOpts.version, "version", "", "Beacon release tag to download, such as v0.0.50")
 
 	cloudGCSSetupCmd.Flags().StringVar(&cloudOpts.project, "project", "", "Google Cloud project ID")
 	cloudGCSSetupCmd.Flags().StringVar(&cloudOpts.bucket, "bucket", "", "GCS bucket for cloud agent telemetry")
@@ -187,6 +224,28 @@ func renderClaudeWebHooks(binaryPath, logPath string) string {
 		},
 		"SessionEnd": {
 			{"hooks": []map[string]interface{}{{"type": "command", "command": prefix + " session-end"}}},
+		},
+	}
+	out := map[string]interface{}{"hooks": hooks}
+	data, _ := json.MarshalIndent(out, "", "  ")
+	return string(data) + "\n"
+}
+
+func renderCodexCloudHooks(binaryPath, logPath string) string {
+	prefix := fmt.Sprintf(
+		"BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=codex_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=%s %s --platform codex",
+		shellQuote(logPath),
+		shellQuote(binaryPath),
+	)
+	hooks := map[string][]map[string]interface{}{
+		"SessionStart": {
+			{"matcher": "startup|resume|clear|compact", "hooks": []map[string]interface{}{{"type": "command", "command": prefix + " cloud-reset", "timeout": 30}}},
+		},
+		"UserPromptSubmit": {
+			{"hooks": []map[string]interface{}{{"type": "command", "command": prefix + " codex-prompt-submit", "timeout": 30}}},
+		},
+		"Stop": {
+			{"hooks": []map[string]interface{}{{"type": "command", "command": prefix + " cloud-upload", "timeout": 45}}},
 		},
 	}
 	out := map[string]interface{}{"hooks": hooks}
@@ -258,6 +317,162 @@ chmod +x /tmp/beacon/bin/beacon /tmp/beacon/bin/beacon-hooks 2>/dev/null || true
 echo "Beacon binaries installed in /tmp/beacon/bin"
 echo "Commit a project-level .cursor/hooks.json before starting Cursor Cloud Agents:"
 echo "  beacon cloud cursor print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .cursor/hooks.json"
+`, version)
+}
+
+func renderCodexCloudSetup(version string) string {
+	return fmt.Sprintf(`set -euo pipefail
+mkdir -p /tmp/beacon/bin /tmp/beacon/logs "$HOME/.codex"
+
+BEACON_VERSION=%q
+OS="linux"
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+ARCHIVE="beacon_${BEACON_VERSION#v}_${OS}_${ARCH}.tar.gz"
+BASE="https://github.com/asymptote-labs/agent-beacon/releases/download/${BEACON_VERSION}"
+curl -fsSL "${BASE}/${ARCHIVE}" -o "/tmp/beacon/${ARCHIVE}"
+tar -xzf "/tmp/beacon/${ARCHIVE}" -C /tmp/beacon/bin
+chmod +x /tmp/beacon/bin/beacon /tmp/beacon/bin/beacon-hooks /tmp/beacon/bin/beacon-otelcol 2>/dev/null || true
+
+cat > /tmp/beacon/otelcol.yaml <<'EOF'
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+      http:
+        endpoint: 127.0.0.1:4318
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 128
+  batch:
+    timeout: 5s
+    send_batch_size: 128
+
+exporters:
+  beaconjson:
+    path: "/tmp/beacon/runtime.jsonl"
+    max_event_bytes: 65536
+    rotate_bytes: 10485760
+    rotate_archives: 5
+    redact_secrets: true
+
+extensions:
+  health_check:
+    endpoint: 127.0.0.1:13133
+
+service:
+  telemetry:
+    metrics:
+      level: none
+  extensions: [health_check]
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [beaconjson]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [beaconjson]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [beaconjson]
+EOF
+
+if [ -f /tmp/beacon/otelcol.pid ] && kill -0 "$(cat /tmp/beacon/otelcol.pid)" 2>/dev/null; then
+  echo "Beacon collector already running with pid $(cat /tmp/beacon/otelcol.pid)"
+else
+  nohup /tmp/beacon/bin/beacon-otelcol --config /tmp/beacon/otelcol.yaml > /tmp/beacon/logs/otelcol.log 2>&1 &
+  echo "$!" > /tmp/beacon/otelcol.pid
+fi
+
+/tmp/beacon/bin/beacon cloud codex print-hooks \
+  --binary-path /tmp/beacon/bin/beacon-hooks \
+  --log-path /tmp/beacon/runtime.jsonl > "$HOME/.codex/hooks.json"
+
+python3 - <<'PY'
+from pathlib import Path
+
+path = Path.home() / ".codex" / "config.toml"
+existing = path.read_text() if path.exists() else ""
+lines = existing.splitlines()
+out = []
+in_otel = False
+wrote = False
+block = [
+    "[otel]",
+    'environment = "cloud"',
+    'exporter = "otlp-grpc"',
+    'log_user_prompt = true',
+    "",
+    '[otel.exporter."otlp-grpc"]',
+    'endpoint = "http://127.0.0.1:4317"',
+    "",
+]
+for line in lines:
+    stripped = line.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        is_otel = stripped == "[otel]" or stripped.startswith("[otel.")
+        if in_otel and not is_otel and not wrote:
+            out.extend(block)
+            wrote = True
+        in_otel = is_otel
+        if not in_otel:
+            out.append(line)
+        continue
+    if in_otel:
+        continue
+    out.append(line)
+if in_otel and not wrote:
+    out.extend(block)
+    wrote = True
+if not wrote:
+    if existing.strip():
+        out.append("")
+    out.extend(block)
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text("\n".join(out).rstrip() + "\n")
+PY
+
+cat > /tmp/beacon/codex-env.sh <<'EOF'
+beacon_cloud_attrs() {
+  attrs="beacon.origin=${BEACON_ORIGIN:-cloud},beacon.run.provider=${BEACON_RUN_PROVIDER:-codex_cloud},beacon.run.ephemeral=${BEACON_RUN_EPHEMERAL:-true}"
+  if [ -n "${BEACON_RUN_ID:-}" ]; then attrs="${attrs},beacon.run.run_id=${BEACON_RUN_ID}"; fi
+  if [ -n "${BEACON_RUN_REPOSITORY:-}" ]; then attrs="${attrs},beacon.run.repository=${BEACON_RUN_REPOSITORY}"; fi
+  if [ -n "${BEACON_RUN_BRANCH:-}" ]; then attrs="${attrs},beacon.run.branch=${BEACON_RUN_BRANCH}"; fi
+  if [ -n "${OTEL_RESOURCE_ATTRIBUTES:-}" ]; then
+    export OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},${attrs}"
+  else
+    export OTEL_RESOURCE_ATTRIBUTES="${attrs}"
+  fi
+  export BEACON_ORIGIN="${BEACON_ORIGIN:-cloud}"
+  export BEACON_RUN_PROVIDER="${BEACON_RUN_PROVIDER:-codex_cloud}"
+  export BEACON_RUN_EPHEMERAL="${BEACON_RUN_EPHEMERAL:-true}"
+  export BEACON_ENDPOINT_LOG="${BEACON_ENDPOINT_LOG:-/tmp/beacon/runtime.jsonl}"
+}
+beacon_cloud_attrs
+EOF
+
+if ! grep -q "/tmp/beacon/codex-env.sh" "$HOME/.bashrc" 2>/dev/null; then
+  printf '\n# Beacon Codex cloud telemetry\n[ -f /tmp/beacon/codex-env.sh ] && . /tmp/beacon/codex-env.sh\n' >> "$HOME/.bashrc"
+fi
+
+nohup /tmp/beacon/bin/beacon-hooks --platform codex cloud-watch > /tmp/beacon/logs/cloud-watch.log 2>&1 &
+echo "$!" > /tmp/beacon/cloud-watch.pid
+
+echo "Beacon Codex cloud telemetry configured:"
+echo "  collector: /tmp/beacon/otelcol.yaml"
+echo "  runtime log: /tmp/beacon/runtime.jsonl"
+echo "  Codex config: $HOME/.codex/config.toml"
+echo "  Codex hooks: $HOME/.codex/hooks.json"
 `, version)
 }
 

--- a/cli/beacon/cmd/cloud.go
+++ b/cli/beacon/cmd/cloud.go
@@ -332,7 +332,17 @@ echo "  beacon cloud cursor print-hooks --binary-path /tmp/beacon/bin/beacon-hoo
 func renderCodexCloudSetup(version string) string {
 	return fmt.Sprintf(`set -euo pipefail
 CODEX_CONFIG_DIR="${CODEX_HOME:-$HOME/.codex}"
-mkdir -p /tmp/beacon/bin /tmp/beacon/logs "$CODEX_CONFIG_DIR"
+CODEX_CONFIG_DIRS="$CODEX_CONFIG_DIR"
+if [ "$CODEX_CONFIG_DIR" != "$HOME/.codex" ]; then
+  CODEX_CONFIG_DIRS="$CODEX_CONFIG_DIRS $HOME/.codex"
+fi
+if [ "$CODEX_CONFIG_DIR" != "/opt/codex" ]; then
+  CODEX_CONFIG_DIRS="$CODEX_CONFIG_DIRS /opt/codex"
+fi
+mkdir -p /tmp/beacon/bin /tmp/beacon/logs
+for dir in $CODEX_CONFIG_DIRS; do
+  mkdir -p "$dir"
+done
 
 BEACON_VERSION=%q
 OS="linux"
@@ -406,17 +416,19 @@ fi
 
 echo "Codex hooks must be committed before starting Codex Cloud Agents:"
 echo "  beacon cloud codex print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .codex/hooks.json"
+/tmp/beacon/bin/beacon cloud codex print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > /tmp/beacon/codex-hooks.json
+for dir in $CODEX_CONFIG_DIRS; do
+  cp /tmp/beacon/codex-hooks.json "$dir/hooks.json"
+done
+if [ -d .codex ]; then
+  cp /tmp/beacon/codex-hooks.json .codex/hooks.json
+fi
 
-python3 - <<'PY'
+python3 - "$CODEX_CONFIG_DIRS" <<'PY'
 import os
+import sys
 from pathlib import Path
 
-path = Path(os.environ.get("CODEX_CONFIG_DIR", str(Path.home() / ".codex"))) / "config.toml"
-existing = path.read_text() if path.exists() else ""
-lines = existing.splitlines()
-out = []
-in_otel = False
-wrote = False
 block = [
     "[otel]",
     'environment = "cloud"',
@@ -427,29 +439,36 @@ block = [
     'endpoint = "http://127.0.0.1:4317"',
     "",
 ]
-for line in lines:
-    stripped = line.strip()
-    if stripped.startswith("[") and stripped.endswith("]"):
-        is_otel = stripped == "[otel]" or stripped.startswith("[otel.")
-        if in_otel and not is_otel and not wrote:
-            out.extend(block)
-            wrote = True
-        in_otel = is_otel
-        if not in_otel:
-            out.append(line)
-        continue
-    if in_otel:
-        continue
-    out.append(line)
-if in_otel and not wrote:
-    out.extend(block)
-    wrote = True
-if not wrote:
-    if existing.strip():
-        out.append("")
-    out.extend(block)
-path.parent.mkdir(parents=True, exist_ok=True)
-path.write_text("\n".join(out).rstrip() + "\n")
+for config_dir in sys.argv[1].split():
+    path = Path(config_dir) / "config.toml"
+    existing = path.read_text() if path.exists() else ""
+    lines = existing.splitlines()
+    out = []
+    in_otel = False
+    wrote = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            is_otel = stripped == "[otel]" or stripped.startswith("[otel.")
+            if in_otel and not is_otel and not wrote:
+                out.extend(block)
+                wrote = True
+            in_otel = is_otel
+            if not in_otel:
+                out.append(line)
+            continue
+        if in_otel:
+            continue
+        out.append(line)
+    if in_otel and not wrote:
+        out.extend(block)
+        wrote = True
+    if not wrote:
+        if existing.strip():
+            out.append("")
+        out.extend(block)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(out).rstrip() + "\n")
 PY
 
 cat > /tmp/beacon/codex-env.sh <<'EOF'
@@ -482,7 +501,7 @@ echo "$!" > /tmp/beacon/cloud-watch.pid
 echo "Beacon Codex cloud telemetry configured:"
 echo "  collector: /tmp/beacon/otelcol.yaml"
 echo "  runtime log: /tmp/beacon/runtime.jsonl"
-echo "  Codex config: $CODEX_CONFIG_DIR/config.toml"
+echo "  Codex config dirs: $CODEX_CONFIG_DIRS"
 echo "  Commit .codex/hooks.json before starting cloud tasks"
 `, version)
 }

--- a/cli/beacon/cmd/cloud.go
+++ b/cli/beacon/cmd/cloud.go
@@ -465,6 +465,7 @@ if ! grep -q "/tmp/beacon/codex-env.sh" "$HOME/.bashrc" 2>/dev/null; then
   printf '\n# Beacon Codex cloud telemetry\n[ -f /tmp/beacon/codex-env.sh ] && . /tmp/beacon/codex-env.sh\n' >> "$HOME/.bashrc"
 fi
 
+. /tmp/beacon/codex-env.sh
 nohup /tmp/beacon/bin/beacon-hooks --platform codex cloud-watch > /tmp/beacon/logs/cloud-watch.log 2>&1 &
 echo "$!" > /tmp/beacon/cloud-watch.pid
 

--- a/cli/beacon/cmd/cloud.go
+++ b/cli/beacon/cmd/cloud.go
@@ -241,6 +241,15 @@ func renderCodexCloudHooks(binaryPath, logPath string) string {
 		"SessionStart": {
 			{"matcher": "startup|resume|clear|compact", "hooks": []map[string]interface{}{{"type": "command", "command": prefix + " cloud-reset", "timeout": 30}}},
 		},
+		"PreToolUse": {
+			{"matcher": "*", "hooks": []map[string]interface{}{{"type": "command", "command": prefix + " pre-tool", "timeout": 30}}},
+		},
+		"PermissionRequest": {
+			{"matcher": "*", "hooks": []map[string]interface{}{{"type": "command", "command": prefix + " permission-request", "timeout": 30}}},
+		},
+		"PostToolUse": {
+			{"matcher": "*", "hooks": []map[string]interface{}{{"type": "command", "command": prefix + " post-tool", "timeout": 30}}},
+		},
 		"UserPromptSubmit": {
 			{"hooks": []map[string]interface{}{{"type": "command", "command": prefix + " codex-prompt-submit", "timeout": 30}}},
 		},
@@ -322,7 +331,8 @@ echo "  beacon cloud cursor print-hooks --binary-path /tmp/beacon/bin/beacon-hoo
 
 func renderCodexCloudSetup(version string) string {
 	return fmt.Sprintf(`set -euo pipefail
-mkdir -p /tmp/beacon/bin /tmp/beacon/logs "$HOME/.codex"
+CODEX_CONFIG_DIR="${CODEX_HOME:-$HOME/.codex}"
+mkdir -p /tmp/beacon/bin /tmp/beacon/logs "$CODEX_CONFIG_DIR"
 
 BEACON_VERSION=%q
 OS="linux"
@@ -394,14 +404,14 @@ else
   echo "$!" > /tmp/beacon/otelcol.pid
 fi
 
-/tmp/beacon/bin/beacon cloud codex print-hooks \
-  --binary-path /tmp/beacon/bin/beacon-hooks \
-  --log-path /tmp/beacon/runtime.jsonl > "$HOME/.codex/hooks.json"
+echo "Codex hooks must be committed before starting Codex Cloud Agents:"
+echo "  beacon cloud codex print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .codex/hooks.json"
 
 python3 - <<'PY'
+import os
 from pathlib import Path
 
-path = Path.home() / ".codex" / "config.toml"
+path = Path(os.environ.get("CODEX_CONFIG_DIR", str(Path.home() / ".codex"))) / "config.toml"
 existing = path.read_text() if path.exists() else ""
 lines = existing.splitlines()
 out = []
@@ -472,8 +482,8 @@ echo "$!" > /tmp/beacon/cloud-watch.pid
 echo "Beacon Codex cloud telemetry configured:"
 echo "  collector: /tmp/beacon/otelcol.yaml"
 echo "  runtime log: /tmp/beacon/runtime.jsonl"
-echo "  Codex config: $HOME/.codex/config.toml"
-echo "  Codex hooks: $HOME/.codex/hooks.json"
+echo "  Codex config: $CODEX_CONFIG_DIR/config.toml"
+echo "  Commit .codex/hooks.json before starting cloud tasks"
 `, version)
 }
 

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -58,10 +58,12 @@ func TestRenderCodexCloudSetupConfiguresCollectorAndPromptLogging(t *testing.T) 
 	for _, want := range []string{
 		`BEACON_VERSION="v0.0.60"`,
 		`CODEX_CONFIG_DIR="${CODEX_HOME:-$HOME/.codex}"`,
+		`CODEX_CONFIG_DIRS="$CODEX_CONFIG_DIRS /opt/codex"`,
 		`chmod +x /tmp/beacon/bin/beacon /tmp/beacon/bin/beacon-hooks /tmp/beacon/bin/beacon-otelcol`,
 		`/tmp/beacon/bin/beacon-otelcol --config /tmp/beacon/otelcol.yaml`,
 		`path: "/tmp/beacon/runtime.jsonl"`,
 		`beacon cloud codex print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .codex/hooks.json`,
+		`cp /tmp/beacon/codex-hooks.json "$dir/hooks.json"`,
 		`exporter = "otlp-grpc"`,
 		`log_user_prompt = true`,
 		`environment = "cloud"`,

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -31,6 +31,9 @@ func TestRenderCodexCloudHooks(t *testing.T) {
 	got := renderCodexCloudHooks("/tmp/beacon/bin/beacon-hooks", "/tmp/beacon/runtime.jsonl")
 	for _, want := range []string{
 		`"SessionStart"`,
+		`"PreToolUse"`,
+		`"PermissionRequest"`,
+		`"PostToolUse"`,
 		`"UserPromptSubmit"`,
 		`"Stop"`,
 		`BEACON_ORIGIN=cloud`,
@@ -38,16 +41,14 @@ func TestRenderCodexCloudHooks(t *testing.T) {
 		`BEACON_RUN_EPHEMERAL=true`,
 		`BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl`,
 		`/tmp/beacon/bin/beacon-hooks --platform codex cloud-reset`,
+		`/tmp/beacon/bin/beacon-hooks --platform codex pre-tool`,
+		`/tmp/beacon/bin/beacon-hooks --platform codex permission-request`,
+		`/tmp/beacon/bin/beacon-hooks --platform codex post-tool`,
 		`/tmp/beacon/bin/beacon-hooks --platform codex codex-prompt-submit`,
 		`/tmp/beacon/bin/beacon-hooks --platform codex cloud-upload`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("rendered Codex hooks missing %q:\n%s", want, got)
-		}
-	}
-	for _, skipped := range []string{`"PreToolUse"`, `"PostToolUse"`} {
-		if strings.Contains(got, skipped) {
-			t.Fatalf("rendered Codex hooks should not contain %q:\n%s", skipped, got)
 		}
 	}
 }
@@ -56,10 +57,11 @@ func TestRenderCodexCloudSetupConfiguresCollectorAndPromptLogging(t *testing.T) 
 	got := renderCodexCloudSetup("v0.0.60")
 	for _, want := range []string{
 		`BEACON_VERSION="v0.0.60"`,
+		`CODEX_CONFIG_DIR="${CODEX_HOME:-$HOME/.codex}"`,
 		`chmod +x /tmp/beacon/bin/beacon /tmp/beacon/bin/beacon-hooks /tmp/beacon/bin/beacon-otelcol`,
 		`/tmp/beacon/bin/beacon-otelcol --config /tmp/beacon/otelcol.yaml`,
 		`path: "/tmp/beacon/runtime.jsonl"`,
-		`beacon cloud codex print-hooks`,
+		`beacon cloud codex print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .codex/hooks.json`,
 		`exporter = "otlp-grpc"`,
 		`log_user_prompt = true`,
 		`environment = "cloud"`,
@@ -67,6 +69,7 @@ func TestRenderCodexCloudSetupConfiguresCollectorAndPromptLogging(t *testing.T) 
 		`beacon.run.provider=${BEACON_RUN_PROVIDER:-codex_cloud}`,
 		`. /tmp/beacon/codex-env.sh`,
 		`beacon-hooks --platform codex cloud-watch`,
+		`Commit .codex/hooks.json before starting cloud tasks`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("rendered Codex setup missing %q:\n%s", want, got)

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -13,6 +13,8 @@ func TestCloudCommandsRegistered(t *testing.T) {
 		{"cloud", "claude-web", "print-setup"},
 		{"cloud", "cursor", "print-hooks"},
 		{"cloud", "cursor", "print-setup"},
+		{"cloud", "codex", "print-hooks"},
+		{"cloud", "codex", "print-setup"},
 		{"cloud", "gcs", "setup"},
 	} {
 		cmd, _, err := rootCmd.Find(path)
@@ -21,6 +23,52 @@ func TestCloudCommandsRegistered(t *testing.T) {
 		}
 		if cmd == nil || cmd.Use != path[len(path)-1] {
 			t.Fatalf("cloud command %v not registered: %#v", path, cmd)
+		}
+	}
+}
+
+func TestRenderCodexCloudHooks(t *testing.T) {
+	got := renderCodexCloudHooks("/tmp/beacon/bin/beacon-hooks", "/tmp/beacon/runtime.jsonl")
+	for _, want := range []string{
+		`"SessionStart"`,
+		`"UserPromptSubmit"`,
+		`"Stop"`,
+		`BEACON_ORIGIN=cloud`,
+		`BEACON_RUN_PROVIDER=codex_cloud`,
+		`BEACON_RUN_EPHEMERAL=true`,
+		`BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl`,
+		`/tmp/beacon/bin/beacon-hooks --platform codex cloud-reset`,
+		`/tmp/beacon/bin/beacon-hooks --platform codex codex-prompt-submit`,
+		`/tmp/beacon/bin/beacon-hooks --platform codex cloud-upload`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered Codex hooks missing %q:\n%s", want, got)
+		}
+	}
+	for _, skipped := range []string{`"PreToolUse"`, `"PostToolUse"`} {
+		if strings.Contains(got, skipped) {
+			t.Fatalf("rendered Codex hooks should not contain %q:\n%s", skipped, got)
+		}
+	}
+}
+
+func TestRenderCodexCloudSetupConfiguresCollectorAndPromptLogging(t *testing.T) {
+	got := renderCodexCloudSetup("v0.0.60")
+	for _, want := range []string{
+		`BEACON_VERSION="v0.0.60"`,
+		`chmod +x /tmp/beacon/bin/beacon /tmp/beacon/bin/beacon-hooks /tmp/beacon/bin/beacon-otelcol`,
+		`/tmp/beacon/bin/beacon-otelcol --config /tmp/beacon/otelcol.yaml`,
+		`path: "/tmp/beacon/runtime.jsonl"`,
+		`beacon cloud codex print-hooks`,
+		`exporter = "otlp-grpc"`,
+		`log_user_prompt = true`,
+		`environment = "cloud"`,
+		`[otel.exporter."otlp-grpc"]`,
+		`beacon.run.provider=${BEACON_RUN_PROVIDER:-codex_cloud}`,
+		`beacon-hooks --platform codex cloud-watch`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered Codex setup missing %q:\n%s", want, got)
 		}
 	}
 }

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -65,6 +65,7 @@ func TestRenderCodexCloudSetupConfiguresCollectorAndPromptLogging(t *testing.T) 
 		`environment = "cloud"`,
 		`[otel.exporter."otlp-grpc"]`,
 		`beacon.run.provider=${BEACON_RUN_PROVIDER:-codex_cloud}`,
+		`. /tmp/beacon/codex-env.sh`,
 		`beacon-hooks --platform codex cloud-watch`,
 	} {
 		if !strings.Contains(got, want) {

--- a/collector-builder/exporter/beaconjsonexporter/exporter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter_test.go
@@ -280,6 +280,45 @@ func TestEventFromLogMapsCIRunRecordAttributes(t *testing.T) {
 	}
 }
 
+func TestEventFromLogMapsCodexCloudPromptRunContext(t *testing.T) {
+	exp, err := newExporter(&Config{
+		Path:          filepath.Join(t.TempDir(), "runtime.jsonl"),
+		MaxEventBytes: defaultMaxEventBytes,
+		RotateBytes:   defaultRotateBytes,
+		RedactSecrets: true,
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+	rec := plog.NewLogRecord()
+	rec.Body().SetStr("codex.user_prompt")
+	attrs := rec.Attributes()
+	attrs.PutStr("service.name", "codex-cli")
+	attrs.PutStr("event.name", "codex.user_prompt")
+	attrs.PutStr("session_id", "codex-session")
+	attrs.PutStr("prompt", "summarize token=codex-secret")
+	attrs.PutStr(asymptoteobserve.AttributeOrigin, string(asymptoteobserve.OriginCloud))
+	attrs.PutStr(asymptoteobserve.AttributeRunProvider, "codex_cloud")
+	attrs.PutBool(asymptoteobserve.AttributeRunEphemeral, true)
+
+	event := exp.eventFromLog(nil, rec)
+	if event.Origin != asymptoteobserve.OriginCloud {
+		t.Fatalf("Origin = %q, want cloud", event.Origin)
+	}
+	if event.Harness.Name != "codex_cli" {
+		t.Fatalf("Harness.Name = %q, want codex_cli", event.Harness.Name)
+	}
+	if event.Event.Action != "prompt.submitted" || event.Event.Category != "prompt" {
+		t.Fatalf("event = %#v, want prompt.submitted prompt", event.Event)
+	}
+	if event.Run == nil || event.Run.Provider != "codex_cloud" || event.Run.RunID != "codex-session" || !event.Run.Ephemeral {
+		t.Fatalf("run context = %#v, want codex_cloud session", event.Run)
+	}
+	if event.Prompt == nil || event.Prompt.Text != "summarize token=codex-secret" {
+		t.Fatalf("prompt = %#v, want retained prompt before writer redaction", event.Prompt)
+	}
+}
+
 func TestConsumeLogsMapsPrompt(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "runtime.jsonl")
 	exp, err := newExporter(&Config{

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -696,10 +696,25 @@ func populateRunContext(event *Event, attrs map[string]interface{}) {
 	if ephemeral, ok := BoolAttr(attrs, asymptoteobserve.AttributeRunEphemeral); ok {
 		run.Ephemeral = ephemeral
 	}
+	if run.Provider == "codex_cloud" && run.RunID == "" {
+		run.RunID = codexCloudRunID(attrs)
+	}
 	if run.Provider == "" && run.RunID == "" && run.RunAttempt == "" && run.Workflow == "" && run.Job == "" && run.EventName == "" && run.Commit == "" && run.Repository == "" && run.Branch == "" && run.PR == "" && run.PRNumber == "" && run.Actor == "" && !run.Ephemeral {
 		return
 	}
 	event.Run = &run
+}
+
+func codexCloudRunID(attrs map[string]interface{}) string {
+	return RunString(attrs,
+		"session_id",
+		"session.id",
+		"conversation.id",
+		"conversation_id",
+		"gen_ai.conversation.id",
+		"codex.session_id",
+		"codex.conversation_id",
+	)
 }
 
 func (c Converter) RawPayload(attrs map[string]interface{}, extra map[string]interface{}) map[string]interface{} {


### PR DESCRIPTION
## Summary
- Add `beacon cloud codex` setup and hook generation for Codex Cloud Agents.
- Configure Codex OTel prompt telemetry through a local Beacon collector and upload runtime JSONL snapshots through the cloud GCS shuttle.
- Document Codex cloud setup and add coverage for command rendering, shuttle uploads, Codex hook commands, and collector run context normalization.

## Test plan
- `cd cli/beacon && go test ./...`
- `cd cli/beacon-hooks && go test ./...`
- `cd collector-builder/exporter/beaconjsonexporter && go test ./...`


Made with [Cursor](https://cursor.com)