### PR TITLE
Readme cleanup: fix hyperlink, sort cloud agents table

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Beacon started with local endpoint telemetry for security and IT teams that need
 Beacon is built to be easy to deploy for Security and IT teams through
 [MDM deployment](#mdm-deployment), CI workflows, and cloud-agent setup paths, and to
 emit agent harness telemetry logs to
-[all the major enterprise-grade SIEMs](#siem--output-destinations).
+all the [major enterprise-grade SIEMs](#siem--output-destinations).
 
 Learn more in the [Agent Beacon Documentation](https://docs.asymptotelabs.ai).
 
@@ -59,7 +59,7 @@ paths under customer control.
 - **Beacon endpoint layer:** Local processing normalizes events, applies
   retention and redaction settings, and writes durable endpoint telemetry.
 - **Output layer:** Teams inspect events in the local dashboard, retain JSONL,
-  or forward records into all the major enterprise-grade SIEMs.
+  or forward records into all the [major enterprise-grade SIEMs](#siem--output-destinations).
 
 ## Supported Surfaces
 
@@ -109,24 +109,12 @@ CI, and cloud surfaces.
 
 | Cloud surface | Collection path | Telemetry coverage |
 | --- | --- | --- |
-| [Claude Code Cloud Agents](https://docs.asymptotelabs.ai/claude-code-cloud-agents) | Cloud sandbox hooks with GCS upload | Session, prompt, tool, command, file, and lifecycle telemetry where Claude Code cloud hook payloads expose it |
-| [Cursor Cloud Agents](https://docs.asymptotelabs.ai/cursor-cloud-agents) | Cloud sandbox hooks with GCS upload | Tool, shell command, file, subagent, and compaction telemetry where Cursor cloud hook payloads expose it |
 | [Anthropic](https://docs.asymptotelabs.ai/sdk/integrations-anthropic) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported Anthropic model call spans, errors, and OpenTelemetry attributes |
 | [Claude Agent SDK](https://docs.asymptotelabs.ai/sdk/integrations-claude-agent-sdk) | Query wrapper through `Observe.wrapClaudeAgentQuery()` | Query root spans with Beacon-compatible prompt attributes |
+| [Claude Code Cloud Agents](https://docs.asymptotelabs.ai/claude-code-cloud-agents) | Cloud sandbox hooks with GCS upload | Session, prompt, tool, command, file, and lifecycle telemetry where Claude Code cloud hook payloads expose it |
+| [Cursor Cloud Agents](https://docs.asymptotelabs.ai/cursor-cloud-agents) | Cloud sandbox hooks with GCS upload | Tool, shell command, file, subagent, and compaction telemetry where Cursor cloud hook payloads expose it |
 | [OpenAI](https://docs.asymptotelabs.ai/sdk/integrations-openai) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported OpenAI model call spans, errors, and OpenTelemetry attributes |
 | [Vercel AI SDK](https://docs.asymptotelabs.ai/sdk/integrations-vercel-ai-sdk) | Tracer handoff through `experimental_telemetry` | AI SDK model call and tool spans where telemetry is enabled |
-
-Cursor Cloud Agents load project hooks from `.cursor/hooks.json` at task start.
-For reliable Cursor Cloud telemetry, commit the generated project hooks to the
-target repository and use the cloud setup script only to install Beacon binaries
-under `/tmp/beacon/bin`. Generate the project hook file locally with:
-
-```bash
-mkdir -p .cursor
-beacon cloud cursor print-hooks \
-  --binary-path /tmp/beacon/bin/beacon-hooks \
-  --log-path /tmp/beacon/runtime.jsonl > .cursor/hooks.json
-```
 
 ### Output Destinations
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, security, or deployment code changes.
> 
> **Overview**
> **README** polish only: **major enterprise-grade SIEMs** is now a link to the SIEM output section in the intro and architecture bullets (same anchor as elsewhere in the doc).
> 
> The **Cloud Agents** table is reordered so SDK-style integrations (Anthropic, Claude Agent SDK, OpenAI, Vercel AI SDK) appear before the Claude Code and Cursor cloud hook rows. The standalone **Cursor Cloud Agents** setup block (`beacon cloud cursor print-hooks`, `.cursor/hooks.json`) was removed from the README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7b1366000a296e90b64dce9959e814469bc692b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->