### PR TITLE
Update readme SIEM hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Beacon started with local endpoint telemetry for security and IT teams that need
 Beacon is built to be easy to deploy for Security and IT teams through
 [MDM deployment](#mdm-deployment), CI workflows, and cloud-agent setup paths, and to
 emit agent harness telemetry logs to
-all the [major enterprise-grade SIEMs](#siem--output-destinations).
+all the [major enterprise-grade SIEMs](https://github.com/Asymptote-Labs/agent-beacon#output-destinations).
 
 Learn more in the [Agent Beacon Documentation](https://docs.asymptotelabs.ai).
 
@@ -59,7 +59,7 @@ paths under customer control.
 - **Beacon endpoint layer:** Local processing normalizes events, applies
   retention and redaction settings, and writes durable endpoint telemetry.
 - **Output layer:** Teams inspect events in the local dashboard, retain JSONL,
-  or forward records into all the [major enterprise-grade SIEMs](#siem--output-destinations).
+  or forward records into all the [major enterprise-grade SIEMs](https://github.com/Asymptote-Labs/agent-beacon#output-destinations).
 
 ## Supported Surfaces
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only hyperlink change with no runtime or security impact.
> 
> **Overview**
> Updates the **“major enterprise-grade SIEMs”** link in two README spots (intro and architecture **Output layer** bullet) from the in-page anchor `#siem--output-destinations` to the GitHub URL `https://github.com/Asymptote-Labs/agent-beacon#output-destinations`, so readers land on the **Output Destinations** section reliably (including off-repo views where local anchors may not work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6833edae7a39c020870fcc02bae138a41a2a952e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->