### PR TITLE
Add beacon managed ingest support

### DIFF
--- a/cli/beacon/cmd/endpoint_install.go
+++ b/cli/beacon/cmd/endpoint_install.go
@@ -157,6 +157,7 @@ func runEndpointStatus(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Println("Last event: present")
 	}
+	printIngestStatus("Endpoint ingest", status.ManagedUpload)
 	return nil
 }
 

--- a/cli/beacon/cmd/ingest.go
+++ b/cli/beacon/cmd/ingest.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	beaconauth "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/auth"
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/ingest"
+	endpointingest "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/ingest/endpoint"
+	"github.com/spf13/cobra"
+)
+
+var ingestCmd = &cobra.Command{
+	Use:   "ingest",
+	Short: "Upload Beacon telemetry to configured ingest destinations",
+}
+
+var ingestStatusCmd = &cobra.Command{
+	Use:          "status",
+	Short:        "Show configured ingest status",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		state := endpointIngestStatus()
+		if endpointOpts.jsonOutput {
+			return json.NewEncoder(os.Stdout).Encode(map[string]ingest.State{
+				"endpoint": state,
+			})
+		}
+		fmt.Println("Beacon ingest")
+		printIngestStatus("Endpoint", state)
+		return nil
+	},
+}
+
+var ingestEndpointCmd = &cobra.Command{
+	Use:   "endpoint",
+	Short: "Manage endpoint telemetry ingest",
+}
+
+var ingestEndpointStatusCmd = &cobra.Command{
+	Use:          "status",
+	Short:        "Show endpoint telemetry upload status",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		state := endpointIngestStatus()
+		if endpointOpts.jsonOutput {
+			return json.NewEncoder(os.Stdout).Encode(state)
+		}
+		printIngestStatus("Endpoint ingest", state)
+		return nil
+	},
+}
+
+var ingestEndpointUploadCmd = &cobra.Command{
+	Use:          "upload",
+	Short:        "Upload endpoint telemetry to managed ingest",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := uploadEndpointIngest(cmd.Context())
+		if endpointOpts.jsonOutput {
+			if encodeErr := json.NewEncoder(os.Stdout).Encode(res.State); encodeErr != nil {
+				return encodeErr
+			}
+		} else {
+			printIngestStatus("Endpoint ingest", res.State)
+		}
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(ingestCmd)
+	ingestCmd.AddCommand(ingestStatusCmd)
+	ingestCmd.AddCommand(ingestEndpointCmd)
+	ingestEndpointCmd.AddCommand(ingestEndpointStatusCmd)
+	ingestEndpointCmd.AddCommand(ingestEndpointUploadCmd)
+
+	for _, c := range []*cobra.Command{ingestStatusCmd, ingestEndpointStatusCmd, ingestEndpointUploadCmd} {
+		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
+		c.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
+		c.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
+		c.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print output as JSON")
+	}
+}
+
+func endpointIngestStatus() ingest.State {
+	cfg, effectiveUserMode, logPath := endpointIngestConfig()
+	creds, _ := beaconauth.LoadCredentials()
+	return ingest.Status(
+		endpointingest.Settings(cfg, logPath, effectiveUserMode),
+		endpointingest.Store(effectiveUserMode),
+		creds,
+	)
+}
+
+func uploadEndpointIngest(ctx context.Context) (ingest.Result, error) {
+	cfg, effectiveUserMode, logPath := endpointIngestConfig()
+	creds, _ := beaconauth.LoadCredentials()
+	uploadCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	res := ingest.Upload(uploadCtx, ingest.Options{
+		Settings: endpointingest.Settings(cfg, logPath, effectiveUserMode),
+		Creds:    creds,
+		Store:    endpointingest.Store(effectiveUserMode),
+		Source:   endpointingest.NewSource(cfg, logPath, effectiveUserMode),
+	})
+	if res.State.Enabled && res.State.Managed && res.State.LastError != "" {
+		return res, fmt.Errorf("%s", res.State.LastError)
+	}
+	return res, nil
+}
+
+func endpointIngestConfig() (endpointconfig.Config, bool, string) {
+	cfg := loadOrDefaultConfig()
+	runtimeLog := lifecycle.ResolveRuntimeLog(endpointUserMode(), endpointOpts.logPath)
+	effectiveCfg := cfg
+	effectiveCfg.UserMode = runtimeLog.EffectiveUserMode
+	if runtimeLog.EffectiveUserMode != cfg.UserMode {
+		effectiveCfg = loadConfigForMode(runtimeLog.EffectiveUserMode, runtimeLog.EffectiveLogPath)
+	}
+	effectiveCfg.LogPath = runtimeLog.EffectiveLogPath
+	return effectiveCfg, effectiveCfg.UserMode, effectiveCfg.LogPath
+}
+
+func printIngestStatus(label string, state ingest.State) {
+	fmt.Printf("%s: enabled=%t managed=%t logged_in=%t", label, state.Enabled, state.Managed, state.LoggedIn)
+	if state.LastUploadAt != "" {
+		fmt.Printf(" last_upload=%s", state.LastUploadAt)
+	}
+	if state.LastCursor.Offset > 0 {
+		fmt.Printf(" cursor_offset=%d", state.LastCursor.Offset)
+	}
+	fmt.Printf(" accepted=%d rejected=%d", state.AcceptedCount, state.RejectedCount)
+	if state.LastError != "" {
+		fmt.Printf(" error=%s", state.LastError)
+	}
+	fmt.Println()
+}

--- a/cli/beacon/internal/endpoint/config/config.go
+++ b/cli/beacon/internal/endpoint/config/config.go
@@ -22,12 +22,13 @@ const (
 )
 
 type Config struct {
-	UserMode        bool          `json:"user_mode"`
-	LogPath         string        `json:"log_path"`
-	Collector       Collector     `json:"collector"`
-	Harnesses       []string      `json:"harnesses"`
-	EventCategories []string      `json:"event_categories,omitempty"`
-	Destinations    *Destinations `json:"destinations,omitempty"`
+	UserMode        bool           `json:"user_mode"`
+	LogPath         string         `json:"log_path"`
+	Collector       Collector      `json:"collector"`
+	Harnesses       []string       `json:"harnesses"`
+	EventCategories []string       `json:"event_categories,omitempty"`
+	Destinations    *Destinations  `json:"destinations,omitempty"`
+	ManagedUpload   *ManagedUpload `json:"managed_upload,omitempty"`
 }
 
 type Collector struct {
@@ -43,6 +44,14 @@ type Collector struct {
 type Destinations struct {
 	SplunkHEC *SplunkHEC `json:"splunk_hec,omitempty"`
 	FalconHEC *FalconHEC `json:"falcon_hec,omitempty"`
+}
+
+type ManagedUpload struct {
+	Enabled          bool   `json:"enabled,omitempty"`
+	Managed          bool   `json:"managed,omitempty"`
+	IngestURL        string `json:"ingest_url,omitempty"`
+	SourceID         string `json:"source_id,omitempty"`
+	ContentRetention string `json:"content_retention,omitempty"`
 }
 
 type SplunkHEC struct {

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"time"
 
+	beaconauth "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/auth"
 	endpointcollector "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/collector"
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/diagnostics"
@@ -15,6 +16,8 @@ import (
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/service"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/writer"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/ingest"
+	endpointingest "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/ingest/endpoint"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/version"
 )
 
@@ -55,16 +58,17 @@ type InstallResult struct {
 }
 
 type Status struct {
-	Version      string                   `json:"version"`
-	ConfigPath   string                   `json:"config_path"`
-	LogPath      string                   `json:"log_path"`
-	RuntimeLog   RuntimeLogSource         `json:"runtime_log"`
-	Collector    endpointcollector.Status `json:"collector"`
-	Service      service.Status           `json:"service"`
-	Harnesses    []harness.Harness        `json:"harnesses"`
-	Diagnostics  []diagnostics.Check      `json:"diagnostics"`
-	LastEvent    string                   `json:"last_event,omitempty"`
-	Destinations DestinationStatus        `json:"destinations"`
+	Version       string                   `json:"version"`
+	ConfigPath    string                   `json:"config_path"`
+	LogPath       string                   `json:"log_path"`
+	RuntimeLog    RuntimeLogSource         `json:"runtime_log"`
+	Collector     endpointcollector.Status `json:"collector"`
+	Service       service.Status           `json:"service"`
+	Harnesses     []harness.Harness        `json:"harnesses"`
+	Diagnostics   []diagnostics.Check      `json:"diagnostics"`
+	LastEvent     string                   `json:"last_event,omitempty"`
+	Destinations  DestinationStatus        `json:"destinations"`
+	ManagedUpload ingest.State             `json:"managed_upload"`
 }
 
 type DestinationStatus struct {
@@ -293,17 +297,24 @@ func GetStatus(userMode bool, logPath string) Status {
 			Message:  runtimeLog.Warning,
 		})
 	}
+	creds, _ := beaconauth.LoadCredentials()
+	managedUpload := ingest.Status(
+		endpointingest.Settings(effectiveCfg, effectiveCfg.LogPath, effectiveCfg.UserMode),
+		endpointingest.Store(effectiveCfg.UserMode),
+		creds,
+	)
 	return Status{
-		Version:      version.GetVersion(),
-		ConfigPath:   endpointconfig.ConfigPath(effectiveCfg.UserMode),
-		LogPath:      effectiveCfg.LogPath,
-		RuntimeLog:   runtimeLog,
-		Collector:    endpointcollector.CheckStatus(effectiveCfg),
-		Service:      service.Manager{UserMode: effectiveCfg.UserMode}.Status(),
-		Harnesses:    harness.DiscoverAll(),
-		Diagnostics:  checks,
-		LastEvent:    last,
-		Destinations: destinationStatus(effectiveCfg),
+		Version:       version.GetVersion(),
+		ConfigPath:    endpointconfig.ConfigPath(effectiveCfg.UserMode),
+		LogPath:       effectiveCfg.LogPath,
+		RuntimeLog:    runtimeLog,
+		Collector:     endpointcollector.CheckStatus(effectiveCfg),
+		Service:       service.Manager{UserMode: effectiveCfg.UserMode}.Status(),
+		Harnesses:     harness.DiscoverAll(),
+		Diagnostics:   checks,
+		LastEvent:     last,
+		Destinations:  destinationStatus(effectiveCfg),
+		ManagedUpload: managedUpload,
 	}
 }
 

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -3,12 +3,15 @@ package lifecycle
 import (
 	"errors"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
+	beaconauth "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/auth"
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/harness"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
@@ -156,6 +159,47 @@ func TestConfigureHarnessesRejectsUnsupportedHarness(t *testing.T) {
 	cfg := endpointconfig.Config{Harnesses: []string{"unknown"}}
 	if _, err := configureHarnesses(cfg); err == nil || !strings.Contains(err.Error(), "unsupported harness") {
 		t.Fatalf("configureHarnesses error = %v, want unsupported harness", err)
+	}
+}
+
+func TestGetStatusDoesNotUploadManagedTelemetry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logPath := filepath.Join(home, "runtime.jsonl")
+	if err := os.WriteFile(logPath, []byte("{\"event\":\"ok\"}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		http.Error(w, "status should not upload", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	_, err := endpointconfig.Save(endpointconfig.Config{
+		UserMode:  true,
+		LogPath:   logPath,
+		Harnesses: []string{},
+		ManagedUpload: &endpointconfig.ManagedUpload{
+			Enabled:   true,
+			Managed:   true,
+			IngestURL: server.URL,
+			SourceID:  "source-1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := beaconauth.SaveCredentials(&beaconauth.Credentials{Token: "token", UserID: "user"}); err != nil {
+		t.Fatal(err)
+	}
+
+	status := GetStatus(true, logPath)
+	if !status.ManagedUpload.Enabled || !status.ManagedUpload.Managed || !status.ManagedUpload.LoggedIn {
+		t.Fatalf("unexpected managed upload status: %#v", status.ManagedUpload)
+	}
+	if called {
+		t.Fatal("GetStatus performed a managed upload network call")
 	}
 }
 

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -196,10 +196,10 @@ func TestGetStatusDoesNotUploadManagedTelemetry(t *testing.T) {
 
 	status := GetStatus(true, logPath)
 	if !status.ManagedUpload.Enabled || !status.ManagedUpload.Managed || !status.ManagedUpload.LoggedIn {
-		t.Fatalf("unexpected managed upload status: %#v", status.ManagedUpload)
+		t.Fatalf("unexpected endpoint ingest status: %#v", status.ManagedUpload)
 	}
 	if called {
-		t.Fatal("GetStatus performed a managed upload network call")
+		t.Fatal("GetStatus performed an ingest upload network call")
 	}
 }
 

--- a/cli/beacon/internal/ingest/client.go
+++ b/cli/beacon/internal/ingest/client.go
@@ -1,0 +1,65 @@
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	beaconauth "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/auth"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/version"
+)
+
+const defaultIngestPath = "/api/v1/ingest/beacon/events"
+
+type Client struct {
+	URL        string
+	HTTPClient *http.Client
+}
+
+func NewClient(ingestURL string, httpClient *http.Client) Client {
+	if strings.TrimSpace(ingestURL) == "" {
+		ingestURL = beaconauth.ResolveDashboardURL("") + defaultIngestPath
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	return Client{
+		URL:        strings.TrimRight(ingestURL, "/"),
+		HTTPClient: httpClient,
+	}
+}
+
+func (c Client) UploadBatch(ctx context.Context, token string, reqBody uploadRequest) (uploadResponse, error) {
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		return uploadResponse{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.URL, bytes.NewReader(data))
+	if err != nil {
+		return uploadResponse{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "beacon/"+version.GetVersion())
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return uploadResponse{}, err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return uploadResponse{}, fmt.Errorf("ingest upload failed: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	var parsed uploadResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil && len(respBody) > 0 {
+		return uploadResponse{}, fmt.Errorf("ingest upload response was invalid: %w", err)
+	}
+	return parsed, nil
+}

--- a/cli/beacon/internal/ingest/client.go
+++ b/cli/beacon/internal/ingest/client.go
@@ -57,9 +57,19 @@ func (c Client) UploadBatch(ctx context.Context, token string, reqBody uploadReq
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return uploadResponse{}, fmt.Errorf("ingest upload failed: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
+	if strings.TrimSpace(string(respBody)) == "" {
+		return uploadResponse{}, fmt.Errorf("ingest upload response was empty")
+	}
 	var parsed uploadResponse
-	if err := json.Unmarshal(respBody, &parsed); err != nil && len(respBody) > 0 {
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
 		return uploadResponse{}, fmt.Errorf("ingest upload response was invalid: %w", err)
+	}
+	if parsed.Accepted < 0 || parsed.Rejected < 0 {
+		return uploadResponse{}, fmt.Errorf("ingest upload response had negative event counts")
+	}
+	accounted := parsed.Accepted + parsed.Rejected
+	if accounted != len(reqBody.Events) {
+		return uploadResponse{}, fmt.Errorf("ingest upload response accounted for %d events, want %d", accounted, len(reqBody.Events))
 	}
 	return parsed, nil
 }

--- a/cli/beacon/internal/ingest/endpoint/reader.go
+++ b/cli/beacon/internal/ingest/endpoint/reader.go
@@ -1,0 +1,142 @@
+package endpoint
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/ingest"
+)
+
+func (s Source) Batches(state ingest.State, maxEvents int, maxBytes int) ([]ingest.Batch, error) {
+	if maxEvents <= 0 {
+		maxEvents = ingest.DefaultBatchEvents
+	}
+	if maxBytes <= 0 {
+		maxBytes = ingest.DefaultBatchBytes
+	}
+	files, err := logFiles(s.logPath)
+	if err != nil {
+		return nil, err
+	}
+	var batches []ingest.Batch
+	for _, file := range files {
+		fileBatches, err := readFileBatches(file, s.logPath, state, maxEvents, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		batches = append(batches, fileBatches...)
+	}
+	return batches, nil
+}
+
+func readFileBatches(path string, activePath string, state ingest.State, maxEvents int, maxBytes int) ([]ingest.Batch, error) {
+	startOffset := state.FileOffsets[path]
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer file.Close()
+
+	if startOffset > 0 {
+		if _, err := file.Seek(startOffset, 0); err != nil {
+			return nil, err
+		}
+	}
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxBytes)
+	var (
+		batches        []ingest.Batch
+		events         []json.RawMessage
+		batchSize      int
+		batchRejected  int
+		batchEndOffset int64
+		batchLine      int
+		line           int
+		offset         = startOffset
+	)
+	flush := func() {
+		if len(events) == 0 && batchRejected == 0 {
+			return
+		}
+		batches = append(batches, ingest.Batch{
+			Cursor: ingest.Cursor{
+				LogPath: path,
+				Offset:  batchEndOffset,
+				Line:    batchLine,
+				Archive: archiveName(activePath, path),
+			},
+			Events:   events,
+			Rejected: batchRejected,
+		})
+		events = nil
+		batchSize = 0
+		batchRejected = 0
+	}
+
+	for scanner.Scan() {
+		line++
+		raw := append([]byte(nil), scanner.Bytes()...)
+		nextOffset := offset + int64(len(raw)) + 1
+		trimmed := bytes.TrimSpace(raw)
+		if len(trimmed) == 0 {
+			batchEndOffset = nextOffset
+			batchLine = line
+			offset = nextOffset
+			continue
+		}
+		if len(events) > 0 && (len(events) >= maxEvents || batchSize+len(trimmed) > maxBytes) {
+			flush()
+		}
+		if !json.Valid(trimmed) {
+			batchRejected++
+			batchEndOffset = nextOffset
+			batchLine = line
+			offset = nextOffset
+			continue
+		}
+		events = append(events, json.RawMessage(trimmed))
+		batchSize += len(trimmed)
+		batchEndOffset = nextOffset
+		batchLine = line
+		offset = nextOffset
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	flush()
+	return batches, nil
+}
+
+func logFiles(path string) ([]string, error) {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var archives []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, base+".") {
+			archives = append(archives, filepath.Join(dir, name))
+		}
+	}
+	sort.Strings(archives)
+	return append(archives, path), nil
+}
+
+func archiveName(activePath string, path string) string {
+	if activePath == path {
+		return ""
+	}
+	return filepath.Base(path)
+}

--- a/cli/beacon/internal/ingest/endpoint/reader.go
+++ b/cli/beacon/internal/ingest/endpoint/reader.go
@@ -4,10 +4,13 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/ingest"
 )
@@ -35,7 +38,6 @@ func (s Source) Batches(state ingest.State, maxEvents int, maxBytes int) ([]inge
 }
 
 func readFileBatches(path string, activePath string, state ingest.State, maxEvents int, maxBytes int) ([]ingest.Batch, error) {
-	startOffset := state.FileOffsets[path]
 	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -44,6 +46,12 @@ func readFileBatches(path string, activePath string, state ingest.State, maxEven
 		return nil, err
 	}
 	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	fileID := fileIdentity(info)
+	startOffset := startOffsetForFile(path, activePath, state, info.Size(), fileID)
 
 	if startOffset > 0 {
 		if _, err := file.Seek(startOffset, 0); err != nil {
@@ -73,6 +81,7 @@ func readFileBatches(path string, activePath string, state ingest.State, maxEven
 				Offset:  batchEndOffset,
 				Line:    batchLine,
 				Archive: archiveName(activePath, path),
+				FileID:  fileID,
 			},
 			Events:   events,
 			Rejected: batchRejected,
@@ -130,8 +139,27 @@ func logFiles(path string) ([]string, error) {
 			archives = append(archives, filepath.Join(dir, name))
 		}
 	}
-	sort.Strings(archives)
+	sort.Slice(archives, func(i, j int) bool {
+		left, leftOK := archiveIndex(base, filepath.Base(archives[i]))
+		right, rightOK := archiveIndex(base, filepath.Base(archives[j]))
+		if leftOK && rightOK {
+			return left > right
+		}
+		return archives[i] < archives[j]
+	})
 	return append(archives, path), nil
+}
+
+func archiveIndex(base string, name string) (int, bool) {
+	suffix, ok := strings.CutPrefix(name, base+".")
+	if !ok {
+		return 0, false
+	}
+	index, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0, false
+	}
+	return index, true
 }
 
 func archiveName(activePath string, path string) string {
@@ -139,4 +167,43 @@ func archiveName(activePath string, path string) string {
 		return ""
 	}
 	return filepath.Base(path)
+}
+
+func startOffsetForFile(path string, activePath string, state ingest.State, fileSize int64, fileID string) int64 {
+	if fileID != "" && len(state.FileIDs) > 0 {
+		if state.FileIDs[path] == fileID {
+			return boundedOffset(state.FileOffsets[path], fileSize)
+		}
+		for savedPath, savedID := range state.FileIDs {
+			if savedID == fileID {
+				return boundedOffset(state.FileOffsets[savedPath], fileSize)
+			}
+		}
+		if _, knownPath := state.FileIDs[path]; knownPath {
+			return 0
+		}
+	}
+
+	if offset := boundedOffset(state.FileOffsets[path], fileSize); offset > 0 {
+		return offset
+	}
+	if path == activePath+".1" && state.FileIDs[activePath] == "" {
+		return boundedOffset(state.FileOffsets[activePath], fileSize)
+	}
+	return 0
+}
+
+func boundedOffset(offset int64, fileSize int64) int64 {
+	if offset <= 0 || offset > fileSize {
+		return 0
+	}
+	return offset
+}
+
+func fileIdentity(info os.FileInfo) string {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%d:%d", stat.Dev, stat.Ino)
 }

--- a/cli/beacon/internal/ingest/endpoint/reader.go
+++ b/cli/beacon/internal/ingest/endpoint/reader.go
@@ -130,12 +130,18 @@ func logFiles(path string) ([]string, error) {
 	base := filepath.Base(path)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{path}, nil
+		}
 		return nil, err
 	}
 	var archives []string
 	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
 		name := entry.Name()
-		if strings.HasPrefix(name, base+".") {
+		if _, ok := archiveIndex(base, name); ok {
 			archives = append(archives, filepath.Join(dir, name))
 		}
 	}

--- a/cli/beacon/internal/ingest/endpoint/reader_test.go
+++ b/cli/beacon/internal/ingest/endpoint/reader_test.go
@@ -59,3 +59,171 @@ func TestEndpointSourceHonorsSavedOffset(t *testing.T) {
 		t.Fatalf("event = %s", batches[0].Events[0])
 	}
 }
+
+func TestEndpointSourceAppliesLegacyActiveOffsetToFirstRotatedArchive(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "runtime.jsonl")
+	archivePath := logPath + ".1"
+	alreadyUploaded := "{\"event\":\"already-uploaded\"}\n"
+	archiveNew := "{\"event\":\"archive-new\"}\n"
+	activeNew := "{\"event\":\"active\"}\n"
+	if err := os.WriteFile(archivePath, []byte(alreadyUploaded+archiveNew), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath, []byte(activeNew), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	source := NewSource(endpointconfig.Config{UserMode: true, LogPath: logPath}, logPath, true)
+	batches, err := source.Batches(ingest.State{
+		FileOffsets: map[string]int64{logPath: int64(len(alreadyUploaded))},
+	}, 500, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(batches) != 2 {
+		t.Fatalf("len(batches) = %d, want 2: %#v", len(batches), batches)
+	}
+	if batches[0].Cursor.LogPath != archivePath || batches[0].Cursor.Archive != "runtime.jsonl.1" {
+		t.Fatalf("unexpected archive cursor: %#v", batches[0].Cursor)
+	}
+	if string(batches[0].Events[0]) != "{\"event\":\"archive-new\"}" {
+		t.Fatalf("archive event = %s", batches[0].Events[0])
+	}
+	if batches[1].Cursor.LogPath != logPath || string(batches[1].Events[0]) != "{\"event\":\"active\"}" {
+		t.Fatalf("unexpected active batch: %#v", batches[1])
+	}
+}
+
+func TestEndpointSourceAppliesLegacyActiveOffsetWithUnrelatedFileIDs(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "runtime.jsonl")
+	archivePath := logPath + ".1"
+	alreadyUploaded := "{\"event\":\"already-uploaded\"}\n"
+	archiveNew := "{\"event\":\"archive-new\"}\n"
+	if err := os.WriteFile(archivePath, []byte(alreadyUploaded+archiveNew), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	source := NewSource(endpointconfig.Config{UserMode: true, LogPath: logPath}, logPath, true)
+	batches, err := source.Batches(ingest.State{
+		FileOffsets: map[string]int64{logPath: int64(len(alreadyUploaded))},
+		FileIDs:     map[string]string{filepath.Join(dir, "other.jsonl"): "dev:ino"},
+	}, 500, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(batches) != 1 || batches[0].Cursor.LogPath != archivePath {
+		t.Fatalf("unexpected batches: %#v", batches)
+	}
+	if string(batches[0].Events[0]) != "{\"event\":\"archive-new\"}" {
+		t.Fatalf("archive event = %s", batches[0].Events[0])
+	}
+}
+
+func TestEndpointSourceDoesNotApplyLegacyActiveOffsetWhenActiveFileIDConflicts(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "runtime.jsonl")
+	archivePath := logPath + ".1"
+	alreadyUploaded := "{\"event\":\"already-uploaded\"}\n"
+	archiveNew := "{\"event\":\"archive-new\"}\n"
+	if err := os.WriteFile(archivePath, []byte(alreadyUploaded+archiveNew), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	source := NewSource(endpointconfig.Config{UserMode: true, LogPath: logPath}, logPath, true)
+	batches, err := source.Batches(ingest.State{
+		FileOffsets: map[string]int64{logPath: int64(len(alreadyUploaded))},
+		FileIDs:     map[string]string{logPath: "different-file"},
+	}, 500, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(batches) != 1 || batches[0].Cursor.LogPath != archivePath {
+		t.Fatalf("unexpected batches: %#v", batches)
+	}
+	if len(batches[0].Events) != 2 || string(batches[0].Events[0]) != "{\"event\":\"already-uploaded\"}" {
+		t.Fatalf("archive batch should start at zero when active file identity conflicts: %#v", batches[0])
+	}
+}
+
+func TestEndpointSourceReadsRotatedArchivesOldestFirst(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "runtime.jsonl")
+	files := map[string]string{
+		logPath + ".10": "{\"event\":\"oldest\"}\n",
+		logPath + ".3":  "{\"event\":\"older\"}\n",
+		logPath + ".2":  "{\"event\":\"middle\"}\n",
+		logPath + ".1":  "{\"event\":\"newer\"}\n",
+		logPath:         "{\"event\":\"active\"}\n",
+	}
+	for path, content := range files {
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	source := NewSource(endpointconfig.Config{UserMode: true, LogPath: logPath}, logPath, true)
+	batches, err := source.Batches(ingest.State{FileOffsets: map[string]int64{}}, 500, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(batches) != 5 {
+		t.Fatalf("len(batches) = %d, want 5: %#v", len(batches), batches)
+	}
+	wantArchives := []string{"runtime.jsonl.10", "runtime.jsonl.3", "runtime.jsonl.2", "runtime.jsonl.1", ""}
+	wantEvents := []string{
+		"{\"event\":\"oldest\"}",
+		"{\"event\":\"older\"}",
+		"{\"event\":\"middle\"}",
+		"{\"event\":\"newer\"}",
+		"{\"event\":\"active\"}",
+	}
+	for i := range batches {
+		if batches[i].Cursor.Archive != wantArchives[i] {
+			t.Fatalf("batch %d archive = %q, want %q", i, batches[i].Cursor.Archive, wantArchives[i])
+		}
+		if string(batches[i].Events[0]) != wantEvents[i] {
+			t.Fatalf("batch %d event = %s, want %s", i, batches[i].Events[0], wantEvents[i])
+		}
+	}
+}
+
+func TestEndpointSourceFollowsSavedOffsetAcrossArchiveRenumbering(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "runtime.jsonl")
+	savedPath := logPath + ".1"
+	renumberedPath := logPath + ".2"
+	first := "{\"event\":\"one\"}\n"
+	second := "{\"event\":\"two\"}\n"
+	if err := os.WriteFile(renumberedPath, []byte(first+second), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(renumberedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := NewSource(endpointconfig.Config{UserMode: true, LogPath: logPath}, logPath, true)
+	batches, err := source.Batches(ingest.State{
+		FileOffsets: map[string]int64{savedPath: int64(len(first))},
+		FileIDs:     map[string]string{savedPath: fileIdentity(info)},
+	}, 500, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(batches) != 1 || len(batches[0].Events) != 1 {
+		t.Fatalf("unexpected batches: %#v", batches)
+	}
+	if batches[0].Cursor.LogPath != renumberedPath || string(batches[0].Events[0]) != "{\"event\":\"two\"}" {
+		t.Fatalf("unexpected renumbered archive batch: %#v", batches[0])
+	}
+	if batches[0].Cursor.FileID == "" {
+		t.Fatalf("missing file identity on cursor: %#v", batches[0].Cursor)
+	}
+}

--- a/cli/beacon/internal/ingest/endpoint/reader_test.go
+++ b/cli/beacon/internal/ingest/endpoint/reader_test.go
@@ -1,10 +1,12 @@
 package endpoint
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
+	beaconauth "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/auth"
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/ingest"
 )
@@ -34,6 +36,34 @@ func TestEndpointSourceBatchesValidEventsAndMalformedRejects(t *testing.T) {
 	}
 	if batches[0].Cursor.Offset != int64(len(content)) {
 		t.Fatalf("Offset = %d, want %d", batches[0].Cursor.Offset, len(content))
+	}
+}
+
+func TestUploadTreatsMissingLogDirectoryAsNoBatches(t *testing.T) {
+	root := t.TempDir()
+	logPath := filepath.Join(root, "missing", "runtime.jsonl")
+	statePath := filepath.Join(root, "upload-state.json")
+	store := ingest.Store{Path: statePath}
+	if err := store.Save(ingest.State{LastError: "stale error"}); err != nil {
+		t.Fatal(err)
+	}
+
+	source := NewSource(endpointconfig.Config{UserMode: true, LogPath: logPath}, logPath, true)
+	res := ingest.Upload(context.Background(), ingest.Options{
+		Settings: ingest.Settings{Enabled: true, Managed: true, SourceID: "source-1"},
+		Store:    store,
+		Creds:    &beaconauth.Credentials{Token: "token", UserID: "user"},
+		Source:   source,
+	})
+
+	if res.Uploaded {
+		t.Fatalf("missing log directory should not upload: %#v", res.State)
+	}
+	if res.State.LastError != "" {
+		t.Fatalf("LastError = %q", res.State.LastError)
+	}
+	if stored := store.Load(); stored.LastError != "" {
+		t.Fatalf("persisted LastError = %q", stored.LastError)
 	}
 }
 
@@ -190,6 +220,36 @@ func TestEndpointSourceReadsRotatedArchivesOldestFirst(t *testing.T) {
 		if string(batches[i].Events[0]) != wantEvents[i] {
 			t.Fatalf("batch %d event = %s, want %s", i, batches[i].Events[0], wantEvents[i])
 		}
+	}
+}
+
+func TestEndpointSourceIgnoresWriterLockFile(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "runtime.jsonl")
+	if err := os.WriteFile(logPath+".lock", []byte("not-json\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath, []byte("{\"event\":\"active\"}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	source := NewSource(endpointconfig.Config{UserMode: true, LogPath: logPath}, logPath, true)
+	batches, err := source.Batches(ingest.State{FileOffsets: map[string]int64{}}, 500, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(batches) != 1 {
+		t.Fatalf("len(batches) = %d, want 1: %#v", len(batches), batches)
+	}
+	if batches[0].Cursor.LogPath != logPath || batches[0].Cursor.Archive != "" {
+		t.Fatalf("unexpected active cursor: %#v", batches[0].Cursor)
+	}
+	if batches[0].Rejected != 0 {
+		t.Fatalf("Rejected = %d, want 0", batches[0].Rejected)
+	}
+	if string(batches[0].Events[0]) != "{\"event\":\"active\"}" {
+		t.Fatalf("event = %s", batches[0].Events[0])
 	}
 }
 

--- a/cli/beacon/internal/ingest/endpoint/reader_test.go
+++ b/cli/beacon/internal/ingest/endpoint/reader_test.go
@@ -1,0 +1,61 @@
+package endpoint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/ingest"
+)
+
+func TestEndpointSourceBatchesValidEventsAndMalformedRejects(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "runtime.jsonl")
+	content := []byte("{\"event\":\"one\"}\nnot-json\n{\"event\":\"two\"}\n")
+	if err := os.WriteFile(logPath, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	source := NewSource(endpointconfig.Config{UserMode: true, LogPath: logPath}, logPath, true)
+	batches, err := source.Batches(ingest.State{FileOffsets: map[string]int64{}}, 500, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(batches) != 1 {
+		t.Fatalf("len(batches) = %d, want 1", len(batches))
+	}
+	if got := len(batches[0].Events); got != 2 {
+		t.Fatalf("events = %d, want 2", got)
+	}
+	if batches[0].Rejected != 1 {
+		t.Fatalf("Rejected = %d, want 1", batches[0].Rejected)
+	}
+	if batches[0].Cursor.Offset != int64(len(content)) {
+		t.Fatalf("Offset = %d, want %d", batches[0].Cursor.Offset, len(content))
+	}
+}
+
+func TestEndpointSourceHonorsSavedOffset(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "runtime.jsonl")
+	first := "{\"event\":\"one\"}\n"
+	second := "{\"event\":\"two\"}\n"
+	if err := os.WriteFile(logPath, []byte(first+second), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	source := NewSource(endpointconfig.Config{UserMode: true, LogPath: logPath}, logPath, true)
+	batches, err := source.Batches(ingest.State{FileOffsets: map[string]int64{logPath: int64(len(first))}}, 500, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(batches) != 1 || len(batches[0].Events) != 1 {
+		t.Fatalf("unexpected batches: %#v", batches)
+	}
+	if string(batches[0].Events[0]) != "{\"event\":\"two\"}" {
+		t.Fatalf("event = %s", batches[0].Events[0])
+	}
+}

--- a/cli/beacon/internal/ingest/endpoint/source.go
+++ b/cli/beacon/internal/ingest/endpoint/source.go
@@ -1,0 +1,90 @@
+package endpoint
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/ingest"
+)
+
+const stateFileName = "upload-state.json"
+
+type Source struct {
+	cfg      endpointconfig.Config
+	logPath  string
+	userMode bool
+}
+
+func NewSource(cfg endpointconfig.Config, logPath string, userMode bool) Source {
+	return Source{
+		cfg:      cfg,
+		logPath:  logPath,
+		userMode: userMode,
+	}
+}
+
+func Settings(cfg endpointconfig.Config, logPath string, userMode bool) ingest.Settings {
+	managed := cfg.ManagedUpload
+	settings := ingest.Settings{
+		SourceID:         sourceID(cfg, logPath, userMode),
+		ContentRetention: contentRetention(managed),
+	}
+	if managed == nil {
+		return settings
+	}
+	settings.Enabled = managed.Enabled
+	settings.Managed = managed.Managed
+	settings.IngestURL = strings.TrimSpace(managed.IngestURL)
+	return settings
+}
+
+func Store(userMode bool) ingest.Store {
+	return ingest.Store{Path: filepath.Join(endpointconfig.BaseDir(userMode), "managed", stateFileName)}
+}
+
+func (s Source) Metadata() ingest.SourceMetadata {
+	settings := Settings(s.cfg, s.logPath, s.userMode)
+	return ingest.SourceMetadata{
+		SourceID:         settings.SourceID,
+		Hostname:         hostname(),
+		EndpointMode:     endpointMode(s.userMode),
+		LogPath:          s.logPath,
+		ContentRetention: settings.ContentRetention,
+		ManagedMode:      settings.Managed,
+	}
+}
+
+func sourceID(cfg endpointconfig.Config, logPath string, userMode bool) string {
+	if cfg.ManagedUpload != nil && strings.TrimSpace(cfg.ManagedUpload.SourceID) != "" {
+		return strings.TrimSpace(cfg.ManagedUpload.SourceID)
+	}
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%t|%s", userMode, logPath)))
+	return "beacon-local-" + hex.EncodeToString(sum[:])[:32]
+}
+
+func hostname() string {
+	name, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	return name
+}
+
+func endpointMode(userMode bool) string {
+	if userMode {
+		return "user"
+	}
+	return "system"
+}
+
+func contentRetention(cfg *endpointconfig.ManagedUpload) string {
+	if cfg == nil || strings.TrimSpace(cfg.ContentRetention) == "" {
+		return "redacted"
+	}
+	return strings.TrimSpace(cfg.ContentRetention)
+}

--- a/cli/beacon/internal/ingest/status.go
+++ b/cli/beacon/internal/ingest/status.go
@@ -20,4 +20,7 @@ func applyRuntimeState(state *State, settings Settings, creds *beaconauth.Creden
 	if state.FileOffsets == nil {
 		state.FileOffsets = map[string]int64{}
 	}
+	if state.FileIDs == nil {
+		state.FileIDs = map[string]string{}
+	}
 }

--- a/cli/beacon/internal/ingest/status.go
+++ b/cli/beacon/internal/ingest/status.go
@@ -1,0 +1,23 @@
+package ingest
+
+import beaconauth "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/auth"
+
+func Status(settings Settings, store Store, creds *beaconauth.Credentials) State {
+	state := store.Load()
+	applyRuntimeState(&state, settings, creds)
+	return state
+}
+
+func applyRuntimeState(state *State, settings Settings, creds *beaconauth.Credentials) {
+	state.Enabled = settings.Enabled
+	state.Managed = settings.Managed
+	state.SourceID = settings.SourceID
+	state.LoggedIn = creds != nil && creds.Token != "" && !creds.IsExpired()
+	if creds != nil {
+		state.UserEmail = creds.Email
+		state.OrgName = creds.OrgName
+	}
+	if state.FileOffsets == nil {
+		state.FileOffsets = map[string]int64{}
+	}
+}

--- a/cli/beacon/internal/ingest/store.go
+++ b/cli/beacon/internal/ingest/store.go
@@ -1,0 +1,44 @@
+package ingest
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+type Store struct {
+	Path string
+}
+
+func (s Store) Load() State {
+	data, err := os.ReadFile(s.Path)
+	if err != nil {
+		return emptyState()
+	}
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return emptyState()
+	}
+	if state.FileOffsets == nil {
+		state.FileOffsets = map[string]int64{}
+	}
+	return state
+}
+
+func (s Store) Save(state State) error {
+	if state.FileOffsets == nil {
+		state.FileOffsets = map[string]int64{}
+	}
+	if err := os.MkdirAll(filepath.Dir(s.Path), 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.Path, data, 0600)
+}
+
+func emptyState() State {
+	return State{FileOffsets: map[string]int64{}}
+}

--- a/cli/beacon/internal/ingest/store.go
+++ b/cli/beacon/internal/ingest/store.go
@@ -22,12 +22,18 @@ func (s Store) Load() State {
 	if state.FileOffsets == nil {
 		state.FileOffsets = map[string]int64{}
 	}
+	if state.FileIDs == nil {
+		state.FileIDs = map[string]string{}
+	}
 	return state
 }
 
 func (s Store) Save(state State) error {
 	if state.FileOffsets == nil {
 		state.FileOffsets = map[string]int64{}
+	}
+	if state.FileIDs == nil {
+		state.FileIDs = map[string]string{}
 	}
 	if err := os.MkdirAll(filepath.Dir(s.Path), 0700); err != nil {
 		return err
@@ -40,5 +46,5 @@ func (s Store) Save(state State) error {
 }
 
 func emptyState() State {
-	return State{FileOffsets: map[string]int64{}}
+	return State{FileOffsets: map[string]int64{}, FileIDs: map[string]string{}}
 }

--- a/cli/beacon/internal/ingest/types.go
+++ b/cli/beacon/internal/ingest/types.go
@@ -21,20 +21,21 @@ type Settings struct {
 }
 
 type State struct {
-	Enabled       bool             `json:"enabled"`
-	Managed       bool             `json:"managed"`
-	LoggedIn      bool             `json:"logged_in"`
-	UserEmail     string           `json:"user_email,omitempty"`
-	OrgName       string           `json:"org_name,omitempty"`
-	SourceID      string           `json:"source_id,omitempty"`
-	LastUploadAt  string           `json:"last_upload_at,omitempty"`
-	LastEventAt   string           `json:"last_event_at,omitempty"`
-	LastCursor    Cursor           `json:"last_cursor,omitempty"`
-	AcceptedCount int              `json:"accepted_count"`
-	RejectedCount int              `json:"rejected_count"`
-	LastError     string           `json:"last_error,omitempty"`
-	FileOffsets   map[string]int64 `json:"file_offsets,omitempty"`
-	UpdatedAt     string           `json:"updated_at,omitempty"`
+	Enabled       bool              `json:"enabled"`
+	Managed       bool              `json:"managed"`
+	LoggedIn      bool              `json:"logged_in"`
+	UserEmail     string            `json:"user_email,omitempty"`
+	OrgName       string            `json:"org_name,omitempty"`
+	SourceID      string            `json:"source_id,omitempty"`
+	LastUploadAt  string            `json:"last_upload_at,omitempty"`
+	LastEventAt   string            `json:"last_event_at,omitempty"`
+	LastCursor    Cursor            `json:"last_cursor,omitempty"`
+	AcceptedCount int               `json:"accepted_count"`
+	RejectedCount int               `json:"rejected_count"`
+	LastError     string            `json:"last_error,omitempty"`
+	FileOffsets   map[string]int64  `json:"file_offsets,omitempty"`
+	FileIDs       map[string]string `json:"file_ids,omitempty"`
+	UpdatedAt     string            `json:"updated_at,omitempty"`
 }
 
 type Cursor struct {
@@ -42,6 +43,7 @@ type Cursor struct {
 	Offset  int64  `json:"offset,omitempty"`
 	Line    int    `json:"line,omitempty"`
 	Archive string `json:"archive,omitempty"`
+	FileID  string `json:"-"`
 }
 
 type SourceMetadata struct {

--- a/cli/beacon/internal/ingest/types.go
+++ b/cli/beacon/internal/ingest/types.go
@@ -1,0 +1,100 @@
+package ingest
+
+import (
+	"encoding/json"
+	"net/http"
+
+	beaconauth "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/auth"
+)
+
+const (
+	DefaultBatchEvents = 500
+	DefaultBatchBytes  = 1024 * 1024
+)
+
+type Settings struct {
+	Enabled          bool
+	Managed          bool
+	IngestURL        string
+	SourceID         string
+	ContentRetention string
+}
+
+type State struct {
+	Enabled       bool             `json:"enabled"`
+	Managed       bool             `json:"managed"`
+	LoggedIn      bool             `json:"logged_in"`
+	UserEmail     string           `json:"user_email,omitempty"`
+	OrgName       string           `json:"org_name,omitempty"`
+	SourceID      string           `json:"source_id,omitempty"`
+	LastUploadAt  string           `json:"last_upload_at,omitempty"`
+	LastEventAt   string           `json:"last_event_at,omitempty"`
+	LastCursor    Cursor           `json:"last_cursor,omitempty"`
+	AcceptedCount int              `json:"accepted_count"`
+	RejectedCount int              `json:"rejected_count"`
+	LastError     string           `json:"last_error,omitempty"`
+	FileOffsets   map[string]int64 `json:"file_offsets,omitempty"`
+	UpdatedAt     string           `json:"updated_at,omitempty"`
+}
+
+type Cursor struct {
+	LogPath string `json:"log_path,omitempty"`
+	Offset  int64  `json:"offset,omitempty"`
+	Line    int    `json:"line,omitempty"`
+	Archive string `json:"archive,omitempty"`
+}
+
+type SourceMetadata struct {
+	SourceID         string
+	Hostname         string
+	EndpointMode     string
+	LogPath          string
+	ContentRetention string
+	ManagedMode      bool
+}
+
+type Batch struct {
+	Cursor   Cursor
+	Events   []json.RawMessage
+	Rejected int
+}
+
+type Source interface {
+	Metadata() SourceMetadata
+	Batches(state State, maxEvents int, maxBytes int) ([]Batch, error)
+}
+
+type Options struct {
+	Settings   Settings
+	Creds      *beaconauth.Credentials
+	Store      Store
+	Client     Client
+	Source     Source
+	HTTPClient *http.Client
+}
+
+type Result struct {
+	State    State
+	Uploaded bool
+}
+
+type uploadRequest struct {
+	UploadID string            `json:"upload_id"`
+	Source   uploadSource      `json:"source"`
+	Cursor   Cursor            `json:"cursor"`
+	Events   []json.RawMessage `json:"events"`
+}
+
+type uploadSource struct {
+	SourceID         string `json:"source_id,omitempty"`
+	Hostname         string `json:"hostname,omitempty"`
+	EndpointMode     string `json:"endpoint_mode"`
+	LogPath          string `json:"log_path,omitempty"`
+	ContentRetention string `json:"content_retention"`
+	ManagedMode      bool   `json:"managed_mode"`
+}
+
+type uploadResponse struct {
+	Accepted int `json:"accepted"`
+	Rejected int `json:"rejected"`
+}

--- a/cli/beacon/internal/ingest/upload.go
+++ b/cli/beacon/internal/ingest/upload.go
@@ -39,11 +39,12 @@ func Upload(ctx context.Context, opts Options) Result {
 		_ = opts.Store.Save(state)
 		return Result{State: state}
 	}
+	state.LastError = ""
 
 	uploaded := false
 	for _, batch := range batches {
-		state.RejectedCount += batch.Rejected
 		if len(batch.Events) == 0 {
+			state.RejectedCount += batch.Rejected
 			state.FileOffsets[batch.Cursor.LogPath] = batch.Cursor.Offset
 			continue
 		}
@@ -59,7 +60,7 @@ func Upload(ctx context.Context, opts Options) Result {
 		}
 		now := time.Now().UTC().Format(time.RFC3339)
 		state.AcceptedCount += response.Accepted
-		state.RejectedCount += response.Rejected
+		state.RejectedCount += batch.Rejected + response.Rejected
 		state.LastUploadAt = now
 		state.LastEventAt = now
 		state.LastCursor = batch.Cursor

--- a/cli/beacon/internal/ingest/upload.go
+++ b/cli/beacon/internal/ingest/upload.go
@@ -1,0 +1,89 @@
+package ingest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+func Upload(ctx context.Context, opts Options) Result {
+	state := opts.Store.Load()
+	applyRuntimeState(&state, opts.Settings, opts.Creds)
+
+	if !state.Enabled || !state.Managed {
+		state.LastError = ""
+		_ = opts.Store.Save(state)
+		return Result{State: state}
+	}
+	if opts.Creds == nil || opts.Creds.Token == "" || opts.Creds.IsExpired() {
+		state.LastError = "run beacon login before endpoint ingest upload"
+		_ = opts.Store.Save(state)
+		return Result{State: state}
+	}
+	if opts.Source == nil {
+		state.LastError = "endpoint ingest source is not configured"
+		_ = opts.Store.Save(state)
+		return Result{State: state}
+	}
+
+	client := opts.Client
+	if client.URL == "" || client.HTTPClient == nil {
+		client = NewClient(opts.Settings.IngestURL, opts.HTTPClient)
+	}
+
+	batches, err := opts.Source.Batches(state, DefaultBatchEvents, DefaultBatchBytes)
+	if err != nil {
+		state.LastError = err.Error()
+		_ = opts.Store.Save(state)
+		return Result{State: state}
+	}
+
+	uploaded := false
+	for _, batch := range batches {
+		state.RejectedCount += batch.Rejected
+		if len(batch.Events) == 0 {
+			state.FileOffsets[batch.Cursor.LogPath] = batch.Cursor.Offset
+			continue
+		}
+		response, err := client.UploadBatch(ctx, opts.Creds.Token, uploadRequest{
+			UploadID: uploadID(state.SourceID, batch.Cursor.LogPath, batch.Cursor.Offset),
+			Source:   uploadSourceFromMetadata(opts.Source.Metadata()),
+			Cursor:   batch.Cursor,
+			Events:   batch.Events,
+		})
+		if err != nil {
+			state.LastError = err.Error()
+			break
+		}
+		now := time.Now().UTC().Format(time.RFC3339)
+		state.AcceptedCount += response.Accepted
+		state.RejectedCount += response.Rejected
+		state.LastUploadAt = now
+		state.LastEventAt = now
+		state.LastCursor = batch.Cursor
+		state.FileOffsets[batch.Cursor.LogPath] = batch.Cursor.Offset
+		state.LastError = ""
+		uploaded = true
+	}
+	state.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	_ = opts.Store.Save(state)
+	return Result{State: state, Uploaded: uploaded}
+}
+
+func uploadSourceFromMetadata(metadata SourceMetadata) uploadSource {
+	return uploadSource{
+		SourceID:         metadata.SourceID,
+		Hostname:         metadata.Hostname,
+		EndpointMode:     metadata.EndpointMode,
+		LogPath:          metadata.LogPath,
+		ContentRetention: metadata.ContentRetention,
+		ManagedMode:      metadata.ManagedMode,
+	}
+}
+
+func uploadID(sourceID, path string, offset int64) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%d", sourceID, path, offset)))
+	return hex.EncodeToString(sum[:])
+}

--- a/cli/beacon/internal/ingest/upload.go
+++ b/cli/beacon/internal/ingest/upload.go
@@ -46,6 +46,9 @@ func Upload(ctx context.Context, opts Options) Result {
 		if len(batch.Events) == 0 {
 			state.RejectedCount += batch.Rejected
 			state.FileOffsets[batch.Cursor.LogPath] = batch.Cursor.Offset
+			if batch.Cursor.FileID != "" {
+				state.FileIDs[batch.Cursor.LogPath] = batch.Cursor.FileID
+			}
 			continue
 		}
 		response, err := client.UploadBatch(ctx, opts.Creds.Token, uploadRequest{
@@ -65,6 +68,9 @@ func Upload(ctx context.Context, opts Options) Result {
 		state.LastEventAt = now
 		state.LastCursor = batch.Cursor
 		state.FileOffsets[batch.Cursor.LogPath] = batch.Cursor.Offset
+		if batch.Cursor.FileID != "" {
+			state.FileIDs[batch.Cursor.LogPath] = batch.Cursor.FileID
+		}
 		state.LastError = ""
 		uploaded = true
 	}

--- a/cli/beacon/internal/ingest/upload_test.go
+++ b/cli/beacon/internal/ingest/upload_test.go
@@ -1,0 +1,147 @@
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	beaconauth "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/auth"
+)
+
+type fakeSource struct {
+	metadata SourceMetadata
+	batches  []Batch
+	called   bool
+}
+
+func (s *fakeSource) Metadata() SourceMetadata {
+	return s.metadata
+}
+
+func (s *fakeSource) Batches(state State, maxEvents int, maxBytes int) ([]Batch, error) {
+	s.called = true
+	return s.batches, nil
+}
+
+func TestStatusIsReadOnly(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "upload-state.json")
+	state := Status(Settings{Enabled: true, Managed: true, SourceID: "source-1"}, Store{Path: statePath}, &beaconauth.Credentials{
+		Token:  "token",
+		UserID: "user",
+		Email:  "user@example.com",
+	})
+
+	if !state.Enabled || !state.Managed || !state.LoggedIn || state.SourceID != "source-1" {
+		t.Fatalf("unexpected status: %#v", state)
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("Status wrote state file, err=%v", err)
+	}
+}
+
+func TestUploadIsInertUnlessManagedEnabled(t *testing.T) {
+	source := &fakeSource{}
+	res := Upload(context.Background(), Options{
+		Settings: Settings{Enabled: false, Managed: false},
+		Store:    Store{Path: filepath.Join(t.TempDir(), "upload-state.json")},
+		Creds:    &beaconauth.Credentials{Token: "token", UserID: "user"},
+		Source:   source,
+	})
+
+	if source.called {
+		t.Fatal("disabled upload should not read source batches")
+	}
+	if res.Uploaded || res.State.AcceptedCount != 0 || res.State.LastUploadAt != "" {
+		t.Fatalf("disabled upload should not send events: %#v", res.State)
+	}
+}
+
+func TestUploadRequiresLogin(t *testing.T) {
+	source := &fakeSource{}
+	res := Upload(context.Background(), Options{
+		Settings: Settings{Enabled: true, Managed: true, SourceID: "source-1"},
+		Store:    Store{Path: filepath.Join(t.TempDir(), "upload-state.json")},
+		Source:   source,
+	})
+
+	if source.called {
+		t.Fatal("upload without login should not read source batches")
+	}
+	if res.State.LastError == "" {
+		t.Fatalf("expected login error: %#v", res.State)
+	}
+}
+
+func TestUploadPostsBatchAndPersistsCursor(t *testing.T) {
+	var received uploadRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			t.Fatalf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"accepted":1,"rejected":0}`))
+	}))
+	defer server.Close()
+
+	statePath := filepath.Join(t.TempDir(), "upload-state.json")
+	source := &fakeSource{
+		metadata: SourceMetadata{SourceID: "source-1", EndpointMode: "user", LogPath: "runtime.jsonl", ContentRetention: "redacted", ManagedMode: true},
+		batches: []Batch{{
+			Cursor: Cursor{LogPath: "runtime.jsonl", Offset: 128, Line: 1},
+			Events: []json.RawMessage{json.RawMessage(`{"event":"ok"}`)},
+		}},
+	}
+	res := Upload(context.Background(), Options{
+		Settings: Settings{Enabled: true, Managed: true, SourceID: "source-1", IngestURL: server.URL},
+		Store:    Store{Path: statePath},
+		Creds:    &beaconauth.Credentials{Token: "token", UserID: "user"},
+		Source:   source,
+	})
+
+	if res.State.LastError != "" {
+		t.Fatalf("LastError = %q", res.State.LastError)
+	}
+	if !res.Uploaded || res.State.AcceptedCount != 1 || res.State.FileOffsets["runtime.jsonl"] != 128 {
+		t.Fatalf("unexpected upload state: %#v", res.State)
+	}
+	if received.Source.SourceID != "source-1" || !received.Source.ManagedMode || len(received.Events) != 1 {
+		t.Fatalf("unexpected request: %#v", received)
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state file not written: %v", err)
+	}
+}
+
+func TestUploadDoesNotAdvanceCursorOnFailedPost(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	source := &fakeSource{
+		metadata: SourceMetadata{SourceID: "source-1", EndpointMode: "user", LogPath: "runtime.jsonl", ContentRetention: "redacted", ManagedMode: true},
+		batches: []Batch{{
+			Cursor: Cursor{LogPath: "runtime.jsonl", Offset: 128, Line: 1},
+			Events: []json.RawMessage{json.RawMessage(`{"event":"ok"}`)},
+		}},
+	}
+	res := Upload(context.Background(), Options{
+		Settings: Settings{Enabled: true, Managed: true, SourceID: "source-1", IngestURL: server.URL},
+		Store:    Store{Path: filepath.Join(t.TempDir(), "upload-state.json")},
+		Creds:    &beaconauth.Credentials{Token: "token", UserID: "user"},
+		Source:   source,
+	})
+
+	if res.State.LastError == "" {
+		t.Fatal("expected upload error")
+	}
+	if res.State.FileOffsets["runtime.jsonl"] != 0 || res.State.LastCursor.Offset != 0 {
+		t.Fatalf("cursor advanced on failed post: %#v", res.State)
+	}
+}

--- a/cli/beacon/internal/ingest/upload_test.go
+++ b/cli/beacon/internal/ingest/upload_test.go
@@ -94,7 +94,7 @@ func TestUploadPostsBatchAndPersistsCursor(t *testing.T) {
 	source := &fakeSource{
 		metadata: SourceMetadata{SourceID: "source-1", EndpointMode: "user", LogPath: "runtime.jsonl", ContentRetention: "redacted", ManagedMode: true},
 		batches: []Batch{{
-			Cursor: Cursor{LogPath: "runtime.jsonl", Offset: 128, Line: 1},
+			Cursor: Cursor{LogPath: "runtime.jsonl", Offset: 128, Line: 1, FileID: "dev:ino"},
 			Events: []json.RawMessage{json.RawMessage(`{"event":"ok"}`)},
 		}},
 	}
@@ -110,6 +110,9 @@ func TestUploadPostsBatchAndPersistsCursor(t *testing.T) {
 	}
 	if !res.Uploaded || res.State.AcceptedCount != 1 || res.State.FileOffsets["runtime.jsonl"] != 128 {
 		t.Fatalf("unexpected upload state: %#v", res.State)
+	}
+	if res.State.FileIDs["runtime.jsonl"] != "dev:ino" {
+		t.Fatalf("file identity not persisted: %#v", res.State.FileIDs)
 	}
 	if received.Source.SourceID != "source-1" || !received.Source.ManagedMode || len(received.Events) != 1 {
 		t.Fatalf("unexpected request: %#v", received)

--- a/cli/beacon/internal/ingest/upload_test.go
+++ b/cli/beacon/internal/ingest/upload_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	beaconauth "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/auth"
@@ -118,6 +119,37 @@ func TestUploadPostsBatchAndPersistsCursor(t *testing.T) {
 	}
 }
 
+func TestUploadClearsStaleErrorWhenNoBatchesRemain(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "upload-state.json")
+	store := Store{Path: statePath}
+	if err := store.Save(State{LastError: "run beacon login before endpoint ingest upload"}); err != nil {
+		t.Fatal(err)
+	}
+
+	source := &fakeSource{
+		metadata: SourceMetadata{SourceID: "source-1", EndpointMode: "user", LogPath: "runtime.jsonl", ContentRetention: "redacted", ManagedMode: true},
+	}
+	res := Upload(context.Background(), Options{
+		Settings: Settings{Enabled: true, Managed: true, SourceID: "source-1"},
+		Store:    store,
+		Creds:    &beaconauth.Credentials{Token: "token", UserID: "user"},
+		Source:   source,
+	})
+
+	if !source.called {
+		t.Fatal("upload should check source batches")
+	}
+	if res.Uploaded {
+		t.Fatalf("no batches should not mark upload as sent: %#v", res.State)
+	}
+	if res.State.LastError != "" {
+		t.Fatalf("LastError = %q", res.State.LastError)
+	}
+	if stored := store.Load(); stored.LastError != "" {
+		t.Fatalf("persisted LastError = %q", stored.LastError)
+	}
+}
+
 func TestUploadDoesNotAdvanceCursorOnFailedPost(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "nope", http.StatusInternalServerError)
@@ -143,5 +175,114 @@ func TestUploadDoesNotAdvanceCursorOnFailedPost(t *testing.T) {
 	}
 	if res.State.FileOffsets["runtime.jsonl"] != 0 || res.State.LastCursor.Offset != 0 {
 		t.Fatalf("cursor advanced on failed post: %#v", res.State)
+	}
+}
+
+func TestUploadDoesNotAdvanceCursorWhenResponseDoesNotAccountForBatch(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "empty body", body: "", want: "response was empty"},
+		{name: "zero counts", body: `{}`, want: "accounted for 0 events, want 1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			source := &fakeSource{
+				metadata: SourceMetadata{SourceID: "source-1", EndpointMode: "user", LogPath: "runtime.jsonl", ContentRetention: "redacted", ManagedMode: true},
+				batches: []Batch{{
+					Cursor: Cursor{LogPath: "runtime.jsonl", Offset: 128, Line: 1},
+					Events: []json.RawMessage{json.RawMessage(`{"event":"ok"}`)},
+				}},
+			}
+			res := Upload(context.Background(), Options{
+				Settings: Settings{Enabled: true, Managed: true, SourceID: "source-1", IngestURL: server.URL},
+				Store:    Store{Path: filepath.Join(t.TempDir(), "upload-state.json")},
+				Creds:    &beaconauth.Credentials{Token: "token", UserID: "user"},
+				Source:   source,
+			})
+
+			if res.Uploaded {
+				t.Fatalf("invalid response should not mark upload as sent: %#v", res.State)
+			}
+			if !strings.Contains(res.State.LastError, tt.want) {
+				t.Fatalf("LastError = %q, want containing %q", res.State.LastError, tt.want)
+			}
+			if res.State.AcceptedCount != 0 || res.State.RejectedCount != 0 {
+				t.Fatalf("counts changed on invalid response: %#v", res.State)
+			}
+			if res.State.FileOffsets["runtime.jsonl"] != 0 || res.State.LastCursor.Offset != 0 {
+				t.Fatalf("cursor advanced on invalid response: %#v", res.State)
+			}
+		})
+	}
+}
+
+func TestUploadDoesNotDoubleCountMalformedLinesOnFailedPostRetry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	store := Store{Path: filepath.Join(t.TempDir(), "upload-state.json")}
+	source := &fakeSource{
+		metadata: SourceMetadata{SourceID: "source-1", EndpointMode: "user", LogPath: "runtime.jsonl", ContentRetention: "redacted", ManagedMode: true},
+		batches: []Batch{{
+			Cursor:   Cursor{LogPath: "runtime.jsonl", Offset: 128, Line: 2},
+			Events:   []json.RawMessage{json.RawMessage(`{"event":"ok"}`)},
+			Rejected: 1,
+		}},
+	}
+	opts := Options{
+		Settings: Settings{Enabled: true, Managed: true, SourceID: "source-1", IngestURL: server.URL},
+		Store:    store,
+		Creds:    &beaconauth.Credentials{Token: "token", UserID: "user"},
+		Source:   source,
+	}
+
+	first := Upload(context.Background(), opts)
+	second := Upload(context.Background(), opts)
+
+	if first.State.LastError == "" || second.State.LastError == "" {
+		t.Fatalf("expected upload errors: first=%#v second=%#v", first.State, second.State)
+	}
+	if second.State.FileOffsets["runtime.jsonl"] != 0 || second.State.LastCursor.Offset != 0 {
+		t.Fatalf("cursor advanced on failed post retry: %#v", second.State)
+	}
+	if second.State.RejectedCount != 0 {
+		t.Fatalf("RejectedCount = %d, want 0 before cursor advances", second.State.RejectedCount)
+	}
+}
+
+func TestUploadCountsMalformedLinesWhenCursorAdvancesWithoutPost(t *testing.T) {
+	source := &fakeSource{
+		metadata: SourceMetadata{SourceID: "source-1", EndpointMode: "user", LogPath: "runtime.jsonl", ContentRetention: "redacted", ManagedMode: true},
+		batches: []Batch{{
+			Cursor:   Cursor{LogPath: "runtime.jsonl", Offset: 128, Line: 1},
+			Rejected: 2,
+		}},
+	}
+	res := Upload(context.Background(), Options{
+		Settings: Settings{Enabled: true, Managed: true, SourceID: "source-1"},
+		Store:    Store{Path: filepath.Join(t.TempDir(), "upload-state.json")},
+		Creds:    &beaconauth.Credentials{Token: "token", UserID: "user"},
+		Source:   source,
+	})
+
+	if res.Uploaded {
+		t.Fatalf("rejected-only batch should not mark upload as sent: %#v", res.State)
+	}
+	if res.State.FileOffsets["runtime.jsonl"] != 128 {
+		t.Fatalf("cursor did not advance for rejected-only batch: %#v", res.State)
+	}
+	if res.State.RejectedCount != 2 {
+		t.Fatalf("RejectedCount = %d, want 2", res.State.RejectedCount)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Uploads endpoint telemetry with bearer tokens and advances durable cursors; behavior is opt-in and well-tested, but mistakes in cursor or batch handling could drop or duplicate events.
> 
> **Overview**
> Adds **managed cloud ingest** for endpoint JSONL telemetry: operators can upload batches to Beacon’s ingest API using saved login credentials, with persisted cursors so uploads resume after rotation or restarts.
> 
> **CLI:** New `beacon ingest` tree (`status`, `endpoint status`, `endpoint upload`) plus managed-upload lines on `beacon endpoint status`. Upload is explicit and gated on `managed_upload` being enabled/managed and a valid `beacon login`.
> 
> **Config:** Endpoint `config.json` gains optional `managed_upload` (`enabled`, `managed`, `ingest_url`, `source_id`, `content_retention`).
> 
> **Ingest stack:** Shared `internal/ingest` handles read-only status, local `upload-state.json`, bearer-authenticated POSTs to `/api/v1/ingest/beacon/events`, and strict response accounting. Endpoint-specific reading walks the active log and numbered archives, skips invalid JSON as rejected, and tracks offsets/file identity across renames. **Status paths do not upload** (covered by tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb1df277da157104d96d2dea251660bced53a54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->