### PR TITLE
Fix token double-count from dual Claude Code telemetry channels

### DIFF
--- a/cli/beacon/internal/endpoint/tokens/tokens.go
+++ b/cli/beacon/internal/endpoint/tokens/tokens.go
@@ -150,6 +150,7 @@ func Aggregate(events []schema.Event, opts Options) Report {
 	}
 	report := Report{TotalEvents: len(events)}
 	usageEvents := collectUsageEvents(events)
+	usageEvents = dedupeOverlappingChannels(usageEvents)
 	resolveCumulativeSeries(usageEvents)
 
 	byModel := map[string]*Usage{}
@@ -243,6 +244,77 @@ func collectUsageEvents(events []schema.Event) []*usageEvent {
 				ue.cumulative = true
 			}
 			ue.metricName, _ = event.Raw["metric_name"].(string)
+		}
+		out = append(out, ue)
+	}
+	return out
+}
+
+// dedupeOverlappingChannels removes double-counted usage when a runtime reports
+// the same tokens through two OTel channels. Claude Code emits each request's
+// usage on both a claude_code.api_request log record and the
+// claude_code.token.usage metric, so ingesting both doubles every token field.
+//
+// The log/span channel (events without a metric_name) is the token source of
+// truth: it carries full per-request usage under the base model name. For each
+// (harness, session) scope, any usage field that channel reports is zeroed on
+// the scope's metric-channel events. Fields the log channel never reports
+// (Claude Code reports cost only on claude_code.cost.usage) survive on the
+// metric channel, so cost still lands exactly once. Runtimes that emit only
+// metrics have no log/span channel in scope and are left untouched.
+func dedupeOverlappingChannels(events []*usageEvent) []*usageEvent {
+	type fieldSet struct {
+		input, output, cacheRead, cacheCreation, reasoning, cost bool
+	}
+	scopeKey := func(ue *usageEvent) string { return ue.harness + "\x00" + ue.session }
+	logFields := map[string]*fieldSet{}
+	for _, ue := range events {
+		if ue.metricName != "" {
+			continue
+		}
+		fs := logFields[scopeKey(ue)]
+		if fs == nil {
+			fs = &fieldSet{}
+			logFields[scopeKey(ue)] = fs
+		}
+		fs.input = fs.input || ue.usage.InputTokens != 0
+		fs.output = fs.output || ue.usage.OutputTokens != 0
+		fs.cacheRead = fs.cacheRead || ue.usage.CacheReadInputTokens != 0
+		fs.cacheCreation = fs.cacheCreation || ue.usage.CacheCreationInputTokens != 0
+		fs.reasoning = fs.reasoning || ue.usage.ReasoningOutputTokens != 0
+		fs.cost = fs.cost || ue.usage.CostUSD != 0
+	}
+	if len(logFields) == 0 {
+		return events
+	}
+	out := events[:0]
+	for _, ue := range events {
+		if ue.metricName != "" {
+			if fs := logFields[scopeKey(ue)]; fs != nil {
+				if fs.input {
+					ue.usage.InputTokens = 0
+				}
+				if fs.output {
+					ue.usage.OutputTokens = 0
+				}
+				if fs.cacheRead {
+					ue.usage.CacheReadInputTokens = 0
+				}
+				if fs.cacheCreation {
+					ue.usage.CacheCreationInputTokens = 0
+				}
+				if fs.reasoning {
+					ue.usage.ReasoningOutputTokens = 0
+				}
+				if fs.cost {
+					ue.usage.CostUSD = 0
+				}
+				// Drop a metric event left with no usage so it neither inflates
+				// event counts nor seeds an empty cumulative series.
+				if ue.usage.TotalTokens() == 0 && ue.usage.ReasoningOutputTokens == 0 && ue.usage.CostUSD == 0 {
+					continue
+				}
+			}
 		}
 		out = append(out, ue)
 	}

--- a/cli/beacon/internal/endpoint/tokens/tokens_test.go
+++ b/cli/beacon/internal/endpoint/tokens/tokens_test.go
@@ -73,6 +73,65 @@ func TestAggregateSumsDeltaUsageAcrossGroups(t *testing.T) {
 	}
 }
 
+func TestAggregateDedupesDualChannelUsage(t *testing.T) {
+	// Claude Code reports each request's usage on both a claude_code.api_request
+	// log record (no metric_name) and the claude_code.token.usage metric, under
+	// the base and 1M-context model names respectively. Counting both doubles
+	// every token field; cost rides only on claude_code.cost.usage.
+	metric := func(name string, mutate func(*schema.Event)) schema.Event {
+		return usageEventFixture("2026-06-11T10:00:05Z", "claude_code", "s1", "claude-opus-4-6[1m]", func(e *schema.Event) {
+			mutate(e)
+			e.Raw = map[string]interface{}{"metric_name": name, "metric_temporality": "Delta"}
+		})
+	}
+	events := []schema.Event{
+		// Log/span channel: full per-request usage, base model name, no cost.
+		usageEventFixture("2026-06-11T10:00:00Z", "claude_code", "s1", "claude-opus-4-6", func(e *schema.Event) {
+			e.Event.Action = "tool.invoked"
+			e.Message = "claude_code.api_request"
+			e.GenAI.Usage.InputTokens = int64Ptr(11)
+			e.GenAI.Usage.OutputTokens = int64Ptr(826)
+			e.GenAI.Usage.CacheRead = &schema.GenAIUsageCacheReadInfo{InputTokens: int64Ptr(119393)}
+			e.GenAI.Usage.CacheCreation = &schema.GenAIUsageCacheCreationInfo{InputTokens: int64Ptr(15751)}
+		}),
+		// Metric channel: same tokens, field-split (must be suppressed) plus cost (must survive).
+		metric("claude_code.token.usage", func(e *schema.Event) { e.GenAI.Usage.InputTokens = int64Ptr(11) }),
+		metric("claude_code.token.usage", func(e *schema.Event) { e.GenAI.Usage.OutputTokens = int64Ptr(826) }),
+		metric("claude_code.token.usage", func(e *schema.Event) {
+			e.GenAI.Usage.CacheRead = &schema.GenAIUsageCacheReadInfo{InputTokens: int64Ptr(119393)}
+		}),
+		metric("claude_code.token.usage", func(e *schema.Event) {
+			e.GenAI.Usage.CacheCreation = &schema.GenAIUsageCacheCreationInfo{InputTokens: int64Ptr(15751)}
+		}),
+		metric("claude_code.cost.usage", func(e *schema.Event) { e.GenAI.Usage.CostUSD = float64Ptr(0.1788) }),
+		// Metrics-only scope (no log/span channel): must be left untouched.
+		usageEventFixture("2026-06-11T10:01:00Z", "codex", "s2", "gpt-5", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(500)
+			e.Raw = map[string]interface{}{"metric_name": "gen_ai.client.token.usage", "metric_temporality": "Delta"}
+		}),
+	}
+
+	report := Aggregate(events, Options{})
+	if got := report.Totals; got.InputTokens != 511 || got.OutputTokens != 826 ||
+		got.CacheReadInputTokens != 119393 || got.CacheCreationInputTokens != 15751 || got.CostUSD != 0.1788 {
+		t.Fatalf("totals double-counted or dropped: %#v", got)
+	}
+	// Base model name carries the deduped tokens; the [1m] metric name carries cost only.
+	byModel := map[string]Usage{}
+	for _, g := range report.ByModel {
+		byModel[g.Key] = g.Usage
+	}
+	if base := byModel["claude-opus-4-6"]; base.InputTokens != 11 || base.OutputTokens != 826 || base.CacheReadInputTokens != 119393 {
+		t.Fatalf("base model tokens = %#v", base)
+	}
+	if oneM := byModel["claude-opus-4-6[1m]"]; oneM.TotalTokens() != 0 || oneM.CostUSD != 0.1788 {
+		t.Fatalf("[1m] model should carry cost only, got %#v", oneM)
+	}
+	if codex := byModel["gpt-5"]; codex.InputTokens != 500 {
+		t.Fatalf("metrics-only scope was dropped: %#v", codex)
+	}
+}
+
 func TestAggregateDedupesCumulativeSeries(t *testing.T) {
 	cumulative := func(ts string, value int64) schema.Event {
 		return usageEventFixture(ts, "claude_code", "s1", "claude-sonnet-4-5", func(e *schema.Event) {


### PR DESCRIPTION
## Problem

End-to-end testing of the token usage feature on a live Claude Code session surfaced that **every token field is counted twice**. Claude Code reports each request's usage on *both* of its OTel channels, and Beacon's install enables both:

- **Logs** — a `claude_code.api_request` record carrying full `gen_ai.usage` (no `metric_name`).
- **Metrics** — `claude_code.token.usage` / `claude_code.cost.usage` datapoints.

`tokens.Aggregate` summed every usage-bearing event with no channel de-dup, so totals, `by_model`, `by_session`, `by_harness`, and the dashboard were all ~2× inflated. Captured proof — the two channels were byte-identical:

| field | log channel | metric channel | reported (2×) |
|---|---|---|---|
| input | 4,261 | 4,261 | 8,522 |
| output | 14,502 | 14,502 | 29,004 |
| cache_read | 1,172,980 | 1,172,980 | 2,345,960 |
| cache_creation | 86,426 | 86,426 | 172,852 |
| cost_usd | 0 | 1.096 | 1.096 ✅ |

Cost was already correct because it rides only on `claude_code.cost.usage`. The `[1m]` two-row symptom was downstream of this (the channels label the model differently: base name on logs, `[1m]` request model on metrics).

## Fix

Treat the **log/span channel as the token source of truth**. Per `(harness, session)` scope, zero any usage field that channel reports on the scope's metric-channel events, and drop metric events left with no usage. Fields the log channel never carries (cost) survive on the metric channel, so cost still lands exactly once. Scopes with **no** log/span channel (metrics-only runtimes like Codex/SDK) are left untouched, so their usage is never dropped.

CLI-only change — the collector binary is unaffected.

## Verification

- `go test ./...`, `go test -race ./internal/endpoint/...`, `gofmt`, `go vet` all pass.
- New `TestAggregateDedupesDualChannelUsage` covers dual-channel collapse, cost-only survival on `[1m]`, and a metrics-only scope passthrough.
- Against **real captured Claude Code telemetry**, report totals now equal `log-channel tokens + metric-channel cost` exactly (e.g. haiku `7940/5032/559750` → `3970/2516/279875`), `[1m]` rows are cost-only, the bogus `103.5%` utilization artifact is gone, and the dashboard `/api/tokens` matches the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core token aggregation logic used by CLI and dashboard; wrong dedupe rules could under-count metrics-only runtimes or drop valid usage, though scoped to (harness, session) and covered by new tests.
> 
> **Overview**
> Fixes **~2× inflated token totals** when Claude Code telemetry is ingested from both OTel logs (`claude_code.api_request`, no `metric_name`) and metrics (`claude_code.token.usage`).
> 
> `tokens.Aggregate` now runs **`dedupeOverlappingChannels`** after collecting usage events and before cumulative delta resolution. Per **(harness, session)**, log/span events define which usage fields are authoritative; matching fields on metric events are zeroed, empty metric rows are dropped, and fields only on metrics (e.g. **cost** on `claude_code.cost.usage`) are kept. Scopes with **metrics only** are unchanged.
> 
> Adds **`TestAggregateDedupesDualChannelUsage`** for dual-channel collapse, cost-only `[1m]` attribution, and metrics-only passthrough. CLI token commands and dashboard `/api/tokens` pick this up via the shared aggregator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8fb55d2beaced4cfee829a26aabc2c0feb08f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->