### PR TITLE
Add dashboard findings + detections

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,10 @@ and collection status, while log search helps teams inspect normalized event
 records during rollout, testing, and investigations. The token usage screen
 breaks captured token telemetry down by model, session (with per-step
 drilldown), CI run, and harness, including context-window utilization and
-runtime-reported cost.
+runtime-reported cost. The detections screen lists the active threat-detection
+rules (the local store when present, otherwise the embedded baseline), and the
+findings screen runs those rules over the runtime log on load and links each hit
+back to its rule — the same read-only, offline detection as `beacon scan`.
 
 For scripted or CI reporting, `beacon endpoint tokens` prints the same token
 usage rollups as text or JSON from any runtime JSONL log, for example

--- a/cli/beacon/cmd/scan.go
+++ b/cli/beacon/cmd/scan.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -42,13 +41,15 @@ Scanning is read-only and never touches the network.`,
 	RunE:         runScan,
 }
 
-// severityRank orders severities for --min-severity / --fail-on comparisons.
-var severityRank = map[asymptoteobserve.Severity]int{
-	asymptoteobserve.SeverityInfo:     0,
-	asymptoteobserve.SeverityLow:      1,
-	asymptoteobserve.SeverityMedium:   2,
-	asymptoteobserve.SeverityHigh:     3,
-	asymptoteobserve.SeverityCritical: 4,
+// severityRanks maps --min-severity / --fail-on flag values to comparable ranks,
+// delegating to the shared ordering in the threatrules package.
+func severityRankOf(s asymptoteobserve.Severity) (int, bool) {
+	switch s {
+	case asymptoteobserve.SeverityInfo, asymptoteobserve.SeverityLow, asymptoteobserve.SeverityMedium,
+		asymptoteobserve.SeverityHigh, asymptoteobserve.SeverityCritical:
+		return threatrules.SeverityRank(s), true
+	}
+	return 0, false
 }
 
 func runScan(cmd *cobra.Command, args []string) error {
@@ -59,7 +60,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 	var minRank int
 	if s := strings.TrimSpace(scanOpts.minSeverity); s != "" {
-		r, ok := severityRank[asymptoteobserve.Severity(s)]
+		r, ok := severityRankOf(asymptoteobserve.Severity(s))
 		if !ok {
 			return fmt.Errorf("invalid --min-severity %q (info|low|medium|high|critical)", s)
 		}
@@ -67,7 +68,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 	failRank := -1
 	if s := strings.TrimSpace(scanOpts.failOn); s != "" {
-		r, ok := severityRank[asymptoteobserve.Severity(s)]
+		r, ok := severityRankOf(asymptoteobserve.Severity(s))
 		if !ok {
 			return fmt.Errorf("invalid --fail-on %q (info|low|medium|high|critical)", s)
 		}
@@ -115,19 +116,13 @@ func runScan(cmd *cobra.Command, args []string) error {
 	// findings from the output slice.
 	failCount := 0
 	if failRank >= 0 {
-		failCount = countAtOrAbove(findings, failRank)
+		failCount = threatrules.CountAtOrAbove(findings, failRank)
 	}
 	if minRank > 0 {
-		findings = filterBySeverity(findings, minRank)
+		findings = threatrules.FilterBySeverity(findings, minRank)
 	}
 	// Highest severity first, then rule id, for stable, useful ordering.
-	sort.SliceStable(findings, func(i, j int) bool {
-		ri, rj := severityRank[findings[i].Severity], severityRank[findings[j].Severity]
-		if ri != rj {
-			return ri > rj
-		}
-		return findings[i].RuleID < findings[j].RuleID
-	})
+	threatrules.SortFindings(findings)
 
 	out := cmd.OutOrStdout()
 	if scanOpts.jsonOutput {
@@ -151,26 +146,6 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 func scanSessionMatches(sessionID, query string) bool {
 	return strings.Contains(strings.ToLower(sessionID), strings.ToLower(strings.TrimSpace(query)))
-}
-
-func filterBySeverity(findings []threatrules.Finding, minRank int) []threatrules.Finding {
-	out := findings[:0]
-	for _, f := range findings {
-		if severityRank[f.Severity] >= minRank {
-			out = append(out, f)
-		}
-	}
-	return out
-}
-
-func countAtOrAbove(findings []threatrules.Finding, rank int) int {
-	n := 0
-	for _, f := range findings {
-		if severityRank[f.Severity] >= rank {
-			n++
-		}
-	}
-	return n
 }
 
 func printFindings(cmd *cobra.Command, findings []threatrules.Finding, scanned int, logPath string) {

--- a/cli/beacon/internal/endpoint/dashboard/detections.go
+++ b/cli/beacon/internal/endpoint/dashboard/detections.go
@@ -1,0 +1,130 @@
+package dashboard
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/detect"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve/threatrules"
+)
+
+// DetectionView is the JSON shape of one active threat rule for the dashboard.
+// Rule fields carry only yaml tags, so the active rule set is mapped into this
+// view rather than serialized directly.
+type DetectionView struct {
+	ID          string                    `json:"id"`
+	Title       string                    `json:"title"`
+	Description string                    `json:"description,omitempty"`
+	Severity    asymptoteobserve.Severity `json:"severity"`
+	Status      threatrules.Status        `json:"status"`
+	Posture     threatrules.Posture       `json:"posture"`
+	Kind        string                    `json:"kind"` // "match" or "correlation"
+	Reason      string                    `json:"reason"`
+	Source      detect.Source             `json:"source"` // baseline | store
+	TestCount   int                       `json:"test_count"`
+	Taxonomy    map[string]string         `json:"taxonomy,omitempty"`
+}
+
+// DetectionsResponse is the /api/detections payload.
+type DetectionsResponse struct {
+	Rules []DetectionView `json:"rules"`
+	Count int             `json:"count"`
+}
+
+// BuildDetections lists the active rule set (store when present, else the
+// embedded baseline — the same set `beacon scan` would run) as detection views.
+func BuildDetections(userMode bool, rulesDir string) (DetectionsResponse, error) {
+	loaded, err := detect.LoadActive(userMode, strings.TrimSpace(rulesDir))
+	if err != nil {
+		return DetectionsResponse{}, err
+	}
+	rules := make([]DetectionView, 0, len(loaded))
+	for _, lr := range loaded {
+		r := lr.Rule
+		kind := "match"
+		if r.Correlation != nil {
+			kind = "correlation"
+		}
+		rules = append(rules, DetectionView{
+			ID:          r.ID,
+			Title:       r.Title,
+			Description: r.Description,
+			Severity:    r.Severity,
+			Status:      r.Status,
+			Posture:     r.Posture,
+			Kind:        kind,
+			Reason:      r.Emit.Reason,
+			Source:      lr.Source,
+			TestCount:   len(r.Tests),
+			Taxonomy:    r.Taxonomy,
+		})
+	}
+	return DetectionsResponse{Rules: rules, Count: len(rules)}, nil
+}
+
+// FindingsResponse is the /api/findings payload: the hits from running the
+// active rules over the runtime log, plus how many events were scanned.
+type FindingsResponse struct {
+	Findings []threatrules.Finding `json:"findings"`
+	Scanned  int                   `json:"scanned"`
+	Count    int                   `json:"count"`
+}
+
+// RunScan loads and compiles the active rules, streams the runtime log (optionally
+// filtered to one session), runs detection, and returns findings sorted highest
+// severity first. It mirrors `beacon scan` and is read-only and offline. minSeverity,
+// when set, drops lower-severity findings from the result (display filter only).
+func RunScan(userMode bool, logPath, rulesDir, session, minSeverity string) (FindingsResponse, error) {
+	minRank := 0
+	if s := strings.TrimSpace(minSeverity); s != "" {
+		sev := asymptoteobserve.Severity(s)
+		switch sev {
+		case asymptoteobserve.SeverityInfo, asymptoteobserve.SeverityLow, asymptoteobserve.SeverityMedium,
+			asymptoteobserve.SeverityHigh, asymptoteobserve.SeverityCritical:
+			minRank = threatrules.SeverityRank(sev)
+		default:
+			return FindingsResponse{}, fmt.Errorf("invalid min_severity %q (info|low|medium|high|critical)", s)
+		}
+	}
+
+	loaded, err := detect.LoadActive(userMode, strings.TrimSpace(rulesDir))
+	if err != nil {
+		return FindingsResponse{}, fmt.Errorf("load rules: %w", err)
+	}
+	compiled := make([]*threatrules.CompiledRule, 0, len(loaded))
+	for _, lr := range loaded {
+		c, err := threatrules.Compile(lr.Rule)
+		if err != nil {
+			return FindingsResponse{}, fmt.Errorf("compile rule %q: %w", lr.Rule.ID, err)
+		}
+		compiled = append(compiled, c)
+	}
+
+	sessionFilter := strings.TrimSpace(session)
+	var events []asymptoteobserve.Event
+	err = StreamEvents(logPath, func(e schema.Event) error {
+		if sessionFilter != "" && (e.Session == nil || !strings.Contains(strings.ToLower(e.Session.ID), strings.ToLower(sessionFilter))) {
+			return nil
+		}
+		events = append(events, e)
+		return nil
+	})
+	if err != nil {
+		return FindingsResponse{}, fmt.Errorf("read telemetry %s: %w", logPath, err)
+	}
+
+	findings, err := threatrules.ScanEvents(compiled, events)
+	if err != nil {
+		return FindingsResponse{}, fmt.Errorf("scan: %w", err)
+	}
+	if minRank > 0 {
+		findings = threatrules.FilterBySeverity(findings, minRank)
+	}
+	threatrules.SortFindings(findings)
+	if findings == nil {
+		findings = []threatrules.Finding{}
+	}
+	return FindingsResponse{Findings: findings, Scanned: len(events), Count: len(findings)}, nil
+}

--- a/cli/beacon/internal/endpoint/dashboard/detections.go
+++ b/cli/beacon/internal/endpoint/dashboard/detections.go
@@ -93,6 +93,9 @@ func RunScan(userMode bool, logPath, rulesDir, session, minSeverity string) (Fin
 	if err != nil {
 		return FindingsResponse{}, fmt.Errorf("load rules: %w", err)
 	}
+	if len(loaded) == 0 {
+		return FindingsResponse{}, fmt.Errorf("no rules to run (store is empty and baseline missing)")
+	}
 	compiled := make([]*threatrules.CompiledRule, 0, len(loaded))
 	for _, lr := range loaded {
 		c, err := threatrules.Compile(lr.Rule)

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -120,6 +120,31 @@ func Handler(opts Options) (http.Handler, error) {
 		}
 		writeJSON(w, tokens.Aggregate(events, tokenOptions(r)))
 	})
+	mux.HandleFunc("/api/detections", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			methodNotAllowed(w)
+			return
+		}
+		resp, err := BuildDetections(opts.UserMode, "")
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err)
+			return
+		}
+		writeJSON(w, resp)
+	})
+	mux.HandleFunc("/api/findings", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			methodNotAllowed(w)
+			return
+		}
+		q := r.URL.Query()
+		resp, err := RunScan(opts.UserMode, opts.LogPath, "", q.Get("session"), q.Get("min_severity"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeJSON(w, resp)
+	})
 	mux.HandleFunc("/api/event", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			methodNotAllowed(w)

--- a/cli/beacon/internal/endpoint/dashboard/server_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/server_test.go
@@ -244,6 +244,81 @@ func TestTokensEndpointSessionFilterIsCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestDetectionsEndpointListsBaselineRules(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // empty store -> embedded baseline
+	handler, err := Handler(Options{UserMode: true, LogPath: filepath.Join(t.TempDir(), "runtime.jsonl")})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/detections", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp DetectionsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal detections: %v", err)
+	}
+	if resp.Count == 0 || resp.Count != len(resp.Rules) {
+		t.Fatalf("count = %d, rules = %d", resp.Count, len(resp.Rules))
+	}
+	for _, rule := range resp.Rules {
+		if rule.Source != "baseline" {
+			t.Fatalf("rule %q source = %q, want baseline", rule.ID, rule.Source)
+		}
+		if rule.ID == "" || rule.Severity == "" || rule.Kind == "" {
+			t.Fatalf("rule missing fields: %#v", rule)
+		}
+	}
+}
+
+func TestFindingsEndpointReturnsHitsLinkedToRules(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // empty store -> embedded baseline
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	// A destructive command the baseline "recursive-root-delete" rule matches.
+	line := `{"timestamp":"2026-06-11T10:00:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"command.executed","category":"command"},"severity":"info","endpoint":{"os":"darwin"},"harness":{"name":"claude_code"},"session":{"id":"local-session"},"command":{"command":"rm -rf /"},"message":"command.executed"}`
+	if err := os.WriteFile(logPath, []byte(line+"\n"), 0644); err != nil {
+		t.Fatalf("write fixture log: %v", err)
+	}
+	handler, err := Handler(Options{UserMode: true, LogPath: logPath})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/findings", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp FindingsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if resp.Scanned != 1 {
+		t.Fatalf("scanned = %d, want 1", resp.Scanned)
+	}
+	found := false
+	for _, f := range resp.Findings {
+		if f.RuleID == "recursive-root-delete" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a recursive-root-delete finding, got %#v", resp.Findings)
+	}
+
+	// An out-of-range min_severity is rejected.
+	bad := httptest.NewRequest(http.MethodGet, "/api/findings?min_severity=nope", nil)
+	badRec := httptest.NewRecorder()
+	handler.ServeHTTP(badRec, bad)
+	if badRec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid min_severity status = %d, want 400", badRec.Code)
+	}
+}
+
 func TestStaticDashboardPagesServe(t *testing.T) {
 	handler, err := Handler(Options{UserMode: true, LogPath: filepath.Join(t.TempDir(), "runtime.jsonl")})
 	if err != nil {
@@ -257,6 +332,8 @@ func TestStaticDashboardPagesServe(t *testing.T) {
 		{path: "/", want: "Beacon Endpoint Log Search"},
 		{path: "/overview.html", want: "Beacon Endpoint Security Overview"},
 		{path: "/tokens.html", want: "Beacon Endpoint Token Usage"},
+		{path: "/detections.html", want: "Beacon Endpoint Detections"},
+		{path: "/findings.html", want: "Beacon Endpoint Findings"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.path, func(t *testing.T) {

--- a/cli/beacon/internal/endpoint/dashboard/server_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/server_test.go
@@ -319,6 +319,17 @@ func TestFindingsEndpointReturnsHitsLinkedToRules(t *testing.T) {
 	}
 }
 
+func TestRunScanRejectsEmptyRuleSet(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	_, err := RunScan(true, filepath.Join(t.TempDir(), "runtime.jsonl"), t.TempDir(), "", "")
+	if err == nil {
+		t.Fatal("expected empty rule set to be rejected")
+	}
+	if !strings.Contains(err.Error(), "no rules to run") {
+		t.Fatalf("error = %q, want no rules to run", err)
+	}
+}
+
 func TestStaticDashboardPagesServe(t *testing.T) {
 	handler, err := Handler(Options{UserMode: true, LogPath: filepath.Join(t.TempDir(), "runtime.jsonl")})
 	if err != nil {

--- a/cli/beacon/internal/endpoint/dashboard/static/app.js
+++ b/cli/beacon/internal/endpoint/dashboard/static/app.js
@@ -7,6 +7,7 @@ const state = {
   error: null,
   currentQuery: "",
   newEventCount: 0,
+  lastDetectionHashScroll: "",
 };
 
 const $ = (selector) => document.querySelector(selector);
@@ -900,6 +901,22 @@ function renderDetections(resp) {
       </tr>
     `)
     .join("");
+  scrollDetectionHashIntoView();
+}
+
+function scrollDetectionHashIntoView({ force = false } = {}) {
+  if (!isDetectionsPage || !window.location.hash) return;
+  let targetID = window.location.hash.slice(1);
+  try {
+    targetID = decodeURIComponent(targetID);
+  } catch (_) {
+    // Use the raw hash when the browser exposes a malformed escape sequence.
+  }
+  if (!targetID || (!force && state.lastDetectionHashScroll === targetID)) return;
+  const target = document.getElementById(targetID);
+  if (!target) return;
+  target.scrollIntoView({ block: "start" });
+  state.lastDetectionHashScroll = targetID;
 }
 
 async function loadFindings() {
@@ -978,6 +995,7 @@ $("#filters")?.addEventListener("submit", (event) => {
 $("#clear-search")?.addEventListener("click", clearSearch);
 $("#close-drawer")?.addEventListener("click", closeDrawer);
 $("#new-events")?.addEventListener("click", showNewEvents);
+window.addEventListener("hashchange", () => scrollDetectionHashIntoView({ force: true }));
 $$("[data-preset]").forEach((button) => {
   button.addEventListener("click", () => applyPreset(button.dataset.preset));
 });

--- a/cli/beacon/internal/endpoint/dashboard/static/app.js
+++ b/cli/beacon/internal/endpoint/dashboard/static/app.js
@@ -13,6 +13,8 @@ const $ = (selector) => document.querySelector(selector);
 const $$ = (selector) => Array.from(document.querySelectorAll(selector));
 const isOverviewPage = document.body.dataset.page === "overview";
 const isTokensPage = document.body.dataset.page === "tokens";
+const isDetectionsPage = document.body.dataset.page === "detections";
+const isFindingsPage = document.body.dataset.page === "findings";
 const formFields = [
   "q",
   "harness",
@@ -865,7 +867,110 @@ function formatRatio(ratio, contextWindow) {
   return `${(ratio * 100).toFixed(1)}%`;
 }
 
-$("#refresh")?.addEventListener("click", () => (isTokensPage ? loadTokens() : load()).catch(console.error));
+async function loadDetections() {
+  try {
+    const resp = await getJSON("/api/detections");
+    state.error = null;
+    renderDetections(resp);
+  } catch (err) {
+    state.error = err;
+    setText("#detections-meta", `Failed to load detections: ${err.message}`);
+  }
+}
+
+function renderDetections(resp) {
+  const rules = resp?.rules || [];
+  setText("#detections-meta", `${rules.length} active rule${rules.length === 1 ? "" : "s"}`);
+  const tbody = $("#detections-rows");
+  if (!tbody) return;
+  if (!rules.length) {
+    tbody.innerHTML = `<tr><td colspan="7" class="muted">No active rules.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = rules
+    .map((rule) => `
+      <tr id="rule-${escapeHTML(rule.id)}">
+        <td>${badge(rule.severity || "unknown", `severity-${rule.severity || "unknown"}`)}</td>
+        <td><span class="mono">${escapeHTML(rule.id)}</span><br /><span class="muted">${escapeHTML(rule.title || "")}</span></td>
+        <td>${escapeHTML(rule.status || "")}</td>
+        <td>${escapeHTML(rule.posture || "")}</td>
+        <td>${escapeHTML(rule.kind || "")}</td>
+        <td>${badge(rule.source || "unknown", "badge-muted")}</td>
+        <td>${escapeHTML(rule.reason || "")}</td>
+      </tr>
+    `)
+    .join("");
+}
+
+async function loadFindings() {
+  const params = new URLSearchParams(window.location.search);
+  const minSeverity = (params.get("min_severity") || "").trim();
+  const select = $("#min-severity");
+  if (select) select.value = minSeverity;
+  const query = new URLSearchParams();
+  if (minSeverity) query.set("min_severity", minSeverity);
+  const session = (params.get("session") || "").trim();
+  if (session) query.set("session", session);
+  const suffix = query.toString() ? `?${query.toString()}` : "";
+  try {
+    const resp = await getJSON(`/api/findings${suffix}`);
+    state.error = null;
+    renderFindings(resp);
+  } catch (err) {
+    state.error = err;
+    setText("#findings-meta", `Failed to load findings: ${err.message}`);
+  }
+}
+
+function renderFindings(resp) {
+  const findings = resp?.findings || [];
+  setText("#findings-meta", `${findings.length} finding${findings.length === 1 ? "" : "s"} across ${resp?.scanned || 0} events`);
+  const tbody = $("#findings-rows");
+  if (!tbody) return;
+  if (!findings.length) {
+    tbody.innerHTML = `<tr><td colspan="5" class="muted">No findings.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = findings
+    .map((f) => `
+      <tr>
+        <td>${badge(f.severity || "unknown", `severity-${f.severity || "unknown"}`)}</td>
+        <td><a class="mono" href="/detections.html#rule-${escapeHTML(f.rule_id)}">${escapeHTML(f.rule_id)}</a><br /><span class="muted">${escapeHTML(f.title || "")}</span></td>
+        <td class="mono">${escapeHTML(f.session_id || "-")}</td>
+        <td>${escapeHTML(f.reason || "")}</td>
+        <td>${summarizeFindingEvents(f.events)}</td>
+      </tr>
+    `)
+    .join("");
+}
+
+function summarizeFindingEvents(events) {
+  if (!events || !events.length) return `<span class="muted">-</span>`;
+  return events
+    .map((e) => {
+      const action = e.event?.action || "event";
+      let detail = "";
+      if (e.command?.command) detail = e.command.command;
+      else if (e.file?.path) detail = e.file.path;
+      else if (e.prompt?.text) detail = e.prompt.text;
+      const when = e.timestamp ? `${escapeHTML(formatTime(e.timestamp))} ` : "";
+      const text = detail ? `${action}: ${detail}` : action;
+      return `<div>${when}<span class="mono">${escapeHTML(text)}</span></div>`;
+    })
+    .join("");
+}
+
+$("#min-severity")?.addEventListener("change", (event) => {
+  const params = new URLSearchParams(window.location.search);
+  if (event.target.value) params.set("min_severity", event.target.value);
+  else params.delete("min_severity");
+  window.location.search = params.toString();
+});
+
+$("#refresh")?.addEventListener("click", () => {
+  const loader = isFindingsPage ? loadFindings : isDetectionsPage ? loadDetections : isTokensPage ? loadTokens : load;
+  loader().catch(console.error);
+});
 $("#filters")?.addEventListener("submit", (event) => {
   event.preventDefault();
   load({ updateLocation: true }).catch(console.error);
@@ -877,7 +982,13 @@ $$("[data-preset]").forEach((button) => {
   button.addEventListener("click", () => applyPreset(button.dataset.preset));
 });
 
-if (isTokensPage) {
+if (isDetectionsPage) {
+  loadDetections().catch(console.error);
+  setInterval(() => loadDetections().catch(console.error), 15000);
+} else if (isFindingsPage) {
+  loadFindings().catch(console.error);
+  setInterval(() => loadFindings().catch(console.error), 15000);
+} else if (isTokensPage) {
   loadTokens().catch(console.error);
   setInterval(() => loadTokens().catch(console.error), 15000);
 } else {

--- a/cli/beacon/internal/endpoint/dashboard/static/detections.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/detections.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Beacon Endpoint Detections</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body data-page="detections">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Local-only</p>
+        <h1>Beacon Endpoint Detections</h1>
+      </div>
+      <nav class="nav-toggle" aria-label="Dashboard navigation">
+        <a href="/">Log Search</a>
+        <a href="/overview.html">Security Overview</a>
+        <a href="/tokens.html">Token Usage</a>
+        <a class="active" href="/detections.html" aria-current="page">Detections</a>
+        <a href="/findings.html">Findings</a>
+      </nav>
+      <button id="refresh">Refresh</button>
+    </header>
+
+    <main>
+      <section class="panel">
+        <div class="section-head overview-head">
+          <div>
+            <h2>Threat Rules</h2>
+            <p class="muted">The active rule set <code>beacon scan</code> runs: the local store when present, otherwise the embedded baseline.</p>
+          </div>
+          <div id="detections-meta" class="muted"></div>
+        </div>
+        <table>
+          <thead>
+            <tr><th>Severity</th><th>Rule</th><th>Status</th><th>Posture</th><th>Kind</th><th>Source</th><th>Reason</th></tr>
+          </thead>
+          <tbody id="detections-rows"></tbody>
+        </table>
+      </section>
+    </main>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/cli/beacon/internal/endpoint/dashboard/static/findings.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/findings.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Beacon Endpoint Findings</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body data-page="findings">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Local-only</p>
+        <h1>Beacon Endpoint Findings</h1>
+      </div>
+      <nav class="nav-toggle" aria-label="Dashboard navigation">
+        <a href="/">Log Search</a>
+        <a href="/overview.html">Security Overview</a>
+        <a href="/tokens.html">Token Usage</a>
+        <a href="/detections.html">Detections</a>
+        <a class="active" href="/findings.html" aria-current="page">Findings</a>
+      </nav>
+      <button id="refresh">Refresh</button>
+    </header>
+
+    <main>
+      <section class="panel">
+        <div class="section-head overview-head">
+          <div>
+            <h2>Findings</h2>
+            <p class="muted">Hits from running the active detection rules over the runtime log. Read-only and offline &mdash; the scan runs live on load.</p>
+          </div>
+          <div class="section-actions">
+            <label class="muted" for="min-severity">Min severity</label>
+            <select id="min-severity">
+              <option value="">all</option>
+              <option value="info">info</option>
+              <option value="low">low</option>
+              <option value="medium">medium</option>
+              <option value="high">high</option>
+              <option value="critical">critical</option>
+            </select>
+            <span id="findings-meta" class="muted"></span>
+          </div>
+        </div>
+        <table>
+          <thead>
+            <tr><th>Severity</th><th>Rule</th><th>Session</th><th>Reason</th><th>Evidence</th></tr>
+          </thead>
+          <tbody id="findings-rows"></tbody>
+        </table>
+      </section>
+    </main>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/cli/beacon/internal/endpoint/dashboard/static/index.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/index.html
@@ -16,6 +16,8 @@
         <a class="active" href="/" aria-current="page">Log Search</a>
         <a href="/overview.html">Security Overview</a>
         <a href="/tokens.html">Token Usage</a>
+        <a href="/detections.html">Detections</a>
+        <a href="/findings.html">Findings</a>
       </nav>
       <button id="refresh">Refresh</button>
     </header>

--- a/cli/beacon/internal/endpoint/dashboard/static/overview.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/overview.html
@@ -16,6 +16,8 @@
         <a href="/">Log Search</a>
         <a class="active" href="/overview.html" aria-current="page">Security Overview</a>
         <a href="/tokens.html">Token Usage</a>
+        <a href="/detections.html">Detections</a>
+        <a href="/findings.html">Findings</a>
       </nav>
       <button id="refresh">Refresh</button>
     </header>

--- a/cli/beacon/internal/endpoint/dashboard/static/tokens.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/tokens.html
@@ -16,6 +16,8 @@
         <a href="/">Log Search</a>
         <a href="/overview.html">Security Overview</a>
         <a class="active" href="/tokens.html" aria-current="page">Token Usage</a>
+        <a href="/detections.html">Detections</a>
+        <a href="/findings.html">Findings</a>
       </nav>
       <button id="refresh">Refresh</button>
     </header>

--- a/pkg/asymptoteobserve/threatrules/findings.go
+++ b/pkg/asymptoteobserve/threatrules/findings.go
@@ -1,6 +1,57 @@
 package threatrules
 
-import "github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+import (
+	"sort"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+)
+
+// severityRank orders severities for filtering and sorting findings.
+var severityRank = map[asymptoteobserve.Severity]int{
+	asymptoteobserve.SeverityInfo:     0,
+	asymptoteobserve.SeverityLow:      1,
+	asymptoteobserve.SeverityMedium:   2,
+	asymptoteobserve.SeverityHigh:     3,
+	asymptoteobserve.SeverityCritical: 4,
+}
+
+// SeverityRank returns the comparable rank of a severity (info=0 … critical=4).
+// Unknown values rank as 0. It is the single ordering shared by the `beacon scan`
+// command and the dashboard findings view.
+func SeverityRank(s asymptoteobserve.Severity) int { return severityRank[s] }
+
+// SortFindings orders findings highest-severity first, then by rule id, in place.
+func SortFindings(findings []Finding) {
+	sort.SliceStable(findings, func(i, j int) bool {
+		ri, rj := severityRank[findings[i].Severity], severityRank[findings[j].Severity]
+		if ri != rj {
+			return ri > rj
+		}
+		return findings[i].RuleID < findings[j].RuleID
+	})
+}
+
+// FilterBySeverity returns the findings at or above minRank (see SeverityRank).
+func FilterBySeverity(findings []Finding, minRank int) []Finding {
+	out := findings[:0]
+	for _, f := range findings {
+		if severityRank[f.Severity] >= minRank {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// CountAtOrAbove returns how many findings are at or above rank.
+func CountAtOrAbove(findings []Finding, rank int) int {
+	n := 0
+	for _, f := range findings {
+		if severityRank[f.Severity] >= rank {
+			n++
+		}
+	}
+	return n
+}
 
 // Finding is a rule match with its supporting evidence, produced when evaluating a rule
 // over a real event stream (as opposed to the boolean Verdict used for conformance).

--- a/pkg/asymptoteobserve/threatrules/findings_test.go
+++ b/pkg/asymptoteobserve/threatrules/findings_test.go
@@ -6,6 +6,32 @@ import (
 	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 )
 
+func TestSortAndFilterFindings(t *testing.T) {
+	findings := []Finding{
+		{RuleID: "b-low", Severity: asymptoteobserve.SeverityLow},
+		{RuleID: "a-critical", Severity: asymptoteobserve.SeverityCritical},
+		{RuleID: "a-low", Severity: asymptoteobserve.SeverityLow},
+		{RuleID: "z-medium", Severity: asymptoteobserve.SeverityMedium},
+	}
+	SortFindings(findings)
+	gotOrder := []string{findings[0].RuleID, findings[1].RuleID, findings[2].RuleID, findings[3].RuleID}
+	wantOrder := []string{"a-critical", "z-medium", "a-low", "b-low"}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Fatalf("sort order = %v, want %v", gotOrder, wantOrder)
+		}
+	}
+
+	// Count before filtering: FilterBySeverity reuses the input's backing array.
+	if n := CountAtOrAbove(findings, SeverityRank(asymptoteobserve.SeverityCritical)); n != 1 {
+		t.Fatalf("count at/above critical = %d, want 1", n)
+	}
+	kept := FilterBySeverity(findings, SeverityRank(asymptoteobserve.SeverityMedium))
+	if len(kept) != 2 {
+		t.Fatalf("filtered len = %d, want 2 (critical+medium)", len(kept))
+	}
+}
+
 func TestSingleEventFindings(t *testing.T) {
 	c, err := Compile(validSingleEventRule()) // matches e.event.action == "file.read"
 	if err != nil {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Read-only local dashboard and API extensions mirroring existing `beacon scan` behavior; no network, auth, or data-persistence changes.
> 
> **Overview**
> Adds **Detections** and **Findings** to the local endpoint dashboard so teams can browse the active threat-rule set and see scan hits without using the CLI.
> 
> **Backend:** New `GET /api/detections` returns the same active rules as `beacon scan` (store or baseline), mapped to `DetectionView`. `GET /api/findings` runs that rule set over the configured runtime log on each request (optional `session` and `min_severity`), read-only and offline. Logic lives in `dashboard.BuildDetections` and `dashboard.RunScan`.
> 
> **Shared engine:** Severity ordering, filtering, counting for `--fail-on`, and stable sort move into `threatrules` (`SeverityRank`, `FilterBySeverity`, `CountAtOrAbove`, `SortFindings`); `beacon scan` delegates to those helpers instead of duplicating them.
> 
> **UI:** New `detections.html` and `findings.html`, nav links on existing pages, client loaders with periodic refresh, min-severity on findings, and rule deep-links from findings to detection rows via hash. README documents the two screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f086b7f18de7df809559ffe74e184a4cdb4b9fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->