### PR TITLE
Fix dashboard routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: cli/beacon/go.mod
+      - name: Build embedded hooks binary
+        working-directory: cli/beacon
+        # hooks.bin is gitignored (build-time artifact). The CLI embeds it via
+        # //go:embed, so build the real binary for this runner before testing —
+        # a placeholder is not enough (InstallFactory requires a real binary).
+        run: make build-hooks-current
       - name: Test CLI
         working-directory: cli/beacon
         run: go test ./...
@@ -64,7 +70,7 @@ jobs:
       - name: Public CLI command tree smoke test
         working-directory: cli/beacon
         run: |
-          go build -o beacon .
+          make build
           ./beacon --help > /tmp/beacon-help.txt
           ./beacon endpoint --help > /tmp/beacon-endpoint-help.txt
           ./beacon endpoint hooks --help > /tmp/beacon-hooks-help.txt
@@ -124,7 +130,7 @@ jobs:
           sh packaging/macos/test-endpoint-scripts.sh
       - name: Build macOS package skeleton
         run: |
-          (cd cli/beacon && go build -o beacon .)
+          (cd cli/beacon && make build)
           mkdir -p /tmp/beacon-collector
           printf '#!/bin/sh\nexit 0\n' > /tmp/beacon-collector/beacon-otelcol
           chmod +x /tmp/beacon-collector/beacon-otelcol

--- a/cli/beacon/cmd/endpoint_install.go
+++ b/cli/beacon/cmd/endpoint_install.go
@@ -82,7 +82,7 @@ func runEndpointDashboard(cmd *cobra.Command, args []string) error {
 	return dashboard.ListenAndServe(dashboard.Options{
 		Addr:     endpointOpts.dashboardAddr,
 		LogPath:  cfg.LogPath,
-		UserMode: cfg.UserMode,
+		UserMode: userMode,
 	})
 }
 

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -41,6 +41,7 @@ type StatusResponse struct {
 }
 
 func Handler(opts Options) (http.Handler, error) {
+	rulesUserMode := opts.UserMode
 	runtimeLog := lifecycle.ResolveRuntimeLog(opts.UserMode, opts.LogPath)
 	opts.LogPath = runtimeLog.EffectiveLogPath
 	opts.UserMode = runtimeLog.EffectiveUserMode
@@ -125,7 +126,7 @@ func Handler(opts Options) (http.Handler, error) {
 			methodNotAllowed(w)
 			return
 		}
-		resp, err := BuildDetections(opts.UserMode, "")
+		resp, err := BuildDetections(rulesUserMode, "")
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err)
 			return
@@ -138,7 +139,7 @@ func Handler(opts Options) (http.Handler, error) {
 			return
 		}
 		q := r.URL.Query()
-		resp, err := RunScan(opts.UserMode, opts.LogPath, "", q.Get("session"), q.Get("min_severity"))
+		resp, err := RunScan(rulesUserMode, opts.LogPath, "", q.Get("session"), q.Get("min_severity"))
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err)
 			return


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized dashboard API and install-dashboard wiring plus CI build steps; no auth or external data path changes beyond correct rule-store resolution for scans.
> 
> **Overview**
> Fixes **dashboard routing** for threat-rule APIs by keeping the **requested** `UserMode` for `/api/detections` and `/api/findings` while `ResolveRuntimeLog` still updates effective log path and user mode for status and event reads.
> 
> `endpoint dashboard` now passes the pre-resolve `userMode` into `ListenAndServe` instead of `cfg.UserMode` after resolution.
> 
> **CI** adds `make build-hooks-current` before CLI tests (embedded `hooks.bin` is required) and switches smoke/package steps from `go build` to **`make build`** so the same build path is used locally and in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f83cdb992a3aa2a259f4578e42f13347b95b4b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->