### PR TITLE
More dashboard routing fixes

### DIFF
--- a/cli/beacon/cmd/endpoint_install.go
+++ b/cli/beacon/cmd/endpoint_install.go
@@ -56,6 +56,8 @@ var endpointDashboardCmd = &cobra.Command{
 	RunE:         runEndpointDashboard,
 }
 
+var dashboardListenAndServe = dashboard.ListenAndServe
+
 func runEndpointDashboard(cmd *cobra.Command, args []string) error {
 	cfg := loadOrDefaultConfig()
 	userMode := endpointUserMode()
@@ -79,9 +81,9 @@ func runEndpointDashboard(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	return dashboard.ListenAndServe(dashboard.Options{
+	return dashboardListenAndServe(dashboard.Options{
 		Addr:     endpointOpts.dashboardAddr,
-		LogPath:  cfg.LogPath,
+		LogPath:  endpointOpts.logPath,
 		UserMode: userMode,
 	})
 }

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/dashboard"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/diagnostics"
 	endpointinventory "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/inventory"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
@@ -654,6 +655,41 @@ func TestEndpointCommandsDefaultToUserMode(t *testing.T) {
 		if cmd.Flags().Lookup("system") == nil {
 			t.Fatalf("%s missing --system flag", cmd.Use)
 		}
+	}
+}
+
+func TestRunEndpointDashboardPassesRequestedLogPathToHandler(t *testing.T) {
+	oldOpts := endpointOpts
+	oldListen := dashboardListenAndServe
+	t.Cleanup(func() {
+		endpointOpts = oldOpts
+		dashboardListenAndServe = oldListen
+	})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configuredLog := filepath.Join(home, ".beacon", "endpoint", "logs", "runtime.jsonl")
+	if _, err := endpointconfig.Save(endpointconfig.Default(true, configuredLog)); err != nil {
+		t.Fatalf("save endpoint config: %v", err)
+	}
+
+	var got dashboard.Options
+	dashboardListenAndServe = func(opts dashboard.Options) error {
+		got = opts
+		return nil
+	}
+	endpointOpts.userMode = true
+	endpointOpts.systemMode = false
+	endpointOpts.logPath = ""
+	endpointOpts.dashboardAddr = "127.0.0.1:0"
+
+	if err := runEndpointDashboard(nil, nil); err != nil {
+		t.Fatalf("runEndpointDashboard returned error: %v", err)
+	}
+	if got.LogPath != "" {
+		t.Fatalf("dashboard LogPath = %q, want empty requested log path so Handler can resolve runtime source", got.LogPath)
+	}
+	if !got.UserMode {
+		t.Fatal("dashboard UserMode = false, want requested user mode")
 	}
 }
 

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -40,9 +40,16 @@ type StatusResponse struct {
 	Diagnostics interface{}                `json:"diagnostics"`
 }
 
+var (
+	resolveRuntimeLog = lifecycle.ResolveRuntimeLog
+	getEndpointStatus = lifecycle.GetStatus
+)
+
 func Handler(opts Options) (http.Handler, error) {
+	requestedUserMode := opts.UserMode
+	requestedLogPath := opts.LogPath
 	rulesUserMode := opts.UserMode
-	runtimeLog := lifecycle.ResolveRuntimeLog(opts.UserMode, opts.LogPath)
+	runtimeLog := resolveRuntimeLog(requestedUserMode, requestedLogPath)
 	opts.LogPath = runtimeLog.EffectiveLogPath
 	opts.UserMode = runtimeLog.EffectiveUserMode
 	staticRoot, err := fs.Sub(staticFiles, "static")
@@ -55,7 +62,7 @@ func Handler(opts Options) (http.Handler, error) {
 			methodNotAllowed(w)
 			return
 		}
-		status := lifecycle.GetStatus(opts.UserMode, opts.LogPath)
+		status := getEndpointStatus(requestedUserMode, requestedLogPath)
 		writeJSON(w, StatusResponse{
 			Version:     status.Version,
 			ConfigPath:  status.ConfigPath,

--- a/cli/beacon/internal/endpoint/dashboard/server_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/server_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/diagnostics"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/tokens"
 )
 
@@ -36,6 +38,83 @@ func TestStatusUsesExplicitRuntimeLogPath(t *testing.T) {
 	}
 	if status.RuntimeLog.EffectiveLogPath != logPath {
 		t.Fatalf("RuntimeLog.EffectiveLogPath = %q, want %q", status.RuntimeLog.EffectiveLogPath, logPath)
+	}
+}
+
+func TestStatusUsesRequestedRuntimeLogSource(t *testing.T) {
+	oldResolveRuntimeLog := resolveRuntimeLog
+	oldGetEndpointStatus := getEndpointStatus
+	t.Cleanup(func() {
+		resolveRuntimeLog = oldResolveRuntimeLog
+		getEndpointStatus = oldGetEndpointStatus
+	})
+
+	dir := t.TempDir()
+	systemLog := filepath.Join(dir, "system-runtime.jsonl")
+	userLog := filepath.Join(dir, "user-runtime.jsonl")
+	warning := "system collector is writing OTLP events to " + systemLog
+	resolveRuntimeLog = func(userMode bool, logPath string) lifecycle.RuntimeLogSource {
+		if !userMode || logPath != "" {
+			t.Fatalf("ResolveRuntimeLog called with userMode=%t logPath=%q, want requested user mode with empty log path", userMode, logPath)
+		}
+		return lifecycle.RuntimeLogSource{
+			RequestedUserMode: true,
+			EffectiveUserMode: false,
+			RequestedLogPath:  userLog,
+			EffectiveLogPath:  systemLog,
+			Warning:           warning,
+		}
+	}
+	getEndpointStatus = func(userMode bool, logPath string) lifecycle.Status {
+		if !userMode || logPath != "" {
+			t.Fatalf("GetStatus called with userMode=%t logPath=%q, want requested user mode with empty log path", userMode, logPath)
+		}
+		return lifecycle.Status{
+			Version:    "test",
+			ConfigPath: "system-config.json",
+			LogPath:    systemLog,
+			Diagnostics: []diagnostics.Check{{
+				Name:     "runtime_log_source",
+				Status:   "warn",
+				Severity: "medium",
+				Message:  warning,
+			}},
+		}
+	}
+	if err := os.WriteFile(systemLog, []byte(`{"timestamp":"2026-06-11T10:00:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"test","category":"test"},"severity":"info","endpoint":{"os":"darwin"},"message":"system event"}`+"\n"), 0644); err != nil {
+		t.Fatalf("write system log: %v", err)
+	}
+
+	handler, err := Handler(Options{UserMode: true})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var status StatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &status); err != nil {
+		t.Fatalf("unmarshal status response: %v", err)
+	}
+	if status.LogPath != systemLog || status.RuntimeLog.EffectiveLogPath != systemLog || status.RuntimeLog.Warning != warning {
+		t.Fatalf("status runtime log = %#v log_path=%q, want effective system log with warning", status.RuntimeLog, status.LogPath)
+	}
+	if !strings.Contains(rec.Body.String(), "runtime_log_source") {
+		t.Fatalf("status body missing runtime log diagnostic: %s", rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("events status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "system event") {
+		t.Fatalf("events body did not read effective system log: %s", rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Local loopback dashboard behavior only, with targeted tests; no auth or remote ingest changes.
> 
> **Overview**
> Fixes **endpoint dashboard** routing when `ResolveRuntimeLog` redirects user-mode requests to a **system** runtime log (e.g. system collector still writing OTLP).
> 
> `beacon endpoint dashboard` now passes **`endpointOpts.logPath`** (requested) into `dashboard.Options` instead of the already-resolved `cfg.LogPath`, and uses a **`dashboardListenAndServe`** hook for tests. In **`dashboard.Handler`**, **`/api/status`** calls **`GetStatus(requestedUserMode, requestedLogPath)`** while event/summary/token routes keep reading **`opts.LogPath`** after resolution to the **effective** file—so status, diagnostics, and the event stream stay aligned with what the CLI shows.
> 
> Adds tests for the CLI wiring and for status/events when resolution returns a system log with a **`runtime_log_source`** warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e31eb0d5ec332f0acc3cef43b6cfb222943e90e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->