### PR TITLE
Split out agent inventory in dashboard

### DIFF
--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/inventory"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/tokens"
@@ -40,9 +41,22 @@ type StatusResponse struct {
 	Diagnostics interface{}                `json:"diagnostics"`
 }
 
+// InventoryResponse is the richer agent inventory served to the dashboard's
+// dedicated Agent Inventory tab. It combines runtime telemetry detection
+// (harnesses) with the local configuration/MCP-server scan, mirroring the
+// shape of `beacon endpoint inventory --json`.
+type InventoryResponse struct {
+	GeneratedAt string                `json:"generated_at"`
+	UserScope   inventory.UserScope   `json:"user_scope"`
+	Harnesses   interface{}           `json:"harnesses"`
+	Configs     []inventory.Config    `json:"configs"`
+	MCPServers  []inventory.MCPServer `json:"mcp_servers"`
+}
+
 var (
 	resolveRuntimeLog = lifecycle.ResolveRuntimeLog
 	getEndpointStatus = lifecycle.GetStatus
+	scanInventory     = inventory.Scan
 )
 
 func Handler(opts Options) (http.Handler, error) {
@@ -72,6 +86,21 @@ func Handler(opts Options) (http.Handler, error) {
 			Collector:   status.Collector,
 			Service:     status.Service,
 			Diagnostics: status.Diagnostics,
+		})
+	})
+	mux.HandleFunc("/api/inventory", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			methodNotAllowed(w)
+			return
+		}
+		status := getEndpointStatus(requestedUserMode, requestedLogPath)
+		scan := scanInventory(inventory.Options{})
+		writeJSON(w, InventoryResponse{
+			GeneratedAt: scan.GeneratedAt,
+			UserScope:   scan.UserScope,
+			Harnesses:   status.Harnesses,
+			Configs:     scan.Configs,
+			MCPServers:  scan.MCPServers,
 		})
 	})
 	mux.HandleFunc("/api/summary", func(w http.ResponseWriter, r *http.Request) {

--- a/cli/beacon/internal/endpoint/dashboard/server_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/server_test.go
@@ -409,6 +409,76 @@ func TestRunScanRejectsEmptyRuleSet(t *testing.T) {
 	}
 }
 
+func TestInventoryEndpointReturnsConfigsAndMCPServers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// A Claude Code user config declaring one MCP server, which the inventory
+	// scan should discover and surface.
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatalf("mkdir claude config dir: %v", err)
+	}
+	settings := `{"mcpServers":{"local-fs":{"command":"npx","args":["-y","server"],"env":{"FS_ROOT":"/tmp"}}}}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(settings), 0644); err != nil {
+		t.Fatalf("write claude settings: %v", err)
+	}
+
+	handler, err := Handler(Options{UserMode: true, LogPath: filepath.Join(t.TempDir(), "runtime.jsonl")})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/inventory", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var resp InventoryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal inventory response: %v", err)
+	}
+	if resp.GeneratedAt == "" {
+		t.Fatal("expected generated_at to be set")
+	}
+	if resp.UserScope.Mode == "" {
+		t.Fatalf("expected user scope mode, got %#v", resp.UserScope)
+	}
+
+	var claudeConfig *struct {
+		exists bool
+		mcp    int
+	}
+	for _, config := range resp.Configs {
+		if config.Runtime == "claude_code" && config.Scope == "user" && config.Exists {
+			claudeConfig = &struct {
+				exists bool
+				mcp    int
+			}{exists: true, mcp: config.MCPServerCount}
+		}
+	}
+	if claudeConfig == nil {
+		t.Fatalf("expected an existing claude_code user config in %#v", resp.Configs)
+	}
+	if claudeConfig.mcp != 1 {
+		t.Fatalf("claude config mcp_server_count = %d, want 1", claudeConfig.mcp)
+	}
+
+	found := false
+	for _, server := range resp.MCPServers {
+		if server.Runtime == "claude_code" && server.ServerName == "local-fs" {
+			found = true
+			if !server.CommandPresent || server.CommandName != "npx" {
+				t.Fatalf("server command = %#v, want npx command present", server)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected a local-fs MCP server, got %#v", resp.MCPServers)
+	}
+}
+
 func TestStaticDashboardPagesServe(t *testing.T) {
 	handler, err := Handler(Options{UserMode: true, LogPath: filepath.Join(t.TempDir(), "runtime.jsonl")})
 	if err != nil {
@@ -420,10 +490,11 @@ func TestStaticDashboardPagesServe(t *testing.T) {
 		want string
 	}{
 		{path: "/", want: "Beacon Endpoint Log Search"},
-		{path: "/overview.html", want: "Beacon Endpoint Security Overview"},
+		{path: "/overview.html", want: "Beacon Endpoint Security Analytics"},
 		{path: "/tokens.html", want: "Beacon Endpoint Token Usage"},
 		{path: "/detections.html", want: "Beacon Endpoint Detections"},
 		{path: "/findings.html", want: "Beacon Endpoint Findings"},
+		{path: "/inventory.html", want: "Beacon Endpoint Agent Inventory"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.path, func(t *testing.T) {

--- a/cli/beacon/internal/endpoint/dashboard/static/app.js
+++ b/cli/beacon/internal/endpoint/dashboard/static/app.js
@@ -3,11 +3,16 @@ const state = {
   summary: null,
   events: [],
   eventResult: null,
+  inventory: null,
   loading: false,
   error: null,
   currentQuery: "",
   newEventCount: 0,
   lastDetectionHashScroll: "",
+  findings: [],
+  findingsRules: null,
+  findingsSessions: new Map(),
+  findingsExpanded: new Set(),
 };
 
 const $ = (selector) => document.querySelector(selector);
@@ -16,6 +21,7 @@ const isOverviewPage = document.body.dataset.page === "overview";
 const isTokensPage = document.body.dataset.page === "tokens";
 const isDetectionsPage = document.body.dataset.page === "detections";
 const isFindingsPage = document.body.dataset.page === "findings";
+const isInventoryPage = document.body.dataset.page === "inventory";
 const formFields = [
   "q",
   "harness",
@@ -132,7 +138,6 @@ function render() {
   renderCards();
   renderInsights();
   renderSearchState();
-  renderHarnesses();
   renderEvents();
 }
 
@@ -243,22 +248,215 @@ function renderSummaryOnly() {
   renderCards();
   renderInsights();
   renderSearchState();
-  renderHarnesses();
 }
 
-function renderHarnesses() {
-  if (!$("#harnesses")) return;
-  const harnesses = state.status?.harnesses || [];
-  $("#harnesses").innerHTML = harnesses
-    .map((harness) => `
-      <div class="harness">
-        <strong>${escapeHTML(harness.display_name || harness.name || "unknown")}</strong>
-        <p class="muted">detected: ${Boolean(harness.detected)}</p>
-        <p class="muted">telemetry: ${escapeHTML(harness.telemetry_status || "unknown")}</p>
-        <p class="muted">${escapeHTML(harness.message || "")}</p>
+async function loadInventory() {
+  try {
+    const [status, inventory] = await Promise.all([
+      getJSON("/api/status"),
+      getJSON("/api/inventory"),
+    ]);
+    state.status = status;
+    state.inventory = inventory;
+    state.error = null;
+    renderInventory(inventory);
+  } catch (err) {
+    state.error = err;
+    setText("#inventory-meta", `Failed to load inventory: ${err.message}`);
+  }
+}
+
+function renderInventory(resp) {
+  setText("#log-path", state.status?.log_path || "Runtime log unavailable");
+  const harnesses = resp?.harnesses || [];
+  const configs = resp?.configs || [];
+  const servers = resp?.mcp_servers || [];
+  const existingConfigs = configs.filter((config) => config.exists);
+  setText("#inventory-meta", resp?.generated_at ? `Scanned ${formatTime(resp.generated_at)}` : "");
+  renderInventoryCards(harnesses, existingConfigs, servers);
+  renderInventoryHarnesses(harnesses);
+  renderInventoryConfigs(configs);
+  renderInventoryMCP(servers);
+  renderInventoryScope(resp?.user_scope || {});
+}
+
+function renderInventoryCards(harnesses, configs, servers) {
+  if (!$("#inventory-cards")) return;
+  const detected = harnesses.filter((harness) => harness.detected).length;
+  const enabled = harnesses.filter((harness) => harness.telemetry_status === "enabled").length;
+  const managed = configs.filter((config) => config.beacon_managed).length;
+  const cards = [
+    { label: "Detected Runtimes", value: detected, hint: `${harnesses.length} probed` },
+    { label: "Telemetry Enabled", value: enabled, hint: "reporting to Beacon" },
+    { label: "Config Files", value: configs.length, hint: `${managed} Beacon-managed` },
+    { label: "MCP Servers", value: servers.length, hint: "across all configs" },
+  ];
+  $("#inventory-cards").innerHTML = cards
+    .map((card) => `
+      <div class="card">
+        <span class="muted">${escapeHTML(card.label)}</span>
+        <span class="value">${escapeHTML(card.value)}</span>
+        ${card.hint ? `<span class="muted">${escapeHTML(card.hint)}</span>` : ""}
       </div>
     `)
     .join("");
+}
+
+function renderInventoryHarnesses(harnesses) {
+  const el = $("#inventory-harnesses");
+  if (!el) return;
+  if (!harnesses.length) {
+    el.innerHTML = `<p class="muted">No runtimes probed.</p>`;
+    return;
+  }
+  el.innerHTML = harnesses
+    .map((harness) => {
+      const rows = [
+        ["Detected", harness.detected ? "yes" : "no"],
+        ["Telemetry", harness.telemetry_status || "unknown"],
+        ["Capability", harness.capability || ""],
+        ["Version", harness.version || ""],
+        ["Config", harness.config_path || ""],
+        ["Executable", harness.executable_path || ""],
+      ].filter(([, value]) => value !== "");
+      return `
+        <div class="harness ${harness.detected ? "" : "harness-muted"}">
+          <div class="harness-head">
+            <strong>${escapeHTML(harness.display_name || harness.name || "unknown")}</strong>
+            ${telemetryBadge(harness.telemetry_status, harness.detected)}
+          </div>
+          <dl class="harness-meta">
+            ${rows.map(([key, value]) => `<div><dt>${escapeHTML(key)}</dt><dd class="${key === "Config" || key === "Executable" ? "mono" : ""}">${escapeHTML(value)}</dd></div>`).join("")}
+          </dl>
+          ${harness.message ? `<p class="muted">${escapeHTML(harness.message)}</p>` : ""}
+        </div>
+      `;
+    })
+    .join("");
+}
+
+function renderInventoryConfigs(configs) {
+  const tbody = $("#inventory-configs");
+  if (!tbody) return;
+  const showAll = $("#inventory-show-all")?.checked;
+  const rows = (configs || []).filter((config) => showAll || config.exists);
+  if (!rows.length) {
+    tbody.innerHTML = `<tr><td colspan="8" class="muted">No configuration files discovered.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = rows
+    .map((config) => `
+      <tr class="${config.exists ? "" : "row-absent"}">
+        <td>${escapeHTML(runtimeLabel(config.runtime))}</td>
+        <td>${badge(config.scope || "unknown", "badge-muted")}</td>
+        <td>${escapeHTML(configKindLabel(config.config_kind))}</td>
+        <td>${parserBadge(config)}</td>
+        <td>${config.exists ? escapeHTML(config.mcp_server_count ?? 0) : `<span class="muted">-</span>`}</td>
+        <td>${config.beacon_managed ? badge("managed", "badge-ok") : `<span class="muted">no</span>`}</td>
+        <td class="nowrap">${config.modified_at ? escapeHTML(formatTime(config.modified_at)) : `<span class="muted">-</span>`}</td>
+        <td class="mono path-cell">${escapeHTML(config.path || config.path_hash || "")}</td>
+      </tr>
+    `)
+    .join("");
+}
+
+function renderInventoryMCP(servers) {
+  const tbody = $("#inventory-mcp");
+  if (!tbody) return;
+  if (!servers.length) {
+    tbody.innerHTML = `<tr><td colspan="8" class="muted">No MCP servers declared in discovered configs.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = servers
+    .map((server) => `
+      <tr>
+        <td>${escapeHTML(runtimeLabel(server.runtime))}</td>
+        <td>${escapeHTML(server.server_name || server.server_name_hash || "")}</td>
+        <td>${badge(server.source_scope || "unknown", "badge-muted")}</td>
+        <td>${badge(server.transport || "unknown", "badge-muted")}</td>
+        <td class="mono">${server.command_present ? escapeHTML(server.command_name || "yes") : `<span class="muted">-</span>`}</td>
+        <td>${escapeHTML(server.args_count ?? 0)}</td>
+        <td>${envKeysCell(server)}</td>
+        <td class="mono path-cell">${escapeHTML(server.source_path || server.source_path_hash || "")}</td>
+      </tr>
+    `)
+    .join("");
+}
+
+function renderInventoryScope(scope) {
+  const el = $("#inventory-scope");
+  if (!el) return;
+  const rows = [
+    ["Mode", scope.mode || ""],
+    ["Home", scope.home_path || ""],
+    ["Working directory", scope.working_dir || ""],
+  ].filter(([, value]) => value);
+  el.innerHTML = rows.length
+    ? rows.map(([key, value]) => `<div><span class="muted">${escapeHTML(key)}</span><strong class="mono">${escapeHTML(value)}</strong></div>`).join("")
+    : `<p class="muted">No scope information.</p>`;
+}
+
+function telemetryBadge(status, detected) {
+  if (!detected) return badge("not detected", "badge-muted");
+  const classes = {
+    enabled: "badge-ok",
+    disabled: "badge-muted",
+    missing: "badge-warn",
+    misconfigured: "badge-warn",
+  };
+  return badge(status || "unknown", classes[status] || "badge-muted");
+}
+
+function parserBadge(config) {
+  const status = config.parser_status || "unknown";
+  const cls =
+    status === "ok" ? "badge-ok" :
+    status === "not_found" ? "badge-muted" :
+    status === "partial" ? "badge-warn" :
+    "badge-danger";
+  const showReason = config.reason && status !== "ok" && status !== "not_found";
+  return `${badge(status, cls)}${showReason ? `<br /><span class="muted">${escapeHTML(config.reason)}</span>` : ""}`;
+}
+
+function envKeysCell(server) {
+  const keys = server.env_keys || [];
+  const total = server.env_key_count || keys.length;
+  const filtered = Math.max(0, total - keys.length);
+  if (!keys.length) {
+    return filtered ? `<span class="muted">${filtered} filtered</span>` : `<span class="muted">-</span>`;
+  }
+  const chips = keys.map((key) => badge(key, "badge-muted")).join(" ");
+  return chips + (filtered ? ` <span class="muted">+${filtered} filtered</span>` : "");
+}
+
+function runtimeLabel(value) {
+  const labels = {
+    claude_code: "Claude Code",
+    codex_cli: "Codex CLI",
+    cursor: "Cursor",
+    gemini_cli: "Gemini CLI",
+    antigravity_cli: "Antigravity CLI",
+    vscode: "VS Code",
+    factory: "Factory Droid",
+    copilot_cli: "GitHub Copilot CLI",
+    opencode: "opencode",
+    hermes: "Hermes Agent",
+    "devin-cli": "Devin CLI",
+    "devin-desktop": "Devin Desktop",
+    grok: "Grok",
+  };
+  return labels[value] || harnessLabel(value);
+}
+
+function configKindLabel(kind) {
+  const labels = {
+    native_config: "Native config",
+    hook_config: "Hook config",
+    plugin: "Plugin",
+    profile: "Shell profile",
+    managed_config: "Managed config",
+  };
+  return labels[kind] || kind || "unknown";
 }
 
 function renderEvents() {
@@ -941,24 +1139,168 @@ async function loadFindings() {
 
 function renderFindings(resp) {
   const findings = resp?.findings || [];
+  state.findings = findings;
   setText("#findings-meta", `${findings.length} finding${findings.length === 1 ? "" : "s"} across ${resp?.scanned || 0} events`);
   const tbody = $("#findings-rows");
   if (!tbody) return;
   if (!findings.length) {
+    state.findingsExpanded.clear();
     tbody.innerHTML = `<tr><td colspan="5" class="muted">No findings.</td></tr>`;
     return;
   }
   tbody.innerHTML = findings
-    .map((f) => `
-      <tr>
+    .map((f, i) => `
+      <tr class="finding-row row-link" data-finding-row="${i}" aria-expanded="false">
         <td>${badge(f.severity || "unknown", `severity-${f.severity || "unknown"}`)}</td>
-        <td><a class="mono" href="/detections.html#rule-${escapeHTML(f.rule_id)}">${escapeHTML(f.rule_id)}</a><br /><span class="muted">${escapeHTML(f.title || "")}</span></td>
-        <td class="mono">${escapeHTML(f.session_id || "-")}</td>
+        <td><span class="cell-link mono"><span class="cell-link-caret" aria-hidden="true">&#9656;</span>${escapeHTML(f.rule_id)}</span><br /><span class="muted">${escapeHTML(f.title || "")}</span></td>
+        <td><span class="cell-link mono">${escapeHTML(f.session_id || "-")}</span></td>
         <td>${escapeHTML(f.reason || "")}</td>
         <td>${summarizeFindingEvents(f.events)}</td>
       </tr>
     `)
     .join("");
+  $$("#findings-rows [data-finding-row]").forEach((row) => {
+    row.addEventListener("click", () => toggleFinding(Number(row.dataset.findingRow)));
+  });
+  applyFindingExpansions();
+}
+
+function toggleFinding(i) {
+  if (state.findingsExpanded.has(i)) state.findingsExpanded.delete(i);
+  else state.findingsExpanded.add(i);
+  applyFindingExpansions();
+}
+
+// applyFindingExpansions reconciles the inline detail rows with the set of
+// expanded findings. It is idempotent: it removes any stale detail rows, then
+// reinserts one detail row after each expanded finding. Async data loads
+// (rule definitions, session events) call back into it once they resolve.
+function applyFindingExpansions() {
+  const tbody = $("#findings-rows");
+  if (!tbody) return;
+  Array.from(tbody.querySelectorAll(".finding-detail")).forEach((el) => el.remove());
+  Array.from(tbody.querySelectorAll("[data-finding-row]")).forEach((row) => {
+    row.setAttribute("aria-expanded", "false");
+    row.classList.remove("open");
+  });
+  for (const i of state.findingsExpanded) {
+    const row = tbody.querySelector(`tr[data-finding-row="${i}"]`);
+    if (!row) continue;
+    row.setAttribute("aria-expanded", "true");
+    row.classList.add("open");
+    row.insertAdjacentHTML("afterend", `<tr class="finding-detail"><td colspan="5">${findingDetailHTML(i)}</td></tr>`);
+  }
+}
+
+function findingDetailHTML(i) {
+  const f = state.findings[i];
+  if (!f) return "";
+  return `
+    <div class="detail-panel">
+      ${ruleDetailHTML(f.rule_id)}
+      ${sessionDetailHTML(f.session_id)}
+    </div>
+  `;
+}
+
+async function ensureDetectionsCache() {
+  if (state.findingsRules) return state.findingsRules;
+  const resp = await getJSON("/api/detections");
+  const map = {};
+  for (const rule of resp?.rules || []) map[rule.id] = rule;
+  state.findingsRules = map;
+  return map;
+}
+
+function ruleDetailHTML(ruleId) {
+  if (!state.findingsRules) {
+    ensureDetectionsCache().then(applyFindingExpansions).catch(() => {
+      state.findingsRules = {};
+      applyFindingExpansions();
+    });
+    return `<div class="detail-section"><h3>Detection rule</h3><p class="muted">Loading rule definition&hellip;</p></div>`;
+  }
+  const rule = state.findingsRules[ruleId];
+  if (!rule) {
+    return `<div class="detail-section"><h3>Detection rule</h3><p class="muted">No active rule found for <span class="mono">${escapeHTML(ruleId)}</span> — it may have been removed from the active set.</p></div>`;
+  }
+  const rows = [
+    ["Rule", rule.id],
+    ["Title", rule.title],
+    ["Severity", rule.severity],
+    ["Status", rule.status],
+    ["Posture", rule.posture],
+    ["Kind", rule.kind],
+    ["Source", rule.source],
+    ["Reason", rule.reason],
+  ].filter(([, value]) => value);
+  const taxonomy = rule.taxonomy ? Object.entries(rule.taxonomy) : [];
+  return `
+    <div class="detail-section">
+      <h3>Detection rule</h3>
+      <div class="detail-grid">
+        ${rows.map(([label, value]) => `<div><span class="muted">${escapeHTML(label)}</span><strong>${escapeHTML(value)}</strong></div>`).join("")}
+      </div>
+      ${rule.description ? `<p>${escapeHTML(rule.description)}</p>` : ""}
+      ${taxonomy.length ? `<div class="detail-tags">${taxonomy.map(([key, value]) => badge(`${key}: ${value}`, "badge-muted")).join("")}</div>` : ""}
+      <a class="text-button" href="/detections.html#rule-${escapeHTML(rule.id)}">Open in Detections</a>
+    </div>
+  `;
+}
+
+function sessionDetailHTML(sessionId) {
+  if (!sessionId) {
+    return `<div class="detail-section"><h3>Session timeline</h3><p class="muted">This finding is not tied to a single session.</p></div>`;
+  }
+  if (!state.findingsSessions.has(sessionId)) {
+    ensureSessionEvents(sessionId).then(applyFindingExpansions).catch(() => {
+      state.findingsSessions.set(sessionId, []);
+      applyFindingExpansions();
+    });
+    return `<div class="detail-section"><h3>Session timeline</h3><p class="muted">Loading session timeline&hellip;</p></div>`;
+  }
+  const records = state.findingsSessions.get(sessionId);
+  if (!records.length) {
+    return `<div class="detail-section"><h3>Session timeline</h3><p class="muted">No events found for session <span class="mono">${escapeHTML(sessionId)}</span>.</p></div>`;
+  }
+  return `
+    <div class="detail-section">
+      <div class="detail-head">
+        <h3>Session timeline</h3>
+        <span class="muted">${escapeHTML(sessionId)} &middot; ${records.length} event${records.length === 1 ? "" : "s"}</span>
+        <a class="text-button" href="/?session=${encodeURIComponent(sessionId)}">Open in Log Search</a>
+      </div>
+      <ol class="session-timeline">${records.map((record) => sessionTimelineRow(record)).join("")}</ol>
+    </div>
+  `;
+}
+
+async function ensureSessionEvents(sessionId) {
+  if (state.findingsSessions.has(sessionId)) return state.findingsSessions.get(sessionId);
+  const resp = await getJSON(`/api/events?session=${encodeURIComponent(sessionId)}&limit=500`);
+  const records = (resp?.events || []).slice().sort((a, b) => {
+    const at = new Date(a.event?.timestamp || 0).getTime();
+    const bt = new Date(b.event?.timestamp || 0).getTime();
+    return at - bt;
+  });
+  state.findingsSessions.set(sessionId, records);
+  return records;
+}
+
+function sessionTimelineRow(record) {
+  const event = record.event || {};
+  const info = event.event || {};
+  const action = info.action || "event";
+  const severity = event.severity || "unknown";
+  const artifact = primaryArtifact(event) || event.message || "";
+  return `
+    <li>
+      <span class="muted nowrap">${escapeHTML(formatTime(event.timestamp))}</span>
+      ${badge(severity, `severity-${severity}`)}
+      <span class="mono">${escapeHTML(action)}</span>
+      ${artifact ? `<span class="artifact">${escapeHTML(truncateMiddle(artifact, 160))}</span>` : ""}
+    </li>
+  `;
 }
 
 function summarizeFindingEvents(events) {
@@ -985,9 +1327,10 @@ $("#min-severity")?.addEventListener("change", (event) => {
 });
 
 $("#refresh")?.addEventListener("click", () => {
-  const loader = isFindingsPage ? loadFindings : isDetectionsPage ? loadDetections : isTokensPage ? loadTokens : load;
+  const loader = isFindingsPage ? loadFindings : isDetectionsPage ? loadDetections : isTokensPage ? loadTokens : isInventoryPage ? loadInventory : load;
   loader().catch(console.error);
 });
+$("#inventory-show-all")?.addEventListener("change", () => renderInventoryConfigs(state.inventory?.configs || []));
 $("#filters")?.addEventListener("submit", (event) => {
   event.preventDefault();
   load({ updateLocation: true }).catch(console.error);
@@ -1009,6 +1352,9 @@ if (isDetectionsPage) {
 } else if (isTokensPage) {
   loadTokens().catch(console.error);
   setInterval(() => loadTokens().catch(console.error), 15000);
+} else if (isInventoryPage) {
+  loadInventory().catch(console.error);
+  setInterval(() => loadInventory().catch(console.error), 15000);
 } else {
   hydrateFiltersFromURL();
   load().catch(console.error);

--- a/cli/beacon/internal/endpoint/dashboard/static/detections.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/detections.html
@@ -14,10 +14,11 @@
       </div>
       <nav class="nav-toggle" aria-label="Dashboard navigation">
         <a href="/">Log Search</a>
-        <a href="/overview.html">Security Overview</a>
-        <a href="/tokens.html">Token Usage</a>
-        <a class="active" href="/detections.html" aria-current="page">Detections</a>
+        <a href="/overview.html">Security Analytics</a>
         <a href="/findings.html">Findings</a>
+        <a class="active" href="/detections.html" aria-current="page">Detections</a>
+        <a href="/inventory.html">Agent Inventory</a>
+        <a href="/tokens.html">Token Usage</a>
       </nav>
       <button id="refresh">Refresh</button>
     </header>

--- a/cli/beacon/internal/endpoint/dashboard/static/findings.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/findings.html
@@ -14,10 +14,11 @@
       </div>
       <nav class="nav-toggle" aria-label="Dashboard navigation">
         <a href="/">Log Search</a>
-        <a href="/overview.html">Security Overview</a>
-        <a href="/tokens.html">Token Usage</a>
-        <a href="/detections.html">Detections</a>
+        <a href="/overview.html">Security Analytics</a>
         <a class="active" href="/findings.html" aria-current="page">Findings</a>
+        <a href="/detections.html">Detections</a>
+        <a href="/inventory.html">Agent Inventory</a>
+        <a href="/tokens.html">Token Usage</a>
       </nav>
       <button id="refresh">Refresh</button>
     </header>

--- a/cli/beacon/internal/endpoint/dashboard/static/index.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/index.html
@@ -14,10 +14,11 @@
       </div>
       <nav class="nav-toggle" aria-label="Dashboard navigation">
         <a class="active" href="/" aria-current="page">Log Search</a>
-        <a href="/overview.html">Security Overview</a>
-        <a href="/tokens.html">Token Usage</a>
-        <a href="/detections.html">Detections</a>
+        <a href="/overview.html">Security Analytics</a>
         <a href="/findings.html">Findings</a>
+        <a href="/detections.html">Detections</a>
+        <a href="/inventory.html">Agent Inventory</a>
+        <a href="/tokens.html">Token Usage</a>
       </nav>
       <button id="refresh">Refresh</button>
     </header>
@@ -156,9 +157,8 @@
             <h2>Endpoint Diagnostics</h2>
             <p id="log-path" class="muted">Loading runtime log...</p>
           </div>
+          <a class="docs-link" href="/inventory.html">View agent inventory &rarr;</a>
         </div>
-        <h2 class="subsection-title">Runtime Inventory</h2>
-        <div id="harnesses" class="harnesses"></div>
       </section>
     </main>
 

--- a/cli/beacon/internal/endpoint/dashboard/static/inventory.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/inventory.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Beacon Endpoint Agent Inventory</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body data-page="inventory">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Local-only</p>
+        <h1>Beacon Endpoint Agent Inventory</h1>
+      </div>
+      <nav class="nav-toggle" aria-label="Dashboard navigation">
+        <a href="/">Log Search</a>
+        <a href="/overview.html">Security Analytics</a>
+        <a href="/findings.html">Findings</a>
+        <a href="/detections.html">Detections</a>
+        <a class="active" href="/inventory.html" aria-current="page">Agent Inventory</a>
+        <a href="/tokens.html">Token Usage</a>
+      </nav>
+      <button id="refresh">Refresh</button>
+    </header>
+
+    <main>
+      <section class="panel status-panel">
+        <div>
+          <h2>Endpoint</h2>
+          <p id="log-path" class="muted">Loading runtime log...</p>
+        </div>
+        <div id="inventory-meta" class="muted"></div>
+      </section>
+
+      <section>
+        <div class="section-head overview-head">
+          <div>
+            <h2>Inventory at a Glance</h2>
+            <p class="muted">Local discovery of installed AI agent runtimes, their telemetry posture, configuration files, and MCP servers. Read-only and offline.</p>
+          </div>
+        </div>
+        <div class="cards" id="inventory-cards"></div>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
+          <div>
+            <h2>Agent Runtimes</h2>
+            <p class="muted">Every supported runtime Beacon probes for, with detection and telemetry status.</p>
+          </div>
+        </div>
+        <div id="inventory-harnesses" class="harnesses"></div>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
+          <div>
+            <h2>Discovered Configurations</h2>
+            <p class="muted">Config, hook, plugin, and profile files found on this endpoint. Paths and hashes only &mdash; file contents are never read into the dashboard.</p>
+          </div>
+          <label class="inline-toggle">
+            <input type="checkbox" id="inventory-show-all" />
+            <span>Show probed paths not found</span>
+          </label>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Runtime</th>
+                <th>Scope</th>
+                <th>Kind</th>
+                <th>Parser</th>
+                <th>MCP</th>
+                <th>Beacon Managed</th>
+                <th>Modified</th>
+                <th>Path</th>
+              </tr>
+            </thead>
+            <tbody id="inventory-configs"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
+          <div>
+            <h2>MCP Servers</h2>
+            <p class="muted">Model Context Protocol servers declared across discovered runtime configs. Secret-bearing env keys are filtered out.</p>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Runtime</th>
+                <th>Server</th>
+                <th>Scope</th>
+                <th>Transport</th>
+                <th>Command</th>
+                <th>Args</th>
+                <th>Env Keys</th>
+                <th>Source</th>
+              </tr>
+            </thead>
+            <tbody id="inventory-mcp"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Scan Scope</h2>
+        <div id="inventory-scope" class="scope-grid"></div>
+      </section>
+    </main>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/cli/beacon/internal/endpoint/dashboard/static/overview.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/overview.html
@@ -3,21 +3,22 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Beacon Endpoint Security Overview</title>
+    <title>Beacon Endpoint Security Analytics</title>
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body data-page="overview">
     <header class="topbar">
       <div>
         <p class="eyebrow">Local-only</p>
-        <h1>Beacon Endpoint Security Overview</h1>
+        <h1>Beacon Endpoint Security Analytics</h1>
       </div>
       <nav class="nav-toggle" aria-label="Dashboard navigation">
         <a href="/">Log Search</a>
-        <a class="active" href="/overview.html" aria-current="page">Security Overview</a>
-        <a href="/tokens.html">Token Usage</a>
-        <a href="/detections.html">Detections</a>
+        <a class="active" href="/overview.html" aria-current="page">Security Analytics</a>
         <a href="/findings.html">Findings</a>
+        <a href="/detections.html">Detections</a>
+        <a href="/inventory.html">Agent Inventory</a>
+        <a href="/tokens.html">Token Usage</a>
       </nav>
       <button id="refresh">Refresh</button>
     </header>
@@ -42,11 +43,6 @@
       </section>
 
       <section class="insights" id="insights"></section>
-
-      <section class="panel">
-        <h2>Runtime Inventory</h2>
-        <div id="harnesses" class="harnesses"></div>
-      </section>
     </main>
 
     <script src="/app.js"></script>

--- a/cli/beacon/internal/endpoint/dashboard/static/styles.css
+++ b/cli/beacon/internal/endpoint/dashboard/static/styles.css
@@ -624,3 +624,188 @@ pre {
 .row-link:hover {
   background: rgba(125, 211, 252, 0.08);
 }
+
+/* Findings: rule + session render as affordances; the whole row toggles an
+   inline detail panel showing the rule definition and session timeline. */
+.cell-link {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
+.finding-row:hover .cell-link {
+  text-decoration-style: solid;
+}
+
+.cell-link-caret {
+  display: inline-block;
+  font-size: 0.7em;
+  transition: transform 120ms ease;
+}
+
+.finding-row.open .cell-link-caret {
+  transform: rotate(90deg);
+}
+
+.finding-detail,
+.finding-detail > td {
+  cursor: default;
+  background: var(--panel-soft);
+}
+
+.finding-detail:hover {
+  background: var(--panel-soft);
+}
+
+.detail-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0.4rem 0.2rem;
+}
+
+.detail-section h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.5rem 1.25rem;
+}
+
+.detail-grid > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.detail-head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.detail-head h3 {
+  margin: 0;
+}
+
+.detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.session-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.session-timeline li {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.badge-ok {
+  color: var(--ok);
+  border-color: #a7f3d0;
+  background: #ecfdf5;
+}
+
+.harness-muted {
+  opacity: 0.72;
+}
+
+.harness-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.6rem;
+}
+
+.harness-meta {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0;
+}
+
+.harness-meta > div {
+  display: grid;
+  grid-template-columns: 6.5rem 1fr;
+  gap: 0.5rem;
+  align-items: baseline;
+  min-width: 0;
+}
+
+.harness-meta dt {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.harness-meta dd {
+  margin: 0;
+  font-size: 0.85rem;
+  overflow-wrap: anywhere;
+}
+
+.inline-toggle {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+}
+
+.inline-toggle input {
+  padding: 0;
+  width: auto;
+}
+
+.inline-toggle span {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 500;
+  font-size: 0.85rem;
+}
+
+.row-absent {
+  opacity: 0.6;
+}
+
+.path-cell {
+  max-width: 26rem;
+}
+
+.scope-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.scope-grid > div {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.scope-grid strong {
+  overflow-wrap: anywhere;
+}

--- a/cli/beacon/internal/endpoint/dashboard/static/tokens.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/tokens.html
@@ -14,10 +14,11 @@
       </div>
       <nav class="nav-toggle" aria-label="Dashboard navigation">
         <a href="/">Log Search</a>
-        <a href="/overview.html">Security Overview</a>
-        <a class="active" href="/tokens.html" aria-current="page">Token Usage</a>
-        <a href="/detections.html">Detections</a>
+        <a href="/overview.html">Security Analytics</a>
         <a href="/findings.html">Findings</a>
+        <a href="/detections.html">Detections</a>
+        <a href="/inventory.html">Agent Inventory</a>
+        <a class="active" href="/tokens.html" aria-current="page">Token Usage</a>
       </nav>
       <button id="refresh">Refresh</button>
     </header>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Local loopback dashboard UI and a read-only inventory API; no auth or remote exposure changes. Inventory surfaces local config paths and MCP metadata as intended for endpoint operators.
> 
> **Overview**
> Adds a dedicated **Agent Inventory** experience to the local endpoint dashboard, backed by a new **`GET /api/inventory`** that merges runtime harness telemetry with the existing **`inventory.Scan`** output (configs, MCP servers, user scope)—aligned with **`beacon endpoint inventory --json`**.
> 
> The new **`inventory.html`** page renders summary cards, runtime probes, config and MCP tables (with optional “show probed paths not found”), and scan scope. **Log Search** and **Security Analytics** no longer embed the harness list; they link to inventory instead. Nav labels are updated (**Security Overview** → **Security Analytics**) and **Agent Inventory** is added across pages.
> 
> **Findings** gains expandable rows: inline panels load detection rule metadata and a per-session event timeline (with links to Detections and Log Search). Styling covers inventory harness cards and finding detail panels. Tests cover **`/api/inventory`** discovery and static serving of **`inventory.html`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac38530ef6638646dc29e74e0fe70b434682a55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->