### PR TITLE
Clean up threat rule descriptions

### DIFF
--- a/rules/context-exfiltration/browser-session-read-then-egress.rule.yaml
+++ b/rules/context-exfiltration/browser-session-read-then-egress.rule.yaml
@@ -8,7 +8,7 @@ description: >
   cookies.sqlite / logins.json by name, or the ambiguous basenames cookies / "login
   data" only inside a known browser profile directory (Chrome/Chromium/Brave/Edge/
   Firefox/Safari, including their real on-disk dir names) so a project file named
-  "cookies" does not trip it. Ported from blastradius saas_session_hijack.
+  "cookies" does not trip it.
 severity: high
 status: stable
 posture: detect

--- a/rules/context-exfiltration/dns-tunnel-exfiltration.rule.yaml
+++ b/rules/context-exfiltration/dns-tunnel-exfiltration.rule.yaml
@@ -6,9 +6,7 @@ description: >
   leading label is an abnormally long alphanumeric/hex string — the canonical shape
   of DNS-tunnel data exfiltration, where stolen bytes are hex/base32-encoded into a
   subdomain and leaked via a recursive resolver even when direct HTTP egress is
-  blocked. Derived from the blastradius egress reachability surface
-  (src/probes/egress.rs), which notes DNS resolution succeeds independently of
-  filtered HTTP egress.
+  blocked, because DNS resolution succeeds independently of filtered HTTP egress.
 severity: high
 status: stable
 posture: detect

--- a/rules/context-exfiltration/env-dump-piped-to-network.rule.yaml
+++ b/rules/context-exfiltration/env-dump-piped-to-network.rule.yaml
@@ -6,9 +6,7 @@ description: >
   `export -p`) and pipes it into an outbound network sender (curl/wget data body,
   netcat, or a /dev/tcp redirect). The environment of an agent runtime commonly
   holds API keys, cloud credentials, and tokens, so streaming it straight to the
-  network is a high-signal credential-exfiltration shape. Grounded in the
-  blastradius egress surface where filtered HTTP egress and DNS/LAN paths can still
-  carry leaked secrets (src/probes/egress.rs).
+  network is a high-signal credential-exfiltration shape.
 severity: critical
 status: stable
 posture: detect

--- a/rules/context-exfiltration/git-bundle-then-egress.rule.yaml
+++ b/rules/context-exfiltration/git-bundle-then-egress.rule.yaml
@@ -7,8 +7,6 @@ description: >
   (curl/wget body, scp/rsync to a remote, or netcat). A bundle is a complete,
   portable copy of a repo's objects and history, so bundling followed by egress is
   a clean whole-repository exfiltration shape that evades per-file read heuristics.
-  Extends the blastradius egress-mediation residual-exfil concern
-  (src/probes/egress_mediation.rs) to source-tree theft.
 severity: high
 status: stable
 posture: detect

--- a/rules/context-exfiltration/secret-read-then-external-mcp.rule.yaml
+++ b/rules/context-exfiltration/secret-read-then-external-mcp.rule.yaml
@@ -6,9 +6,9 @@ description: >
   tool on a non-local MCP server — a read-then-handoff exfiltration path where the
   egress is the MCP transport rather than a shell command. The secret-read step
   excludes .pub public keys; the MCP step anchors the local-server tokens at both ends
-  so a look-alike host (localhost-evil.attacker.com) still fires. Complements
-  secret-read-then-egress; ported from blastradius exfiltration_path with the
-  external_mcp_call egress leg.
+  so a look-alike host (localhost-evil.attacker.com) still fires. Complements the
+  secret-read-then-egress rule, covering the case where the egress leg is an
+  external MCP call rather than a shell command.
 severity: high
 status: stable
 posture: detect

--- a/rules/context-exfiltration/upload-to-paste-transfer-site.rule.yaml
+++ b/rules/context-exfiltration/upload-to-paste-transfer-site.rule.yaml
@@ -7,9 +7,8 @@ description: >
   ngrok, bashupload, termbin, gofile, catbox, oshi.at). These hosts are common
   exfiltration channels because they accept anonymous uploads to attacker-readable
   URLs and bypass curl-to-arbitrary-host heuristics by targeting a "legitimate"
-  domain. Complements the blastradius egress-mediation note that hostname-only
-  allowlists leave exfil to an allowed domain residual
-  (src/probes/egress_mediation.rs).
+  domain. Hostname-only allowlists do not stop this, since the destination is an
+  otherwise-allowed domain.
 severity: high
 status: stable
 posture: detect

--- a/rules/credential-access/browser-session-store-read.rule.yaml
+++ b/rules/credential-access/browser-session-store-read.rule.yaml
@@ -7,8 +7,7 @@ description: >
   known browser profile directory — Chrome/Chromium/Brave/Edge/Firefox/Safari). These
   carry live session material that can hijack a SaaS session past password + MFA. The
   browser-dir requirement keeps a non-browser file named "cookies" from firing, and
-  matches the read step of the browser-session-read-then-egress correlation. Ported
-  from blastradius is_browser_session_path.
+  matches the read step of the browser-session-read-then-egress correlation.
 severity: high
 status: stable
 posture: detect

--- a/rules/credential-access/credential-file-read.rule.yaml
+++ b/rules/credential-access/credential-file-read.rule.yaml
@@ -4,9 +4,8 @@ title: Agent read a credential-bearing file
 description: >
   The agent read a concrete secret artifact — cloud credentials, an SSH private
   key, a dotenv file, a git credential store, .netrc/.pgpass, or a generic
-  credentials file. Ported from blastradius `is_secret_store_path` (§24.3.1): the
-  secret-bearing member only (e.g. ~/.aws/credentials not ~/.aws/config, id_rsa
-  not id_rsa.pub).
+  credentials file. It matches the secret-bearing member only (e.g.
+  ~/.aws/credentials not ~/.aws/config, id_rsa not id_rsa.pub).
 severity: high
 status: stable
 posture: detect

--- a/rules/credential-access/env-secret-enumeration.rule.yaml
+++ b/rules/credential-access/env-secret-enumeration.rule.yaml
@@ -5,9 +5,7 @@ description: >
   A command lists the process environment (env / printenv / `set`) and pipes it
   into a grep/filter for credential-shaped names (TOKEN, SECRET, KEY, PASSWORD,
   API_KEY, ACCESS_KEY). This is the classic agent secret-enumeration shape:
-  harvesting live credential env vars rather than reading a file. Derived from
-  blastradius env_scrub.rs, which tracks the curated credential names (GITHUB_TOKEN,
-  NPM_TOKEN, OPENAI_API_KEY, ...) that flow unscrubbed into subprocess environments.
+  harvesting live credential env vars rather than reading a file.
 severity: high
 status: stable
 posture: detect

--- a/rules/credential-access/process-table-secret-scrape.rule.yaml
+++ b/rules/credential-access/process-table-secret-scrape.rule.yaml
@@ -6,8 +6,7 @@ description: >
   /proc/*/cmdline and filters it for credential-shaped flags or names (--password,
   --token, --api-key, SECRET, PASSWORD). Secrets passed as CLI args are visible to
   every same-uid process; scraping the process table harvests them without touching
-  disk. Ported from blastradius process_introspect.rs cmdline_finding, which counts
-  same-uid processes exposing secret-shaped command-line arguments via /proc/*/cmdline.
+  disk.
 severity: high
 status: stable
 posture: detect

--- a/rules/credential-access/shell-history-secret-scan.rule.yaml
+++ b/rules/credential-access/shell-history-secret-scan.rule.yaml
@@ -6,8 +6,7 @@ description: >
   fish_history) — either dumping it whole (cat/less/tail) or grepping it for
   credential-shaped names. Shell history persists secrets passed as inline command
   arguments; an agent scraping it can recover tokens, passwords, and credential
-  URLs. Ported from blastradius shell_history.rs, which counts secret-looking lines
-  across exactly these history files.
+  URLs.
 severity: high
 status: stable
 posture: detect

--- a/rules/credential-access/ssh-agent-key-enumeration.rule.yaml
+++ b/rules/credential-access/ssh-agent-key-enumeration.rule.yaml
@@ -5,9 +5,7 @@ description: >
   A command lists the private keys loaded in the running ssh-agent (`ssh-add -l`
   / `ssh-add -L`) or sets SSH_AUTH_SOCK to probe an agent socket. The agent holds
   decrypted private keys in memory; enumerating them is a reconnaissance step
-  toward using them for lateral movement. Derived from blastradius
-  process_introspect.rs, which flags that same-uid code can reach ssh-agent
-  in-memory keys when ptrace_scope is unrestricted.
+  toward using them for lateral movement.
 severity: medium
 status: stable
 posture: detect

--- a/rules/external-access/external-mcp-tool-call.rule.yaml
+++ b/rules/external-access/external-mcp-tool-call.rule.yaml
@@ -6,8 +6,7 @@ description: >
   loopback, a unix socket, or stdio). External MCP servers are an egress and
   data-handoff path that the operator may not have vetted. The local-server check uses
   exact matches for local/localhost/::1 (so a look-alike host such as localhost.evil.com
-  is still flagged) and prefix matches for stdio/unix:/local:/127. Ported from
-  blastradius is_local_mcp_server / external_mcp_call.
+  is still flagged) and prefix matches for stdio/unix:/local:/127.
 severity: low
 status: stable
 posture: detect

--- a/rules/prompt-injection/invisible-character-prompt-injection.rule.yaml
+++ b/rules/prompt-injection/invisible-character-prompt-injection.rule.yaml
@@ -6,9 +6,8 @@ description: >
   past human review — Unicode Tag characters (U+E0000–U+E007F, the "ASCII smuggling"
   range), bidirectional overrides (U+202A–U+202E / U+2066–U+2069), or zero-width
   spacing (ZWSP, word joiner, BOM). Legitimate prompts almost never contain these.
-  Inspired by the encoded/obfuscated prompt-injection family in the ATR corpus
-  (github.com/Agent-Threat-Rule/agent-threat-rules); OWASP LLM01. The zero-width
-  joiner/non-joiner used by emoji and some scripts are intentionally excluded.
+  The zero-width joiner/non-joiner used by emoji and some scripts are intentionally
+  excluded.
 severity: high
 status: stable
 posture: detect

--- a/rules/risky-command/base64-decode-piped-to-shell.rule.yaml
+++ b/rules/risky-command/base64-decode-piped-to-shell.rule.yaml
@@ -4,8 +4,7 @@ title: Base64-decoded payload piped into a shell
 description: >
   A command base64-decodes content and pipes it straight into a shell — the classic
   obfuscated remote-code-execution shape that hides the payload from a casual review.
-  Combines blastradius DangerousCategory::Base64Decode with the pipe-to-shell shape;
-  the pipe-to-shell match is case-insensitive so an uppercase shell name cannot evade.
+  The pipe-to-shell match is case-insensitive so an uppercase shell name cannot evade.
 severity: high
 status: stable
 posture: detect

--- a/rules/risky-command/path-injection-into-login-file.rule.yaml
+++ b/rules/risky-command/path-injection-into-login-file.rule.yaml
@@ -7,9 +7,7 @@ description: >
   appending `set -gx PATH ...` to fish config, or a drop-in under /etc/profile.d).
   Prepending an attacker-controlled directory to PATH in a file that is sourced on
   every new shell or login is durable persistence and a binary-shadowing primitive
-  that runs outside any agent sandbox with no further prompt. Derived from
-  blastradius host.deferred_exec_sinks / write_reach login-dotfile surface
-  (the "adding to PATH" persistence vector).
+  that runs outside any agent sandbox with no further prompt.
 severity: high
 status: stable
 posture: detect

--- a/rules/risky-command/persistence-install-command.rule.yaml
+++ b/rules/risky-command/persistence-install-command.rule.yaml
@@ -6,8 +6,7 @@ description: >
   boot, or on a schedule: editing the user/root crontab (crontab -, crontab a
   file), enabling a systemd service or timer (systemctl enable / --user enable),
   or loading a launchd agent/daemon (launchctl load / bootstrap / enable). These
-  survive the session and re-execute later with no further prompt. Ported from
-  blastradius host.autostart_sinks / deferred_exec_sinks scheduled-job surface.
+  survive the session and re-execute later with no further prompt.
 severity: high
 status: stable
 posture: detect

--- a/rules/risky-command/privileged-container-run.rule.yaml
+++ b/rules/risky-command/privileged-container-run.rule.yaml
@@ -8,7 +8,7 @@ description: >
   bind mount (-v /:...), a kernel capability add (--cap-add), or a mount of the docker
   socket. The docker/podman token is anchored to command/segment start (allowing a
   flagged sudo, env, or VAR=value prefix) so it is not matched inside an unrelated
-  commit message. Ported from blastradius container-runtime / post_root_host_visibility.
+  commit message.
 severity: high
 status: stable
 posture: detect

--- a/rules/risky-command/root-equivalent-group-add.rule.yaml
+++ b/rules/risky-command/root-equivalent-group-add.rule.yaml
@@ -8,8 +8,7 @@ description: >
   is done with usermod -aG, gpasswd -a, adduser <user> <group>, or by writing the
   group into /etc/group. Membership in any of these is a standing path to root.
   The group token is required so unrelated usermod calls (e.g. changing a shell) do
-  not match. Ported from blastradius host.privilege_escalation ROOT_EQUIVALENT_GROUPS
-  and ADMIN_GROUPS.
+  not match.
 severity: high
 status: stable
 posture: detect

--- a/rules/risky-command/setuid-or-root-shell-escalation.rule.yaml
+++ b/rules/risky-command/setuid-or-root-shell-escalation.rule.yaml
@@ -8,8 +8,7 @@ description: >
   `su - root` / `su root` / `su -` or `pkexec` (polkit). Setuid root binaries and
   pkexec are classic local-privilege-escalation primitives. The setuid mode is
   anchored to the chmod command position, and su is required to target root so that
-  `su someuser` does not match. Ported from blastradius host.privilege_escalation
-  (pkexec presence) and the setuid/setgid escalation surface.
+  `su someuser` does not match.
 severity: high
 status: stable
 posture: detect

--- a/rules/risky-command/shell-escape-via-interactive-tool.rule.yaml
+++ b/rules/risky-command/shell-escape-via-interactive-tool.rule.yaml
@@ -6,8 +6,7 @@ description: >
   BEGIN{system()}, perl exec/system of a shell, python pty.spawn, an editor
   (vim -c :!/:shell), find -exec sh, a tar checkpoint action, or ssh ProxyCommand. In
   a sandboxed or restricted-shell context these break out to arbitrary command
-  execution. Inspired by the ATR privilege-escalation "shell escape" category
-  (GTFObins); OWASP LLM06.
+  execution.
 severity: medium
 status: stable
 posture: detect

--- a/rules/risky-command/sudoers-nopasswd-tampering.rule.yaml
+++ b/rules/risky-command/sudoers-nopasswd-tampering.rule.yaml
@@ -7,8 +7,7 @@ description: >
   non-interactive listing (sudo -n -l). Any of these establishes or confirms a path
   to root that bypasses the password prompt. The match requires an actual write, a
   NOPASSWD grant token, a visudo invocation, or the non-interactive sudo listing
-  probe rather than incidental mentions of "sudo". Ported from blastradius
-  host.privilege_escalation (passwordless sudo via `sudo -n -l` and NOPASSWD).
+  probe rather than incidental mentions of "sudo".
 severity: high
 status: stable
 posture: detect

--- a/rules/risky-command/world-writable-chmod.rule.yaml
+++ b/rules/risky-command/world-writable-chmod.rule.yaml
@@ -6,8 +6,7 @@ description: >
   (via + or =) that grants write to other or all (e.g. o+w, a+rwx, a=rwx, o=rwx,
   ugo+rwx). Owner- or group-only grants (u+w, g=rw) are intentionally excluded because
   they are not world-writable. chmod is anchored to the acting command position so it
-  is not matched as an argument to another program. Ported from blastradius
-  DangerousCategory::WorldWritableChmod, broadened to the = symbolic form.
+  is not matched as an argument to another program.
 severity: medium
 status: stable
 posture: detect

--- a/rules/sensitive-edit/agent-control-surface-modified.rule.yaml
+++ b/rules/sensitive-edit/agent-control-surface-modified.rule.yaml
@@ -6,8 +6,7 @@ description: >
   Code settings file (.claude/settings.json, .claude/settings.local.json,
   .claude.json) or an MCP server registration (.mcp.json). Writing these can
   disable the sandbox, add an excludedCommands entry, register a hook, or wire in
-  a new MCP server that runs on every future session. Ported from blastradius
-  claude_code.writable_control_surface (control-kind targets).
+  a new MCP server that runs on every future session.
 severity: high
 status: stable
 posture: detect

--- a/rules/sensitive-edit/agent-instruction-surface-modified.rule.yaml
+++ b/rules/sensitive-edit/agent-instruction-surface-modified.rule.yaml
@@ -6,8 +6,7 @@ description: >
   session: a CLAUDE.md or AGENTS.md guidance file, or an entry under .claude/skills,
   .claude/commands, or .claude/agents. Writing these is durable prompt-injection
   persistence — instructions planted here ride along on later runs with no further
-  prompt. Ported from blastradius claude_code.writable_control_surface
-  (instruction-kind targets).
+  prompt.
 severity: high
 status: stable
 posture: detect

--- a/rules/sensitive-edit/auth-security-code-modified.rule.yaml
+++ b/rules/sensitive-edit/auth-security-code-modified.rule.yaml
@@ -5,13 +5,10 @@ description: >
   The agent modified a source file in the auth / payment / security surface (basename
   containing auth, login, session, password, payment, billing, charge, stripe, checkout,
   security, crypto, token, oauth, jwt, rbac, permission, credential). Changes here carry
-  outsized risk and warrant review. Ported from blastradius
-  is_auth_payment_security_path; documentation (.md/.txt), lockfiles, CI workflow
+  outsized risk and warrant review. Documentation (.md/.txt), lockfiles, CI workflow
   manifests, and credential stores (credentials.json/.toml — covered by
   credential-file-read) are excluded so they are not double-counted. Keyword matching
-  is substring-based (faithful to the ported source), so a basename that embeds a
-  keyword (e.g. tokenizer) may match; the 3-char `acl` needle was dropped because it
-  false-matched unrelated words (oracle, miracle).
+  is substring-based, so a basename that embeds a keyword (e.g. tokenizer) may match.
 severity: medium
 status: stable
 posture: detect

--- a/rules/sensitive-edit/autostart-unit-file-installed.rule.yaml
+++ b/rules/sensitive-edit/autostart-unit-file-installed.rule.yaml
@@ -8,9 +8,8 @@ description: >
   a launchd property list under a LaunchAgents/LaunchDaemons directory
   (*.plist), an XDG autostart entry (~/.config/autostart/*.desktop), or an
   environment.d generator (~/.config/environment.d/*.conf). Planting one of these
-  is durable host persistence triggered with no further prompt. Derived from
-  blastradius host.autostart_sinks (the file-write counterpart of the
-  systemctl/launchctl command rule).
+  is durable host persistence triggered with no further prompt. This is the
+  file-write counterpart of the systemctl/launchctl command rule.
 severity: high
 status: stable
 posture: detect

--- a/rules/sensitive-edit/cicd-pipeline-file-modified.rule.yaml
+++ b/rules/sensitive-edit/cicd-pipeline-file-modified.rule.yaml
@@ -6,8 +6,7 @@ description: >
   GitLab CI, CircleCI, k8s/kustomize manifest, fly.toml, vercel.json, render.yaml).
   These run with deploy/push privileges, so an edit here can reach production or
   inject a build-time step. The k8s/kubernetes/.circleci directory branch matches at
-  repo root or nested. Ported from blastradius is_deploy_path
-  (modified_production_deploy / production_deployment_path).
+  repo root or nested.
 severity: medium
 status: stable
 posture: detect

--- a/rules/sensitive-edit/dependency-manifest-modified.rule.yaml
+++ b/rules/sensitive-edit/dependency-manifest-modified.rule.yaml
@@ -5,7 +5,7 @@ description: >
   The agent modified a dependency manifest or lockfile (package.json, lockfiles,
   Cargo.toml, requirements.txt, go.mod, Gemfile, composer.json, …). A changed
   dependency edge is a supply-chain insertion point — a malicious or typosquatted
-  package can run install-time code. Ported from blastradius is_dependency_manifest_path.
+  package can run install-time code.
 severity: medium
 status: stable
 posture: detect

--- a/rules/sensitive-edit/direnv-envrc-modified.rule.yaml
+++ b/rules/sensitive-edit/direnv-envrc-modified.rule.yaml
@@ -7,8 +7,6 @@ description: >
   time a developer cd's into the directory (or an editor/terminal opens it),
   outside any agent sandbox and with no further prompt. An injected command,
   export, or PATH manipulation here is durable, ambient-triggered code execution.
-  Derived from blastradius host.deferred_exec_sinks (.envrc deferred-execution
-  sink).
 severity: high
 status: stable
 posture: detect

--- a/rules/sensitive-edit/shell-login-dotfile-modified.rule.yaml
+++ b/rules/sensitive-edit/shell-login-dotfile-modified.rule.yaml
@@ -6,8 +6,7 @@ description: >
   .profile, .zshrc, .zprofile, .zshenv, .kshrc, .login, or fish config.fish).
   These run on every new shell or login session, outside any agent sandbox, so an
   edit here is durable user-level persistence (e.g. an injected command, alias, or
-  PATH change). Ported from blastradius host.deferred_exec_sinks / write_reach
-  login-dotfile surface.
+  PATH change).
 severity: high
 status: stable
 posture: detect

--- a/rules/source-control/git-config-exec-injection.rule.yaml
+++ b/rules/source-control/git-config-exec-injection.rule.yaml
@@ -7,8 +7,7 @@ description: >
   the true/false boolean), a content filter (clean/smudge/process), or a shell-escape
   alias (alias.<name>=!...). Matches the `git config ...` and inline `git -c key=`
   set forms and excludes read subcommands (--get/--unset/--list/...), so a directive
-  name appearing in a commit message, a path, or a read does not fire. Ported from
-  blastradius git_config dangerous-directive probe.
+  name appearing in a commit message, a path, or a read does not fire.
 severity: high
 status: stable
 posture: detect

--- a/rules/source-control/git-hook-installed.rule.yaml
+++ b/rules/source-control/git-hook-installed.rule.yaml
@@ -6,8 +6,7 @@ description: >
   pre-push, post-merge, prepare-commit-msg, etc.). Git hooks execute on the next
   matching git operation, outside any agent sandbox and with no further prompt, so
   planting one is durable code-execution persistence triggered by ordinary
-  developer git activity. Derived from blastradius deferred-execution sink
-  analysis (.git/hooks).
+  developer git activity.
 severity: high
 status: stable
 posture: detect

--- a/rules/source-control/git-remote-tampering.rule.yaml
+++ b/rules/source-control/git-remote-tampering.rule.yaml
@@ -8,7 +8,6 @@ description: >
   code to an attacker-controlled destination or overwrite remote history. Every clause
   is git-anchored to a command boundary and kept within one command segment, so a
   benign mention, a `grep insteadOf`, or a read-only `git config --get` does not fire.
-  Ported from blastradius is_git_write_shape (source_control_mutation_path).
 severity: high
 status: stable
 posture: detect


### PR DESCRIPTION
## Summary

Cleans up the `description` field of all 34 threat rule files so each is self-contained, clear, and focused on what the rule detects and how it scopes matches — for both human and machine readers.

- Removed source-attribution / porting references from descriptions: `blastradius` probe names (`is_secret_store_path`, `host.privilege_escalation`, etc.), Rust file paths (`egress.rs`, `process_introspect.rs`), section numbers (`§24.3.1`), and the ATR corpus / `Agent-Threat-Rule` repo link.
- Where a porting sentence carried real context, rephrased it as a plain statement rather than dropping the information (e.g. the autostart rule now notes it is "the file-write counterpart of the systemctl/launchctl command rule"; the DNS-tunnel rule folds "DNS resolution succeeds independently of filtered HTTP egress" into the main sentence).
- Preserved the useful behavioral notes — scoping/exclusion details, look-alike-host handling, and cross-references to companion rules.

Left intentionally:
- `GTFObins-style` in the shell-escape rule's title/reason — names the attack technique class (like the OWASP/ATLAS taxonomy), not where the rule came from.
- The `excessive-single-call-cost` "never derives cost from a local pricing table" wording — unrelated to attribution and a deliberate product contract.

## Testing

- `go test ./threatrules/...` in `pkg/asymptoteobserve` passes. This conformance suite loads and validates the entire `rules/` pack and runs every embedded fixture.
- Edits are description-only and don't touch match logic, so rule versions are unchanged.

https://claude.ai/code/session_01BJZzdvwWY4RNHYJ4a4KVJc

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJZzdvwWY4RNHYJ4a4KVJc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Description-only edits with no detection logic or rule version bumps; detection behavior is unchanged.
> 
> **Overview**
> Rewrites the **`description`** fields across **34** threat rule YAML files so each rule reads as a **self-contained** explanation of what it detects and how scoping works, without upstream porting notes.
> 
> **Removed** blastradius / Rust probe references (`is_secret_store_path`, `egress.rs`, `§24.3.1`, ATR corpus links, "Ported from…", "Derived from…").
> 
> **Kept** behavioral detail: exclusions, look-alike host handling, companion-rule cross-references, and scoping notes—often **rephrased** when the old text only made sense as attribution (e.g. DNS tunnel notes that DNS works when HTTP egress is filtered; autostart rule notes it pairs with the systemctl/launchctl command rule; secret-read-then-external-mcp complements secret-read-then-egress).
> 
> **Unchanged:** `match` / `correlation` logic, `version`, `tests`, titles, and emit reasons—documentation-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce192c62105167e51617723f56a1ae9e4160f23c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->