### PR TITLE
Add Devin Cloud agent telemetry support

### DIFF
--- a/.devin/hooks.v1.json
+++ b/.devin/hooks.v1.json
@@ -1,0 +1,74 @@
+{
+  "PermissionRequest": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=devin_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/usr/local/bin/beacon-hooks' --platform devin permission-request"
+        }
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=devin_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/usr/local/bin/beacon-hooks' --platform devin post-tool"
+        }
+      ]
+    }
+  ],
+  "PreToolUse": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=devin_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/usr/local/bin/beacon-hooks' --platform devin pre-tool"
+        }
+      ]
+    }
+  ],
+  "SessionEnd": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=devin_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/usr/local/bin/beacon-hooks' --platform devin session-end"
+        }
+      ]
+    }
+  ],
+  "SessionStart": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=devin_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/usr/local/bin/beacon-hooks' --platform devin session-start"
+        }
+      ]
+    }
+  ],
+  "Stop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=devin_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/usr/local/bin/beacon-hooks' --platform devin stop",
+          "timeout": 45
+        }
+      ]
+    }
+  ],
+  "UserPromptSubmit": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=devin_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/usr/local/bin/beacon-hooks' --platform devin prompt-submit",
+          "timeout": 30
+        }
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ CI, and cloud surfaces.
 | [Claude Agent SDK](https://docs.asymptotelabs.ai/sdk/integrations-claude-agent-sdk) | Query wrapper through `Observe.wrapClaudeAgentQuery()` | Query root spans with Beacon-compatible prompt attributes |
 | [Claude Code Cloud Agents](https://docs.asymptotelabs.ai/claude-code-cloud-agents) | Cloud sandbox hooks with GCS upload | Session, prompt, tool, command, file, and lifecycle telemetry where Claude Code cloud hook payloads expose it |
 | [Cursor Cloud Agents](https://docs.asymptotelabs.ai/cursor-cloud-agents) | Cloud sandbox hooks with GCS upload | Tool, shell command, file, subagent, and compaction telemetry where Cursor cloud hook payloads expose it |
+| [Devin Cloud Agents](https://docs.asymptotelabs.ai/devin-cloud-agents) | Cloud sandbox hooks with GCS upload | Session, prompt, tool, command, file, and lifecycle telemetry where Devin cloud hook payloads expose it |
 | [OpenAI](https://docs.asymptotelabs.ai/sdk/integrations-openai) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported OpenAI model call spans, errors, and OpenTelemetry attributes |
 | [Vercel AI SDK](https://docs.asymptotelabs.ai/sdk/integrations-vercel-ai-sdk) | Tracer handoff through `experimental_telemetry` | AI SDK model call and tool spans where telemetry is enabled |
 

--- a/cli/beacon-hooks/cmd/devin_cloud_test.go
+++ b/cli/beacon-hooks/cmd/devin_cloud_test.go
@@ -47,7 +47,7 @@ func TestSeedDevinCloudRunIDNoopOutsideDevinCloud(t *testing.T) {
 	}
 }
 
-func TestSeedDevinCloudRunIDFallsBackWhenNoDevinEnv(t *testing.T) {
+func TestSeedDevinCloudRunIDFallsBackToUnknownWhenNoDevinEnv(t *testing.T) {
 	platformFlag = "devin"
 	t.Setenv("BEACON_ORIGIN", "cloud")
 	t.Setenv("BEACON_RUN_PROVIDER", "devin_cloud")
@@ -59,7 +59,8 @@ func TestSeedDevinCloudRunIDFallsBackWhenNoDevinEnv(t *testing.T) {
 
 	seedDevinCloudRunID()
 
-	if got := os.Getenv("BEACON_RUN_ID"); got != "" {
-		t.Fatalf("BEACON_RUN_ID = %q, want empty so shuttle falls back to unknown", got)
+	// Must be non-empty: cloudshuttle.Upload skips the upload when RunID == "".
+	if got := os.Getenv("BEACON_RUN_ID"); got != "unknown" {
+		t.Fatalf("BEACON_RUN_ID = %q, want unknown so the shuttle still uploads", got)
 	}
 }

--- a/cli/beacon-hooks/cmd/devin_cloud_test.go
+++ b/cli/beacon-hooks/cmd/devin_cloud_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -47,10 +49,12 @@ func TestSeedDevinCloudRunIDNoopOutsideDevinCloud(t *testing.T) {
 	}
 }
 
-func TestSeedDevinCloudRunIDFallsBackToUnknownWhenNoDevinEnv(t *testing.T) {
+func TestSeedDevinCloudRunIDGeneratesAndPersistsWhenNoDevinEnv(t *testing.T) {
+	dir := t.TempDir()
 	platformFlag = "devin"
 	t.Setenv("BEACON_ORIGIN", "cloud")
 	t.Setenv("BEACON_RUN_PROVIDER", "devin_cloud")
+	t.Setenv("BEACON_ENDPOINT_LOG", filepath.Join(dir, "runtime.jsonl"))
 	t.Setenv("BEACON_RUN_ID", "")
 	// No DEVIN_* identifiers present.
 	for _, key := range []string{"DEVIN_SESSION_ID", "DEVIN_RUN_ID", "DEVIN_SESSION", "ACI_RUN_ID"} {
@@ -59,8 +63,17 @@ func TestSeedDevinCloudRunIDFallsBackToUnknownWhenNoDevinEnv(t *testing.T) {
 
 	seedDevinCloudRunID()
 
-	// Must be non-empty: cloudshuttle.Upload skips the upload when RunID == "".
-	if got := os.Getenv("BEACON_RUN_ID"); got != "unknown" {
-		t.Fatalf("BEACON_RUN_ID = %q, want unknown so the shuttle still uploads", got)
+	// Must be non-empty (cloudshuttle.Upload skips when RunID == "") and unique.
+	first := os.Getenv("BEACON_RUN_ID")
+	if !strings.HasPrefix(first, "devin-") || len(first) <= len("devin-") {
+		t.Fatalf("BEACON_RUN_ID = %q, want a generated devin- id", first)
+	}
+
+	// A second hook process in the same session (run id cleared from env) must
+	// reuse the persisted id rather than mint a new one.
+	t.Setenv("BEACON_RUN_ID", "")
+	seedDevinCloudRunID()
+	if got := os.Getenv("BEACON_RUN_ID"); got != first {
+		t.Fatalf("second seed = %q, want persisted %q", got, first)
 	}
 }

--- a/cli/beacon-hooks/cmd/devin_cloud_test.go
+++ b/cli/beacon-hooks/cmd/devin_cloud_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSeedDevinCloudRunIDFromDevinSessionEnv(t *testing.T) {
+	platformFlag = "devin"
+	t.Setenv("BEACON_ORIGIN", "cloud")
+	t.Setenv("BEACON_RUN_PROVIDER", "devin_cloud")
+	t.Setenv("BEACON_RUN_ID", "")
+	t.Setenv("DEVIN_SESSION_ID", "devin-session-42")
+
+	seedDevinCloudRunID()
+
+	if got := os.Getenv("BEACON_RUN_ID"); got != "devin-session-42" {
+		t.Fatalf("BEACON_RUN_ID = %q, want devin-session-42", got)
+	}
+}
+
+func TestSeedDevinCloudRunIDKeepsExplicitRunID(t *testing.T) {
+	platformFlag = "devin-cli"
+	t.Setenv("BEACON_ORIGIN", "cloud")
+	t.Setenv("BEACON_RUN_PROVIDER", "devin_cloud")
+	t.Setenv("BEACON_RUN_ID", "explicit-run")
+	t.Setenv("DEVIN_SESSION_ID", "devin-session-42")
+
+	seedDevinCloudRunID()
+
+	if got := os.Getenv("BEACON_RUN_ID"); got != "explicit-run" {
+		t.Fatalf("BEACON_RUN_ID = %q, want explicit-run preserved", got)
+	}
+}
+
+func TestSeedDevinCloudRunIDNoopOutsideDevinCloud(t *testing.T) {
+	platformFlag = "claude"
+	t.Setenv("BEACON_ORIGIN", "cloud")
+	t.Setenv("BEACON_RUN_PROVIDER", "devin_cloud")
+	t.Setenv("BEACON_RUN_ID", "")
+	t.Setenv("DEVIN_SESSION_ID", "devin-session-42")
+
+	seedDevinCloudRunID()
+
+	if got := os.Getenv("BEACON_RUN_ID"); got != "" {
+		t.Fatalf("BEACON_RUN_ID = %q, want empty for non-Devin platform", got)
+	}
+}
+
+func TestSeedDevinCloudRunIDFallsBackWhenNoDevinEnv(t *testing.T) {
+	platformFlag = "devin"
+	t.Setenv("BEACON_ORIGIN", "cloud")
+	t.Setenv("BEACON_RUN_PROVIDER", "devin_cloud")
+	t.Setenv("BEACON_RUN_ID", "")
+	// No DEVIN_* identifiers present.
+	for _, key := range []string{"DEVIN_SESSION_ID", "DEVIN_RUN_ID", "DEVIN_SESSION", "ACI_RUN_ID"} {
+		t.Setenv(key, "")
+	}
+
+	seedDevinCloudRunID()
+
+	if got := os.Getenv("BEACON_RUN_ID"); got != "" {
+		t.Fatalf("BEACON_RUN_ID = %q, want empty so shuttle falls back to unknown", got)
+	}
+}

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -77,7 +77,10 @@ func isDevinCloudMode() bool {
 // seedDevinCloudRunID resolves a run id for Devin Cloud sessions. The Devin hook
 // payloads do not carry a session id, so derive BEACON_RUN_ID from a
 // Devin-provided session environment variable when one is available. If none is
-// set, leave BEACON_RUN_ID unset so the cloud shuttle falls back to "unknown".
+// found it falls back to "unknown" rather than leaving BEACON_RUN_ID empty:
+// cloudshuttle.Upload skips the upload entirely when RunID is empty, so an empty
+// value would silently drop all telemetry. Sessions without a discoverable id
+// therefore share the run_id=unknown object path (last writer wins).
 func seedDevinCloudRunID() {
 	if !isDevinLikePlatform(platformFlag) || !isDevinCloudMode() || strings.TrimSpace(os.Getenv("BEACON_RUN_ID")) != "" {
 		return
@@ -90,6 +93,7 @@ func seedDevinCloudRunID() {
 			return
 		}
 	}
+	_ = os.Setenv("BEACON_RUN_ID", "unknown")
 }
 
 func maybeUploadCursorCloudTelemetry(logger *logging.Logger) {

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -19,6 +19,7 @@ func emitHookEvent(logger *logging.Logger, action, category, severity, message s
 		fields = map[string]interface{}{}
 	}
 	seedCursorCloudRunID(input)
+	seedDevinCloudRunID()
 	if platformFlag == "grok" {
 		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"grok": input})
 	}
@@ -65,6 +66,29 @@ func seedCursorCloudRunID(input map[string]interface{}) {
 	}
 	if runID := getFirstStr(input, "conversation_id", "parent_conversation_id"); runID != "" {
 		_ = os.Setenv("BEACON_RUN_ID", runID)
+	}
+}
+
+func isDevinCloudMode() bool {
+	return strings.TrimSpace(os.Getenv("BEACON_ORIGIN")) == "cloud" &&
+		strings.TrimSpace(os.Getenv("BEACON_RUN_PROVIDER")) == "devin_cloud"
+}
+
+// seedDevinCloudRunID resolves a run id for Devin Cloud sessions. The Devin hook
+// payloads do not carry a session id, so derive BEACON_RUN_ID from a
+// Devin-provided session environment variable when one is available. If none is
+// set, leave BEACON_RUN_ID unset so the cloud shuttle falls back to "unknown".
+func seedDevinCloudRunID() {
+	if !isDevinLikePlatform(platformFlag) || !isDevinCloudMode() || strings.TrimSpace(os.Getenv("BEACON_RUN_ID")) != "" {
+		return
+	}
+	// Candidate session/run identifiers Devin may expose inside the sandbox.
+	// Confirm the authoritative name from a live session and trim this list.
+	for _, key := range []string{"DEVIN_SESSION_ID", "DEVIN_RUN_ID", "DEVIN_SESSION", "ACI_RUN_ID"} {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			_ = os.Setenv("BEACON_RUN_ID", value)
+			return
+		}
 	}
 }
 

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -74,13 +75,17 @@ func isDevinCloudMode() bool {
 		strings.TrimSpace(os.Getenv("BEACON_RUN_PROVIDER")) == "devin_cloud"
 }
 
-// seedDevinCloudRunID resolves a run id for Devin Cloud sessions. The Devin hook
-// payloads do not carry a session id, so derive BEACON_RUN_ID from a
-// Devin-provided session environment variable when one is available. If none is
-// found it falls back to "unknown" rather than leaving BEACON_RUN_ID empty:
-// cloudshuttle.Upload skips the upload entirely when RunID is empty, so an empty
-// value would silently drop all telemetry. Sessions without a discoverable id
-// therefore share the run_id=unknown object path (last writer wins).
+// seedDevinCloudRunID resolves a run id for Devin Cloud sessions and exports it
+// as BEACON_RUN_ID. The Devin hook payloads carry no session id, and Devin does
+// not expose one through the environment, so the resolution order is:
+//
+//  1. An explicit BEACON_RUN_ID (operator override) — left untouched.
+//  2. A Devin-provided session env var, if a future Devin release adds one.
+//  3. A per-session id minted on first use and persisted next to the runtime log
+//     so every hook invocation in the same session reuses it.
+//
+// A non-empty value is always set: cloudshuttle.Upload skips the upload entirely
+// when RunID is empty, so leaving it blank would silently drop all telemetry.
 func seedDevinCloudRunID() {
 	if !isDevinLikePlatform(platformFlag) || !isDevinCloudMode() || strings.TrimSpace(os.Getenv("BEACON_RUN_ID")) != "" {
 		return
@@ -93,7 +98,51 @@ func seedDevinCloudRunID() {
 			return
 		}
 	}
-	_ = os.Setenv("BEACON_RUN_ID", "unknown")
+	_ = os.Setenv("BEACON_RUN_ID", loadOrCreateDevinCloudRunID())
+}
+
+// devinCloudRunIDPath returns the per-session run-id file, kept beside the
+// runtime log so every hook process in the session resolves the same path.
+func devinCloudRunIDPath() string {
+	logPath := strings.TrimSpace(os.Getenv("BEACON_ENDPOINT_LOG"))
+	if logPath == "" {
+		logPath = "/tmp/beacon/runtime.jsonl"
+	}
+	return filepath.Join(filepath.Dir(logPath), "devin-run-id")
+}
+
+// loadOrCreateDevinCloudRunID returns the session's persisted run id, minting and
+// writing one on first use. Hooks run as separate processes, so the id must be
+// persisted; without it each process would pick a different id and scatter one
+// session across many GCS objects. The O_EXCL write keeps the first writer's id
+// if two early hooks race.
+func loadOrCreateDevinCloudRunID() string {
+	path := devinCloudRunIDPath()
+	if data, err := os.ReadFile(path); err == nil {
+		if existing := strings.TrimSpace(string(data)); existing != "" {
+			return existing
+		}
+	}
+	runID := generateRunID()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err == nil {
+		if f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644); err == nil {
+			_, _ = f.WriteString(runID)
+			_ = f.Close()
+		} else if data, err := os.ReadFile(path); err == nil {
+			if existing := strings.TrimSpace(string(data)); existing != "" {
+				return existing
+			}
+		}
+	}
+	return runID
+}
+
+func generateRunID() string {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return "unknown"
+	}
+	return "devin-" + hex.EncodeToString(buf)
 }
 
 func maybeUploadCursorCloudTelemetry(logger *logging.Logger) {

--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
@@ -44,6 +44,19 @@ func TestObjectNameUsesCursorCloudProvider(t *testing.T) {
 	}
 }
 
+func TestObjectNameUsesDevinCloudProvider(t *testing.T) {
+	got := ObjectName(Config{
+		Prefix:   "agent-traces",
+		Provider: "devin_cloud",
+		UserID:   "user-1",
+		RunID:    "devin-123",
+	})
+	want := "agent-traces/provider=devin_cloud/user_id=user-1/run_id=devin-123/runtime.jsonl"
+	if got != want {
+		t.Fatalf("ObjectName = %q, want %q", got, want)
+	}
+}
+
 func TestUploadNoopsWithoutCredentials(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
 	if err := os.WriteFile(logPath, []byte("{}\n"), 0644); err != nil {

--- a/cli/beacon/cmd/cloud.go
+++ b/cli/beacon/cmd/cloud.go
@@ -307,10 +307,9 @@ echo "  beacon cloud cursor print-hooks --binary-path /tmp/beacon/bin/beacon-hoo
 
 func renderDevinCloudSetup(version string) string {
 	return fmt.Sprintf(`set -euo pipefail
-# Run this from a Devin blueprint "maintenance" step so the Beacon binaries are
-# provisioned into every cloud session's machine.
-mkdir -p /tmp/beacon/bin /tmp/beacon/logs
-
+# Run this from a Devin blueprint "initialize" step. Devin boots each session from
+# a frozen snapshot, so beacon-hooks is installed to a persistent system path
+# (/usr/local/bin) rather than /tmp, which is not guaranteed to survive the boot.
 BEACON_VERSION=%q
 OS="linux"
 case "$(uname -m)" in
@@ -321,13 +320,15 @@ esac
 
 ARCHIVE="beacon_${BEACON_VERSION#v}_${OS}_${ARCH}.tar.gz"
 BASE="https://github.com/asymptote-labs/agent-beacon/releases/download/${BEACON_VERSION}"
-curl -fsSL "${BASE}/${ARCHIVE}" -o "/tmp/beacon/${ARCHIVE}"
-tar -xzf "/tmp/beacon/${ARCHIVE}" -C /tmp/beacon/bin
-chmod +x /tmp/beacon/bin/beacon /tmp/beacon/bin/beacon-hooks 2>/dev/null || true
+TMP="$(mktemp -d)"
+curl -fsSL "${BASE}/${ARCHIVE}" -o "${TMP}/${ARCHIVE}"
+tar -xzf "${TMP}/${ARCHIVE}" -C "${TMP}"
+sudo install -m 0755 "${TMP}/beacon-hooks" /usr/local/bin/beacon-hooks
+rm -rf "${TMP}"
 
-echo "Beacon binaries installed in /tmp/beacon/bin"
+echo "beacon-hooks installed at /usr/local/bin/beacon-hooks"
 echo "Commit a project-level .devin/hooks.v1.json before starting Devin Cloud Agents:"
-echo "  beacon cloud devin print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .devin/hooks.v1.json"
+echo "  beacon cloud devin print-hooks --binary-path /usr/local/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .devin/hooks.v1.json"
 `, version)
 }
 

--- a/cli/beacon/cmd/cloud.go
+++ b/cli/beacon/cmd/cloud.go
@@ -107,6 +107,44 @@ var cloudCursorPrintSetupCmd = &cobra.Command{
 	},
 }
 
+var cloudDevinCmd = &cobra.Command{
+	Use:   "devin",
+	Short: "Generate Devin cloud agent telemetry setup",
+}
+
+var cloudDevinPrintHooksCmd = &cobra.Command{
+	Use:          "print-hooks",
+	Short:        "Print project-level Devin hook settings for a cloud sandbox",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if strings.TrimSpace(cloudOpts.binaryPath) == "" {
+			return fmt.Errorf("--binary-path is required")
+		}
+		rendered, err := endpointhooks.RenderDevinCloudHooks(endpointhooks.DevinCloudOptions{
+			BinaryPath: cloudOpts.binaryPath,
+			LogPath:    defaultCloudLogPath(cloudOpts.logPath),
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Print(rendered)
+		return nil
+	},
+}
+
+var cloudDevinPrintSetupCmd = &cobra.Command{
+	Use:          "print-setup",
+	Short:        "Print a Devin cloud agent binary setup script",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if strings.TrimSpace(cloudOpts.version) == "" {
+			return fmt.Errorf("--version is required")
+		}
+		fmt.Print(renderDevinCloudSetup(cloudOpts.version))
+		return nil
+	},
+}
+
 var cloudGCSCmd = &cobra.Command{
 	Use:   "gcs",
 	Short: "Configure GCS forwarding for cloud agent telemetry",
@@ -123,11 +161,14 @@ func init() {
 	rootCmd.AddCommand(cloudCmd)
 	cloudCmd.AddCommand(cloudClaudeWebCmd)
 	cloudCmd.AddCommand(cloudCursorCmd)
+	cloudCmd.AddCommand(cloudDevinCmd)
 	cloudCmd.AddCommand(cloudGCSCmd)
 	cloudClaudeWebCmd.AddCommand(cloudClaudeWebPrintHooksCmd)
 	cloudClaudeWebCmd.AddCommand(cloudClaudeWebPrintSetupCmd)
 	cloudCursorCmd.AddCommand(cloudCursorPrintHooksCmd)
 	cloudCursorCmd.AddCommand(cloudCursorPrintSetupCmd)
+	cloudDevinCmd.AddCommand(cloudDevinPrintHooksCmd)
+	cloudDevinCmd.AddCommand(cloudDevinPrintSetupCmd)
 	cloudGCSCmd.AddCommand(cloudGCSSetupCmd)
 
 	cloudClaudeWebPrintHooksCmd.Flags().StringVar(&cloudOpts.binaryPath, "binary-path", "", "Path to beacon-hooks inside the cloud sandbox")
@@ -137,6 +178,9 @@ func init() {
 	cloudCursorPrintHooksCmd.Flags().StringVar(&cloudOpts.logPath, "log-path", "/tmp/beacon/runtime.jsonl", "Cloud sandbox runtime JSONL path")
 	cloudCursorPrintHooksCmd.Flags().BoolVar(&cloudOpts.safeHooks, "safe-hooks", false, "Skip Cursor cloud shell/edit-specific hooks while testing telemetry forwarding")
 	cloudCursorPrintSetupCmd.Flags().StringVar(&cloudOpts.version, "version", "", "Beacon release tag to download, such as v0.0.50")
+	cloudDevinPrintHooksCmd.Flags().StringVar(&cloudOpts.binaryPath, "binary-path", "", "Path to beacon-hooks inside the cloud sandbox")
+	cloudDevinPrintHooksCmd.Flags().StringVar(&cloudOpts.logPath, "log-path", "/tmp/beacon/runtime.jsonl", "Cloud sandbox runtime JSONL path")
+	cloudDevinPrintSetupCmd.Flags().StringVar(&cloudOpts.version, "version", "", "Beacon release tag to download, such as v0.0.50")
 
 	cloudGCSSetupCmd.Flags().StringVar(&cloudOpts.project, "project", "", "Google Cloud project ID")
 	cloudGCSSetupCmd.Flags().StringVar(&cloudOpts.bucket, "bucket", "", "GCS bucket for cloud agent telemetry")
@@ -258,6 +302,32 @@ chmod +x /tmp/beacon/bin/beacon /tmp/beacon/bin/beacon-hooks 2>/dev/null || true
 echo "Beacon binaries installed in /tmp/beacon/bin"
 echo "Commit a project-level .cursor/hooks.json before starting Cursor Cloud Agents:"
 echo "  beacon cloud cursor print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .cursor/hooks.json"
+`, version)
+}
+
+func renderDevinCloudSetup(version string) string {
+	return fmt.Sprintf(`set -euo pipefail
+# Run this from a Devin blueprint "maintenance" step so the Beacon binaries are
+# provisioned into every cloud session's machine.
+mkdir -p /tmp/beacon/bin /tmp/beacon/logs
+
+BEACON_VERSION=%q
+OS="linux"
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+ARCHIVE="beacon_${BEACON_VERSION#v}_${OS}_${ARCH}.tar.gz"
+BASE="https://github.com/asymptote-labs/agent-beacon/releases/download/${BEACON_VERSION}"
+curl -fsSL "${BASE}/${ARCHIVE}" -o "/tmp/beacon/${ARCHIVE}"
+tar -xzf "/tmp/beacon/${ARCHIVE}" -C /tmp/beacon/bin
+chmod +x /tmp/beacon/bin/beacon /tmp/beacon/bin/beacon-hooks 2>/dev/null || true
+
+echo "Beacon binaries installed in /tmp/beacon/bin"
+echo "Commit a project-level .devin/hooks.v1.json before starting Devin Cloud Agents:"
+echo "  beacon cloud devin print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .devin/hooks.v1.json"
 `, version)
 }
 

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -13,6 +14,8 @@ func TestCloudCommandsRegistered(t *testing.T) {
 		{"cloud", "claude-web", "print-setup"},
 		{"cloud", "cursor", "print-hooks"},
 		{"cloud", "cursor", "print-setup"},
+		{"cloud", "devin", "print-hooks"},
+		{"cloud", "devin", "print-setup"},
 		{"cloud", "gcs", "setup"},
 	} {
 		cmd, _, err := rootCmd.Find(path)
@@ -103,6 +106,70 @@ func TestRenderCursorCloudSetupInstallsBinariesOnly(t *testing.T) {
 	for _, forbidden := range []string{`beacon cloud cursor install-hooks`, `--hooks-json`, `.git/info/exclude`} {
 		if strings.Contains(got, forbidden) {
 			t.Fatalf("cursor setup should not rewrite project hooks with %q:\n%s", forbidden, got)
+		}
+	}
+}
+
+func TestRenderDevinCloudHooks(t *testing.T) {
+	got, err := endpointhooks.RenderDevinCloudHooks(endpointhooks.DevinCloudOptions{
+		BinaryPath: "/tmp/beacon/bin/beacon-hooks",
+		LogPath:    "/tmp/beacon/runtime.jsonl",
+	})
+	if err != nil {
+		t.Fatalf("render devin cloud hooks: %v", err)
+	}
+	for _, want := range []string{
+		`"SessionStart"`,
+		`"UserPromptSubmit"`,
+		`"PreToolUse"`,
+		`"PermissionRequest"`,
+		`"PostToolUse"`,
+		`"Stop"`,
+		`"SessionEnd"`,
+		`BEACON_ORIGIN=cloud`,
+		`BEACON_RUN_PROVIDER=devin_cloud`,
+		`BEACON_RUN_EPHEMERAL=true`,
+		`'/tmp/beacon/bin/beacon-hooks' --platform devin session-start`,
+		`'/tmp/beacon/bin/beacon-hooks' --platform devin post-tool`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered hooks missing %q:\n%s", want, got)
+		}
+	}
+	// Standalone .devin/hooks.v1.json: the top level is the bare event map, not a
+	// Cursor-style {"version":1,"hooks":{...}} wrapper.
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(got), &top); err != nil {
+		t.Fatalf("rendered hooks not valid JSON: %v\n%s", err, got)
+	}
+	if _, ok := top["SessionStart"]; !ok {
+		t.Fatalf("expected top-level event keys in standalone format, got keys %v", topLevelKeys(top))
+	}
+	for _, wrapper := range []string{"version", "hooks"} {
+		if _, ok := top[wrapper]; ok {
+			t.Fatalf("devin cloud hooks should not be wrapped under %q:\n%s", wrapper, got)
+		}
+	}
+}
+
+func topLevelKeys(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func TestRenderDevinCloudSetupInstallsBinariesOnly(t *testing.T) {
+	got := renderDevinCloudSetup("v0.0.50")
+	for _, want := range []string{
+		`BEACON_VERSION="v0.0.50"`,
+		`tar -xzf "/tmp/beacon/${ARCHIVE}" -C /tmp/beacon/bin`,
+		`Beacon binaries installed in /tmp/beacon/bin`,
+		`beacon cloud devin print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .devin/hooks.v1.json`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered setup missing %q:\n%s", want, got)
 		}
 	}
 }

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -164,13 +164,17 @@ func TestRenderDevinCloudSetupInstallsBinariesOnly(t *testing.T) {
 	got := renderDevinCloudSetup("v0.0.50")
 	for _, want := range []string{
 		`BEACON_VERSION="v0.0.50"`,
-		`tar -xzf "/tmp/beacon/${ARCHIVE}" -C /tmp/beacon/bin`,
-		`Beacon binaries installed in /tmp/beacon/bin`,
-		`beacon cloud devin print-hooks --binary-path /tmp/beacon/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .devin/hooks.v1.json`,
+		`sudo install -m 0755 "${TMP}/beacon-hooks" /usr/local/bin/beacon-hooks`,
+		`beacon-hooks installed at /usr/local/bin/beacon-hooks`,
+		`beacon cloud devin print-hooks --binary-path /usr/local/bin/beacon-hooks --log-path /tmp/beacon/runtime.jsonl > .devin/hooks.v1.json`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("rendered setup missing %q:\n%s", want, got)
 		}
+	}
+	// beacon-hooks must land on a persistent path, not /tmp (snapshot-boot model).
+	if strings.Contains(got, "/tmp/beacon/bin") {
+		t.Fatalf("devin setup should install to a persistent path, not /tmp/beacon/bin:\n%s", got)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/hooks/devin.go
+++ b/cli/beacon/internal/endpoint/hooks/devin.go
@@ -160,7 +160,22 @@ func installDevinHooksForPlatform(path, binaryPath, logPath, configPath, platfor
 		return err
 	}
 	prefix := endpointCommandPrefix(platform, binaryPath, logPath, configPath)
-	endpointHooks := map[string]devinHookGroup{
+	for eventName, group := range devinEndpointHookGroups(prefix) {
+		config.hooks[eventName] = mergeDevinEndpointHook(config.hooks[eventName], group, replacePlatforms...)
+	}
+	data, err := config.marshal()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// devinEndpointHookGroups maps Devin lifecycle events to Beacon hook command
+// groups for the given command prefix. Shared by the local installer and the
+// cloud renderer so the two never drift; the only difference between them is the
+// command prefix passed in.
+func devinEndpointHookGroups(prefix string) map[string]devinHookGroup {
+	return map[string]devinHookGroup{
 		"SessionStart":      {Hooks: []devinHookRef{{Type: "command", Command: prefix + " session-start"}}},
 		"UserPromptSubmit":  {Hooks: []devinHookRef{{Type: "command", Command: prefix + " prompt-submit", Timeout: 30}}},
 		"PreToolUse":        {Matcher: "", Hooks: []devinHookRef{{Type: "command", Command: prefix + " pre-tool"}}},
@@ -169,14 +184,41 @@ func installDevinHooksForPlatform(path, binaryPath, logPath, configPath, platfor
 		"Stop":              {Hooks: []devinHookRef{{Type: "command", Command: prefix + " stop", Timeout: 45}}},
 		"SessionEnd":        {Hooks: []devinHookRef{{Type: "command", Command: prefix + " session-end"}}},
 	}
-	for eventName, group := range endpointHooks {
-		config.hooks[eventName] = mergeDevinEndpointHook(config.hooks[eventName], group, replacePlatforms...)
+}
+
+// DevinCloudOptions configures the standalone .devin/hooks.v1.json emitted for
+// Devin Cloud agent sandboxes.
+type DevinCloudOptions struct {
+	BinaryPath string
+	LogPath    string
+}
+
+// RenderDevinCloudHooks renders a standalone .devin/hooks.v1.json that forwards
+// Devin Cloud telemetry through beacon-hooks. The cloud command prefix tags
+// every event with BEACON_ORIGIN=cloud and BEACON_RUN_PROVIDER=devin_cloud so
+// the cloud shuttle uploads runtime JSONL under provider=devin_cloud.
+func RenderDevinCloudHooks(opts DevinCloudOptions) (string, error) {
+	if opts.LogPath == "" {
+		opts.LogPath = "/tmp/beacon/runtime.jsonl"
 	}
-	data, err := config.marshal()
+	prefix := devinCloudCommandPrefix(opts.BinaryPath, opts.LogPath)
+	hooks := map[string][]devinHookGroup{}
+	for eventName, group := range devinEndpointHookGroups(prefix) {
+		hooks[eventName] = []devinHookGroup{group}
+	}
+	data, err := json.MarshalIndent(hooks, "", "  ")
 	if err != nil {
-		return err
+		return "", err
 	}
-	return os.WriteFile(path, data, 0600)
+	return string(data) + "\n", nil
+}
+
+func devinCloudCommandPrefix(binaryPath, logPath string) string {
+	return fmt.Sprintf(
+		"BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=devin_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=%s %s --platform devin",
+		shellQuote(logPath),
+		shellQuote(binaryPath),
+	)
 }
 
 func readDevinConfig(path string) (devinConfig, error) {


### PR DESCRIPTION
## Summary

Extends Beacon's cloud-agent telemetry coverage to **Devin Cloud agents**, mirroring the existing Claude Code web and Cursor cloud flows. No Devin Enterprise plan required.

Devin Cloud runs the **same lifecycle-hook engine as the Devin CLI** and reads **project-committed** hook config (`.devin/hooks.v1.json`). Beacon already ships a working `--platform devin` hook adapter, so this adds the cloud packaging: a `beacon cloud devin` command set plus a `devin_cloud` provider. Telemetry is captured by hooks inside the sandbox, written to `/tmp/beacon/runtime.jsonl`, and uploaded to a customer-managed GCS bucket at session end — preserving the local-only/no-hosted-dependency posture.

## Changes

- **`hooks/devin.go`** — `RenderDevinCloudHooks` + `devinCloudCommandPrefix`. The event→subcommand map is extracted into a shared `devinEndpointHookGroups` helper reused by the local installer so the two can't drift. Emits the full 7-event Devin hook set (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, `Stop`, `SessionEnd`) in standalone `.devin/hooks.v1.json` format, tagged `BEACON_ORIGIN=cloud`/`BEACON_RUN_PROVIDER=devin_cloud`.
- **`cmd/cloud.go`** — `beacon cloud devin print-hooks` / `print-setup` commands + flags, and `renderDevinCloudSetup` (framed as a Devin blueprint `maintenance` step that installs the binaries).
- **`beacon-hooks/cmd/endpoint_events.go`** — `isDevinCloudMode()` + `seedDevinCloudRunID()` resolve the GCS `run_id` from a Devin session env var (`BEACON_RUN_ID` override → `DEVIN_*` candidates → `unknown`). The provider-agnostic GCS shuttle needs no changes.
- **Tests** — renderer output, command registration, setup script, run-id seeding (4 cases), and `devin_cloud` GCS object-path partitioning.
- **README** — lists Devin Cloud Agents under Cloud Agents.

## Verification

- `go test ./...` green in `cli/beacon`, `cli/beacon-hooks`, and the collector exporter; `go test -race ./internal/endpoint/...` green.
- Local end-to-end hook run: all 7 lifecycle events emit with `origin:cloud`, `provider:devin_cloud`, `run_id` from `DEVIN_SESSION_ID`, and `ephemeral:true`; `permission-request` returns `{"decision":"approve"}`.
- **Real GCS upload** verified against `asymptote-beacon-cloud-agent-traces-test`: object landed at `…/provider=devin_cloud/…/runtime.jsonl`, byte-identical to the local log (test object cleaned up afterward).

## Open follow-up

The Devin hook stdin carries no session id and the docs only confirm `DEVIN_PROJECT_DIR`. `seedDevinCloudRunID` probes `DEVIN_SESSION_ID → DEVIN_RUN_ID → DEVIN_SESSION → ACI_RUN_ID` and falls back to `run_id=unknown`. The authoritative var name still needs confirmation from a live Devin session; once known, the candidate list will be trimmed. A `docs.asymptotelabs.ai/devin-cloud-agents` page is a separate follow-up (external docs repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cloud hook execution and GCS partitioning via run-id logic; behavior is modeled on existing cloud agents but wrong session ids could split or mis-attribute traces until Devin env vars are confirmed.
> 
> **Overview**
> Adds **Devin Cloud Agents** to Beacon’s cloud telemetry path, parallel to Claude Code web and Cursor cloud: sandbox hooks write JSONL and the existing GCS shuttle can upload under `provider=devin_cloud`.
> 
> New **`beacon cloud devin print-hooks`** and **`print-setup`** emit a committed **`.devin/hooks.v1.json`** (seven lifecycle events) and a blueprint-friendly install script that puts **`beacon-hooks`** on **`/usr/local/bin`** for snapshot-based Devin boots. Hook commands are centralized in **`devinEndpointHookGroups`** so local Devin install and cloud rendering stay aligned.
> 
> **`beacon-hooks`** gains **`seedDevinCloudRunID()`** so **`BEACON_RUN_ID`** is always set in Devin cloud mode (override → candidate **`DEVIN_*`** env vars → persisted generated id beside the runtime log), avoiding silent upload skips when the id is empty. README documents the new cloud surface; tests cover hook JSON shape, CLI registration, run-id seeding, and GCS object naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2fa374850e6f326bb0496471d792f7664ccdd3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->