### PR TITLE
Add claude compliance API support

### DIFF
--- a/cli/beacon/cmd/integrations_claude_compliance.go
+++ b/cli/beacon/cmd/integrations_claude_compliance.go
@@ -1,0 +1,303 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/writer"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/integrations/claudecompliance"
+)
+
+var integrationsOpts struct {
+	userMode        bool
+	systemMode      bool
+	logPath         string
+	jsonOutput      bool
+	apiKeyEnv       string
+	limit           int
+	maxPages        int
+	since           string
+	overlap         string
+	activityTypes   []string
+	organizationIDs []string
+	actorIDs        []string
+	resetCursor     bool
+	dryRun          bool
+}
+
+var integrationsCmd = &cobra.Command{
+	Use:   "integrations",
+	Short: "Manage local Beacon integrations for external telemetry sources",
+}
+
+var integrationsClaudeComplianceCmd = &cobra.Command{
+	Use:   "claude-compliance",
+	Short: "Pull Claude Compliance API activity into local Beacon JSONL",
+}
+
+var integrationsClaudeCompliancePullCmd = &cobra.Command{
+	Use:          "pull",
+	Short:        "Pull Claude Compliance Activity Feed events",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runClaudeCompliancePull(cmd.Context())
+	},
+}
+
+var integrationsClaudeComplianceStatusCmd = &cobra.Command{
+	Use:          "status",
+	Short:        "Show Claude Compliance integration state",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runClaudeComplianceStatus()
+	},
+}
+
+var integrationsClaudeComplianceValidateCmd = &cobra.Command{
+	Use:          "validate",
+	Short:        "Validate Claude Compliance API access",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runClaudeComplianceValidate(cmd.Context())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(integrationsCmd)
+	integrationsCmd.AddCommand(integrationsClaudeComplianceCmd)
+	integrationsClaudeComplianceCmd.AddCommand(integrationsClaudeCompliancePullCmd)
+	integrationsClaudeComplianceCmd.AddCommand(integrationsClaudeComplianceStatusCmd)
+	integrationsClaudeComplianceCmd.AddCommand(integrationsClaudeComplianceValidateCmd)
+
+	for _, c := range []*cobra.Command{
+		integrationsClaudeCompliancePullCmd,
+		integrationsClaudeComplianceStatusCmd,
+		integrationsClaudeComplianceValidateCmd,
+	} {
+		c.Flags().BoolVar(&integrationsOpts.userMode, "user", true, "Use per-user Beacon paths")
+		c.Flags().BoolVar(&integrationsOpts.systemMode, "system", false, "Use system Beacon paths")
+		c.Flags().StringVar(&integrationsOpts.logPath, "log-path", "", "Local Beacon JSONL log path")
+		c.Flags().StringVar(&integrationsOpts.apiKeyEnv, "api-key-env", claudecompliance.DefaultAPIKeyEnv, "Environment variable containing the Claude Compliance API key")
+	}
+
+	integrationsClaudeCompliancePullCmd.Flags().IntVar(&integrationsOpts.limit, "limit", claudecompliance.DefaultLimit, "Maximum activities per API request")
+	integrationsClaudeCompliancePullCmd.Flags().IntVar(&integrationsOpts.maxPages, "max-pages", claudecompliance.DefaultMaxPages, "Maximum API pages to fetch per pull")
+	integrationsClaudeCompliancePullCmd.Flags().StringVar(&integrationsOpts.since, "since", "", "Initial or manual lookback window, such as 24h, or an RFC3339 timestamp")
+	integrationsClaudeCompliancePullCmd.Flags().StringVar(&integrationsOpts.overlap, "overlap", claudecompliance.DefaultOverlap.String(), "Overlap window for incremental sync, such as 10m; set 0 to disable")
+	integrationsClaudeCompliancePullCmd.Flags().StringArrayVar(&integrationsOpts.activityTypes, "activity-type", nil, "Activity type to include; repeat for multiple values")
+	integrationsClaudeCompliancePullCmd.Flags().StringArrayVar(&integrationsOpts.organizationIDs, "organization-id", nil, "Organization ID or UUID to include; repeat for multiple values")
+	integrationsClaudeCompliancePullCmd.Flags().StringArrayVar(&integrationsOpts.actorIDs, "actor-id", nil, "Actor user ID to include; repeat for multiple values")
+	integrationsClaudeCompliancePullCmd.Flags().BoolVar(&integrationsOpts.resetCursor, "reset-cursor", false, "Ignore saved cursor state for this pull")
+	integrationsClaudeCompliancePullCmd.Flags().BoolVar(&integrationsOpts.dryRun, "dry-run", false, "Fetch and normalize without writing JSONL or state")
+	integrationsClaudeCompliancePullCmd.Flags().BoolVar(&integrationsOpts.jsonOutput, "json", false, "Print pull summary as JSON")
+
+	integrationsClaudeComplianceStatusCmd.Flags().BoolVar(&integrationsOpts.jsonOutput, "json", false, "Print status as JSON")
+	integrationsClaudeComplianceValidateCmd.Flags().BoolVar(&integrationsOpts.jsonOutput, "json", false, "Print validation result as JSON")
+}
+
+func runClaudeCompliancePull(ctx context.Context) error {
+	userMode := integrationsUserMode()
+	now := time.Now().UTC()
+	query, err := claudeComplianceQuery(now)
+	if err != nil {
+		return err
+	}
+	overlap, err := parseDurationFlag("overlap", integrationsOpts.overlap)
+	if err != nil {
+		return err
+	}
+	logPath := integrationsLogPath(userMode)
+	client, err := claudeComplianceClientFromEnv()
+	if err != nil {
+		return err
+	}
+	summary, err := claudecompliance.PullActivities(ctx, claudecompliance.SyncOptions{
+		Client:      client,
+		StatePath:   claudecompliance.DefaultStatePath(userMode),
+		Query:       query,
+		MaxPages:    integrationsOpts.maxPages,
+		Overlap:     overlap,
+		ResetCursor: integrationsOpts.resetCursor,
+		DryRun:      integrationsOpts.dryRun,
+		Now:         func() time.Time { return now },
+		WriteEvent: func(event schema.Event) error {
+			_, err := writer.AppendEvent(event, writer.Options{Path: logPath, UserMode: userMode})
+			return err
+		},
+	})
+	if err != nil {
+		if err == claudecompliance.ErrSinceRequired {
+			return fmt.Errorf("%w; rerun with --since, for example --since 24h", err)
+		}
+		return err
+	}
+	if integrationsOpts.jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(summary)
+	}
+	verb := "wrote"
+	if integrationsOpts.dryRun {
+		verb = "would write"
+	}
+	fmt.Printf("Claude Compliance pull fetched %d activities, %s %d, skipped %d across %d page(s).\n", summary.Fetched, verb, summary.Written, summary.Skipped, summary.Pages)
+	fmt.Printf("State: %s\n", summary.StatePath)
+	fmt.Printf("Log: %s\n", logPath)
+	return nil
+}
+
+func runClaudeComplianceStatus() error {
+	userMode := integrationsUserMode()
+	statePath := claudecompliance.DefaultStatePath(userMode)
+	state, err := claudecompliance.LoadState(statePath)
+	if err != nil {
+		return err
+	}
+	logPath := integrationsLogPath(userMode)
+	lastObserved, observed := claudecompliance.LastComplianceEvent(logPath)
+	status := struct {
+		Name                string `json:"name"`
+		DisplayName         string `json:"display_name"`
+		StatePath           string `json:"state_path"`
+		LogPath             string `json:"log_path"`
+		LastID              string `json:"last_id,omitempty"`
+		LastSyncedAt        string `json:"last_synced_at,omitempty"`
+		RecentIDs           int    `json:"recent_ids"`
+		LastEventObserved   bool   `json:"last_event_observed"`
+		LastEventObservedAt string `json:"last_event_observed_at,omitempty"`
+		Message             string `json:"message"`
+	}{
+		Name:              claudecompliance.Name,
+		DisplayName:       claudecompliance.DisplayName,
+		StatePath:         statePath,
+		LogPath:           logPath,
+		LastID:            state.LastID,
+		LastSyncedAt:      state.LastSyncedAt,
+		RecentIDs:         len(state.RecentIDs),
+		LastEventObserved: observed,
+		Message:           "Run `beacon integrations claude-compliance pull --since 24h` to import recent activity",
+	}
+	if observed {
+		status.LastEventObservedAt = lastObserved.UTC().Format(time.RFC3339)
+		status.Message = "Claude Compliance events have been observed in local Beacon JSONL"
+	}
+	if integrationsOpts.jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(status)
+	}
+	fmt.Printf("%s: observed=%t recent_ids=%d", status.DisplayName, status.LastEventObserved, status.RecentIDs)
+	if status.LastSyncedAt != "" {
+		fmt.Printf(" synced=%s", status.LastSyncedAt)
+	}
+	if status.LastEventObservedAt != "" {
+		fmt.Printf(" last=%s", status.LastEventObservedAt)
+	}
+	fmt.Println()
+	fmt.Println(status.Message)
+	return nil
+}
+
+func runClaudeComplianceValidate(ctx context.Context) error {
+	client, err := claudeComplianceClientFromEnv()
+	if err != nil {
+		return err
+	}
+	resp, err := client.ListActivities(ctx, claudecompliance.Query{Limit: 1, Order: "desc"})
+	if err != nil {
+		return err
+	}
+	result := struct {
+		OK      bool `json:"ok"`
+		Records int  `json:"records"`
+	}{
+		OK:      true,
+		Records: len(resp.Data),
+	}
+	if integrationsOpts.jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(result)
+	}
+	fmt.Printf("Claude Compliance API access validated (%d record(s) returned).\n", result.Records)
+	return nil
+}
+
+func integrationsUserMode() bool {
+	return integrationsOpts.userMode && !integrationsOpts.systemMode
+}
+
+func integrationsLogPath(userMode bool) string {
+	if strings.TrimSpace(integrationsOpts.logPath) != "" {
+		return integrationsOpts.logPath
+	}
+	return writer.DefaultPath(userMode)
+}
+
+func claudeComplianceClientFromEnv() (*claudecompliance.Client, error) {
+	envName := strings.TrimSpace(integrationsOpts.apiKeyEnv)
+	if envName == "" {
+		envName = claudecompliance.DefaultAPIKeyEnv
+	}
+	apiKey := strings.TrimSpace(os.Getenv(envName))
+	if apiKey == "" {
+		return nil, fmt.Errorf("%s is not set", envName)
+	}
+	return &claudecompliance.Client{APIKey: apiKey}, nil
+}
+
+func claudeComplianceQuery(now time.Time) (claudecompliance.Query, error) {
+	query := claudecompliance.Query{
+		Limit:           integrationsOpts.limit,
+		Order:           "asc",
+		ActivityTypes:   cleanStringSlice(integrationsOpts.activityTypes),
+		OrganizationIDs: cleanStringSlice(integrationsOpts.organizationIDs),
+		ActorIDs:        cleanStringSlice(integrationsOpts.actorIDs),
+	}
+	if strings.TrimSpace(integrationsOpts.since) != "" {
+		since, err := parseSinceFlag(integrationsOpts.since, now)
+		if err != nil {
+			return claudecompliance.Query{}, err
+		}
+		query.CreatedAtGTE = since.UTC().Format(time.RFC3339)
+	}
+	return query, nil
+}
+
+func parseSinceFlag(value string, now time.Time) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	if duration, err := time.ParseDuration(value); err == nil {
+		return now.Add(-duration), nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("--since must be a duration such as 24h or an RFC3339 timestamp: %w", err)
+	}
+	return parsed, nil
+}
+
+func parseDurationFlag(name, value string) (time.Duration, error) {
+	if strings.TrimSpace(value) == "" {
+		return 0, nil
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("--%s must be a duration such as 10m: %w", name, err)
+	}
+	return duration, nil
+}
+
+func cleanStringSlice(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/cli/beacon/cmd/integrations_claude_compliance_test.go
+++ b/cli/beacon/cmd/integrations_claude_compliance_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClaudeComplianceCommandsRegistered(t *testing.T) {
+	for _, path := range [][]string{
+		{"integrations", "claude-compliance", "pull"},
+		{"integrations", "claude-compliance", "status"},
+		{"integrations", "claude-compliance", "validate"},
+	} {
+		cmd, _, err := rootCmd.Find(path)
+		if err != nil {
+			t.Fatalf("Find %v returned error: %v", path, err)
+		}
+		if cmd == nil || cmd.Use != path[len(path)-1] {
+			t.Fatalf("command %v not registered: %#v", path, cmd)
+		}
+	}
+}
+
+func TestClaudeCompliancePullFlagsRegistered(t *testing.T) {
+	for _, name := range []string{
+		"api-key-env",
+		"limit",
+		"max-pages",
+		"since",
+		"overlap",
+		"activity-type",
+		"organization-id",
+		"actor-id",
+		"reset-cursor",
+		"dry-run",
+		"user",
+		"system",
+		"log-path",
+	} {
+		if integrationsClaudeCompliancePullCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("pull command missing --%s flag", name)
+		}
+	}
+}
+
+func TestParseSinceFlagAcceptsDurationAndRFC3339(t *testing.T) {
+	now := time.Date(2026, 4, 10, 8, 30, 0, 0, time.UTC)
+	duration, err := parseSinceFlag("24h", now)
+	if err != nil {
+		t.Fatalf("parseSinceFlag duration returned error: %v", err)
+	}
+	if got, want := duration.UTC().Format(time.RFC3339), "2026-04-09T08:30:00Z"; got != want {
+		t.Fatalf("duration since = %s, want %s", got, want)
+	}
+	absolute, err := parseSinceFlag("2026-04-01T00:00:00Z", now)
+	if err != nil {
+		t.Fatalf("parseSinceFlag RFC3339 returned error: %v", err)
+	}
+	if got, want := absolute.UTC().Format(time.RFC3339), "2026-04-01T00:00:00Z"; got != want {
+		t.Fatalf("absolute since = %s, want %s", got, want)
+	}
+}

--- a/cli/beacon/internal/integrations/claudecompliance/claudecompliance.go
+++ b/cli/beacon/internal/integrations/claudecompliance/claudecompliance.go
@@ -1,0 +1,587 @@
+package claudecompliance
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+)
+
+const (
+	Name             = "claude_compliance"
+	DisplayName      = "Claude Compliance"
+	DefaultBaseURL   = "https://api.anthropic.com"
+	DefaultAPIKeyEnv = "ANTHROPIC_COMPLIANCE_ACCESS_KEY"
+
+	UserStatePath   = ".beacon/integrations/claude-compliance/state.json"
+	SystemStatePath = "/Library/Application Support/Beacon/Integrations/claude-compliance/state.json"
+
+	DefaultLimit     = 100
+	MaxLimit         = 5000
+	DefaultMaxPages  = 1
+	DefaultOverlap   = 10 * time.Minute
+	DefaultRecentIDs = 10000
+)
+
+var ErrSinceRequired = errors.New("first pull requires --since to avoid importing the entire activity history")
+
+type Client struct {
+	BaseURL       string
+	APIKey        string
+	HTTPClient    *http.Client
+	MaxRetries    int
+	RetryMaxDelay time.Duration
+	Sleep         func(context.Context, time.Duration) error
+}
+
+type Query struct {
+	Limit           int
+	Order           string
+	AfterID         string
+	BeforeID        string
+	CreatedAtGTE    string
+	CreatedAtGT     string
+	CreatedAtLTE    string
+	CreatedAtLT     string
+	ActivityTypes   []string
+	OrganizationIDs []string
+	ActorIDs        []string
+}
+
+type Activity struct {
+	ID               string                 `json:"id"`
+	CreatedAt        string                 `json:"created_at"`
+	OrganizationID   string                 `json:"organization_id"`
+	OrganizationUUID string                 `json:"organization_uuid"`
+	Type             string                 `json:"type"`
+	Actor            map[string]interface{} `json:"actor,omitempty"`
+	Raw              map[string]interface{} `json:"-"`
+}
+
+func (a *Activity) UnmarshalJSON(data []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	type alias Activity
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*a = Activity(decoded)
+	a.Raw = raw
+	return nil
+}
+
+type ActivitiesResponse struct {
+	Data    []Activity `json:"data"`
+	HasMore bool       `json:"has_more"`
+	FirstID string     `json:"first_id"`
+	LastID  string     `json:"last_id"`
+}
+
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	if strings.TrimSpace(e.Body) == "" {
+		return fmt.Sprintf("claude compliance API returned HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("claude compliance API returned HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+func (c *Client) ListActivities(ctx context.Context, query Query) (ActivitiesResponse, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return ActivitiesResponse{}, fmt.Errorf("%s API key is required", DisplayName)
+	}
+	retries := c.MaxRetries
+	if retries == 0 {
+		retries = 3
+	}
+	if retries < 0 {
+		retries = 0
+	}
+	var lastErr error
+	for attempt := 0; attempt <= retries; attempt++ {
+		resp, retryAfter, err := c.listActivitiesOnce(ctx, query)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) || !retryableStatus(apiErr.StatusCode) || attempt == retries {
+			return ActivitiesResponse{}, err
+		}
+		delay := retryAfter
+		if delay <= 0 {
+			delay = time.Duration(attempt+1) * time.Second
+		}
+		if max := c.retryMaxDelay(); max > 0 && delay > max {
+			delay = max
+		}
+		if err := c.sleep(ctx, delay); err != nil {
+			return ActivitiesResponse{}, err
+		}
+	}
+	return ActivitiesResponse{}, lastErr
+}
+
+func (c *Client) listActivitiesOnce(ctx context.Context, query Query) (ActivitiesResponse, time.Duration, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.activitiesURL(query), nil)
+	if err != nil {
+		return ActivitiesResponse{}, 0, err
+	}
+	req.Header.Set("x-api-key", c.APIKey)
+	req.Header.Set("accept", "application/json")
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return ActivitiesResponse{}, 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return ActivitiesResponse{}, parseRetryAfter(resp.Header.Get("Retry-After")), &APIError{
+			StatusCode: resp.StatusCode,
+			Body:       string(bytes.TrimSpace(body)),
+		}
+	}
+	var out ActivitiesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return ActivitiesResponse{}, 0, err
+	}
+	return out, 0, nil
+}
+
+func (c *Client) activitiesURL(query Query) string {
+	base := strings.TrimRight(c.BaseURL, "/")
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	u, err := url.Parse(base + "/v1/compliance/activities")
+	if err != nil {
+		return base + "/v1/compliance/activities"
+	}
+	values := u.Query()
+	limit := query.Limit
+	if limit <= 0 {
+		limit = DefaultLimit
+	}
+	if limit > MaxLimit {
+		limit = MaxLimit
+	}
+	values.Set("limit", strconv.Itoa(limit))
+	order := strings.TrimSpace(query.Order)
+	if order == "" {
+		order = "asc"
+	}
+	values.Set("order", order)
+	setIfNotEmpty(values, "after_id", query.AfterID)
+	setIfNotEmpty(values, "before_id", query.BeforeID)
+	setIfNotEmpty(values, "created_at.gte", query.CreatedAtGTE)
+	setIfNotEmpty(values, "created_at.gt", query.CreatedAtGT)
+	setIfNotEmpty(values, "created_at.lte", query.CreatedAtLTE)
+	setIfNotEmpty(values, "created_at.lt", query.CreatedAtLT)
+	addRepeated(values, "activity_types[]", query.ActivityTypes)
+	addRepeated(values, "organization_ids[]", query.OrganizationIDs)
+	addRepeated(values, "actor_ids[]", query.ActorIDs)
+	u.RawQuery = values.Encode()
+	return u.String()
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+func (c *Client) retryMaxDelay() time.Duration {
+	if c.RetryMaxDelay > 0 {
+		return c.RetryMaxDelay
+	}
+	return 30 * time.Second
+}
+
+func (c *Client) sleep(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	if c.Sleep != nil {
+		return c.Sleep(ctx, delay)
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func retryableStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status >= 500
+}
+
+func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if when, err := http.ParseTime(value); err == nil {
+		delay := time.Until(when)
+		if delay > 0 {
+			return delay
+		}
+	}
+	return 0
+}
+
+func setIfNotEmpty(values url.Values, key, value string) {
+	if strings.TrimSpace(value) != "" {
+		values.Set(key, strings.TrimSpace(value))
+	}
+}
+
+func addRepeated(values url.Values, key string, items []string) {
+	for _, item := range items {
+		if strings.TrimSpace(item) != "" {
+			values.Add(key, strings.TrimSpace(item))
+		}
+	}
+}
+
+type State struct {
+	LastID       string   `json:"last_id,omitempty"`
+	LastSyncedAt string   `json:"last_synced_at,omitempty"`
+	RecentIDs    []SeenID `json:"recent_ids,omitempty"`
+}
+
+type SeenID struct {
+	ID     string `json:"id"`
+	SeenAt string `json:"seen_at,omitempty"`
+}
+
+func DefaultStatePath(userMode bool) string {
+	if userMode {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return filepath.Join(".", UserStatePath)
+		}
+		return filepath.Join(home, UserStatePath)
+	}
+	return SystemStatePath
+}
+
+func LoadState(path string) (State, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return State{}, nil
+		}
+		return State{}, err
+	}
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return State{}, err
+	}
+	return state, nil
+}
+
+func SaveState(path string, state State) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0600)
+}
+
+func (s State) HasSeen(id string) bool {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return false
+	}
+	for _, seen := range s.RecentIDs {
+		if seen.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *State) MarkSeen(id string, seenAt time.Time) {
+	id = strings.TrimSpace(id)
+	if id == "" || s.HasSeen(id) {
+		return
+	}
+	s.RecentIDs = append(s.RecentIDs, SeenID{
+		ID:     id,
+		SeenAt: seenAt.UTC().Format(time.RFC3339),
+	})
+}
+
+func (s *State) TrimRecentIDs(max int) {
+	if max <= 0 {
+		max = DefaultRecentIDs
+	}
+	if len(s.RecentIDs) <= max {
+		return
+	}
+	s.RecentIDs = append([]SeenID(nil), s.RecentIDs[len(s.RecentIDs)-max:]...)
+}
+
+type SyncOptions struct {
+	Client      *Client
+	StatePath   string
+	Query       Query
+	MaxPages    int
+	Overlap     time.Duration
+	ResetCursor bool
+	DryRun      bool
+	WriteEvent  func(schema.Event) error
+	Now         func() time.Time
+}
+
+type SyncSummary struct {
+	Fetched      int    `json:"fetched"`
+	Written      int    `json:"written"`
+	Skipped      int    `json:"skipped"`
+	Pages        int    `json:"pages"`
+	StatePath    string `json:"state_path"`
+	LastID       string `json:"last_id,omitempty"`
+	LastSyncedAt string `json:"last_synced_at,omitempty"`
+	DryRun       bool   `json:"dry_run,omitempty"`
+}
+
+func PullActivities(ctx context.Context, opts SyncOptions) (SyncSummary, error) {
+	if opts.Client == nil {
+		return SyncSummary{}, errors.New("client is required")
+	}
+	statePath := opts.StatePath
+	if strings.TrimSpace(statePath) == "" {
+		statePath = DefaultStatePath(true)
+	}
+	state := State{}
+	if !opts.ResetCursor {
+		loaded, err := LoadState(statePath)
+		if err != nil {
+			return SyncSummary{}, err
+		}
+		state = loaded
+	}
+	now := time.Now().UTC()
+	if opts.Now != nil {
+		now = opts.Now().UTC()
+	}
+	query := opts.Query
+	query.Order = "asc"
+	if query.Limit <= 0 {
+		query.Limit = DefaultLimit
+	}
+	maxPages := opts.MaxPages
+	if maxPages <= 0 {
+		maxPages = DefaultMaxPages
+	}
+	if strings.TrimSpace(state.LastID) == "" && strings.TrimSpace(query.CreatedAtGTE) == "" {
+		return SyncSummary{}, ErrSinceRequired
+	}
+	summary := SyncSummary{StatePath: statePath, DryRun: opts.DryRun}
+	originalLastID := state.LastID
+
+	if originalLastID != "" && strings.TrimSpace(query.CreatedAtGTE) == "" {
+		if since := overlapSince(state, opts.Overlap); since != "" {
+			overlapQuery := query
+			overlapQuery.AfterID = ""
+			overlapQuery.CreatedAtGTE = since
+			if err := fetchPages(ctx, opts, overlapQuery, maxPages, now, &state, &summary, false); err != nil {
+				return SyncSummary{}, err
+			}
+		}
+		query.AfterID = originalLastID
+	}
+
+	if err := fetchPages(ctx, opts, query, maxPages, now, &state, &summary, true); err != nil {
+		return SyncSummary{}, err
+	}
+	state.LastSyncedAt = now.Format(time.RFC3339)
+	state.TrimRecentIDs(DefaultRecentIDs)
+	summary.LastID = state.LastID
+	summary.LastSyncedAt = state.LastSyncedAt
+	if !opts.DryRun {
+		if err := SaveState(statePath, state); err != nil {
+			return SyncSummary{}, err
+		}
+	}
+	return summary, nil
+}
+
+func fetchPages(ctx context.Context, opts SyncOptions, query Query, maxPages int, now time.Time, state *State, summary *SyncSummary, updateCursor bool) error {
+	for page := 0; page < maxPages; page++ {
+		resp, err := opts.Client.ListActivities(ctx, query)
+		if err != nil {
+			return err
+		}
+		summary.Pages++
+		summary.Fetched += len(resp.Data)
+		for _, activity := range resp.Data {
+			if state.HasSeen(activity.ID) {
+				summary.Skipped++
+				continue
+			}
+			event := EventFromActivity(activity, now)
+			if !opts.DryRun {
+				if opts.WriteEvent == nil {
+					return errors.New("event writer is required")
+				}
+				if err := opts.WriteEvent(event); err != nil {
+					return err
+				}
+			}
+			state.MarkSeen(activity.ID, now)
+			summary.Written++
+		}
+		if updateCursor && strings.TrimSpace(resp.LastID) != "" {
+			state.LastID = resp.LastID
+		}
+		if !resp.HasMore || strings.TrimSpace(resp.LastID) == "" {
+			return nil
+		}
+		query.AfterID = resp.LastID
+	}
+	return nil
+}
+
+func overlapSince(state State, overlap time.Duration) string {
+	if overlap <= 0 {
+		overlap = DefaultOverlap
+	}
+	if strings.TrimSpace(state.LastSyncedAt) == "" {
+		return ""
+	}
+	lastSyncedAt, err := time.Parse(time.RFC3339, state.LastSyncedAt)
+	if err != nil {
+		return ""
+	}
+	return lastSyncedAt.Add(-overlap).UTC().Format(time.RFC3339)
+}
+
+func EventFromActivity(activity Activity, fallbackNow time.Time) schema.Event {
+	timestamp := activity.CreatedAt
+	if _, err := time.Parse(time.RFC3339, timestamp); err != nil {
+		timestamp = fallbackNow.UTC().Format(time.RFC3339)
+	}
+	hostname, _ := os.Hostname()
+	event := schema.Event{
+		Timestamp:     timestamp,
+		Vendor:        schema.Vendor,
+		Product:       schema.Product,
+		SchemaVersion: schema.SchemaVersion,
+		Event: schema.EventInfo{
+			Kind:     "compliance_activity",
+			Action:   "compliance.activity." + normalizeAction(activity.Type),
+			Category: "compliance",
+		},
+		Severity: schema.SeverityInfo,
+		Endpoint: schema.EndpointInfo{
+			Hostname: hostname,
+			OS:       runtime.GOOS,
+		},
+		Harness: schema.HarnessInfo{Name: Name},
+		Origin:  schema.OriginCloud,
+		User: schema.UserInfo{
+			Name: actorString(activity.Actor, "email_address", "unauthenticated_email_address"),
+			UID:  actorString(activity.Actor, "user_id", "api_key_id", "admin_api_key_id", "service_account_id"),
+		},
+		Message: fmt.Sprintf("Claude Compliance activity: %s", activity.Type),
+		Raw: map[string]interface{}{
+			"anthropic_compliance_activity": activity.Raw,
+		},
+	}
+	if chatID, _ := activity.Raw["claude_chat_id"].(string); chatID != "" {
+		event.GenAI = &schema.GenAIInfo{Conversation: &schema.GenAIConversationInfo{ID: chatID}}
+	}
+	return event
+}
+
+func normalizeAction(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	lastDot := false
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastDot = false
+			continue
+		}
+		if !lastDot {
+			b.WriteByte('.')
+			lastDot = true
+		}
+	}
+	return strings.Trim(b.String(), ".")
+}
+
+func actorString(actor map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		if value, _ := actor[key].(string); strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func LastComplianceEvent(logPath string) (time.Time, bool) {
+	if strings.TrimSpace(logPath) == "" {
+		return time.Time{}, false
+	}
+	file, err := os.Open(logPath)
+	if err != nil {
+		return time.Time{}, false
+	}
+	defer file.Close()
+	var last time.Time
+	found := false
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var event schema.Event
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			continue
+		}
+		if event.Harness.Name != Name {
+			continue
+		}
+		found = true
+		if parsed, err := time.Parse(time.RFC3339, event.Timestamp); err == nil && parsed.After(last) {
+			last = parsed
+		}
+	}
+	return last, found
+}

--- a/cli/beacon/internal/integrations/claudecompliance/claudecompliance_test.go
+++ b/cli/beacon/internal/integrations/claudecompliance/claudecompliance_test.go
@@ -1,0 +1,276 @@
+package claudecompliance
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+)
+
+func TestPullActivitiesPaginatesWritesAndAdvancesCursor(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-api-key") != "test-key" {
+			t.Fatalf("missing API key header")
+		}
+		query := r.URL.Query()
+		if query.Get("order") != "asc" || query.Get("limit") != "2" {
+			t.Fatalf("unexpected query: %s", r.URL.RawQuery)
+		}
+		if got := query["activity_types[]"]; len(got) != 1 || got[0] != "claude_chat_created" {
+			t.Fatalf("activity type filter = %#v", got)
+		}
+		switch query.Get("after_id") {
+		case "":
+			_, _ = w.Write([]byte(`{"data":[{"id":"activity_1","created_at":"2026-04-10T08:09:10Z","type":"claude_chat_created","actor":{"type":"user_actor","email_address":"user@example.com","user_id":"user_1"}}],"has_more":true,"first_id":"activity_1","last_id":"activity_1"}`))
+		case "activity_1":
+			_, _ = w.Write([]byte(`{"data":[{"id":"activity_2","created_at":"2026-04-10T08:10:10Z","type":"claude_file_uploaded","actor":{"type":"user_actor","email_address":"user@example.com","user_id":"user_1"}}],"has_more":false,"first_id":"activity_2","last_id":"activity_2"}`))
+		default:
+			t.Fatalf("unexpected after_id %q", query.Get("after_id"))
+		}
+	}))
+	defer server.Close()
+
+	var written []schema.Event
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	summary, err := PullActivities(context.Background(), SyncOptions{
+		Client: &Client{
+			BaseURL:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+			MaxRetries: -1,
+		},
+		StatePath: statePath,
+		Query: Query{
+			Limit:         2,
+			CreatedAtGTE:  "2026-04-10T00:00:00Z",
+			ActivityTypes: []string{"claude_chat_created"},
+		},
+		MaxPages: 2,
+		Now:      fixedNow,
+		WriteEvent: func(event schema.Event) error {
+			written = append(written, event)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("PullActivities returned error: %v", err)
+	}
+	if summary.Fetched != 2 || summary.Written != 2 || summary.Pages != 2 {
+		t.Fatalf("summary = %#v, want fetched/written/pages 2", summary)
+	}
+	if len(written) != 2 {
+		t.Fatalf("written events = %d, want 2", len(written))
+	}
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.LastID != "activity_2" || len(state.RecentIDs) != 2 {
+		t.Fatalf("state = %#v, want last activity_2 and 2 recent IDs", state)
+	}
+	info, err := os.Stat(statePath)
+	if err != nil {
+		t.Fatalf("stat state: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0600); got != want {
+		t.Fatalf("state permissions = %o, want %o", got, want)
+	}
+}
+
+func TestPullActivitiesUsesOverlapAndDedupesRecentIDs(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	if err := SaveState(statePath, State{
+		LastID:       "activity_old",
+		LastSyncedAt: "2026-04-10T08:20:00Z",
+		RecentIDs:    []SeenID{{ID: "activity_old", SeenAt: "2026-04-10T08:20:00Z"}},
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		if query.Get("created_at.gte") != "" {
+			if got, want := query.Get("created_at.gte"), "2026-04-10T08:10:00Z"; got != want {
+				t.Fatalf("overlap created_at.gte = %q, want %q", got, want)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":"activity_late","created_at":"2026-04-10T08:15:00Z","type":"claude_chat_created"}],"has_more":false,"first_id":"activity_late","last_id":"activity_late"}`))
+			return
+		}
+		if got := query.Get("after_id"); got != "activity_old" {
+			t.Fatalf("incremental after_id = %q, want activity_old", got)
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"activity_late","created_at":"2026-04-10T08:15:00Z","type":"claude_chat_created"},{"id":"activity_new","created_at":"2026-04-10T08:21:00Z","type":"claude_chat_created"}],"has_more":false,"first_id":"activity_late","last_id":"activity_new"}`))
+	}))
+	defer server.Close()
+
+	var written []schema.Event
+	summary, err := PullActivities(context.Background(), SyncOptions{
+		Client:    &Client{BaseURL: server.URL, APIKey: "test-key", HTTPClient: server.Client(), MaxRetries: -1},
+		StatePath: statePath,
+		Query:     Query{Limit: 100},
+		MaxPages:  1,
+		Overlap:   10 * time.Minute,
+		Now:       fixedNow,
+		WriteEvent: func(event schema.Event) error {
+			written = append(written, event)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("PullActivities returned error: %v", err)
+	}
+	if summary.Fetched != 3 || summary.Written != 2 || summary.Skipped != 1 || len(written) != 2 {
+		t.Fatalf("summary=%#v written=%d, want fetched 3 written 2 skipped 1", summary, len(written))
+	}
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.LastID != "activity_new" || !state.HasSeen("activity_late") || !state.HasSeen("activity_new") {
+		t.Fatalf("state after overlap = %#v", state)
+	}
+}
+
+func TestPullActivitiesRequiresSinceForFirstPull(t *testing.T) {
+	_, err := PullActivities(context.Background(), SyncOptions{
+		Client:    &Client{APIKey: "test-key"},
+		StatePath: filepath.Join(t.TempDir(), "state.json"),
+		Query:     Query{Limit: 1},
+	})
+	if err != ErrSinceRequired {
+		t.Fatalf("PullActivities error = %v, want ErrSinceRequired", err)
+	}
+}
+
+func TestPullActivitiesDryRunDoesNotWriteStateOrEvents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"id":"activity_1","created_at":"2026-04-10T08:09:10Z","type":"claude_chat_created"}],"has_more":false,"first_id":"activity_1","last_id":"activity_1"}`))
+	}))
+	defer server.Close()
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	summary, err := PullActivities(context.Background(), SyncOptions{
+		Client:    &Client{BaseURL: server.URL, APIKey: "test-key", HTTPClient: server.Client(), MaxRetries: -1},
+		StatePath: statePath,
+		Query:     Query{CreatedAtGTE: "2026-04-10T00:00:00Z"},
+		DryRun:    true,
+		Now:       fixedNow,
+		WriteEvent: func(event schema.Event) error {
+			t.Fatal("dry-run should not write events")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("PullActivities returned error: %v", err)
+	}
+	if summary.Written != 1 || !summary.DryRun {
+		t.Fatalf("summary = %#v, want dry-run would-write count", summary)
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("dry-run state stat error = %v, want not exist", err)
+	}
+}
+
+func TestEventFromActivityUsesComplianceKind(t *testing.T) {
+	activity := Activity{
+		ID:        "activity_1",
+		CreatedAt: "2026-04-10T08:09:10Z",
+		Type:      "claude_chat_created",
+		Actor: map[string]interface{}{
+			"email_address": "user@example.com",
+			"user_id":       "user_1",
+		},
+		Raw: map[string]interface{}{
+			"id":             "activity_1",
+			"type":           "claude_chat_created",
+			"claude_chat_id": "claude_chat_1",
+		},
+	}
+	event := EventFromActivity(activity, fixedNow())
+	if event.Event.Kind == "agent_runtime" {
+		t.Fatal("Compliance API event must not be emitted as agent_runtime")
+	}
+	if event.Event.Kind != "compliance_activity" || event.Event.Action != "compliance.activity.claude.chat.created" {
+		t.Fatalf("event info = %#v", event.Event)
+	}
+	if event.Harness.Name != Name || event.Origin != schema.OriginCloud {
+		t.Fatalf("source fields = harness %#v origin %q", event.Harness, event.Origin)
+	}
+	if event.User.Name != "user@example.com" || event.User.UID != "user_1" {
+		t.Fatalf("user = %#v", event.User)
+	}
+	if event.GenAI == nil || event.GenAI.Conversation == nil || event.GenAI.Conversation.ID != "claude_chat_1" {
+		t.Fatalf("gen_ai conversation missing: %#v", event.GenAI)
+	}
+	if err := event.Validate(); err != nil {
+		t.Fatalf("event Validate returned error: %v", err)
+	}
+}
+
+func TestClientRetriesRetryableStatus(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, `{"error":"rate limited"}`, http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[],"has_more":false}`))
+	}))
+	defer server.Close()
+	client := &Client{
+		BaseURL:    server.URL,
+		APIKey:     "test-key",
+		HTTPClient: server.Client(),
+		MaxRetries: 1,
+		Sleep: func(ctx context.Context, delay time.Duration) error {
+			if delay != time.Second {
+				t.Fatalf("retry delay = %s, want 1s", delay)
+			}
+			return nil
+		},
+	}
+	if _, err := client.ListActivities(context.Background(), Query{Limit: 1}); err != nil {
+		t.Fatalf("ListActivities returned error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestLastComplianceEventSkipsMalformedLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	lines := []byte(`not json
+{"timestamp":"2026-04-10T08:09:10Z","harness":{"name":"other"}}
+{"timestamp":"2026-04-10T08:10:10Z","harness":{"name":"claude_compliance"}}
+`)
+	if err := os.WriteFile(path, lines, 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	last, ok := LastComplianceEvent(path)
+	if !ok {
+		t.Fatal("expected compliance event")
+	}
+	if got, want := last.UTC().Format(time.RFC3339), "2026-04-10T08:10:10Z"; got != want {
+		t.Fatalf("LastComplianceEvent = %s, want %s", got, want)
+	}
+}
+
+func fixedNow() time.Time {
+	return time.Date(2026, 4, 10, 8, 30, 0, 0, time.UTC)
+}
+
+func TestActivityCapturesRawFields(t *testing.T) {
+	var activity Activity
+	if err := json.Unmarshal([]byte(`{"id":"activity_1","created_at":"2026-04-10T08:09:10Z","type":"claude_chat_created","extra":"value"}`), &activity); err != nil {
+		t.Fatalf("unmarshal activity: %v", err)
+	}
+	if activity.ID != "activity_1" || activity.Raw["extra"] != "value" {
+		t.Fatalf("activity = %#v", activity)
+	}
+}

--- a/docs/cli/claude-compliance.mdx
+++ b/docs/cli/claude-compliance.mdx
@@ -1,0 +1,150 @@
+---
+title: "beacon integrations claude-compliance"
+description: "Pull Claude Compliance API activity into local Beacon JSONL"
+---
+
+## Integration Command
+
+`beacon integrations claude-compliance` pulls organization-level Claude Compliance Activity Feed records from Anthropic's Compliance API and writes normalized Beacon JSONL locally. This is a cloud compliance feed, not endpoint runtime telemetry, so it lives outside `beacon endpoint`.
+
+The integration is explicit and pull-based. Beacon does not store the Compliance API key; provide it through an environment variable when you run `pull` or `validate`.
+
+```bash title="Command syntax"
+beacon integrations claude-compliance [command]
+```
+
+## Commands
+
+<Columns cols={2}>
+  <Card title="pull" icon="cloud-arrow-down" href="#beacon-integrations-claude-compliance-pull">
+    Fetch activity records and append normalized events to local Beacon JSONL.
+  </Card>
+  <Card title="status" icon="circle-info" href="#beacon-integrations-claude-compliance-status">
+    Show local cursor state and whether Compliance events have been observed.
+  </Card>
+  <Card title="validate" icon="check" href="#beacon-integrations-claude-compliance-validate">
+    Verify API key access without writing logs or state.
+  </Card>
+</Columns>
+
+## Setup
+
+Create a Claude Compliance Access Key or Admin API key with the `read:compliance_activities` scope, then export it locally:
+
+```bash title="Set the API key"
+export ANTHROPIC_COMPLIANCE_ACCESS_KEY="sk-ant-..."
+```
+
+Validate access:
+
+```bash title="Validate access"
+beacon integrations claude-compliance validate
+```
+
+Run the first pull with an explicit lookback window:
+
+```bash title="Pull the last 24 hours"
+beacon integrations claude-compliance pull --since 24h
+```
+
+Subsequent pulls use saved cursor state and re-poll an overlap window to catch late-arriving activity records. Beacon deduplicates by Compliance API activity `id`.
+
+## Local Paths
+
+| Item | User mode | System mode |
+|------|-----------|-------------|
+| State | `~/.beacon/integrations/claude-compliance/state.json` | `/Library/Application Support/Beacon/Integrations/claude-compliance/state.json` |
+| JSONL output | `~/.beacon/endpoint/logs/runtime.jsonl` | `/var/log/beacon-agent/runtime.jsonl` |
+
+State files use `0600` permissions and store only cursors and recent activity IDs. API keys stay in your environment.
+
+## beacon integrations claude-compliance pull
+
+`pull` fetches Activity Feed records, normalizes each activity into a Beacon event with `event.kind = "compliance_activity"`, and appends it to local Beacon JSONL.
+
+```bash title="Pull recent activity"
+beacon integrations claude-compliance pull --since 24h
+```
+
+### Examples
+
+Pull only chat-created activity:
+
+```bash title="Filter by activity type"
+beacon integrations claude-compliance pull \
+  --since 24h \
+  --activity-type claude_chat_created
+```
+
+Pull multiple pages:
+
+```bash title="Fetch multiple pages"
+beacon integrations claude-compliance pull \
+  --since 24h \
+  --limit 500 \
+  --max-pages 5
+```
+
+Preview without writing JSONL or cursor state:
+
+```bash title="Dry run"
+beacon integrations claude-compliance pull \
+  --since 1h \
+  --dry-run
+```
+
+Use a custom API key environment variable:
+
+```bash title="Use a custom API key env var"
+CLAUDE_COMPLIANCE_KEY="sk-ant-..." \
+  beacon integrations claude-compliance pull \
+  --api-key-env CLAUDE_COMPLIANCE_KEY \
+  --since 24h
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--api-key-env <name>` | Environment variable containing the Claude Compliance API key. Defaults to `ANTHROPIC_COMPLIANCE_ACCESS_KEY` |
+| `--since <duration-or-time>` | Initial or manual lookback window, such as `24h`, or an RFC3339 timestamp |
+| `--overlap <duration>` | Incremental overlap window for late-arriving activity records. Defaults to `10m`; set `0` to disable |
+| `--limit <n>` | Maximum activities per API request. Defaults to `100`; API max is `5000` |
+| `--max-pages <n>` | Maximum API pages to fetch per pull. Defaults to `1` |
+| `--activity-type <type>` | Activity type to include. Repeat for multiple values |
+| `--organization-id <id>` | Organization ID or UUID to include. Repeat for multiple values |
+| `--actor-id <id>` | Actor user ID to include. Repeat for multiple values |
+| `--reset-cursor` | Ignore saved cursor state for this pull |
+| `--dry-run` | Fetch and normalize without writing JSONL or state |
+| `--json` | Print pull summary as JSON |
+| `--user` | Use per-user Beacon paths. Enabled by default |
+| `--system` | Use system Beacon paths |
+| `--log-path <path>` | Local Beacon JSONL output path |
+
+## beacon integrations claude-compliance status
+
+`status` shows the local cursor state and whether Beacon has observed Claude Compliance events in the configured JSONL log.
+
+```bash title="Show status"
+beacon integrations claude-compliance status
+```
+
+Print status as JSON:
+
+```bash title="Print JSON status"
+beacon integrations claude-compliance status --json
+```
+
+## beacon integrations claude-compliance validate
+
+`validate` makes a small Activity Feed request to verify the API key and scope. It does not write JSONL or update cursor state.
+
+```bash title="Validate API access"
+beacon integrations claude-compliance validate
+```
+
+Print validation output as JSON:
+
+```bash title="Print JSON validation"
+beacon integrations claude-compliance validate --json
+```

--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -39,6 +39,7 @@ Top-level Agent Beacon CLI commands.
 | [`beacon rules`](/cli/rules) | Manage and author Beacon threat-detection rules. |
 | [`beacon ci`](/cli/ci) | Run ephemeral AI runtime telemetry collection in CI. |
 | [`beacon cloud`](/cli/cloud) | Configure provider-managed cloud agent telemetry setup helpers. |
+| [`beacon integrations`](/cli/claude-compliance) | Pull external telemetry and compliance sources into local Beacon JSONL. |
 | [`beacon mcp`](/cli/mcp) | Expose local Beacon activity to MCP clients. |
 | [`beacon ingest`](/cli/ingest) | Upload Beacon telemetry to configured ingest destinations. |
 | [`beacon endpoint`](/cli/endpoint) | Manage local endpoint telemetry, runtime logs, and integrations. |
@@ -119,6 +120,18 @@ Configure provider-managed cloud agent telemetry setup helpers.
 | [`beacon cloud cursor print-setup`](/cli/cloud-cursor-print-setup) | Print a Cursor cloud agent binary setup script. |
 | [`beacon cloud cursor print-hooks`](/cli/cloud-cursor-print-hooks) | Print Cursor project hook settings to commit for cloud agents. |
 | [`beacon cloud gcs setup`](/cli/cloud-gcs-setup) | Create or print GCS setup commands for cloud-agent telemetry. |
+
+## beacon integrations
+
+```bash title="Command syntax"
+beacon integrations [command]
+```
+
+Pull external telemetry and compliance sources into local Beacon JSONL.
+
+| Command | Description |
+|---------|-------------|
+| [`beacon integrations claude-compliance`](/cli/claude-compliance) | Pull Claude Compliance API activity into local Beacon JSONL. |
 
 ## beacon mcp
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -60,7 +60,10 @@
             "icon": "cloud-arrow-up",
             "pages": [
               "deployment/hosting-options",
-              "deployment/managed",
+              {
+                "page": "deployment/managed",
+                "tag": "Enterprise"
+              },
               "deployment/open-source"
             ]
           },
@@ -280,6 +283,7 @@
                   "cli/cloud-gcs-setup"
                 ]
               },
+              "cli/claude-compliance",
               {
                 "group": "beacon mcp",
                 "root": "cli/mcp",
@@ -948,22 +952,6 @@
     {
       "source": "/cursor-cloud-agents",
       "destination": "/runtimes/cursor-cloud-agents"
-    },
-    {
-      "source": "/detections",
-      "destination": "/detections"
-    },
-    {
-      "source": "/detections-engine",
-      "destination": "/detections/engine"
-    },
-    {
-      "source": "/detections-standard",
-      "destination": "/detections/standard"
-    },
-    {
-      "source": "/detections-yaml-schema",
-      "destination": "/detections/yaml-schema"
     },
     {
       "source": "/development",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New external API client and local log writes affect compliance telemetry ingestion; API keys are env-only and first-pull guards limit accidental full-history imports.
> 
> **Overview**
> Adds a new **`beacon integrations`** command group with **`claude-compliance`** subcommands (`pull`, `status`, `validate`) to import Anthropic’s Compliance Activity Feed into local Beacon JSONL, separate from endpoint runtime telemetry.
> 
> **`pull`** reads the API key from env (default `ANTHROPIC_COMPLIANCE_ACCESS_KEY`), pages `/v1/compliance/activities` with retries, maps records to `compliance_activity` events (including raw payload and optional `gen_ai.conversation`), and appends via the existing JSONL writer. Sync uses on-disk cursor state (`last_id`, overlap window, recent-ID dedup), requires **`--since`** on first run, and supports filters, dry-run, and user/system paths.
> 
> Docs add `docs/cli/claude-compliance.mdx` and wire the command into the CLI index and `docs.json`; unrelated doc tweaks tag managed deployment as Enterprise and remove some detection redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad74f9b9d3bcc8e20ed02bc3ed644f1512fffa00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->