### PR TITLE
Persist S3 forwarder AWS provider env

### DIFF
--- a/cli/beacon/internal/endpoint/s3/pack/README.md
+++ b/cli/beacon/internal/endpoint/s3/pack/README.md
@@ -111,7 +111,14 @@ vector --config /etc/vector/beacon-s3.toml
 In managed deployments, provide `BEACON_S3_BUCKET`, optional
 `BEACON_S3_PREFIX`, `AWS_REGION`, and any AWS credential-provider settings
 through the Vector service environment, host identity, or MDM/secret tooling.
-Do not store AWS destination secrets in Beacon endpoint configuration.
+For the packaged macOS helper, set AWS provider-chain variables in the MDM
+script environment; the helper persists set values such as `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_PROFILE`,
+`AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE`,
+`AWS_WEB_IDENTITY_TOKEN_FILE`, and `AWS_ROLE_ARN` to
+`/Library/Application Support/Beacon/Forwarders/s3-vector.env` with mode
+`0600` so launchd-started Vector can authenticate. Do not store AWS
+destination secrets in Beacon endpoint configuration or `s3-vector.toml`.
 
 The Vector template is intentionally simple and expects a Vector version with
 the `file` source, `remap` transform, and `aws_s3` sink. It parses each Beacon

--- a/docs/cli/s3.mdx
+++ b/docs/cli/s3.mdx
@@ -7,7 +7,7 @@ description: "Generate AWS S3 forwarding content and validation events for Beaco
 
 Use `beacon endpoint s3` to generate AWS S3 forwarding content for Beacon endpoint events. The generated pack keeps Beacon as a local JSONL producer and helps your customer-managed Vector agent upload `runtime.jsonl` to an S3 bucket as gzip-compressed NDJSON.
 
-Beacon does not store AWS credentials, profiles, IAM roles, bucket policies, lifecycle rules, or encryption settings. Keep those values in AWS, Vector, endpoint-management policy, or deployment tooling.
+Beacon does not store AWS credentials, profiles, IAM roles, bucket policies, lifecycle rules, or encryption settings in endpoint configuration. Keep those values in AWS, Vector, endpoint-management policy, or deployment tooling. For packaged macOS MDM deployments, the managed S3 helper can persist MDM-injected AWS provider-chain environment variables to the root-owned Vector environment file used by launchd.
 
 ```bash title="Command syntax"
 beacon endpoint s3 [command]
@@ -155,6 +155,12 @@ Expected validation fields:
 ```text
 vendor=beacon product=endpoint-agent destination.type=s3 destination.mode=aws_s3_jsonl
 ```
+
+## macOS MDM Credential Injection
+
+For a managed macOS package, run `/opt/beacon/jamf/claude/s3/repair-hooks-and-forwarder.sh` from MDM or a root shell with destination settings in the environment. The helper writes non-secret forwarding settings and any set AWS provider-chain variables to `/Library/Application Support/Beacon/Forwarders/s3-vector.env` with mode `0600`, then starts `com.beacon.endpoint.s3-forwarder`.
+
+Supported provider-chain variables include `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_PROFILE`, `AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE`, `AWS_WEB_IDENTITY_TOKEN_FILE`, and `AWS_ROLE_ARN`. These values are not written to Beacon endpoint config or `s3-vector.toml`.
 
 ### Flags
 

--- a/docs/log-forwarding/s3.mdx
+++ b/docs/log-forwarding/s3.mdx
@@ -113,7 +113,7 @@ vector validate /etc/vector/beacon-s3.toml
 vector --config /etc/vector/beacon-s3.toml
 ```
 
-In managed deployments, provide `BEACON_S3_BUCKET`, optional `BEACON_S3_PREFIX`, `AWS_REGION`, optional `BEACON_S3_STORAGE_CLASS`, and any AWS credential-provider settings through the Vector service environment, host identity, or MDM/secret tooling. Do not store AWS destination secrets in Beacon endpoint configuration.
+In managed deployments, provide `BEACON_S3_BUCKET`, optional `BEACON_S3_PREFIX`, `AWS_REGION`, optional `BEACON_S3_STORAGE_CLASS`, and any AWS credential-provider settings through the Vector service environment, host identity, or MDM/secret tooling. The packaged macOS S3 helper persists set AWS provider-chain environment variables such as `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_PROFILE`, `AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE`, `AWS_WEB_IDENTITY_TOKEN_FILE`, and `AWS_ROLE_ARN` to `/Library/Application Support/Beacon/Forwarders/s3-vector.env` with mode `0600` for the launchd-managed Vector process. Do not store AWS destination secrets in Beacon endpoint configuration.
 
 The template expects a Vector version with the `file` source, `remap` transform, and `aws_s3` sink. It parses each Beacon JSONL line and re-encodes the original Beacon event as JSON with newline-delimited framing so S3 receives one Beacon event per line, without a Vector wrapper.
 

--- a/docs/mdm/jamf/claude.mdx
+++ b/docs/mdm/jamf/claude.mdx
@@ -68,7 +68,7 @@ Create a dedicated bucket prefix for the pilot and grant the identity used by th
 }
 ```
 
-Provide AWS credentials through host identity, MDM secret tooling, or the standard AWS credential provider chain available to the LaunchDaemon. Do not place AWS access keys in Beacon endpoint configuration.
+Provide AWS credentials through host identity, MDM secret tooling, or the standard AWS credential provider chain available to the LaunchDaemon. When `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_PROFILE`, `AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE`, `AWS_WEB_IDENTITY_TOKEN_FILE`, or `AWS_ROLE_ARN` are present in the MDM script environment, the helper persists them to the root-owned forwarder environment file so launchd-started Vector can use them. Do not place AWS access keys in Beacon endpoint configuration.
 
 ## Jamf Policy
 
@@ -90,6 +90,8 @@ Environment variables take precedence over Jamf parameters:
 | 9 | `BEACON_OTLP_GRPC_PORT` | Optional Beacon OTLP gRPC port, default `4317` |
 | 10 | `BEACON_OTLP_HTTP_PORT` | Optional Beacon OTLP HTTP port, default `4318` |
 
+The S3 helper also persists any standard AWS provider-chain environment variables listed above when they are set. This supports MDM secret injection without baking secrets into the package.
+
 The helper:
 
 - writes `/Library/Application Support/Beacon/Forwarders/s3-vector.toml`
@@ -107,6 +109,8 @@ For a one-Mac pilot without Jamf policy parameters, install the signed package a
 ```bash
 sudo BEACON_S3_BUCKET="example-security-logs" \
   AWS_REGION="us-west-2" \
+  AWS_ACCESS_KEY_ID="AKIA..." \
+  AWS_SECRET_ACCESS_KEY="..." \
   BEACON_S3_PREFIX="beacon/claude" \
   /opt/beacon/jamf/claude/s3/repair-hooks-and-forwarder.sh
 ```

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -133,6 +133,29 @@ credential-provider settings through the Vector service environment, host
 identity, MDM, or secret tooling. Keep AWS credentials, IAM roles, log group
 retention, and encryption outside Beacon endpoint configuration.
 
+For AWS S3, keep Beacon as the local JSONL producer and deploy Vector to tail
+`/var/log/beacon-agent/runtime.jsonl` into a customer-managed bucket. Generate
+Beacon's S3 content pack for setup guidance, a Vector config, sample events, and
+validation commands:
+
+```bash
+/opt/beacon/bin/beacon endpoint s3 install-pack --system --output ./beacon-s3-pack
+/opt/beacon/bin/beacon endpoint s3 validate --system
+```
+
+For Jamf-managed Claude deployments, the Beacon package can include Vector and
+run `/opt/beacon/jamf/claude/s3/install-forwarder.sh` or the combined
+`/opt/beacon/jamf/claude/s3/repair-hooks-and-forwarder.sh`. Provide
+`BEACON_S3_BUCKET`, `AWS_REGION`, optional `BEACON_S3_PREFIX`, and AWS
+provider-chain values through MDM secret tooling or a root environment. The
+helper persists set AWS provider-chain variables such as `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_PROFILE`,
+`AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE`,
+`AWS_WEB_IDENTITY_TOKEN_FILE`, and `AWS_ROLE_ARN` to
+`/Library/Application Support/Beacon/Forwarders/s3-vector.env` with mode `0600`
+for the launchd-managed Vector process. Keep bucket policy, IAM, lifecycle, and
+encryption in AWS.
+
 For CrowdStrike Falcon, use Beacon as the local JSONL producer and deploy Vector
 to tail hook-written or OTLP-written `runtime.jsonl` events into the Falcon HEC
 connector. Generate Beacon's Falcon content pack for setup guidance, a Vector

--- a/packaging/macos/jamf/claude/s3/install-forwarder.sh
+++ b/packaging/macos/jamf/claude/s3/install-forwarder.sh
@@ -45,6 +45,14 @@ shell_quote() {
   printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
 }
 
+write_env_if_set() {
+  name="$1"
+  eval "value=\${$name:-}"
+  if [ -n "$value" ]; then
+    printf 'export %s=%s\n' "$name" "$(shell_quote "$value")"
+  fi
+}
+
 toml_quote() {
   printf '"%s"' "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')"
 }
@@ -139,6 +147,14 @@ chmod 0644 "$CONFIG_PATH"
   printf 'export BEACON_S3_PREFIX=%s\n' "$(shell_quote "$S3_PREFIX")"
   printf 'export BEACON_S3_STORAGE_CLASS=%s\n' "$(shell_quote "$S3_STORAGE_CLASS")"
   printf 'export BEACON_VECTOR_READ_FROM=%s\n' "$(shell_quote "$VECTOR_READ_FROM")"
+  write_env_if_set AWS_ACCESS_KEY_ID
+  write_env_if_set AWS_SECRET_ACCESS_KEY
+  write_env_if_set AWS_SESSION_TOKEN
+  write_env_if_set AWS_PROFILE
+  write_env_if_set AWS_SHARED_CREDENTIALS_FILE
+  write_env_if_set AWS_CONFIG_FILE
+  write_env_if_set AWS_WEB_IDENTITY_TOKEN_FILE
+  write_env_if_set AWS_ROLE_ARN
 } >"$ENV_PATH"
 chmod 0600 "$ENV_PATH"
 

--- a/packaging/macos/test-endpoint-scripts.sh
+++ b/packaging/macos/test-endpoint-scripts.sh
@@ -450,7 +450,14 @@ BEACON_FORWARDER_BASE_DIR="$S3_FORWARDER_BASE" \
 BEACON_LAUNCHDAEMONS_DIR="$S3_LAUNCHDAEMONS_DIR" \
 BEACON_RUNTIME_LOG_PATHS="$TMP_DIR/s3-runtime.jsonl" \
 BEACON_NO_START="1" \
-AWS_SECRET_ACCESS_KEY="dont-write-me" \
+AWS_ACCESS_KEY_ID="test-access-key" \
+AWS_SECRET_ACCESS_KEY="test-secret-key" \
+AWS_SESSION_TOKEN="test-session-token" \
+AWS_PROFILE="test-profile" \
+AWS_SHARED_CREDENTIALS_FILE="/tmp/test-aws-credentials" \
+AWS_CONFIG_FILE="/tmp/test-aws-config" \
+AWS_WEB_IDENTITY_TOKEN_FILE="/tmp/test-web-identity-token" \
+AWS_ROLE_ARN="arn:aws:iam::123456789012:role/beacon-demo" \
 "$ROOT_DIR/packaging/macos/jamf/claude/s3/install-forwarder.sh" _ _ _ "beacon-test-bucket" "us-west-2" "beacon/claude" "STANDARD_IA" "end" >/dev/null
 
 if [ ! -f "$S3_FORWARDER_BASE/s3-vector.toml" ]; then
@@ -481,8 +488,8 @@ if ! grep -q 'bucket = "${BEACON_S3_BUCKET}"' "$S3_FORWARDER_BASE/s3-vector.toml
   echo "S3 Vector config should reference bucket env var" >&2
   exit 1
 fi
-if grep -q 'beacon-test-bucket\|dont-write-me' "$S3_FORWARDER_BASE/s3-vector.toml"; then
-  echo "S3 Vector config should not contain bucket values or AWS secrets" >&2
+if grep -q 'beacon-test-bucket\|test-access-key\|test-secret-key\|test-session-token' "$S3_FORWARDER_BASE/s3-vector.toml"; then
+  echo "S3 Vector config should not contain bucket values or AWS credentials" >&2
   exit 1
 fi
 if ! grep -q "beacon-test-bucket" "$S3_FORWARDER_BASE/s3-vector.env"; then
@@ -493,10 +500,21 @@ if ! grep -q "us-west-2" "$S3_FORWARDER_BASE/s3-vector.env"; then
   echo "S3 Vector env missing region" >&2
   exit 1
 fi
-if grep -q "dont-write-me" "$S3_FORWARDER_BASE/s3-vector.env"; then
-  echo "S3 Vector env should not contain AWS secrets" >&2
-  exit 1
-fi
+for expected in \
+  "AWS_ACCESS_KEY_ID='test-access-key'" \
+  "AWS_SECRET_ACCESS_KEY='test-secret-key'" \
+  "AWS_SESSION_TOKEN='test-session-token'" \
+  "AWS_PROFILE='test-profile'" \
+  "AWS_SHARED_CREDENTIALS_FILE='/tmp/test-aws-credentials'" \
+  "AWS_CONFIG_FILE='/tmp/test-aws-config'" \
+  "AWS_WEB_IDENTITY_TOKEN_FILE='/tmp/test-web-identity-token'" \
+  "AWS_ROLE_ARN='arn:aws:iam::123456789012:role/beacon-demo'"
+do
+  if ! grep -q "$expected" "$S3_FORWARDER_BASE/s3-vector.env"; then
+    echo "S3 Vector env missing AWS provider setting: $expected" >&2
+    exit 1
+  fi
+done
 case "$(ls -l "$S3_FORWARDER_BASE/s3-vector.env" | awk '{print $1}')" in
   -rw-------*) ;;
   *)


### PR DESCRIPTION
## Summary
- Persist MDM-injected AWS provider-chain env vars into the root-owned S3 Vector env file so launchd-started forwarding can authenticate.
- Keep credentials out of `s3-vector.toml` while extending packaging tests to cover the env-file behavior.
- Document how S3 MDM secret injection is stored and used by the managed macOS helper.

## Test plan
- `sh packaging/macos/test-endpoint-scripts.sh`
- Manual demo validation: patched env file allowed `com.beacon.endpoint.s3-forwarder` healthcheck to pass and fresh Claude/Beacon events to appear in S3.


Made with [Cursor](https://cursor.com)