### PR TITLE
Refactor docs

### DIFF
--- a/docs/cli/endpoint-paths.mdx
+++ b/docs/cli/endpoint-paths.mdx
@@ -22,15 +22,17 @@ Antigravity CLI, Claude Code, Cursor, Devin CLI, Devin Desktop, Factory, Grok Bu
 
 Hook and plugin configuration is written to:
 
-- Antigravity CLI: `~/.gemini/config/hooks.json` or `./.agents/hooks.json`
-- Claude Code: `~/.claude/settings.json` or `./.claude/settings.json`
-- Cursor: `~/.cursor/hooks.json` or `./.cursor/hooks.json`
-- Devin CLI: `~/.config/devin/config.json` or `./.devin/hooks.v1.json`
-- Devin Desktop: `~/.codeium/windsurf/hooks.json` or `./.windsurf/hooks.json`
-- Factory: `~/.factory/settings.json` or `./.factory/settings.json`
-- Grok Build: `~/.grok/hooks/beacon-endpoint.json` or `./.grok/hooks/beacon-endpoint.json`
-- Hermes Agent: `~/.hermes/config.yaml`
-- OpenCode: `~/.config/opencode/plugins/beacon.ts` or `./.opencode/plugins/beacon.ts`
+| Runtime | Global config path | Project-local config path |
+|---|---|---|
+| Antigravity CLI | `~/.gemini/config/hooks.json` | `./.agents/hooks.json` |
+| Claude Code | `~/.claude/settings.json` | `./.claude/settings.json` |
+| Cursor | `~/.cursor/hooks.json` | `./.cursor/hooks.json` |
+| Devin CLI | `~/.config/devin/config.json` | `./.devin/hooks.v1.json` |
+| Devin Desktop | `~/.codeium/windsurf/hooks.json` | `./.windsurf/hooks.json` |
+| Factory | `~/.factory/settings.json` | `./.factory/settings.json` |
+| Grok Build | `~/.grok/hooks/beacon-endpoint.json` | `./.grok/hooks/beacon-endpoint.json` |
+| Hermes Agent | `~/.hermes/config.yaml` | — |
+| OpenCode | `~/.config/opencode/plugins/beacon.ts` | `./.opencode/plugins/beacon.ts` |
 
 ## Related
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -157,11 +157,16 @@
               {
                 "group": "Cloud Agents",
                 "pages": [
-                  "sdk/integrations-anthropic",
-                  "sdk/integrations-claude-agent-sdk",
                   "runtimes/claude-code-cloud-agents",
                   "runtimes/cursor-cloud-agents",
-                  "runtimes/devin-cloud-agents",
+                  "runtimes/devin-cloud-agents"
+                ]
+              },
+              {
+                "group": "Agent SDKs",
+                "pages": [
+                  "sdk/integrations-anthropic",
+                  "sdk/integrations-claude-agent-sdk",
                   "sdk/integrations-openai",
                   "sdk/integrations-vercel-ai-sdk"
                 ]
@@ -248,6 +253,13 @@
               "cli/install",
               "cli/upgrade",
               "cli/manual-install"
+            ]
+          },
+          {
+            "group": "CLI Resources",
+            "icon": "folder-open",
+            "pages": [
+              "cli/endpoint-paths"
             ]
           },
           {
@@ -343,13 +355,6 @@
                   }
                 ]
               }
-            ]
-          },
-          {
-            "group": "CLI Resources",
-            "icon": "folder-open",
-            "pages": [
-              "cli/endpoint-paths"
             ]
           }
         ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and Mintlify navigation only; no product code or behavior changes.
> 
> **Overview**
> **Docs navigation** is reorganized so SDK integration pages sit in a dedicated **Agent SDKs** group under Agent Harness Integrations, separate from **Cloud Agents** (runtime-only pages). On the **CLI** tab, **CLI Resources** (`endpoint-paths`) now appears right after Install and Upgrade, before the Command Manual, instead of at the bottom.
> 
> **Endpoint Paths** replaces the bullet list of hook/plugin config locations with a **Runtime / Global / Project-local** table matching the style of the file-locations table; Hermes Agent is shown with no project-local path (`—`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62ea146964c4d29715981d264b587de6ca1b7d1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->