### PR TITLE
Add release notes for v0.0.70

### DIFF
--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -11,6 +11,13 @@ Stay up to date with the latest changes to the Agent Beacon CLI.
 
 ## June 2026
 
+### v0.0.70 · June 18, 2026
+
+- **Top-level token usage command** · `beacon token-usage` replaces the previous `beacon endpoint tokens` command path for local token, cost, model, session, run, harness, and repository attribution from Beacon runtime logs. Update scripts and runbooks that still call the old endpoint subcommand.
+- **Consistent token rollups across CLI and dashboard** · The CLI and local dashboard now share the same token aggregation helpers, read the full filtered runtime log in append order, and apply exact case-insensitive session filtering so cumulative metrics and per-session drilldowns stay aligned.
+- **CI run filtering improvements** · `--run-id` accepts either a bare run id or the composite `provider/run_id` key shown in the report, making copied CI runtime logs easier to inspect.
+- **Docs navigation cleanup** · The docs now separate Agent SDK integration pages from cloud-agent runtime pages and move CLI resources closer to install and upgrade guidance. Endpoint hook paths are presented in a runtime/global/project-local table for quicker deployment review.
+
 ### v0.0.69 · June 17, 2026
 
 - **Persistent S3 forwarder credentials on macOS** · Fixed an issue where MDM-injected AWS provider-chain settings for the [S3 log forwarder](/log-forwarding/s3) were lost across `launchd` restarts. Provider env vars now persist in a root-owned env file so the managed `com.beacon.endpoint.s3-forwarder` job keeps shipping events after reboots and policy refreshes.

--- a/docs/cli/token-usage.mdx
+++ b/docs/cli/token-usage.mdx
@@ -13,6 +13,10 @@ beacon token-usage [flags]
 
 Use this command when you need a local report before opening the dashboard, sending diagnostics, or validating token attribution for a specific agent session.
 
+<Note>
+  In Beacon `v0.0.70`, token reporting moved from `beacon endpoint tokens` to the top-level `beacon token-usage` command. Update scripts, CI jobs, and runbooks that still invoke the old endpoint subcommand.
+</Note>
+
 ## How token attribution works
 
 Beacon normalizes token telemetry from every runtime into one canonical [`gen_ai.usage`](/telemetry-schema/normalization#usage-metadata) representation, then aggregates it locally from the runtime JSONL log. There are no per-harness token fields — a report over mixed runtimes uses the same vocabulary throughout.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -267,22 +267,6 @@
             "icon": "terminal",
             "pages": [
               "cli/index",
-              "cli/version",
-              "cli/login",
-              "cli/scan",
-              "cli/token-usage",
-              {
-                "group": "beacon rules",
-                "root": "cli/rules",
-                "pages": [
-                  "cli/rules-list",
-                  "cli/rules-add",
-                  "cli/rules-remove",
-                  "cli/rules-pull",
-                  "cli/rules-lint",
-                  "cli/rules-fields"
-                ]
-              },
               {
                 "group": "beacon ci",
                 "root": "cli/ci",
@@ -302,22 +286,6 @@
                   "cli/cloud-cursor-print-setup",
                   "cli/cloud-cursor-print-hooks",
                   "cli/cloud-gcs-setup"
-                ]
-              },
-              {
-                "group": "beacon mcp",
-                "root": "cli/mcp",
-                "pages": [
-                  "cli/mcp-serve",
-                  "cli/mcp-doctor"
-                ]
-              },
-              {
-                "group": "beacon ingest",
-                "root": "cli/ingest",
-                "tag": "Enterprise",
-                "pages": [
-                  "cli/ingest-endpoint"
                 ]
               },
               {
@@ -354,7 +322,39 @@
                     ]
                   }
                 ]
-              }
+              },
+              {
+                "group": "beacon ingest",
+                "root": "cli/ingest",
+                "tag": "Enterprise",
+                "pages": [
+                  "cli/ingest-endpoint"
+                ]
+              },
+              "cli/login",
+              {
+                "group": "beacon mcp",
+                "root": "cli/mcp",
+                "pages": [
+                  "cli/mcp-serve",
+                  "cli/mcp-doctor"
+                ]
+              },
+              {
+                "group": "beacon rules",
+                "root": "cli/rules",
+                "pages": [
+                  "cli/rules-list",
+                  "cli/rules-add",
+                  "cli/rules-remove",
+                  "cli/rules-pull",
+                  "cli/rules-lint",
+                  "cli/rules-fields"
+                ]
+              },
+              "cli/scan",
+              "cli/token-usage",
+              "cli/version"
             ]
           }
         ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Documents **Beacon v0.0.70** in the CLI changelog, covering the move from `beacon endpoint tokens` to top-level **`beacon token-usage`**, shared token rollups between the CLI and local dashboard, and **`--run-id`** accepting bare or `provider/run_id` values for CI logs. It also calls out broader docs navigation changes (SDK vs cloud-agent pages, CLI resources placement, endpoint hook path table) that ship with the release.
> 
> The **`beacon token-usage`** page adds a **v0.0.70** note telling operators to update scripts and runbooks that still call the old endpoint subcommand.
> 
> **`docs.json`** reorders the CLI **Command Manual** sidebar so `beacon ci`, `beacon cloud`, and `beacon endpoint` lead the list, with `ingest`, `login`, `mcp`, `rules`, `scan`, `token-usage`, and `version` grouped after the endpoint section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0385aa60dbd78e8f25d335246da6376ec8667e89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->