### PR TITLE
Update dashboard with hooks breakdown, add extra flags for inventory CLI command

### DIFF
--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -70,6 +70,9 @@ var endpointOpts struct {
 	includeEventSummaries    bool
 	includeRawEvents         bool
 	writeInventoryEvent      bool
+	inventoryMCP             bool
+	inventorySkills          bool
+	inventoryHooks           bool
 	inventoryHeartbeatForce  bool
 	inventoryHeartbeatConfig string
 	inventoryWorkingDir      string
@@ -429,6 +432,9 @@ func init() {
 	endpointDoctorCmd.Flags().BoolVar(&endpointOpts.fix, "fix", false, "Apply safe endpoint doctor remediations")
 	endpointInventoryCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print inventory as JSON")
 	endpointInventoryCmd.Flags().BoolVar(&endpointOpts.allTargets, "all", false, "Include all supported targets")
+	endpointInventoryCmd.Flags().BoolVar(&endpointOpts.inventoryMCP, "mcp", false, "Show only MCP server inventory and source configs")
+	endpointInventoryCmd.Flags().BoolVar(&endpointOpts.inventorySkills, "skills", false, "Show only local agent skill inventory")
+	endpointInventoryCmd.Flags().BoolVar(&endpointOpts.inventoryHooks, "hooks", false, "Show only hook integration and hook config inventory")
 	endpointInventoryCmd.Flags().BoolVar(&endpointOpts.writeInventoryEvent, "write-event", false, "Append inventory events to the endpoint runtime log")
 	endpointInventoryHeartbeatCmd.Flags().BoolVar(&endpointOpts.inventoryHeartbeatForce, "force", false, "Write inventory heartbeat even when TTL has not expired")
 	endpointInventoryHeartbeatCmd.Flags().StringVar(&endpointOpts.inventoryHeartbeatConfig, "config", "", "Endpoint config path")
@@ -441,6 +447,9 @@ func init() {
 	topLevelStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
 	topLevelInventoryCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print inventory as JSON")
 	topLevelInventoryCmd.Flags().BoolVar(&endpointOpts.allTargets, "all", false, "Include all supported targets")
+	topLevelInventoryCmd.Flags().BoolVar(&endpointOpts.inventoryMCP, "mcp", false, "Show only MCP server inventory and source configs")
+	topLevelInventoryCmd.Flags().BoolVar(&endpointOpts.inventorySkills, "skills", false, "Show only local agent skill inventory")
+	topLevelInventoryCmd.Flags().BoolVar(&endpointOpts.inventoryHooks, "hooks", false, "Show only hook integration and hook config inventory")
 	topLevelInventoryCmd.Flags().BoolVar(&endpointOpts.writeInventoryEvent, "write-event", false, "Append inventory events to the endpoint runtime log")
 	endpointTestEventCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print validation stages as JSON")
 	endpointBundleDiagnosticsCmd.Flags().StringVar(&endpointOpts.outputDir, "output", "", "Output directory for diagnostics bundle")

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -207,7 +207,7 @@ func printDoctorChecks(checks []diagnostics.Check, status string) {
 func runEndpointInventory(cmd *cobra.Command, args []string) error {
 	status := lifecycle.GetStatus(endpointUserMode(), endpointOpts.logPath)
 	effectiveCfg := loadConfigForMode(status.RuntimeLog.EffectiveUserMode, status.LogPath)
-	hookTargetNames, err := hookTargets()
+	hookTargetNames, err := inventoryHookTargets()
 	if err != nil {
 		return err
 	}
@@ -808,22 +808,33 @@ func printPlannedAction(action plannedAction) {
 	fmt.Println()
 }
 
+func inventoryHookTargets() ([]string, error) {
+	if endpointOpts.inventoryHooks && !endpointOpts.allTargets && strings.TrimSpace(endpointOpts.hookHarnesses) == "" {
+		return allHookTargetsForLevel(), nil
+	}
+	return hookTargets()
+}
+
 func hookTargets() ([]string, error) {
 	if endpointOpts.allTargets {
-		all := []string{"cursor", "vscode", "factory", "opencode", "grok", "hermes", "devin-cli", "devin-desktop", "antigravity"}
-		if endpointOpts.hookLevel == "project" {
-			filtered := all[:0:0]
-			for _, t := range all {
-				if t == "hermes" {
-					continue
-				}
-				filtered = append(filtered, t)
-			}
-			return filtered, nil
-		}
-		return all, nil
+		return allHookTargetsForLevel(), nil
 	}
 	return canonicalHookTargets(splitCSV(endpointOpts.hookHarnesses))
+}
+
+func allHookTargetsForLevel() []string {
+	all := []string{"cursor", "vscode", "factory", "opencode", "grok", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	if endpointOpts.hookLevel != "project" {
+		return all
+	}
+	filtered := all[:0:0]
+	for _, t := range all {
+		if t == "hermes" {
+			continue
+		}
+		filtered = append(filtered, t)
+	}
+	return filtered
 }
 
 func hookStatuses(targets []string) map[string]hookTargetResult {

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -227,41 +227,8 @@ func runEndpointInventory(cmd *cobra.Command, args []string) error {
 		UserScope:         configInventory.UserScope,
 	}
 	if endpointOpts.jsonOutput {
-		if !endpointOpts.allTargets {
-			filtered := []harness.Harness{}
-			for _, h := range result.Harnesses {
-				if h.Detected {
-					filtered = append(filtered, h)
-				}
-			}
-			result.Harnesses = filtered
-
-			filteredConfigs := []endpointinventory.Config{}
-			existingPaths := map[string]bool{}
-			for _, c := range result.Configs {
-				if c.Exists {
-					filteredConfigs = append(filteredConfigs, c)
-					existingPaths[c.PathHash] = true
-				}
-			}
-			result.Configs = filteredConfigs
-
-			filteredServers := []endpointinventory.MCPServer{}
-			for _, s := range result.MCPServers {
-				if existingPaths[s.SourcePathHash] {
-					filteredServers = append(filteredServers, s)
-				}
-			}
-			result.MCPServers = filteredServers
-
-			filteredSkills := []endpointinventory.Skill{}
-			for _, s := range result.Skills {
-				if s.Exists {
-					filteredSkills = append(filteredSkills, s)
-				}
-			}
-			result.Skills = filteredSkills
-		}
+		result = filterInventoryDefaults(result)
+		result = filterInventorySections(result)
 		if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
 			return err
 		}
@@ -270,21 +237,29 @@ func runEndpointInventory(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	}
-	fmt.Printf("Config: %s\n", result.ConfigPath)
-	fmt.Printf("Runtime log: %s\n", result.LogPath)
-	for _, h := range result.Harnesses {
-		if !endpointOpts.allTargets && !h.Detected {
-			continue
+	showAllInventorySections := !inventorySectionFilterActive()
+	if showAllInventorySections {
+		fmt.Printf("Config: %s\n", result.ConfigPath)
+		fmt.Printf("Runtime log: %s\n", result.LogPath)
+		for _, h := range result.Harnesses {
+			if !endpointOpts.allTargets && !h.Detected {
+				continue
+			}
+			fmt.Printf("Harness: %s detected=%t telemetry=%s\n", h.DisplayName, h.Detected, h.TelemetryStatus)
 		}
-		fmt.Printf("Harness: %s detected=%t telemetry=%s\n", h.DisplayName, h.Detected, h.TelemetryStatus)
 	}
-	for _, name := range hookTargetNames {
-		if hook, ok := result.Hooks[name]; ok {
-			fmt.Printf("Hook: %s status=%s installed=%t\n", name, hook.Status, hook.Installed)
+	if showAllInventorySections || endpointOpts.inventoryHooks {
+		for _, name := range hookTargetNames {
+			if hook, ok := result.Hooks[name]; ok {
+				fmt.Printf("Hook: %s status=%s installed=%t\n", name, hook.Status, hook.Installed)
+			}
 		}
 	}
 	for _, config := range result.Configs {
 		if !endpointOpts.allTargets && !config.Exists {
+			continue
+		}
+		if !inventoryConfigIncluded(config) {
 			continue
 		}
 		path := config.Path
@@ -293,34 +268,114 @@ func runEndpointInventory(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("Config: %s scope=%s status=%s mcp_servers=%d path=%s\n", config.Runtime, config.Scope, config.ParserStatus, config.MCPServerCount, path)
 	}
-	for _, server := range result.MCPServers {
-		name := server.ServerName
-		if name == "" {
-			name = server.ServerNameHash
+	if showAllInventorySections || endpointOpts.inventoryMCP {
+		for _, server := range result.MCPServers {
+			name := server.ServerName
+			if name == "" {
+				name = server.ServerNameHash
+			}
+			fmt.Printf("MCP: %s %s scope=%s transport=%s command_present=%t args=%d env_keys=%d\n", server.Runtime, name, server.SourceScope, server.Transport, server.CommandPresent, server.ArgsCount, server.EnvKeyCount)
 		}
-		fmt.Printf("MCP: %s %s scope=%s transport=%s command_present=%t args=%d env_keys=%d\n", server.Runtime, name, server.SourceScope, server.Transport, server.CommandPresent, server.ArgsCount, server.EnvKeyCount)
 	}
-	for _, skill := range result.Skills {
-		if !endpointOpts.allTargets && !skill.Exists {
-			continue
+	if showAllInventorySections || endpointOpts.inventorySkills {
+		for _, skill := range result.Skills {
+			if !endpointOpts.allTargets && !skill.Exists {
+				continue
+			}
+			name := skill.SkillName
+			if name == "" {
+				name = skill.SkillNameHash
+			}
+			path := skill.ManifestPath
+			if path == "" {
+				path = skill.RootPath
+			}
+			if path == "" {
+				path = skill.ManifestPathHash
+			}
+			fmt.Printf("Skill: %s %s scope=%s status=%s path=%s\n", skill.Runtime, name, skill.SourceScope, skill.ParserStatus, path)
 		}
-		name := skill.SkillName
-		if name == "" {
-			name = skill.SkillNameHash
-		}
-		path := skill.ManifestPath
-		if path == "" {
-			path = skill.RootPath
-		}
-		if path == "" {
-			path = skill.ManifestPathHash
-		}
-		fmt.Printf("Skill: %s %s scope=%s status=%s path=%s\n", skill.Runtime, name, skill.SourceScope, skill.ParserStatus, path)
 	}
 	if endpointOpts.writeInventoryEvent {
 		return writeInventoryEvents(effectiveCfg, configInventory)
 	}
 	return nil
+}
+
+func filterInventoryDefaults(result inventoryResult) inventoryResult {
+	if endpointOpts.allTargets {
+		return result
+	}
+	filtered := []harness.Harness{}
+	for _, h := range result.Harnesses {
+		if h.Detected {
+			filtered = append(filtered, h)
+		}
+	}
+	result.Harnesses = filtered
+
+	filteredConfigs := []endpointinventory.Config{}
+	existingPaths := map[string]bool{}
+	for _, c := range result.Configs {
+		if c.Exists {
+			filteredConfigs = append(filteredConfigs, c)
+			existingPaths[c.PathHash] = true
+		}
+	}
+	result.Configs = filteredConfigs
+
+	filteredServers := []endpointinventory.MCPServer{}
+	for _, s := range result.MCPServers {
+		if existingPaths[s.SourcePathHash] {
+			filteredServers = append(filteredServers, s)
+		}
+	}
+	result.MCPServers = filteredServers
+
+	filteredSkills := []endpointinventory.Skill{}
+	for _, s := range result.Skills {
+		if s.Exists {
+			filteredSkills = append(filteredSkills, s)
+		}
+	}
+	result.Skills = filteredSkills
+	return result
+}
+
+func inventorySectionFilterActive() bool {
+	return endpointOpts.inventoryMCP || endpointOpts.inventorySkills || endpointOpts.inventoryHooks
+}
+
+func filterInventorySections(result inventoryResult) inventoryResult {
+	if !inventorySectionFilterActive() {
+		return result
+	}
+	result.Harnesses = nil
+	if !endpointOpts.inventoryHooks {
+		result.Hooks = nil
+	}
+	if !endpointOpts.inventoryMCP {
+		result.MCPServers = nil
+	}
+	if !endpointOpts.inventorySkills {
+		result.Skills = nil
+	}
+	filteredConfigs := []endpointinventory.Config{}
+	for _, config := range result.Configs {
+		if inventoryConfigIncluded(config) {
+			filteredConfigs = append(filteredConfigs, config)
+		}
+	}
+	result.Configs = filteredConfigs
+	return result
+}
+
+func inventoryConfigIncluded(config endpointinventory.Config) bool {
+	if !inventorySectionFilterActive() {
+		return true
+	}
+	return (endpointOpts.inventoryMCP && config.MCPServerCount > 0) ||
+		(endpointOpts.inventoryHooks && config.ConfigKind == endpointinventory.KindHookConfig)
 }
 
 func writeInventoryEvents(cfg endpointconfig.Config, result endpointinventory.Result) error {

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -1004,6 +1004,60 @@ func TestRobustCLIFlagsRegistered(t *testing.T) {
 			t.Fatalf("%s should not register --dry-run", cmd.Use)
 		}
 	}
+	for _, cmd := range []*cobra.Command{endpointInventoryCmd, topLevelInventoryCmd} {
+		for _, name := range []string{"mcp", "skills", "hooks"} {
+			if cmd.Flags().Lookup(name) == nil {
+				t.Fatalf("%s missing --%s", cmd.Use, name)
+			}
+		}
+	}
+}
+
+func TestFilterInventorySectionsKeepsOnlyRequestedBuckets(t *testing.T) {
+	old := endpointOpts
+	t.Cleanup(func() { endpointOpts = old })
+	result := inventoryResult{
+		Hooks: map[string]hookTargetResult{
+			"cursor": {Target: "cursor", Status: "ok"},
+		},
+		Configs: []endpointinventory.Config{
+			{Runtime: "cursor", ConfigKind: endpointinventory.KindNativeConfig, MCPServerCount: 1},
+			{Runtime: "cursor", ConfigKind: endpointinventory.KindHookConfig},
+			{Runtime: "claude_code", ConfigKind: endpointinventory.KindNativeConfig},
+		},
+		MCPServers: []endpointinventory.MCPServer{
+			{Runtime: "cursor", ServerName: "filesystem"},
+		},
+		Skills: []endpointinventory.Skill{
+			{Runtime: "cursor", SkillName: "review"},
+		},
+	}
+
+	endpointOpts.inventoryMCP = true
+	filtered := filterInventorySections(result)
+	if len(filtered.MCPServers) != 1 || len(filtered.Configs) != 1 {
+		t.Fatalf("mcp filter kept wrong inventory: %#v", filtered)
+	}
+	if filtered.Hooks != nil || filtered.Skills != nil {
+		t.Fatalf("mcp filter should drop hooks and skills: %#v", filtered)
+	}
+	if filtered.Configs[0].MCPServerCount != 1 {
+		t.Fatalf("mcp filter kept wrong config: %#v", filtered.Configs)
+	}
+
+	endpointOpts.inventoryMCP = false
+	endpointOpts.inventoryHooks = true
+	endpointOpts.inventorySkills = true
+	filtered = filterInventorySections(result)
+	if len(filtered.Skills) != 1 || len(filtered.Hooks) != 1 {
+		t.Fatalf("hooks+skills filter dropped requested inventory: %#v", filtered)
+	}
+	if len(filtered.MCPServers) != 0 {
+		t.Fatalf("hooks+skills filter should drop MCP servers: %#v", filtered.MCPServers)
+	}
+	if len(filtered.Configs) != 1 || filtered.Configs[0].ConfigKind != endpointinventory.KindHookConfig {
+		t.Fatalf("hooks filter kept wrong configs: %#v", filtered.Configs)
+	}
 }
 
 func TestCompletionAndDocsCommandsRegistered(t *testing.T) {

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -1060,6 +1060,34 @@ func TestFilterInventorySectionsKeepsOnlyRequestedBuckets(t *testing.T) {
 	}
 }
 
+func TestEndpointInventoryHooksJSONIncludesDefaultHookStatuses(t *testing.T) {
+	old := endpointOpts
+	t.Cleanup(func() { endpointOpts = old })
+	t.Setenv("HOME", t.TempDir())
+	endpointOpts.userMode = true
+	endpointOpts.logPath = filepath.Join(t.TempDir(), "runtime.jsonl")
+	endpointOpts.jsonOutput = true
+	endpointOpts.inventoryHooks = true
+	endpointOpts.hookHarnesses = ""
+
+	output, err := captureStdout(t, func() error {
+		return runEndpointInventory(endpointInventoryCmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("runEndpointInventory returned error: %v", err)
+	}
+	var result inventoryResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("inventory JSON did not decode: %v output=%s", err, output)
+	}
+	if len(result.Hooks) == 0 {
+		t.Fatalf("hooks inventory was empty: %#v", result)
+	}
+	if hook, ok := result.Hooks["cursor"]; !ok || hook.Target != "cursor" {
+		t.Fatalf("hooks inventory missing cursor status: %#v", result.Hooks)
+	}
+}
+
 func TestCompletionAndDocsCommandsRegistered(t *testing.T) {
 	for _, name := range []string{"completion", "docs"} {
 		cmd, _, err := rootCmd.Find([]string{name})

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/inventory"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/tokens"
@@ -48,9 +49,19 @@ type InventoryResponse struct {
 	GeneratedAt string                `json:"generated_at"`
 	UserScope   inventory.UserScope   `json:"user_scope"`
 	Harnesses   interface{}           `json:"harnesses"`
+	Hooks       []HookStatus          `json:"hooks"`
 	Configs     []inventory.Config    `json:"configs"`
 	MCPServers  []inventory.MCPServer `json:"mcp_servers"`
 	Skills      []inventory.Skill     `json:"skills"`
+}
+
+type HookStatus struct {
+	Target     string `json:"target"`
+	Status     string `json:"status"`
+	Installed  bool   `json:"installed"`
+	Path       string `json:"path,omitempty"`
+	BinaryPath string `json:"binary_path,omitempty"`
+	Message    string `json:"message,omitempty"`
 }
 
 var (
@@ -99,6 +110,7 @@ func Handler(opts Options) (http.Handler, error) {
 			GeneratedAt: scan.GeneratedAt,
 			UserScope:   scan.UserScope,
 			Harnesses:   status.Harnesses,
+			Hooks:       hookStatuses(opts.LogPath, opts.UserMode),
 			Configs:     scan.Configs,
 			MCPServers:  scan.MCPServers,
 			Skills:      scan.Skills,
@@ -291,6 +303,44 @@ func tokenOptions(r *http.Request) tokens.Options {
 		opts.TopLimit = top
 	}
 	return opts
+}
+
+func hookStatuses(logPath string, userMode bool) []HookStatus {
+	out := []HookStatus{}
+	add := func(target string, installed bool, path, binaryPath, message string) {
+		status := "not_installed"
+		if installed {
+			status = "configured"
+		}
+		out = append(out, HookStatus{
+			Target:     target,
+			Status:     status,
+			Installed:  installed,
+			Path:       path,
+			BinaryPath: binaryPath,
+			Message:    message,
+		})
+	}
+	level := endpointhooks.LevelUser
+	antigravity := endpointhooks.AntigravityHookStatus(endpointhooks.AntigravityOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("antigravity", antigravity.Installed, antigravity.ConfigPath, antigravity.BinaryPath, antigravity.Message)
+	cursor := endpointhooks.CursorHookStatus(endpointhooks.CursorOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("cursor", cursor.Installed, cursor.HooksJSONPath, cursor.BinaryPath, cursor.Message)
+	devin := endpointhooks.DevinHookStatus(endpointhooks.DevinOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("devin-cli", devin.Installed, devin.ConfigPath, devin.BinaryPath, devin.Message)
+	devinDesktop := endpointhooks.DevinDesktopHookStatus(endpointhooks.DevinDesktopOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("devin-desktop", devinDesktop.Installed, devinDesktop.ConfigPath, devinDesktop.BinaryPath, devinDesktop.Message)
+	factory := endpointhooks.FactoryHookStatus(endpointhooks.FactoryOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("factory", factory.Installed, factory.SettingsPath, factory.BinaryPath, factory.Message)
+	grok := endpointhooks.GrokHookStatus(endpointhooks.GrokOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("grok", grok.Installed, grok.HooksPath, grok.BinaryPath, grok.Message)
+	hermes := endpointhooks.HermesHookStatus(endpointhooks.HermesOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("hermes", hermes.Installed, hermes.ConfigPath, hermes.BinaryPath, hermes.Message)
+	opencode := endpointhooks.OpenCodeHookStatus(endpointhooks.OpenCodeOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("opencode", opencode.Installed, opencode.PluginPath, opencode.BinaryPath, opencode.Message)
+	vscode := endpointhooks.VSCodeHookStatus(endpointhooks.VSCodeOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("vscode", vscode.Installed, vscode.HooksPath, vscode.BinaryPath, vscode.Message)
+	return out
 }
 
 func writeJSON(w http.ResponseWriter, value interface{}) {

--- a/cli/beacon/internal/endpoint/dashboard/static/app.js
+++ b/cli/beacon/internal/endpoint/dashboard/static/app.js
@@ -272,18 +272,21 @@ function renderInventory(resp) {
   const configs = resp?.configs || [];
   const servers = resp?.mcp_servers || [];
   const skills = resp?.skills || [];
+  const hooks = resp?.hooks || [];
   const existingConfigs = configs.filter((config) => config.exists);
   const existingSkills = skills.filter((skill) => skill.exists);
+  const hookConfigs = existingConfigs.filter((config) => config.config_kind === "hook_config");
   setText("#inventory-meta", resp?.generated_at ? `Scanned ${formatTime(resp.generated_at)}` : "");
-  renderInventoryCards(harnesses, existingConfigs, servers, existingSkills);
+  renderInventoryCards(harnesses, existingConfigs, servers, existingSkills, hooks.length ? hooks.filter((hook) => hook.installed) : hookConfigs);
   renderInventoryHarnesses(harnesses);
   renderInventoryConfigs(configs);
-  renderInventoryMCP(servers);
+  renderInventoryMCP(servers, configs);
   renderInventorySkills(existingSkills);
+  renderInventoryHooks(hooks, hookConfigs);
   renderInventoryScope(resp?.user_scope || {});
 }
 
-function renderInventoryCards(harnesses, configs, servers, skills = []) {
+function renderInventoryCards(harnesses, configs, servers, skills = [], hooks = []) {
   if (!$("#inventory-cards")) return;
   const detected = harnesses.filter((harness) => harness.detected).length;
   const enabled = harnesses.filter((harness) => harness.telemetry_status === "enabled").length;
@@ -294,6 +297,7 @@ function renderInventoryCards(harnesses, configs, servers, skills = []) {
     { label: "Config Files", value: configs.length, hint: `${managed} Beacon-managed` },
     { label: "MCP Servers", value: servers.length, hint: "across all configs" },
     { label: "Agent Skills", value: skills.length, hint: "local manifests" },
+    { label: "Hook Configs", value: hooks.length, hint: "discovered manifests" },
   ];
   $("#inventory-cards").innerHTML = cards
     .map((card) => `
@@ -345,7 +349,7 @@ function renderInventoryConfigs(configs) {
   const showAll = $("#inventory-show-all")?.checked;
   const rows = (configs || []).filter((config) => showAll || config.exists);
   if (!rows.length) {
-    tbody.innerHTML = `<tr><td colspan="8" class="muted">No configuration files discovered.</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="9" class="muted">No configuration files discovered.</td></tr>`;
     return;
   }
   tbody.innerHTML = rows
@@ -358,19 +362,21 @@ function renderInventoryConfigs(configs) {
         <td>${config.exists ? escapeHTML(config.mcp_server_count ?? 0) : `<span class="muted">-</span>`}</td>
         <td>${config.beacon_managed ? badge("managed", "badge-ok") : `<span class="muted">no</span>`}</td>
         <td class="nowrap">${config.modified_at ? escapeHTML(formatTime(config.modified_at)) : `<span class="muted">-</span>`}</td>
+        <td class="mono sha-cell">${hashCell(config.file_sha256)}</td>
         <td class="mono path-cell">${escapeHTML(config.path || config.path_hash || "")}</td>
       </tr>
     `)
     .join("");
 }
 
-function renderInventoryMCP(servers) {
+function renderInventoryMCP(servers, configs = []) {
   const tbody = $("#inventory-mcp");
   if (!tbody) return;
   if (!servers.length) {
-    tbody.innerHTML = `<tr><td colspan="8" class="muted">No MCP servers declared in discovered configs.</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="10" class="muted">No MCP servers declared in discovered configs.</td></tr>`;
     return;
   }
+  const sourceSHAs = configSHAsByPathHash(configs);
   tbody.innerHTML = servers
     .map((server) => `
       <tr>
@@ -381,6 +387,8 @@ function renderInventoryMCP(servers) {
         <td class="mono">${server.command_present ? escapeHTML(server.command_name || "yes") : `<span class="muted">-</span>`}</td>
         <td>${escapeHTML(server.args_count ?? 0)}</td>
         <td>${envKeysCell(server)}</td>
+        <td class="mono sha-cell">${hashCell(sourceSHAs.get(server.source_path_hash))}</td>
+        <td class="mono sha-cell">${hashCell(server.definition_hash)}</td>
         <td class="mono path-cell">${escapeHTML(server.source_path || server.source_path_hash || "")}</td>
       </tr>
     `)
@@ -391,7 +399,7 @@ function renderInventorySkills(skills) {
   const tbody = $("#inventory-skills");
   if (!tbody) return;
   if (!skills.length) {
-    tbody.innerHTML = `<tr><td colspan="6" class="muted">No agent skills discovered in supported local roots.</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="7" class="muted">No agent skills discovered in supported local roots.</td></tr>`;
     return;
   }
   tbody.innerHTML = skills
@@ -402,9 +410,43 @@ function renderInventorySkills(skills) {
         <td>${badge(skill.source_scope || "unknown", "badge-muted")}</td>
         <td>${parserBadge(skill)}</td>
         <td class="nowrap">${skill.modified_at ? escapeHTML(formatTime(skill.modified_at)) : `<span class="muted">-</span>`}</td>
+        <td class="mono sha-cell">${hashCell(skill.file_sha256)}</td>
         <td class="mono path-cell">${escapeHTML(skill.manifest_path || skill.manifest_path_hash || skill.root_path || skill.root_path_hash || "")}</td>
       </tr>
     `)
+    .join("");
+}
+
+function renderInventoryHooks(hooks, configs = []) {
+  const tbody = $("#inventory-hooks");
+  if (!tbody) return;
+  const rows = hooks?.length ? hooks : configs.map((config) => ({
+    target: config.runtime,
+    status: config.exists ? "configured" : "not_installed",
+    installed: config.exists,
+    path: config.path,
+    message: "",
+  }));
+  if (!rows.length) {
+    tbody.innerHTML = `<tr><td colspan="7" class="muted">No hook configuration manifests discovered.</td></tr>`;
+    return;
+  }
+  const configByPath = configsByPath(configs);
+  tbody.innerHTML = rows
+    .map((hook) => {
+      const config = configByPath.get(hook.path) || {};
+      return `
+        <tr class="${hook.installed ? "" : "row-absent"}">
+          <td>${escapeHTML(runtimeLabel(hook.target))}</td>
+          <td>${config.scope ? badge(config.scope, "badge-muted") : `<span class="muted">-</span>`}</td>
+          <td>${badge(hook.status || (hook.installed ? "configured" : "not_installed"), hook.installed ? "badge-ok" : "badge-muted")}</td>
+          <td>${config.beacon_managed ? badge("managed", "badge-ok") : `<span class="muted">no</span>`}</td>
+          <td class="nowrap">${config.modified_at ? escapeHTML(formatTime(config.modified_at)) : `<span class="muted">-</span>`}</td>
+          <td class="mono sha-cell">${hashCell(config.file_sha256)}</td>
+          <td class="mono path-cell">${escapeHTML(hook.path || config.path || config.path_hash || "")}${hook.message ? `<br /><span class="muted">${escapeHTML(hook.message)}</span>` : ""}</td>
+        </tr>
+      `;
+    })
     .join("");
 }
 
@@ -454,12 +496,38 @@ function envKeysCell(server) {
   return chips + (filtered ? ` <span class="muted">+${filtered} filtered</span>` : "");
 }
 
+function hashCell(value) {
+  if (!value) return `<span class="muted">-</span>`;
+  return escapeHTML(value);
+}
+
+function configSHAsByPathHash(configs) {
+  const values = new Map();
+  for (const config of configs || []) {
+    if (config.path_hash && config.file_sha256) {
+      values.set(config.path_hash, config.file_sha256);
+    }
+  }
+  return values;
+}
+
+function configsByPath(configs) {
+  const values = new Map();
+  for (const config of configs || []) {
+    if (config.path) {
+      values.set(config.path, config);
+    }
+  }
+  return values;
+}
+
 function runtimeLabel(value) {
   const labels = {
     claude_code: "Claude Code",
     codex_cli: "Codex CLI",
     cursor: "Cursor",
     gemini_cli: "Gemini CLI",
+    antigravity: "Antigravity CLI",
     antigravity_cli: "Antigravity CLI",
     vscode: "VS Code",
     factory: "Factory Droid",

--- a/cli/beacon/internal/endpoint/dashboard/static/app.js
+++ b/cli/beacon/internal/endpoint/dashboard/static/app.js
@@ -277,7 +277,7 @@ function renderInventory(resp) {
   const existingSkills = skills.filter((skill) => skill.exists);
   const hookConfigs = existingConfigs.filter((config) => config.config_kind === "hook_config");
   setText("#inventory-meta", resp?.generated_at ? `Scanned ${formatTime(resp.generated_at)}` : "");
-  renderInventoryCards(harnesses, existingConfigs, servers, existingSkills, hooks.length ? hooks.filter((hook) => hook.installed) : hookConfigs);
+  renderInventoryCards(harnesses, existingConfigs, servers, existingSkills, hookConfigs);
   renderInventoryHarnesses(harnesses);
   renderInventoryConfigs(configs);
   renderInventoryMCP(servers, configs);

--- a/cli/beacon/internal/endpoint/dashboard/static/inventory.html
+++ b/cli/beacon/internal/endpoint/dashboard/static/inventory.html
@@ -74,6 +74,7 @@
                 <th>MCP</th>
                 <th>Beacon Managed</th>
                 <th>Modified</th>
+                <th>Manifest SHA</th>
                 <th>Path</th>
               </tr>
             </thead>
@@ -100,6 +101,8 @@
                 <th>Command</th>
                 <th>Args</th>
                 <th>Env Keys</th>
+                <th>Source SHA</th>
+                <th>Definition SHA</th>
                 <th>Source</th>
               </tr>
             </thead>
@@ -124,10 +127,36 @@
                 <th>Scope</th>
                 <th>Status</th>
                 <th>Modified</th>
+                <th>Manifest SHA</th>
                 <th>Manifest</th>
               </tr>
             </thead>
             <tbody id="inventory-skills"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
+          <div>
+            <h2>Hook Configurations</h2>
+            <p class="muted">Hook manifests discovered across supported runtimes. Hook command bodies are not shown here.</p>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Runtime</th>
+                <th>Scope</th>
+                <th>Status</th>
+                <th>Beacon Managed</th>
+                <th>Modified</th>
+                <th>Manifest SHA</th>
+                <th>Manifest</th>
+              </tr>
+            </thead>
+            <tbody id="inventory-hooks"></tbody>
           </table>
         </div>
       </section>

--- a/cli/beacon/internal/endpoint/dashboard/static/styles.css
+++ b/cli/beacon/internal/endpoint/dashboard/static/styles.css
@@ -793,6 +793,10 @@ pre {
   max-width: 26rem;
 }
 
+.sha-cell {
+  max-width: 18rem;
+}
+
 .scope-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/docs/cli/endpoint-inventory.mdx
+++ b/docs/cli/endpoint-inventory.mdx
@@ -29,6 +29,14 @@ Inventory can include:
 
 Human-readable and JSON inventory use the same default filtering: configuration records, MCP server context, and skill manifests are shown when they are relevant to the local endpoint state. Use `--all` with `--json` when you need the complete supported inventory surface for fleet comparison or troubleshooting.
 
+Use the section filters when you only need one inventory surface:
+
+- `--mcp` shows MCP server inventory and the source config files that define MCP servers.
+- `--skills` shows local agent skill manifests.
+- `--hooks` shows hook integration status and hook config files.
+
+The section filters can be combined. For example, `--mcp --skills --json` prints only MCP and skill inventory buckets in the JSON output.
+
 ## Inventory Heartbeats
 
 Cursor and Claude Code endpoint hooks can periodically append inventory telemetry to a separate `inventory_state.jsonl` file beside `runtime.jsonl`:
@@ -61,6 +69,9 @@ For a manual smoke test, temporarily lower `ttl_seconds`, start a Cursor or Clau
 | `--log-path <path>` | Runtime JSONL log path |
 | `--json` | Print inventory as JSON |
 | `--all` | Include all supported targets, not only configured, detected, or observed targets |
+| `--mcp` | Show only MCP server inventory and source configs |
+| `--skills` | Show only local agent skill inventory |
+| `--hooks` | Show only hook integration and hook config inventory |
 
 ## Examples
 
@@ -80,6 +91,18 @@ Print machine-readable inventory:
 
 ```bash title="Print machine-readable inventory"
 beacon endpoint inventory --json
+```
+
+Show only MCP server inventory:
+
+```bash title="Show MCP inventory"
+beacon endpoint inventory --mcp
+```
+
+Show only skill manifests and hook configuration:
+
+```bash title="Show skills and hooks"
+beacon endpoint inventory --skills --hooks --json
 ```
 
 Inventory a system-mode endpoint:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to inventory CLI filtering, read-only dashboard inventory APIs/UI, and documentation—no auth, persistence, or telemetry pipeline behavior changes.
> 
> **Overview**
> **Endpoint inventory** gains combinable section flags `--mcp`, `--skills`, and `--hooks` on `beacon endpoint inventory` and the top-level `beacon inventory` alias. JSON output now runs through shared helpers (`filterInventoryDefaults`, `filterInventorySections`) so filtered runs drop unrelated buckets (e.g. `--mcp` keeps MCP servers and configs that declare MCP servers). Text output follows the same sections, and `--hooks` without an explicit harness list reports default hook targets via `inventoryHookTargets` / `allHookTargetsForLevel`.
> 
> **Local dashboard** inventory API now includes a `hooks` array built from the same hook status probes as the CLI. The Agent Inventory UI adds a **Hook Configurations** table, a hook-config summary card, and **manifest/source/definition SHA** columns on config, MCP, and skill tables for metadata-only comparison.
> 
> Docs in `endpoint-inventory.mdx` describe the new flags and examples; tests cover flag registration, section filtering, and hooks JSON with default statuses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4906d374d088c9451df982c21d42c818c867f81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->