### PR TITLE
Fix initial inventory forwarding

### DIFF
--- a/cli/beacon/internal/endpoint/inventory/heartbeat.go
+++ b/cli/beacon/internal/endpoint/inventory/heartbeat.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -108,6 +109,9 @@ func ReadState(path string) (State, error) {
 			return State{}, nil
 		}
 		return State{}, err
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return State{}, nil
 	}
 	var state State
 	if err := json.Unmarshal(data, &state); err != nil {

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -475,6 +475,20 @@ func TestInventoryLogAndStatePathsFollowRuntimeLog(t *testing.T) {
 	}
 }
 
+func TestReadStateTreatsEmptyFileAsFreshState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "inventory-state.json")
+	if err := os.WriteFile(path, []byte(" \n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	state, err := ReadState(path)
+	if err != nil {
+		t.Fatalf("ReadState returned error for empty state file: %v", err)
+	}
+	if state != (State{}) {
+		t.Fatalf("state = %#v, want empty", state)
+	}
+}
+
 func fixedNow() time.Time {
 	return time.Date(2026, 6, 5, 7, 0, 0, 0, time.UTC)
 }

--- a/cli/beacon/internal/endpoint/s3/pack/vector.toml.tmpl
+++ b/cli/beacon/internal/endpoint/s3/pack/vector.toml.tmpl
@@ -14,7 +14,7 @@ read_from = "end"
 [sources.beacon_inventory]
 type = "file"
 include = ["{{INVENTORY_LOG_PATH}}"]
-read_from = "end"
+read_from = "beginning"
 
 [transforms.beacon_runtime_json]
 type = "remap"

--- a/cli/beacon/internal/endpoint/s3/s3_test.go
+++ b/cli/beacon/internal/endpoint/s3/s3_test.go
@@ -90,6 +90,7 @@ func TestVectorConfigUsesAWSS3SinkAndPreservesJSONShape(t *testing.T) {
 		`include = ["{{LOG_PATH}}"]`,
 		`include = ["{{INVENTORY_LOG_PATH}}"]`,
 		`read_from = "end"`,
+		`read_from = "beginning"`,
 		`. = parse_json!(.message)`,
 		`type = "aws_s3"`,
 		`bucket = "${BEACON_S3_BUCKET}"`,

--- a/packaging/macos/jamf/claude/s3/install-forwarder.sh
+++ b/packaging/macos/jamf/claude/s3/install-forwarder.sh
@@ -138,7 +138,7 @@ read_from = "\${BEACON_VECTOR_READ_FROM:-end}"
 [sources.beacon_inventory]
 type = "file"
 include = $INVENTORY_INCLUDES
-read_from = "\${BEACON_VECTOR_READ_FROM:-end}"
+read_from = "beginning"
 
 [transforms.beacon_runtime_json]
 type = "remap"

--- a/packaging/macos/test-endpoint-scripts.sh
+++ b/packaging/macos/test-endpoint-scripts.sh
@@ -500,6 +500,10 @@ if ! grep -q 'key_prefix = "${BEACON_S3_PREFIX:-beacon}/inventory/date=%F/"' "$S
   echo "S3 Vector config missing inventory prefix" >&2
   exit 1
 fi
+if ! grep -q 'read_from = "beginning"' "$S3_FORWARDER_BASE/s3-vector.toml"; then
+  echo "S3 Vector config should read inventory log from beginning" >&2
+  exit 1
+fi
 if ! grep -q 'compression = "gzip"' "$S3_FORWARDER_BASE/s3-vector.toml"; then
   echo "S3 Vector config missing gzip compression" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Treat empty inventory heartbeat state files as fresh state so Jamf-precreated state files do not break heartbeat writes.
- Configure S3 inventory sources to read from the beginning while keeping runtime sources at end, so first inventory snapshots are forwarded after Vector starts.
- Add focused tests for empty state handling and Jamf/S3 inventory source configuration.

## Test plan
- `cd cli/beacon && go test ./internal/endpoint/inventory ./internal/endpoint/s3 ./internal/endpoint/siempack`
- `sh packaging/macos/test-endpoint-scripts.sh`
- `git diff --check`


Made with [Cursor](https://cursor.com)