### PR TITLE
Cover Claude MCP and symlinked skills in inventory

### DIFF
--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -210,6 +210,7 @@ func candidates(home, wd string) []candidate {
 
 func claudeCandidates(home, wd string) []candidate {
 	return []candidate{
+		{runtime: "claude_code", path: filepath.Join(home, ".claude.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
 		{runtime: "claude_code", path: filepath.Join(home, ".claude", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
 		{runtime: "claude_code", path: filepath.Join(wd, ".claude", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindNativeConfig},
 		{runtime: "claude_code", path: "/Library/Application Support/ClaudeCode/managed-settings.json", scope: ScopeManaged, format: formatJSON, kind: KindManagedConfig},

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -51,26 +51,21 @@ GITHUB_TOKEN = "secret"
 	assertServer(t, result.MCPServers, "codex_cli", "github", TransportStdio, true, 2, 0, 1)
 	assertServer(t, result.MCPServers, "cursor", "remote", TransportSSE, false, 0, 0, 0)
 
-	foundClaudeConfig := false
-	for _, config := range result.Configs {
-		if config.Runtime == "claude_code" && config.Scope == ScopeUser {
-			foundClaudeConfig = true
-			if !config.Exists || !config.Readable || config.ParserStatus != StatusOK {
-				t.Fatalf("Claude config status = exists:%t readable:%t parser:%s", config.Exists, config.Readable, config.ParserStatus)
-			}
-			if config.MCPServerCount != 1 {
-				t.Fatalf("Claude MCPServerCount = %d, want 1", config.MCPServerCount)
-			}
-			if config.FileSHA256 == "" || config.PathHash == "" {
-				t.Fatal("Claude config missing hashes")
-			}
-			if config.ParserMode != formatJSON || config.ConfigKind != KindNativeConfig {
-				t.Fatalf("Claude config mode/kind = %s/%s, want %s/%s", config.ParserMode, config.ConfigKind, formatJSON, KindNativeConfig)
-			}
-		}
+	claudeSettings := findConfig(result.Configs, "claude_code", filepath.Join(home, ".claude", "settings.json"))
+	if claudeSettings == nil {
+		t.Fatal("Claude settings config not found in inventory")
 	}
-	if !foundClaudeConfig {
-		t.Fatal("Claude user config not found in inventory")
+	if !claudeSettings.Exists || !claudeSettings.Readable || claudeSettings.ParserStatus != StatusOK {
+		t.Fatalf("Claude config status = exists:%t readable:%t parser:%s", claudeSettings.Exists, claudeSettings.Readable, claudeSettings.ParserStatus)
+	}
+	if claudeSettings.MCPServerCount != 1 {
+		t.Fatalf("Claude MCPServerCount = %d, want 1", claudeSettings.MCPServerCount)
+	}
+	if claudeSettings.FileSHA256 == "" || claudeSettings.PathHash == "" {
+		t.Fatal("Claude config missing hashes")
+	}
+	if claudeSettings.ParserMode != formatJSON || claudeSettings.ConfigKind != KindNativeConfig {
+		t.Fatalf("Claude config mode/kind = %s/%s, want %s/%s", claudeSettings.ParserMode, claudeSettings.ConfigKind, formatJSON, KindNativeConfig)
 	}
 }
 
@@ -103,6 +98,36 @@ func TestScanIncludesNamesAndPaths(t *testing.T) {
 		if config.Exists && config.Path == "" {
 			t.Fatalf("config missing path: %#v", config)
 		}
+	}
+}
+
+func TestScanClaudeJSONMCPInventory(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	writeFile(t, filepath.Join(home, ".claude.json"), `{
+  "mcpServers": {
+    "github": {
+      "command": "gh",
+      "args": ["mcp", "serve"],
+      "env": {"GITHUB_TOKEN": "secret", "GH_HOST": "github.com"}
+    }
+  }
+}`)
+
+	result := Scan(Options{
+		HomeDir:    home,
+		WorkingDir: work,
+		Runtimes:   []string{"claude_code"},
+		Now:        fixedNow,
+	})
+
+	assertServer(t, result.MCPServers, "claude_code", "github", TransportStdio, true, 2, 1, 2)
+	config := findConfig(result.Configs, "claude_code", filepath.Join(home, ".claude.json"))
+	if config == nil {
+		t.Fatalf("Claude ~/.claude.json config not found in %#v", result.Configs)
+	}
+	if config.MCPServerCount != 1 || config.ParserStatus != StatusOK {
+		t.Fatalf("Claude ~/.claude.json status = %#v, want one MCP server", config)
 	}
 }
 
@@ -162,17 +187,12 @@ command = "gh"
 		Now:        fixedNow,
 	})
 
-	var malformedFound bool
-	for _, config := range result.Configs {
-		if config.Runtime == "claude_code" && config.Scope == ScopeUser {
-			malformedFound = true
-			if config.ParserStatus != StatusParseFailed {
-				t.Fatalf("malformed Claude parser status = %s, want %s", config.ParserStatus, StatusParseFailed)
-			}
-		}
-	}
-	if !malformedFound {
+	malformed := findConfig(result.Configs, "claude_code", filepath.Join(home, ".claude", "settings.json"))
+	if malformed == nil {
 		t.Fatal("malformed Claude config result not found")
+	}
+	if malformed.ParserStatus != StatusParseFailed {
+		t.Fatalf("malformed Claude parser status = %s, want %s", malformed.ParserStatus, StatusParseFailed)
 	}
 	assertServer(t, result.MCPServers, "codex_cli", "github", TransportStdio, true, 0, 0, 0)
 }
@@ -211,6 +231,7 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 	})
 
 	expected := []candidate{
+		{runtime: "claude_code", path: filepath.Join(home, ".claude.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
 		{runtime: "claude_code", path: filepath.Join(home, ".claude", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
 		{runtime: "claude_code", path: filepath.Join(work, ".claude", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindNativeConfig},
 		{runtime: "claude_code", path: "/Library/Application Support/ClaudeCode/managed-settings.json", scope: ScopeManaged, format: formatJSON, kind: KindManagedConfig},
@@ -462,6 +483,35 @@ func TestSkillScanIsBoundedToDirectSkillManifests(t *testing.T) {
 	}
 	if findSkill(result.Skills, "cursor", "package", filepath.Join(home, ".cursor", "skills", "node_modules", "package", "SKILL.md")) != nil {
 		t.Fatal("vendor skill manifest should not be discovered")
+	}
+}
+
+func TestSkillScanFollowsSymlinkedSkillDirectories(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	target := filepath.Join(home, ".agents", "skills", "find-skills")
+	writeFile(t, filepath.Join(target, "SKILL.md"), "# Find Skills")
+	linkRoot := filepath.Join(home, ".claude", "skills")
+	if err := os.MkdirAll(linkRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(linkRoot, "find-skills")); err != nil {
+		t.Fatal(err)
+	}
+
+	result := Scan(Options{
+		HomeDir:    home,
+		WorkingDir: work,
+		Runtimes:   []string{"claude_code"},
+		Now:        fixedNow,
+	})
+
+	skill := findSkill(result.Skills, "claude_code", "find-skills", filepath.Join(linkRoot, "find-skills", "SKILL.md"))
+	if skill == nil {
+		t.Fatalf("symlinked Claude skill not found in %#v", result.Skills)
+	}
+	if !skill.Exists || !skill.Readable || skill.ParserStatus != StatusOK {
+		t.Fatalf("symlinked Claude skill status = %#v", skill)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/inventory/skills.go
+++ b/cli/beacon/internal/endpoint/inventory/skills.go
@@ -113,7 +113,10 @@ func inspectSkillRoot(root skillRoot, redaction string) []Skill {
 		if len(skills) >= maxSkillsPerRoot {
 			break
 		}
-		if !entry.IsDir() || skipSkillDir(entry.Name()) {
+		if skipSkillDir(entry.Name()) {
+			continue
+		}
+		if !entry.IsDir() && entry.Type()&os.ModeSymlink == 0 {
 			continue
 		}
 		manifestPath := filepath.Join(root.path, entry.Name(), "SKILL.md")

--- a/cli/beacon/internal/endpoint/s3/pack/README.md
+++ b/cli/beacon/internal/endpoint/s3/pack/README.md
@@ -140,7 +140,11 @@ under `${BEACON_S3_PREFIX}/inventory/date=.../`.
 
 The template uses date-partitioned `key_prefix`, `filename_time_format = "%s"`,
 and `filename_append_uuid = true` so production forwarding does not overwrite
-previous S3 objects. It also sets `compression = "gzip"`,
+previous S3 objects. Runtime log forwarding starts at the end of the active log
+to avoid backfilling historical session activity when Vector is first installed.
+Inventory forwarding starts at the beginning of `inventory_state.jsonl` so the
+first snapshot is not missed if the file was created before Vector began
+watching it. The template also sets `compression = "gzip"`,
 `content_encoding = "gzip"`, and `content_type = "application/x-ndjson"`.
 
 If you adapt the config or use another forwarder, it should:

--- a/docs/cli/endpoint-inventory.mdx
+++ b/docs/cli/endpoint-inventory.mdx
@@ -22,8 +22,8 @@ Inventory can include:
 - Endpoint config path, runtime log path, and configured OTLP harnesses
 - Detected supported runtimes and telemetry status, including MDM-managed launch-environment state for GitHub Copilot CLI and Factory Droid
 - Hook integration status for Antigravity CLI, Claude Code, Cursor, Devin CLI, Devin Desktop, Factory Droid, Grok Build, Hermes Agent, and OpenCode
-- Supported agent configuration files and MCP server configuration context where Beacon can inspect them locally
-- Local agent skill manifests discovered under supported skill roots, reported as metadata and hashes only
+- Supported agent configuration files and MCP server configuration context where Beacon can inspect them locally, including Claude Code `~/.claude.json` and Cursor `mcp.json`
+- Local agent skill manifests discovered under supported skill roots, including symlinked Claude Code skill directories, reported as metadata and hashes only
 - Recently observed Beacon runtime events when the runtime log exists
 - Admin-configured integration observations such as Claude Cowork and OpenClaw Gateway events
 
@@ -58,7 +58,7 @@ The heartbeat TTL is configured in the existing endpoint config file:
 }
 ```
 
-For a manual smoke test, temporarily lower `ttl_seconds`, start a Cursor or Claude Code session with Beacon hooks installed, add a harmless test MCP server to `~/.cursor/mcp.json`, `.cursor/mcp.json`, `~/.claude/settings.json`, or `.claude/settings.json`, then trigger another hook action. `inventory_state.jsonl` should contain an `inventory.heartbeat` event and, when the digest changes, an `inventory.snapshot` event with the new MCP server metadata under `raw.inventory.mcp_servers`. `runtime.jsonl` should remain limited to agent runtime activity.
+For a manual smoke test, temporarily lower `ttl_seconds`, start a Cursor or Claude Code session with Beacon hooks installed, add a harmless test MCP server to `~/.cursor/mcp.json`, `.cursor/mcp.json`, `~/.claude.json`, or `.claude/settings.json`, then trigger another hook action. `inventory_state.jsonl` should contain an `inventory.heartbeat` event and, when the digest changes, an `inventory.snapshot` event with the new MCP server metadata under `raw.inventory.mcp_servers`. `runtime.jsonl` should remain limited to agent runtime activity.
 
 ## Flags
 

--- a/docs/inventory/mcp-servers.mdx
+++ b/docs/inventory/mcp-servers.mdx
@@ -14,7 +14,7 @@ Use it to review the tool surface an agent may be able to call from local config
 - Server references introduced by user-level, project-level, or runtime-specific config.
 - User-mode versus system-mode differences when Beacon reads different endpoint paths and runtime logs.
 
-Inventory reads local config and runtime state only. It does not authenticate to MCP servers, call their tools, or verify remote service permissions.
+Inventory reads local config and runtime state only. It does not authenticate to MCP servers, call their tools, or verify remote service permissions. For Claude Code, user-scoped MCP servers are commonly stored in `~/.claude.json`; project-scoped servers may also appear in project MCP/config files. For Cursor, Beacon inspects user and project `mcp.json` files.
 
 ## Run MCP Inventory
 

--- a/docs/inventory/skills.mdx
+++ b/docs/inventory/skills.mdx
@@ -7,7 +7,7 @@ description: "Review local agent skills as an extension and configuration surfac
 
 Skills are a local agent extension and configuration surface. A skill can add durable instructions, scripts, workflows, or tool guidance that changes how an agent behaves when the runtime loads it.
 
-Beacon inventory can help identify local skill manifests under supported skill roots. It reports metadata such as names, paths, hashes, scope, modified time, and parser status. It does not retain `SKILL.md` instruction bodies in inventory output, dashboard responses, or inventory events.
+Beacon inventory can help identify local skill manifests under supported skill roots. It follows symlinked skill directories, which is common for Claude Code skills linked from a shared `.agents/skills` store. It reports metadata such as names, paths, hashes, scope, modified time, and parser status. It does not retain `SKILL.md` instruction bodies in inventory output, dashboard responses, or inventory events.
 
 ## What Inventory Can Infer Today
 


### PR DESCRIPTION
## Summary
- Adds `~/.claude.json` as a Claude Code inventory source so user-scoped MCP servers are captured.
- Follows symlinked skill directories under Claude/Cursor skill roots so linked Claude skills are included.
- Updates inventory tests for Claude JSON MCP config and symlinked skill manifests.

## Test plan
- `cd cli/beacon && go test ./internal/endpoint/inventory`


Made with [Cursor](https://cursor.com)