### PR TITLE
Add Jamf S3 self-serve setup guide

### DIFF
--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -11,6 +11,12 @@ Stay up to date with the latest changes to the Agent Beacon CLI.
 
 ## June 2026
 
+### v0.0.72 · June 18, 2026
+
+- **Inventory state separated from runtime activity** · Inventory heartbeat and snapshot telemetry now write to `inventory_state.jsonl`, keeping agent runtime activity in `runtime.jsonl` while preserving customer-managed forwarding paths.
+- **Claude Code MCP and skill inventory fixes** · Beacon inventories Claude Code MCP servers from `~/.claude.json` and follows symlinked Claude skill directories, so shared skill stores such as `.agents/skills` appear in endpoint inventory.
+- **Jamf S3 runtime and inventory forwarding** · The Jamf S3 Vector flow now forwards runtime and inventory JSONL to distinct S3 prefixes, supports MDM-injected AWS provider settings, normalizes older `.../runtime` prefixes, and reads initial inventory snapshots reliably.
+
 ### v0.0.71 · June 18, 2026
 
 - **Inventory heartbeat telemetry** · Beacon can now emit metadata-only inventory heartbeat events for local agent harnesses, hooks, MCP servers, and skills, making endpoint coverage drift easier to inspect from the runtime log without collecting skill contents.

--- a/docs/concepts/faq.mdx
+++ b/docs/concepts/faq.mdx
@@ -1,0 +1,65 @@
+---
+title: "FAQ"
+description: "Common questions about Asymptote Open Source, Agent Beacon, local telemetry, inventory, and forwarding"
+---
+
+## What telemetry does open-source Beacon capture?
+
+Open-source Beacon captures supported AI agent activity from configured local, CI, and cloud-agent surfaces. Depending on the runtime and integration mode, endpoint telemetry can include prompts, tool calls, shell commands, file activity, approvals, MCP-like tool use, model/session context, token usage, runtime-reported cost, and related event metadata.
+
+Beacon can also capture metadata-only local inventory for supported agent harnesses. Inventory can include detected runtimes, hook/config status, local MCP server metadata, and skill manifest metadata. For example, Beacon can inventory Cursor MCP servers from `mcp.json`, Claude Code MCP servers from `~/.claude.json`, and local skills under Cursor or Claude Code skill roots.
+
+Inventory is intentionally metadata-only. Beacon does not retain `SKILL.md` instruction bodies, MCP secret values, full environment values, full command arguments, or unrelated config contents in inventory events.
+
+## Where does open-source Beacon write data?
+
+For endpoint installs, Beacon writes runtime activity to `runtime.jsonl`.
+
+Inventory heartbeat telemetry is written separately to `inventory_state.jsonl` so runtime activity and configuration inventory can be routed or reviewed independently.
+
+Default user-mode paths:
+
+```text
+~/.beacon/endpoint/logs/runtime.jsonl
+~/.beacon/endpoint/logs/inventory_state.jsonl
+```
+
+Default system-mode paths:
+
+```text
+/var/log/beacon-agent/runtime.jsonl
+/var/log/beacon-agent/inventory_state.jsonl
+```
+
+## Does open-source Beacon require a hosted account?
+
+No. Beacon endpoint collection is local-only by default. It does not require a hosted Beacon account, remote policy fetch, or external network dependency during normal local hook execution.
+
+You can keep logs local, inspect them with the local dashboard and CLI, or forward them to customer-managed destinations such as S3, Wazuh, Elastic, Datadog, Sumo Logic, Rapid7, Falcon LogScale, Splunk HEC, or Microsoft Sentinel.
+
+## Does Beacon send secrets or skill contents downstream?
+
+Beacon applies redaction, sanitization, truncation, and event-size controls before writing endpoint events.
+
+Inventory records are conservative by design:
+
+- Skill inventory includes names, paths, hashes, scope, modified time, and parser status, but not skill instruction bodies.
+- MCP inventory includes server name, source config path, transport, command basename, argument count, safe environment key names/counts, and hashes, but not secret values or full environment values.
+- Config inventory includes file metadata, hashes, parser status, and counts, but not full unrelated config contents.
+
+## How do I forward Beacon logs to S3?
+
+Use the Beacon S3 content pack or the packaged Jamf helper for managed macOS deployments.
+
+The S3 forwarder writes runtime and inventory logs to separate prefixes under the same bucket root:
+
+```text
+s3://<bucket>/<prefix>/runtime/date=YYYY-MM-DD/<object>.jsonl.gz
+s3://<bucket>/<prefix>/inventory/date=YYYY-MM-DD/<object>.jsonl.gz
+```
+
+For Jamf Pro deployments with MDM secret injection, see [Deploy Beacon With Jamf And S3](/guides/jamf-s3-mdm).
+
+## When should I use Asymptote Managed instead?
+
+Use open-source Beacon when you want local telemetry and customer-managed forwarding. Consider Asymptote Managed when you need centralized ingest, retention, search, detections, fleet-wide visibility, policy controls, identity mapping, approvals, SSO/RBAC, or investigation workflows operated as a managed service.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,6 +69,7 @@
             "icon": "book-open",
             "pages": [
               "concepts/core-concepts",
+              "concepts/faq",
               {
                 "group": "System Architecture",
                 "root": "architecture/system-architecture",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -405,7 +405,8 @@
             "icon": "clipboard-list",
             "root": "guides/use-cases",
             "pages": [
-              "guides/agent-runtime-telemetry"
+              "guides/agent-runtime-telemetry",
+              "guides/jamf-s3-mdm"
             ]
           },
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -195,6 +195,7 @@
                 "pages": [
                   "mdm/jamf",
                   "mdm/jamf/claude",
+                  "guides/jamf-s3-mdm",
                   "mdm/fleet"
                 ]
               },

--- a/docs/guides/jamf-s3-mdm.mdx
+++ b/docs/guides/jamf-s3-mdm.mdx
@@ -79,11 +79,18 @@ That file is mode `0600` and is sourced by the Vector LaunchDaemon wrapper.
 
 ## Jamf Policy Setup
 
-Create a Jamf Pro policy scoped to the target Macs.
+Jamf Pro separates package installation from script execution. Use the Packages payload to install the Beacon `.pkg`, then use a Scripts payload to run a small wrapper that calls Beacon's packaged Jamf helper.
 
-### 1. Install The Beacon Package
+For the most reliable rollout, use two policies:
 
-Add the signed Beacon endpoint package to the policy.
+- **Policy 1: Install Beacon package.** Installs the signed `.pkg`.
+- **Policy 2: Configure Beacon S3 forwarding.** Runs after the package is installed and calls the packaged helper.
+
+You can also combine package and script payloads in one policy if your Jamf workflow guarantees the package is installed before the script runs. The two-policy approach is easier to reason about and troubleshoot.
+
+### 1. Upload The Beacon Package
+
+Upload the signed Beacon endpoint package to Jamf Pro and add it to a policy using the Packages payload with the install action.
 
 The package installs:
 
@@ -97,15 +104,63 @@ The package installs:
 /opt/beacon/jamf/claude/s3/run-forwarder.sh
 ```
 
-### 2. Run The Combined Jamf Helper
+### 2. Add A Jamf Script Wrapper
 
-Add a script step after the package install:
+Add a script to Jamf Pro that invokes Beacon's packaged helper. The script must exist in Jamf Pro before it can be added to a policy.
 
 ```bash
+#!/bin/bash
+set -euo pipefail
+
+BEACON_S3_BUCKET="${4:-}"
+AWS_REGION="${5:-}"
+BEACON_S3_PREFIX="${6:-beacon}"
+BEACON_S3_STORAGE_CLASS="${7:-STANDARD}"
+BEACON_VECTOR_READ_FROM="${8:-end}"
+
+export BEACON_S3_BUCKET
+export AWS_REGION
+export BEACON_S3_PREFIX
+export BEACON_S3_STORAGE_CLASS
+export BEACON_VECTOR_READ_FROM
+
+# Use your Jamf secret injection mechanism or managed credential delivery here.
+# The Beacon helper will persist any AWS provider-chain variables that are set.
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}"
+export AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}"
+export AWS_PROFILE="${AWS_PROFILE:-}"
+export AWS_SHARED_CREDENTIALS_FILE="${AWS_SHARED_CREDENTIALS_FILE:-}"
+export AWS_CONFIG_FILE="${AWS_CONFIG_FILE:-}"
+export AWS_WEB_IDENTITY_TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE:-}"
+export AWS_ROLE_ARN="${AWS_ROLE_ARN:-}"
+
 /opt/beacon/jamf/claude/s3/repair-hooks-and-forwarder.sh
 ```
 
-Pass the S3 settings and AWS provider values through Jamf script environment variables or Jamf secret injection:
+Use Jamf script parameter labels so policy editors know what each value means:
+
+| Parameter | Label | Example |
+| --- | --- | --- |
+| 4 | S3 bucket | `example-security-logs` |
+| 5 | AWS region | `us-west-2` |
+| 6 | S3 prefix root | `beacon-prod` |
+| 7 | S3 storage class | `STANDARD` |
+| 8 | Vector read position | `end` |
+
+Jamf script parameters are convenient for non-secret values such as bucket, region, and prefix. For AWS credentials, prefer your Jamf secret injection mechanism, device identity, AWS profiles, web identity, or managed credential files. Avoid putting long-lived access keys directly in ordinary policy parameter fields or policy logs.
+
+### 3. Inject AWS Provider Settings
+
+The Beacon helper persists any AWS provider-chain variables it receives. Use one of these patterns:
+
+| Credential pattern | Variables to provide |
+| --- | --- |
+| Access key | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN` |
+| AWS profile | `AWS_PROFILE`, optional `AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE` |
+| Web identity | `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_ARN` |
+
+For a local test, this is equivalent to:
 
 ```bash
 BEACON_S3_BUCKET="example-security-logs"
@@ -113,22 +168,7 @@ AWS_REGION="us-west-2"
 BEACON_S3_PREFIX="beacon-prod"
 AWS_ACCESS_KEY_ID="..."
 AWS_SECRET_ACCESS_KEY="..."
-```
-
-If you use temporary credentials, also pass:
-
-```bash
-AWS_SESSION_TOKEN="..."
-```
-
-If you use AWS profiles or shared credential files, pass the relevant provider-chain variables instead:
-
-```bash
-AWS_PROFILE="..."
-AWS_SHARED_CREDENTIALS_FILE="..."
-AWS_CONFIG_FILE="..."
-AWS_WEB_IDENTITY_TOKEN_FILE="..."
-AWS_ROLE_ARN="..."
+/opt/beacon/jamf/claude/s3/repair-hooks-and-forwarder.sh
 ```
 
 ## What The Helper Does

--- a/docs/guides/jamf-s3-mdm.mdx
+++ b/docs/guides/jamf-s3-mdm.mdx
@@ -1,0 +1,453 @@
+---
+title: "Deploy Beacon With Jamf And S3"
+description: "Self-serve Jamf Pro setup for Beacon endpoint telemetry, Claude Code hooks, inventory snapshots, and AWS S3 forwarding"
+---
+
+## Overview
+
+Use this guide when you want a Jamf Pro policy to install Beacon for macOS users and forward both runtime and inventory telemetry to AWS S3 without asking end users to configure anything manually.
+
+The end state is:
+
+- Beacon is installed under `/opt/beacon`.
+- The system endpoint collector runs as a LaunchDaemon.
+- Claude Code hooks are installed for the logged-in console user.
+- Runtime activity is written to `/var/log/beacon-agent/runtime.jsonl`.
+- Agent config inventory is written to `/var/log/beacon-agent/inventory_state.jsonl`.
+- Vector forwards both JSONL streams to S3:
+  - `s3://<bucket>/<prefix>/runtime/date=YYYY-MM-DD/...`
+  - `s3://<bucket>/<prefix>/inventory/date=YYYY-MM-DD/...`
+
+```mermaid
+flowchart LR
+  JamfPolicy[Jamf policy] --> Package[Beacon pkg]
+  JamfPolicy --> Helper[repair-hooks-and-forwarder.sh]
+  Package --> Beacon["/opt/beacon"]
+  Helper --> Collector[Endpoint collector]
+  Helper --> Hooks[Claude Code hooks]
+  Hooks --> RuntimeLog["runtime.jsonl"]
+  Hooks --> InventoryLog["inventory_state.jsonl"]
+  RuntimeLog --> Vector[Vector LaunchDaemon]
+  InventoryLog --> Vector
+  Vector --> S3[AWS S3]
+```
+
+## Prerequisites
+
+Before creating the Jamf policy, prepare:
+
+- A signed and notarized Beacon endpoint `.pkg` that includes `/opt/beacon/bin/vector`.
+- A target AWS S3 bucket.
+- An S3 prefix root such as `beacon`, `beacon-prod`, or `beacon-e2e`.
+- AWS credentials or a role available to the Jamf policy at install time.
+- `s3:PutObject` permission for the selected bucket prefix.
+- Claude Code installed on the target Mac.
+
+Use a root prefix. Do not include `runtime` or `inventory` in the value:
+
+```bash
+BEACON_S3_PREFIX="beacon-prod" # good
+BEACON_S3_PREFIX="beacon-prod/runtime" # avoid
+```
+
+The helper normalizes old prefixes ending in `/runtime` or `/inventory`, but new deployments should use the root prefix.
+
+## AWS Permission
+
+Use a bucket policy or IAM policy scoped to the Beacon prefix. Example:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:PutObject"],
+      "Resource": "arn:aws:s3:::example-security-logs/beacon-prod/*"
+    }
+  ]
+}
+```
+
+Beacon does not store AWS credentials in endpoint configuration. The Jamf helper persists only the AWS provider-chain values it receives into a root-owned Vector environment file:
+
+```text
+/Library/Application Support/Beacon/Forwarders/s3-vector.env
+```
+
+That file is mode `0600` and is sourced by the Vector LaunchDaemon wrapper.
+
+## Jamf Policy Setup
+
+Create a Jamf Pro policy scoped to the target Macs.
+
+### 1. Install The Beacon Package
+
+Add the signed Beacon endpoint package to the policy.
+
+The package installs:
+
+```text
+/opt/beacon/bin/beacon
+/opt/beacon/bin/beacon-otelcol
+/opt/beacon/bin/vector
+/opt/beacon/jamf/claude/common/repair-hooks.sh
+/opt/beacon/jamf/claude/s3/install-forwarder.sh
+/opt/beacon/jamf/claude/s3/repair-hooks-and-forwarder.sh
+/opt/beacon/jamf/claude/s3/run-forwarder.sh
+```
+
+### 2. Run The Combined Jamf Helper
+
+Add a script step after the package install:
+
+```bash
+/opt/beacon/jamf/claude/s3/repair-hooks-and-forwarder.sh
+```
+
+Pass the S3 settings and AWS provider values through Jamf script environment variables or Jamf secret injection:
+
+```bash
+BEACON_S3_BUCKET="example-security-logs"
+AWS_REGION="us-west-2"
+BEACON_S3_PREFIX="beacon-prod"
+AWS_ACCESS_KEY_ID="..."
+AWS_SECRET_ACCESS_KEY="..."
+```
+
+If you use temporary credentials, also pass:
+
+```bash
+AWS_SESSION_TOKEN="..."
+```
+
+If you use AWS profiles or shared credential files, pass the relevant provider-chain variables instead:
+
+```bash
+AWS_PROFILE="..."
+AWS_SHARED_CREDENTIALS_FILE="..."
+AWS_CONFIG_FILE="..."
+AWS_WEB_IDENTITY_TOKEN_FILE="..."
+AWS_ROLE_ARN="..."
+```
+
+## What The Helper Does
+
+The combined helper performs all endpoint and forwarding setup:
+
+- Repairs the Beacon system endpoint.
+- Starts `com.beacon.endpoint.collector`.
+- Prepares:
+  - `/var/log/beacon-agent/runtime.jsonl`
+  - `/var/log/beacon-agent/inventory_state.jsonl`
+  - `/var/log/beacon-agent/inventory-state.json`
+- Grants the console user append access for hook-written logs.
+- Installs Claude Code hooks for the interactive console user.
+- Writes:
+  - `/Library/Application Support/Beacon/Forwarders/s3-vector.toml`
+  - `/Library/Application Support/Beacon/Forwarders/s3-vector.env`
+  - `/Library/LaunchDaemons/com.beacon.endpoint.s3-forwarder.plist`
+- Starts `com.beacon.endpoint.s3-forwarder`.
+
+End users do not need to run any Beacon command or edit any local config.
+
+## Expected S3 Layout
+
+If you configure:
+
+```text
+BEACON_S3_BUCKET=example-security-logs
+BEACON_S3_PREFIX=beacon-prod
+```
+
+Beacon writes objects under:
+
+```text
+s3://example-security-logs/beacon-prod/runtime/date=YYYY-MM-DD/<timestamp>-<uuid>.jsonl.gz
+s3://example-security-logs/beacon-prod/inventory/date=YYYY-MM-DD/<timestamp>-<uuid>.jsonl.gz
+```
+
+Runtime objects contain agent activity from `runtime.jsonl`.
+
+Inventory objects contain `inventory.heartbeat` and `inventory.snapshot` events from `inventory_state.jsonl`.
+
+## Validate A Deployed Mac
+
+Run these commands on a target Mac after the Jamf policy completes.
+
+### Check Services
+
+```bash
+sudo launchctl print system/com.beacon.endpoint.collector
+sudo launchctl print system/com.beacon.endpoint.s3-forwarder
+```
+
+Both services should be `running`.
+
+### Check Local Files
+
+```bash
+ls -l /var/log/beacon-agent/runtime.jsonl
+ls -l /var/log/beacon-agent/inventory_state.jsonl
+ls -l /var/log/beacon-agent/inventory-state.json
+```
+
+### Check Vector Config
+
+```bash
+sudo grep -E 'runtime.jsonl|inventory_state.jsonl|runtime/date|inventory/date|read_from' \
+  "/Library/Application Support/Beacon/Forwarders/s3-vector.toml"
+```
+
+Expected:
+
+```text
+include = ["/var/log/beacon-agent/runtime.jsonl"]
+read_from = "${BEACON_VECTOR_READ_FROM:-end}"
+include = ["/var/log/beacon-agent/inventory_state.jsonl"]
+read_from = "beginning"
+key_prefix = "${BEACON_S3_PREFIX:-beacon}/runtime/date=%F/"
+key_prefix = "${BEACON_S3_PREFIX:-beacon}/inventory/date=%F/"
+```
+
+Runtime forwarding starts at the end of the runtime log so historical session activity is not backfilled when Vector is first installed.
+
+Inventory forwarding starts at the beginning of `inventory_state.jsonl` so the first inventory snapshot is not missed if the file was created before Vector began watching it.
+
+## Generate Test Events
+
+### Runtime Event
+
+Write a synthetic runtime validation event:
+
+```bash
+sudo /opt/beacon/bin/beacon endpoint test-event \
+  --system \
+  --log-path /var/log/beacon-agent/runtime.jsonl
+```
+
+### Inventory Event
+
+Write an inventory heartbeat and snapshot:
+
+```bash
+sudo /opt/beacon/bin/beacon endpoint inventory heartbeat \
+  --system \
+  --force \
+  --trigger manual \
+  --trigger-harness claude \
+  --working-dir /Users/Shared \
+  --log-path /var/log/beacon-agent/runtime.jsonl
+```
+
+Confirm both files have events:
+
+```bash
+tail -n 5 /var/log/beacon-agent/runtime.jsonl
+tail -n 5 /var/log/beacon-agent/inventory_state.jsonl
+```
+
+## Confirm S3 Delivery
+
+Vector batches uploads. Production configs use `timeout_secs = 300`, so allow up to five minutes unless you lower the batch timeout for a demo.
+
+```bash
+aws s3 ls "s3://${BEACON_S3_BUCKET}/${BEACON_S3_PREFIX}/runtime/" \
+  --recursive \
+  --region "$AWS_REGION"
+
+aws s3 ls "s3://${BEACON_S3_BUCKET}/${BEACON_S3_PREFIX}/inventory/" \
+  --recursive \
+  --region "$AWS_REGION"
+```
+
+Inspect the latest inventory object:
+
+```bash
+aws s3 cp "s3://${BEACON_S3_BUCKET}/${BEACON_S3_PREFIX}/inventory/date=<YYYY-MM-DD>/<object>.jsonl.gz" - \
+  --region "$AWS_REGION" | gzip -dc | grep 'inventory.snapshot'
+```
+
+## Live Demo Settings
+
+For a live demo, reduce the inventory TTL:
+
+```bash
+sudo python3 - <<'PY'
+import json
+from pathlib import Path
+
+path = Path("/Library/Application Support/Beacon/Endpoint/config.json")
+data = json.loads(path.read_text())
+data["inventory_heartbeat"] = {
+    "enabled": True,
+    "ttl_seconds": 5,
+    "runtimes": ["cursor", "claude_code"]
+}
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+```
+
+Reduce Vector S3 batch timeout:
+
+```bash
+sudo python3 - <<'PY'
+from pathlib import Path
+
+path = Path("/Library/Application Support/Beacon/Forwarders/s3-vector.toml")
+text = path.read_text()
+text = text.replace("timeout_secs = 300", "timeout_secs = 5")
+path.write_text(text)
+PY
+```
+
+Restart the forwarder:
+
+```bash
+sudo launchctl bootout system/com.beacon.endpoint.s3-forwarder 2>/dev/null || true
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.beacon.endpoint.s3-forwarder.plist
+```
+
+If launchd returns `Bootstrap failed: 5`, run Vector in the foreground for the demo:
+
+```bash
+sudo /opt/beacon/jamf/claude/s3/run-forwarder.sh
+```
+
+Keep that terminal open while generating runtime and inventory events.
+
+## Test A Live Skill And MCP Change
+
+Create a Claude Code skill:
+
+```bash
+mkdir -p ~/.claude/skills/beacon-live-skill
+cat > ~/.claude/skills/beacon-live-skill/SKILL.md <<'EOF'
+# Beacon Live Skill
+
+Harmless inventory validation skill.
+EOF
+```
+
+Add a Claude Code MCP server to top-level `mcpServers` in `~/.claude.json`:
+
+```json
+"beacon_live_mcp": {
+  "command": "node",
+  "args": ["-e", "process.exit(0)"],
+  "env": {
+    "BEACON_SMOKE_ENV": "present"
+  }
+}
+```
+
+Then force inventory:
+
+```bash
+sudo /opt/beacon/bin/beacon endpoint inventory heartbeat \
+  --system \
+  --force \
+  --trigger manual \
+  --trigger-harness claude \
+  --working-dir /Users/Shared \
+  --log-path /var/log/beacon-agent/runtime.jsonl
+```
+
+Confirm the local inventory event includes both names:
+
+```bash
+grep 'beacon-live-skill\|beacon_live_mcp' /var/log/beacon-agent/inventory_state.jsonl
+```
+
+After Vector flushes, the same names should appear in an object under the S3 `inventory/` prefix.
+
+## Restore Production Settings
+
+After a demo, restore the production TTL:
+
+```bash
+sudo python3 - <<'PY'
+import json
+from pathlib import Path
+
+path = Path("/Library/Application Support/Beacon/Endpoint/config.json")
+data = json.loads(path.read_text())
+data["inventory_heartbeat"] = {
+    "enabled": True,
+    "ttl_seconds": 86400,
+    "runtimes": ["cursor", "claude_code"]
+}
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+```
+
+Regenerate the Vector config by rerunning the Jamf helper if you changed `timeout_secs` manually:
+
+```bash
+sudo env \
+  BEACON_S3_BUCKET="$BEACON_S3_BUCKET" \
+  AWS_REGION="$AWS_REGION" \
+  BEACON_S3_PREFIX="$BEACON_S3_PREFIX" \
+  AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+  AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+  /opt/beacon/jamf/claude/s3/install-forwarder.sh
+```
+
+## Troubleshooting
+
+### No S3 Objects
+
+Check the forwarder:
+
+```bash
+sudo launchctl print system/com.beacon.endpoint.s3-forwarder
+sudo tail -n 100 /tmp/com.beacon.endpoint.s3-forwarder.err
+```
+
+### Forwarder Is Not Loaded
+
+Load it manually:
+
+```bash
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.beacon.endpoint.s3-forwarder.plist
+```
+
+If launchd remains opaque, run Vector in the foreground:
+
+```bash
+sudo /opt/beacon/jamf/claude/s3/run-forwarder.sh
+```
+
+### Credentials Are Missing
+
+Check the env file without exposing secrets:
+
+```bash
+sudo sh -c 'sed -E "s/(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|BEACON_S3_BUCKET|AWS_REGION|BEACON_S3_PREFIX)=.*/\1=<redacted>/" "/Library/Application Support/Beacon/Forwarders/s3-vector.env"'
+```
+
+### Inventory Is Empty
+
+Force inventory and inspect the local file:
+
+```bash
+sudo /opt/beacon/bin/beacon endpoint inventory heartbeat \
+  --system \
+  --force \
+  --trigger manual \
+  --trigger-harness claude \
+  --working-dir /Users/Shared \
+  --log-path /var/log/beacon-agent/runtime.jsonl
+
+tail -n 5 /var/log/beacon-agent/inventory_state.jsonl
+```
+
+### Claude Hooks Are Missing
+
+Fully restart Claude Code after the Jamf policy runs. Then inspect the user's Claude settings:
+
+```bash
+grep -n 'BEACON_ENDPOINT_CLI\|beacon-hooks' ~/.claude/settings.json
+```
+
+You should see commands that call the packaged Beacon hook binary.

--- a/docs/mdm/jamf/claude.mdx
+++ b/docs/mdm/jamf/claude.mdx
@@ -1,157 +1,48 @@
 ---
 title: "Claude with Jamf"
-description: "Run Jamf pilots that install Claude Code hooks and forward Beacon runtime JSONL to destinations such as AWS S3."
+description: "Deploy Claude Code endpoint telemetry with Jamf Pro and route Beacon logs to managed destinations."
 ---
 
-## S3 Forwarding Overview
+Use this page as the Claude-specific Jamf entry point. For the complete AWS S3 forwarding setup, follow the canonical self-serve guide:
 
-Use this flow to test a managed Claude Code deployment on a pilot Mac where Beacon writes local endpoint events to `/var/log/beacon-agent/runtime.jsonl` and a packaged Vector service forwards those events to AWS S3.
+<Card title="Deploy Beacon With Jamf And S3" icon="bucket" href="/guides/jamf-s3-mdm">
+  Install Beacon with Jamf Pro, inject AWS provider settings through MDM, configure Claude Code hooks, and forward runtime plus inventory JSONL to S3.
+</Card>
 
-Beacon remains the local JSONL producer. AWS credentials, bucket policy, encryption, lifecycle, retention, and access logging stay in AWS, host identity, or MDM secret tooling.
+## What The Jamf Claude Flow Installs
 
-```mermaid
-flowchart LR
-  claudeCode["Claude Code"] -->|"user hooks"| runtimeLog["runtime.jsonl"]
-  beaconEndpoint["Beacon endpoint repair"] --> runtimeLog
-  runtimeLog -->|"file source"| vectorForwarder["Vector LaunchDaemon"]
-  vectorForwarder -->|"gzip NDJSON"| s3Bucket["AWS S3 bucket"]
-  jamfPolicy["Jamf policy"] -->|"bucket, region, prefix"| vectorForwarder
-```
+The packaged Claude Jamf helpers configure:
 
-## Package Requirements
+- the Beacon system endpoint collector
+- Claude Code hooks for the logged-in console user
+- `/var/log/beacon-agent/runtime.jsonl` for runtime activity
+- `/var/log/beacon-agent/inventory_state.jsonl` for metadata-only inventory snapshots
+- optional Vector forwarding for supported destinations such as AWS S3 or Falcon LogScale
 
-Build or obtain a signed and notarized Beacon macOS package that includes:
+End users should not need to run Beacon commands or edit local Beacon configuration when the Jamf policy is configured correctly.
+
+## Packaged Helper Scripts
+
+The macOS package includes these Claude-specific helpers:
 
 ```text
-/opt/beacon/bin/beacon
-/opt/beacon/bin/beacon-otelcol
-/opt/beacon/bin/vector
 /opt/beacon/jamf/claude/common/repair-hooks.sh
 /opt/beacon/jamf/claude/s3/install-forwarder.sh
 /opt/beacon/jamf/claude/s3/repair-hooks-and-forwarder.sh
 /opt/beacon/jamf/claude/s3/run-forwarder.sh
 ```
 
-These packaged helpers come from the repository paths:
+Use `repair-hooks.sh` when you only need to repair the system endpoint and reinstall Claude hooks.
 
-- [`packaging/macos/jamf/claude/common/repair-hooks.sh`](https://github.com/Asymptote-Labs/agent-beacon/blob/main/packaging/macos/jamf/claude/common/repair-hooks.sh)
-- [`packaging/macos/jamf/claude/s3/install-forwarder.sh`](https://github.com/Asymptote-Labs/agent-beacon/blob/main/packaging/macos/jamf/claude/s3/install-forwarder.sh)
-- [`packaging/macos/jamf/claude/s3/repair-hooks-and-forwarder.sh`](https://github.com/Asymptote-Labs/agent-beacon/blob/main/packaging/macos/jamf/claude/s3/repair-hooks-and-forwarder.sh)
-- [`packaging/macos/jamf/claude/s3/run-forwarder.sh`](https://github.com/Asymptote-Labs/agent-beacon/blob/main/packaging/macos/jamf/claude/s3/run-forwarder.sh)
+Use `s3/repair-hooks-and-forwarder.sh` when one Jamf policy should repair the endpoint, reinstall Claude hooks, and configure S3 forwarding.
 
-When building from source, pass a Vector binary into the package build:
+## Related
 
-```bash
-BEACON_VECTOR_BIN=/path/to/vector \
-BEACON_APP_SIGN_IDENTITY="Developer ID Application: Example Team" \
-PKG_SIGN_IDENTITY="Developer ID Installer: Example Team" \
-NOTARYTOOL_PROFILE="notarytool-profile" \
-  sh packaging/macos/build-pkg.sh
-```
-
-`BEACON_APP_SIGN_IDENTITY` signs the payload binaries with hardened runtime. `PKG_SIGN_IDENTITY` signs the package with `pkgbuild`. `NOTARYTOOL_PROFILE` submits the package to Apple notary service and staples the result.
-
-## AWS Setup
-
-Create a dedicated bucket prefix for the pilot and grant the identity used by the Vector process permission to write only that prefix:
-
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": ["s3:PutObject"],
-      "Resource": "arn:aws:s3:::example-security-logs/beacon/claude/*"
-    }
-  ]
-}
-```
-
-Provide AWS credentials through host identity, MDM secret tooling, or the standard AWS credential provider chain available to the LaunchDaemon. When `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_PROFILE`, `AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE`, `AWS_WEB_IDENTITY_TOKEN_FILE`, or `AWS_ROLE_ARN` are present in the MDM script environment, the helper persists them to the root-owned forwarder environment file so launchd-started Vector can use them. Do not place AWS access keys in Beacon endpoint configuration.
-
-## Jamf Policy
-
-Install the Beacon package first, then run the combined helper from a policy scoped to the pilot Mac:
-
-```bash
-/opt/beacon/jamf/claude/s3/repair-hooks-and-forwarder.sh "$@"
-```
-
-Environment variables take precedence over Jamf parameters:
-
-| Parameter | Environment variable | Value |
-| --- | --- | --- |
-| 4 | `BEACON_S3_BUCKET` | Required S3 bucket name |
-| 5 | `AWS_REGION` | Required AWS region |
-| 6 | `BEACON_S3_PREFIX` | Optional prefix, default `beacon/runtime` |
-| 7 | `BEACON_S3_STORAGE_CLASS` | Optional storage class, default `STANDARD` |
-| 8 | `BEACON_VECTOR_READ_FROM` | Optional Vector read position, default `end` |
-| 9 | `BEACON_OTLP_GRPC_PORT` | Optional Beacon OTLP gRPC port, default `4317` |
-| 10 | `BEACON_OTLP_HTTP_PORT` | Optional Beacon OTLP HTTP port, default `4318` |
-
-The S3 helper also persists any standard AWS provider-chain environment variables listed above when they are set. This supports MDM secret injection without baking secrets into the package.
-
-The helper:
-
-- writes `/Library/Application Support/Beacon/Forwarders/s3-vector.toml`
-- writes `/Library/Application Support/Beacon/Forwarders/s3-vector.env` with mode `0600`
-- starts `com.beacon.endpoint.s3-forwarder`
-- repairs the Beacon system endpoint
-- prepares `/var/log/beacon-agent/runtime.jsonl` for user-run hooks
-- installs Claude Code hooks for the interactive console user
-- writes a manual Claude hook smoke event
-
-## Manual Pilot Command
-
-For a one-Mac pilot without Jamf policy parameters, install the signed package and run:
-
-```bash
-sudo BEACON_S3_BUCKET="example-security-logs" \
-  AWS_REGION="us-west-2" \
-  AWS_ACCESS_KEY_ID="AKIA..." \
-  AWS_SECRET_ACCESS_KEY="..." \
-  BEACON_S3_PREFIX="beacon/claude" \
-  /opt/beacon/jamf/claude/s3/repair-hooks-and-forwarder.sh
-```
-
-Fully restart Claude Code after the hook install, then start a new Claude session to generate real hook events.
-
-## Validate Delivery
-
-Confirm local state on the Mac:
-
-```bash
-sudo /opt/beacon/bin/beacon endpoint status --system --json
-sudo test -r /var/log/beacon-agent/runtime.jsonl
-sudo launchctl print system/com.beacon.endpoint.s3-forwarder
-```
-
-Write a Beacon S3 validation event:
-
-```bash
-sudo /opt/beacon/bin/beacon endpoint s3 validate --system
-```
-
-Confirm an object arrives in S3:
-
-```bash
-aws s3 ls "s3://${BEACON_S3_BUCKET}/${BEACON_S3_PREFIX}/" \
-  --recursive \
-  --region "$AWS_REGION"
-
-aws s3 cp "s3://${BEACON_S3_BUCKET}/${BEACON_S3_PREFIX}/date=<date>/<object>.jsonl.gz" - \
-  --region "$AWS_REGION" | gzip -dc | grep "Beacon endpoint S3 validation event"
-```
-
-S3 objects are gzip-compressed newline-delimited JSON with non-overwriting names under:
-
-```text
-s3://<bucket>/<prefix>/date=YYYY-MM-DD/<timestamp>-<uuid>.jsonl.gz
-```
-
-## Troubleshooting
-
-If objects do not arrive, check that Vector is running, that `/tmp/com.beacon.endpoint.s3-forwarder.err` is empty or actionable, that the env file contains the expected bucket and region, and that the identity available to the Vector LaunchDaemon has `s3:PutObject` for the selected prefix.
-
-If Claude hook events do not appear in `/var/log/beacon-agent/runtime.jsonl`, rerun the policy while an interactive user is logged in, then fully restart Claude Code.
+<Columns cols={2}>
+  <Card title="Jamf Pro Overview" icon="laptop" href="/mdm/jamf">
+    Review the general Beacon Jamf deployment model and package layout.
+  </Card>
+  <Card title="S3 Log Forwarding" icon="bucket" href="/log-forwarding/s3">
+    Review the generated S3 content pack and Vector forwarding behavior.
+  </Card>
+</Columns>


### PR DESCRIPTION
## Summary
- Adds a self-serve Jamf Pro guide for installing Beacon and forwarding runtime plus inventory telemetry to AWS S3.
- Covers MDM secret injection, expected S3 layout, validation commands, live-demo TTL/batch settings, and troubleshooting.
- Adds the guide to the MDM deployment navigation.

## Test plan
- `python3 -m json.tool docs/docs.json >/dev/null`
- `git diff --check`


Made with [Cursor](https://cursor.com)