### PR TITLE
Refactor docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,14 +69,13 @@
             "icon": "book-open",
             "pages": [
               "concepts/core-concepts",
-              "concepts/vector-forwarding",
-              "concepts/faq",
               {
                 "group": "System Architecture",
                 "root": "architecture/system-architecture",
                 "pages": [
                   "architecture/architecture",
-                  "architecture/managed-architecture"
+                  "architecture/managed-architecture",
+                  "concepts/vector-forwarding"
                 ]
               },
               {
@@ -87,7 +86,8 @@
                   "telemetry-schema/fields",
                   "telemetry-schema/examples"
                 ]
-              }
+              },
+              "concepts/faq"
             ]
           },
           {
@@ -195,10 +195,15 @@
                 "group": "MDM Deployment",
                 "root": "mdm/index",
                 "pages": [
-                  "mdm/jamf",
-                  "mdm/jamf/claude",
-                  "guides/jamf-s3-mdm",
-                  "guides/jamf-falcon-mdm",
+                  {
+                    "group": "Jamf",
+                    "root": "mdm/jamf",
+                    "pages": [
+                      "mdm/jamf/claude",
+                      "guides/jamf-s3-mdm",
+                      "guides/jamf-falcon-mdm"
+                    ]
+                  },
                   "mdm/fleet"
                 ]
               },
@@ -407,9 +412,7 @@
             "icon": "clipboard-list",
             "root": "guides/use-cases",
             "pages": [
-              "guides/agent-runtime-telemetry",
-              "guides/jamf-s3-mdm",
-              "guides/jamf-falcon-mdm"
+              "guides/agent-runtime-telemetry"
             ]
           },
           {
@@ -428,6 +431,22 @@
               },
               "guides/local-testing/dashboard",
               "guides/local-testing/mcp"
+            ]
+          },
+          {
+            "group": "MDM Deployments",
+            "icon": "building-shield",
+            "root": "mdm/index",
+            "pages": [
+              {
+                "group": "Jamf",
+                "root": "mdm/jamf",
+                "pages": [
+                  "mdm/jamf/claude",
+                  "guides/jamf-s3-mdm",
+                  "guides/jamf-falcon-mdm"
+                ]
+              }
             ]
           }
         ]

--- a/docs/guides/jamf-falcon-mdm.mdx
+++ b/docs/guides/jamf-falcon-mdm.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Deploy Beacon With Jamf And CrowdStrike Falcon"
+title: "Claude with Jamf and Crowdstrike Falcon"
 description: "Self-serve Jamf Pro setup for Beacon endpoint telemetry, Claude Code hooks, and CrowdStrike Falcon LogScale HEC forwarding"
 ---
 

--- a/docs/guides/jamf-s3-mdm.mdx
+++ b/docs/guides/jamf-s3-mdm.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Deploy Beacon With Jamf And S3"
+title: "Claude with Jamf and S3"
 description: "Self-serve Jamf Pro setup for Beacon endpoint telemetry, Claude Code hooks, inventory snapshots, and AWS S3 forwarding"
 ---
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only navigation and title changes; no application code, auth, or deployment behavior.
> 
> **Overview**
> **Reorganizes Mintlify navigation** in `docs/docs.json` without changing page URLs or redirects.
> 
> Under **How Asymptote Works**, `concepts/vector-forwarding` moves into the **System Architecture** subgroup, and `concepts/faq` moves to the end of that top-level group (after the telemetry schema section).
> 
> **Jamf MDM guides** are grouped under a nested **Jamf** entry in both **For Security & IT Teams → MDM Deployment** and a new **Guides → MDM Deployments** section. The S3 and Falcon walkthroughs (`guides/jamf-s3-mdm`, `guides/jamf-falcon-mdm`) are removed from **Agent Activity Guides** so that group only lists `guides/agent-runtime-telemetry`.
> 
> **Page titles** in frontmatter are updated to **"Claude with Jamf and S3"** and **"Claude with Jamf and Crowdstrike Falcon"** (paths unchanged). Other docs may still show older link labels until updated separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5955271968ed1c25e339855bbe0233a84428aff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->