### PR TITLE
test(observe): pin Beacon contract constants across Go and TS SDK

### DIFF
--- a/pkg/asymptoteobserve/contract_conformance_test.go
+++ b/pkg/asymptoteobserve/contract_conformance_test.go
@@ -1,0 +1,67 @@
+package asymptoteobserve
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// tsConstantsPath is the TypeScript SDK constants file, resolved relative to this
+// package directory (repo root is two levels up from pkg/asymptoteobserve).
+var tsConstantsPath = filepath.Join("..", "..", "packages", "asymptote-sdk-js", "src", "constants.ts")
+
+// tsExportConst matches `export const NAME = "VALUE";` declarations.
+var tsExportConst = regexp.MustCompile(`(?m)^export const (\w+) = "([^"]*)";`)
+
+// TestContractConstantsInSyncWithTypeScriptSDK pins the Beacon contract constants that
+// are duplicated across the Go endpoint schema and the TypeScript SDK. CLAUDE.md treats
+// vendor/product/schema_version as release contracts and the beacon.* attribute names as
+// stable identifiers; this guard fails CI if the two copies ever drift apart.
+//
+// Coverage today is limited to the constants that both sides define explicitly. As the Go
+// converter's bare attribute-name literals are promoted to a shared const block (a later
+// cleanup PR), extend `want` to cover them too.
+func TestContractConstantsInSyncWithTypeScriptSDK(t *testing.T) {
+	tsConsts := readTSConstants(t)
+
+	// Go constant value -> TypeScript export name expected to match it.
+	want := map[string]struct {
+		goName, goValue, tsName string
+	}{
+		"vendor":         {"Vendor", Vendor, "BEACON_VENDOR"},
+		"product":        {"Product", Product, "BEACON_PRODUCT"},
+		"schema_version": {"SchemaVersion", SchemaVersion, "BEACON_SCHEMA_VERSION"},
+		"origin_attr":    {"AttributeOrigin", AttributeOrigin, "ATTR_BEACON_ORIGIN"},
+	}
+
+	for _, c := range want {
+		tsValue, ok := tsConsts[c.tsName]
+		if !ok {
+			t.Errorf("TypeScript SDK is missing export const %s in %s; it must mirror Go %s = %q",
+				c.tsName, tsConstantsPath, c.goName, c.goValue)
+			continue
+		}
+		if tsValue != c.goValue {
+			t.Errorf("contract drift: Go %s = %q but TypeScript %s = %q.\n"+
+				"Keep %s (event.go) and %s (constants.ts) in sync.",
+				c.goName, c.goValue, c.tsName, tsValue, c.goName, c.tsName)
+		}
+	}
+}
+
+func readTSConstants(t *testing.T) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(tsConstantsPath)
+	if err != nil {
+		t.Fatalf("read TypeScript SDK constants at %s: %v", tsConstantsPath, err)
+	}
+	consts := make(map[string]string)
+	for _, m := range tsExportConst.FindAllStringSubmatch(string(data), -1) {
+		consts[m[1]] = m[2]
+	}
+	if len(consts) == 0 {
+		t.Fatalf("no `export const NAME = \"...\"` declarations parsed from %s", tsConstantsPath)
+	}
+	return consts
+}


### PR DESCRIPTION
## What

Adds a Go test (`pkg/asymptoteobserve/contract_conformance_test.go`) that parses the TypeScript SDK's `constants.ts` and asserts the shared Beacon contract constants match the Go endpoint schema in `event.go`:

- `Vendor` ↔ `BEACON_VENDOR`
- `Product` ↔ `BEACON_PRODUCT`
- `SchemaVersion` ↔ `BEACON_SCHEMA_VERSION`
- `AttributeOrigin` ↔ `ATTR_BEACON_ORIGIN`

## Why

These values are duplicated across the Go and TypeScript code paths with no single source of truth. `CLAUDE.md` treats `vendor`/`product`/`schema_version` and the `beacon.*` attribute names as **release contracts**, so silent drift across the Go/TS boundary is a real risk. This guard fails CI the moment the two copies diverge.

This is the first PR in a stacked cleanup series tracked in the code-smell audit. It is **test-only** — no production code changes — and intentionally establishes the guardrail before later PRs centralize the constants.

## Coverage note

Scoped to the constants both sides define explicitly today. It can be widened as the converter's bare attribute-name literals are promoted to a shared const block (a later PR in the series).

## Verification

- `go test ./...` in `pkg/asymptoteobserve` — green.
- Verified the test fails on an intentional `BEACON_SCHEMA_VERSION = "9.9"` mismatch and passes once restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior impact.
> 
> **Overview**
> Adds **`TestContractConstantsInSyncWithTypeScriptSDK`** in `pkg/asymptoteobserve`, which reads `packages/asymptote-sdk-js/src/constants.ts` and asserts four release-contract values stay aligned with Go (`Vendor`, `Product`, `SchemaVersion`, `AttributeOrigin` vs `BEACON_*` / `ATTR_BEACON_ORIGIN`).
> 
> CI will fail on missing exports or value mismatches, with errors pointing at `event.go` and `constants.ts`. Coverage is intentionally limited to constants both sides define today; comments note widening after a later shared const cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89d070b7d7932b4f8dfe45d60bb93d5e164696f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->