### PR TITLE
Document v0.0.73 CLI release

### DIFF
--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -11,6 +11,12 @@ Stay up to date with the latest changes to the Agent Beacon CLI.
 
 ## June 2026
 
+### v0.0.73 · June 21, 2026
+
+- **S3 token and cost analytics fields** · The S3 Vector forwarding template now preserves canonical `gen_ai.usage` and also emits top-level `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `reasoning_output_tokens`, and `cost_usd` fields so downstream warehouses such as ClickHouse can persist usage attribution reliably.
+- **Managed onboarding docs** · Added an onboarding page for managed ingest setup and clarified the S3 forwarding path for teams wiring Beacon endpoint telemetry into managed analytics.
+- **Observe contract conformance** · Added cross-language contract checks to keep Beacon event constants aligned between the Go schema package and the TypeScript SDK.
+
 ### v0.0.72 · June 18, 2026
 
 - **Inventory state separated from runtime activity** · Inventory heartbeat and snapshot telemetry now write to `inventory_state.jsonl`, keeping agent runtime activity in `runtime.jsonl` while preserving customer-managed forwarding paths.


### PR DESCRIPTION
## Summary
- Add the v0.0.73 CLI changelog entry.
- Call out S3 token/cost analytics forwarding, managed onboarding docs, and observe contract conformance.

## Test plan
- Documentation-only change.


Made with [Cursor](https://cursor.com)