### PR TITLE
refactor(beaconevent): name the tool-name attribute precedence lists

### DIFF
--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -42,6 +42,21 @@ const (
 	ActionMCPToolInvoked    = "mcp.tool_invoked"
 )
 
+// Ordered attribute-key precedence lists for resolving a tool name from the differing
+// conventions emitted by runtimes. The orderings are deliberate and context-specific, so
+// they are named here (rather than repeated as inline literals) to make the precedence
+// explicit and reviewable:
+//   - toolNameKeys: general resolution for the top-level Tool.Name (OTel tool.name first).
+//   - genAIToolNameKeys: GenAI tool info prefers the gen_ai.* name.
+//   - mcpToolNameKeys: MCP activity prefers the mcp.* name.
+//   - codexToolNameKeys: Codex tool-result records use their own field set.
+var (
+	toolNameKeys      = []string{"tool.name", "gen_ai.tool.name", "mcp.tool.name", "function_name", "tool_name"}
+	genAIToolNameKeys = []string{"gen_ai.tool.name", "tool.name"}
+	mcpToolNameKeys   = []string{"mcp.tool.name", "tool.name", "function_name"}
+	codexToolNameKeys = []string{"tool.name", "tool_name", "function_name", "tool", "mcp_server"}
+)
+
 var allowedCodexLogEvents = map[string]struct{}{
 	CodexConversationStarts: {},
 	CodexUserPrompt:         {},
@@ -378,7 +393,7 @@ func CodexLogEventName(attrs map[string]interface{}) string {
 }
 
 func NormalizeCodexToolResult(event *Event, attrs map[string]interface{}) {
-	toolName := FirstString(attrs, "tool.name", "tool_name", "function_name", "tool", "mcp_server")
+	toolName := FirstString(attrs, codexToolNameKeys...)
 	args := FirstString(attrs, "arguments", "function_args", "tool.command", "command")
 	event.Event.Action = ActionToolInvoked
 	event.Event.Category = "tool"
@@ -641,7 +656,7 @@ func (c Converter) PopulateCommon(event *Event, attrs map[string]interface{}) {
 			WorkingDirectory: FirstString(attrs, "cwd", "working_directory", "beacon.session.working_directory", "process.command_args.cwd", "workspace"),
 		}
 	}
-	if name := FirstString(attrs, "tool.name", "gen_ai.tool.name", "mcp.tool.name", "function_name", "tool_name"); name != "" || ToolCommandString(attrs) != "" {
+	if name := FirstString(attrs, toolNameKeys...); name != "" || ToolCommandString(attrs) != "" {
 		event.Tool = &ToolInfo{
 			Name:    name,
 			Command: FirstNonEmpty(ToolCommandString(attrs), FirstString(attrs, "process.command_line")),
@@ -834,7 +849,7 @@ func GenAIResponseFromAttrs(attrs map[string]interface{}) *GenAIResponseInfo {
 func GenAIToolFromAttrs(attrs map[string]interface{}) *GenAIToolInfo {
 	tool := &GenAIToolInfo{
 		Description: FirstString(attrs, "gen_ai.tool.description"),
-		Name:        FirstString(attrs, "gen_ai.tool.name", "tool.name"),
+		Name:        FirstString(attrs, genAIToolNameKeys...),
 		Type:        FirstString(attrs, "gen_ai.tool.type"),
 	}
 	if definitions, ok := AnyAttr(attrs, "gen_ai.tool.definitions"); ok {
@@ -890,7 +905,7 @@ func GenAIUsageFromAttrs(attrs map[string]interface{}) *GenAIUsageInfo {
 
 func MCPFromAttrs(attrs map[string]interface{}) *MCPInfo {
 	server := FirstString(attrs, "mcp.server.name", "mcp.server", "gen_ai.mcp.server", "mcp_server_name")
-	tool := FirstString(attrs, "mcp.tool.name", "tool.name", "function_name")
+	tool := FirstString(attrs, mcpToolNameKeys...)
 	method := FirstString(attrs, "mcp.method.name")
 	protocol := FirstString(attrs, "mcp.protocol.version")
 	resource := FirstString(attrs, "mcp.resource.uri")
@@ -1376,7 +1391,7 @@ func NormalizeHarnessName(name string) string {
 }
 
 func InferAction(attrs map[string]interface{}, fallback string) string {
-	tool := strings.ToLower(FirstString(attrs, "tool.name", "gen_ai.tool.name", "mcp.tool.name", "function_name", "tool_name"))
+	tool := strings.ToLower(FirstString(attrs, toolNameKeys...))
 	operation := strings.ToLower(FirstString(attrs, "gen_ai.operation.name"))
 	mcpMethod := strings.ToLower(FirstString(attrs, "mcp.method.name"))
 	harness := HarnessName(attrs, fallback)


### PR DESCRIPTION
## What

Promotes the converter's five inline tool-name `FirstString` key lists into four named package vars and routes the call sites through them:

- `toolNameKeys` — general top-level `Tool.Name` resolution (used in `PopulateCommon` and `InferAction`, previously byte-identical duplicates)
- `genAIToolNameKeys` — GenAI tool info (`gen_ai.tool.name` first)
- `mcpToolNameKeys` — MCP activity (`mcp.tool.name` first)
- `codexToolNameKeys` — Codex tool-result field set

## Why

The audit flagged the repeated, divergent key orderings as a precedence risk. On inspection, the divergence is **deliberate and context-appropriate** (a GenAI tool struct should prefer `gen_ai.tool.name`; MCP info should prefer `mcp.tool.name`). The real smell is that these precedence rules were invisible, scattered literals — and that two of them were exact duplicates.

This PR makes each precedence explicit and named, deduplicates the genuine duplicate, and documents why the orderings differ — **without** forcibly unifying them (which would regress GenAI/MCP semantics).

## Safety

Behavior-preserving — orderings are unchanged. The PR 4 classification characterization tests stay green, confirming no mapping changed.

## Verification

- `go build ./...` and `go test ./...` in `collector-builder/exporter/beaconjsonexporter` — green.
- `gofmt -l` clean.

## Stacking

Based on #204 (PR 4) → #201 → #200. Review/merge those first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in the beacon event converter with existing characterization tests expected to stay green.
> 
> **Overview**
> **Refactors** how the beacon JSON converter picks a tool name from OTel attributes: repeated inline `FirstString(...)` key lists become four documented package variables, and every call site uses those vars instead of literals.
> 
> The new lists are **`toolNameKeys`** (general `Tool.Name` and `InferAction`), **`genAIToolNameKeys`**, **`mcpToolNameKeys`**, and **`codexToolNameKeys`**, each with a comment explaining why its key order differs. **`PopulateCommon`** and **`InferAction`** now share **`toolNameKeys`**, removing a duplicate ordering that was easy to drift.
> 
> **No semantic change** — key order and membership are unchanged; this only makes precedence visible and reviewable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af317df1fe10a887172d0269927e5cf0eccdb57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->