### PR TITLE
Add operator-selectable prompt redaction mode for persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Do not recreate or depend on removed `asymptote` mirror trees. Keep new work foc
 - Do not add dependency vulnerability scanning, OSV/GHSA lookups, package remediation, or other vulnerability-enforcement flows to the public hook path.
 - Do not add broad runtime enforcement unless explicitly requested. Current control behavior is limited to hook-native approvals/denials exposed by supported agent runtimes.
 - Keep direct destination support scoped to local JSONL/Wazuh unless explicitly requested. Elastic support is a file-tailing pack over local JSONL; Beacon itself must not store Elastic credentials or require a hosted Elastic dependency.
-- Beacon writes retained prompt text, command output, raw tool inputs, raw OTLP attributes, and raw diffs to local or customer-controlled logs, subject to local redaction and size limits where supported.
+- Beacon writes retained prompt text, command output, raw tool inputs, raw OTLP attributes, and raw diffs to local or customer-controlled logs, subject to local redaction and size limits where supported. Prompt body retention is operator-selectable via the `redaction.prompt_mode` endpoint config (`full` default, `redacted`, or `metadata`), read from the trusted config file (never from process environment) and applied in both the hook and CLI persistence paths; secret-pattern redaction always applies as a floor.
 - The Asymptote Observe TypeScript SDK may default to the hosted `/v1/observe` endpoint as an opt-in cloud SDK contract. Beacon endpoint execution stays local-only/no-network.
 
 ## Telemetry Scope

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ Beacon writes endpoint activity to `runtime.jsonl` and periodic Cursor/Claude
 Code configuration inventory metadata to the sibling `inventory_state.jsonl`.
 Local log storage and retention behavior are summarized in the
 [local testing and logs docs](https://docs.asymptotelabs.ai/cli/local-testing-logs).
+Prompt bodies are persisted in full by default (with secrets redacted); set
+`beacon endpoint install --prompt-redaction redacted` (or `metadata`) to replace
+or drop prompt bodies while keeping a correlation digest. See
+[redaction and size limits](https://docs.asymptotelabs.ai/security/retention-redaction).
 
 For offline threat detection, `beacon scan` runs open threat rules over local
 telemetry with no network access. See the

--- a/cli/beacon-hooks/internal/logging/logging.go
+++ b/cli/beacon-hooks/internal/logging/logging.go
@@ -102,6 +102,7 @@ func (l *Logger) EndpointEvent(action, category, severity, message string, field
 	if severity == "" {
 		severity = "info"
 	}
+	applyPromptRetention(fields)
 	event := l.baseEndpointEvent(action, category, severity, message)
 	for key, value := range fields {
 		if value == nil {

--- a/cli/beacon-hooks/internal/logging/retention.go
+++ b/cli/beacon-hooks/internal/logging/retention.go
@@ -1,0 +1,72 @@
+package logging
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+)
+
+// applyPromptRetention rewrites a prompt field in place according to the prompt
+// retention mode configured in the trusted endpoint config file. It is a no-op in
+// full mode (the default), so existing behavior is preserved unless an operator
+// opts into redacted or metadata retention.
+//
+// The mode is read from the config file rather than an environment variable so a
+// monitored runtime cannot relax its own redaction by setting an env var.
+func applyPromptRetention(fields map[string]interface{}) {
+	if fields == nil {
+		return
+	}
+	promptVal, ok := fields["prompt"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	text, _ := promptVal["text"].(string)
+	info, content := asymptoteobserve.RetainPrompt(promptRetentionMode(), text)
+	if info.Text == "" {
+		delete(promptVal, "text")
+	} else {
+		promptVal["text"] = info.Text
+	}
+	if info.Hash != "" {
+		promptVal["hash"] = info.Hash
+	}
+	if info.Length != 0 {
+		promptVal["length"] = info.Length
+	}
+	if content != nil {
+		marker := map[string]interface{}{
+			"retention": content.Retention,
+			"included":  content.Included,
+		}
+		if content.Redacted {
+			marker["redacted"] = true
+		}
+		fields["content"] = marker
+	}
+}
+
+// promptRetentionMode reads the prompt retention mode from the endpoint config file
+// referenced by BEACON_ENDPOINT_CONFIG. Any missing/unreadable/invalid config falls
+// back to full retention (the default), so telemetry never silently stops on a
+// malformed config.
+func promptRetentionMode() string {
+	path := firstEnv("BEACON_ENDPOINT_CONFIG")
+	if path == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var cfg struct {
+		Redaction *struct {
+			PromptMode string `json:"prompt_mode"`
+		} `json:"redaction"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil || cfg.Redaction == nil {
+		return ""
+	}
+	return cfg.Redaction.PromptMode
+}

--- a/cli/beacon-hooks/internal/logging/retention_test.go
+++ b/cli/beacon-hooks/internal/logging/retention_test.go
@@ -1,0 +1,118 @@
+package logging
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeRedactionConfig(t *testing.T, mode string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.json")
+	body := `{"user_mode":true,"redaction":{"prompt_mode":"` + mode + `"}}`
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func promptEvent(t *testing.T, logPath string) map[string]interface{} {
+	t.Helper()
+	logger := NewLoggerForPlatform("prompt-submit", "claude")
+	fields := map[string]interface{}{"prompt": map[string]interface{}{"text": "deploy api_key=hunter2"}}
+	if err := logger.EndpointEvent("prompt.submitted", "prompt", "info", "Prompt submitted", fields); err != nil {
+		t.Fatalf("EndpointEvent: %v", err)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	var event map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &event); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return event
+}
+
+func TestPromptRetentionFullKeepsBody(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_ENDPOINT_CONFIG", writeRedactionConfig(t, "full"))
+
+	event := promptEvent(t, logPath)
+	prompt := event["prompt"].(map[string]interface{})
+	// Secret redaction still applies as a floor, but the prompt body is retained.
+	if got := prompt["text"]; got != "deploy api_key=[REDACTED]" {
+		t.Fatalf("prompt.text = %q, want secret-redacted body", got)
+	}
+	if _, ok := prompt["hash"]; ok {
+		t.Fatalf("full mode should not add a digest: %#v", prompt)
+	}
+	if _, ok := event["content"]; ok {
+		t.Fatalf("full mode should not add a content marker: %#v", event["content"])
+	}
+}
+
+func TestPromptRetentionRedactedReplacesBody(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_ENDPOINT_CONFIG", writeRedactionConfig(t, "redacted"))
+
+	event := promptEvent(t, logPath)
+	prompt := event["prompt"].(map[string]interface{})
+	if got := prompt["text"]; got != "[REDACTED]" {
+		t.Fatalf("prompt.text = %q, want placeholder", got)
+	}
+	if prompt["hash"] == nil || prompt["hash"] == "" {
+		t.Fatalf("redacted mode should keep a digest hash: %#v", prompt)
+	}
+	content := event["content"].(map[string]interface{})
+	if content["retention"] != "redacted" || content["included"] != true || content["redacted"] != true {
+		t.Fatalf("content marker = %#v", content)
+	}
+	if strings.Contains(string(mustMarshal(t, event)), "hunter2") {
+		t.Fatalf("redacted mode leaked prompt body")
+	}
+}
+
+func TestPromptRetentionMetadataDropsBody(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_ENDPOINT_CONFIG", writeRedactionConfig(t, "metadata"))
+
+	event := promptEvent(t, logPath)
+	prompt := event["prompt"].(map[string]interface{})
+	if _, ok := prompt["text"]; ok {
+		t.Fatalf("metadata mode should drop the body: %#v", prompt)
+	}
+	if prompt["hash"] == nil || prompt["length"] == nil {
+		t.Fatalf("metadata mode should keep a digest: %#v", prompt)
+	}
+	content := event["content"].(map[string]interface{})
+	if content["retention"] != "metadata" || content["included"] != false {
+		t.Fatalf("content marker = %#v", content)
+	}
+}
+
+func TestPromptRetentionDefaultsToFullWithoutConfig(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	// No BEACON_ENDPOINT_CONFIG set.
+
+	event := promptEvent(t, logPath)
+	prompt := event["prompt"].(map[string]interface{})
+	if got := prompt["text"]; got != "deploy api_key=[REDACTED]" {
+		t.Fatalf("prompt.text = %q, want retained body when no config", got)
+	}
+}
+
+func mustMarshal(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return data
+}

--- a/cli/beacon/cmd/cloud_devin_pull.go
+++ b/cli/beacon/cmd/cloud_devin_pull.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/devincloud"
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
 	"github.com/spf13/cobra"
 )
@@ -84,12 +85,13 @@ func runCloudDevinPull(cmd *cobra.Command, args []string) error {
 
 	userMode := endpointDevinUserMode()
 	opts := devincloud.PullOptions{
-		Print:        devinPullOpts.print,
-		Out:          cmd.OutOrStdout(),
-		Write:        !devinPullOpts.print,
-		UserMode:     userMode,
-		UploadPrefix: devincloud.GCSPrefixFromEnv(),
-		ForceRefresh: devinPullOpts.fullResync,
+		Print:           devinPullOpts.print,
+		Out:             cmd.OutOrStdout(),
+		Write:           !devinPullOpts.print,
+		UserMode:        userMode,
+		UploadPrefix:    devincloud.GCSPrefixFromEnv(),
+		ForceRefresh:    devinPullOpts.fullResync,
+		PromptRetention: devinPromptRetention(userMode),
 	}
 	// --print is a dry run: do not read or write dedup state (so every event is
 	// shown on each run) and do not resolve a log path to write to.
@@ -159,6 +161,17 @@ func endpointDevinUserMode() bool {
 		return false
 	}
 	return devinPullOpts.userMode
+}
+
+// devinPromptRetention resolves the prompt retention mode from the local endpoint
+// config, defaulting to full when no config is present so the connector keeps
+// working on hosts that only run the cloud pull.
+func devinPromptRetention(userMode bool) string {
+	cfg, err := endpointconfig.Load(userMode)
+	if err != nil {
+		return ""
+	}
+	return endpointconfig.PromptRetentionMode(cfg)
 }
 
 // resolveDevinStatePath always returns a non-empty path so dedup state is

--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -51,6 +51,7 @@ var endpointOpts struct {
 	elasticPackDir           string
 	hookLevel                string
 	contentRetention         string
+	promptRetention          string
 	splunkHECEndpoint        string
 	splunkHECToken           string
 	splunkIndex              string
@@ -404,6 +405,7 @@ func init() {
 	endpointInstallCmd.Flags().StringVar(&endpointOpts.contentRetention, "content-retention", "", "Deprecated no-op; Beacon always captures full content subject to redaction and size limits")
 	_ = endpointInstallCmd.Flags().MarkHidden("content-retention")
 	_ = endpointInstallCmd.Flags().MarkDeprecated("content-retention", "Beacon now always captures full content; this flag is ignored")
+	endpointInstallCmd.Flags().StringVar(&endpointOpts.promptRetention, "prompt-redaction", "", "Prompt body retention in the local log: full (default), redacted, or metadata")
 	registerSplunkFlags(endpointInstallCmd)
 	registerFalconFlags(endpointInstallCmd)
 	endpointRepairCmd.Flags().StringVar(&endpointOpts.harnesses, "harness", "claude,codex", "Comma-separated harnesses to configure")
@@ -417,6 +419,7 @@ func init() {
 	endpointRepairCmd.Flags().StringVar(&endpointOpts.contentRetention, "content-retention", "", "Deprecated no-op; Beacon always captures full content subject to redaction and size limits")
 	_ = endpointRepairCmd.Flags().MarkHidden("content-retention")
 	_ = endpointRepairCmd.Flags().MarkDeprecated("content-retention", "Beacon now always captures full content; this flag is ignored")
+	endpointRepairCmd.Flags().StringVar(&endpointOpts.promptRetention, "prompt-redaction", "", "Prompt body retention in the local log: full (default), redacted, or metadata")
 	registerSplunkFlags(endpointRepairCmd)
 	registerFalconFlags(endpointRepairCmd)
 	endpointDashboardCmd.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")

--- a/cli/beacon/cmd/endpoint_install.go
+++ b/cli/beacon/cmd/endpoint_install.go
@@ -106,6 +106,7 @@ func runEndpointInstall(cmd *cobra.Command, args []string) error {
 		StartService:          !endpointOpts.noStart,
 		IncludeRuntimeMetrics: endpointOpts.includeRuntimeMetrics,
 		IncludeCodexSpans:     endpointOpts.includeCodexSpans,
+		PromptRetention:       endpointOpts.promptRetention,
 		SplunkHEC:             splunkHECOptions(),
 		FalconHEC:             falconHECOptions(),
 	})
@@ -244,6 +245,7 @@ func runEndpointRepair(cmd *cobra.Command, args []string) error {
 		StartService:          !endpointOpts.noStart,
 		IncludeRuntimeMetrics: endpointOpts.includeRuntimeMetrics,
 		IncludeCodexSpans:     endpointOpts.includeCodexSpans,
+		PromptRetention:       endpointOpts.promptRetention,
 		SplunkHEC:             splunkHECOptions(),
 		FalconHEC:             falconHECOptions(),
 	})

--- a/cli/beacon/internal/devincloud/pull.go
+++ b/cli/beacon/internal/devincloud/pull.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/writer"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 )
 
 // Uploader uploads one session's full JSONL snapshot to a destination (GCS).
@@ -26,6 +27,10 @@ type PullOptions struct {
 	LogPath   string    // runtime JSONL path (resolved by caller)
 	UserMode  bool      // writer user/system mode
 	StatePath string    // dedup state file (empty = no persistence)
+
+	// PromptRetention controls how prompt bodies are persisted and uploaded: ""/"full"
+	// keeps the body, "redacted" replaces it with a placeholder, "metadata" drops it.
+	PromptRetention string
 
 	Upload       Uploader // optional GCS uploader
 	UploadPrefix string   // GCS object prefix (e.g. "agent-traces")
@@ -163,7 +168,7 @@ func processSession(ctx context.Context, client *Client, s Session, ss *SessionS
 		if terminal {
 			snapshot = append(snapshot, MappedEvent{Event: EndedEvent(s)})
 		}
-		data, err := marshalEvents(snapshot)
+		data, err := marshalEvents(snapshot, opts.PromptRetention)
 		if err != nil {
 			return err
 		}
@@ -197,7 +202,7 @@ func emit(ev schema.Event, opts PullOptions) error {
 		}
 	}
 	if opts.Write {
-		if _, err := writer.AppendEvent(ev, writer.Options{Path: opts.LogPath, UserMode: opts.UserMode}); err != nil {
+		if _, err := writer.AppendEvent(ev, writer.Options{Path: opts.LogPath, UserMode: opts.UserMode, PromptRetention: opts.PromptRetention}); err != nil {
 			return err
 		}
 	}
@@ -207,10 +212,18 @@ func emit(ev schema.Event, opts PullOptions) error {
 // marshalEvents builds the per-session JSONL snapshot for upload. Events are run
 // through the same redaction/truncation/size controls as the local writer so
 // the GCS snapshot never carries more raw content than the local log.
-func marshalEvents(mapped []MappedEvent) ([]byte, error) {
+func marshalEvents(mapped []MappedEvent, promptRetention string) ([]byte, error) {
 	var buf []byte
 	for _, me := range mapped {
-		data, err := json.Marshal(writer.SanitizeEvent(me.Event, writer.MaxEventBytes))
+		ev := me.Event
+		if ev.Prompt != nil {
+			prompt, content := asymptoteobserve.RetainPrompt(promptRetention, ev.Prompt.Text)
+			ev.Prompt = prompt
+			if content != nil {
+				ev.Content = content
+			}
+		}
+		data, err := json.Marshal(writer.SanitizeEvent(ev, writer.MaxEventBytes))
 		if err != nil {
 			return nil, err
 		}

--- a/cli/beacon/internal/endpoint/config/config.go
+++ b/cli/beacon/internal/endpoint/config/config.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 )
 
 const (
@@ -30,6 +32,17 @@ type Config struct {
 	Inventory       *Inventory     `json:"inventory_heartbeat,omitempty"`
 	Destinations    *Destinations  `json:"destinations,omitempty"`
 	ManagedUpload   *ManagedUpload `json:"managed_upload,omitempty"`
+	Redaction       *Redaction     `json:"redaction,omitempty"`
+}
+
+// Redaction controls how retained content is transformed before it is written to
+// the local runtime log. It is read from the trusted endpoint config file (not from
+// process environment) so a monitored runtime cannot relax its own redaction.
+type Redaction struct {
+	// PromptMode selects how prompt text is persisted: "full" (default) keeps the
+	// prompt body, "redacted" replaces it with a placeholder while keeping a digest,
+	// and "metadata" drops the body and keeps only the digest.
+	PromptMode string `json:"prompt_mode,omitempty"`
 }
 
 type Collector struct {
@@ -165,12 +178,18 @@ func Load(userMode bool) (Config, error) {
 	if err := ValidateDestinations(cfg.Destinations); err != nil {
 		return Config{}, err
 	}
+	if err := ValidateRedaction(cfg.Redaction); err != nil {
+		return Config{}, err
+	}
 	return cfg, nil
 }
 
 func Save(cfg Config) (string, error) {
 	NormalizeDestinations(&cfg)
 	if err := ValidateDestinations(cfg.Destinations); err != nil {
+		return "", err
+	}
+	if err := ValidateRedaction(cfg.Redaction); err != nil {
 		return "", err
 	}
 	path := ConfigPath(cfg.UserMode)
@@ -269,6 +288,35 @@ func ValidateDestinations(destinations *Destinations) error {
 		}
 	}
 	return nil
+}
+
+// ValidateRedaction rejects unknown prompt retention modes so a typo fails closed at
+// load/save time rather than silently defaulting at write time.
+func ValidateRedaction(r *Redaction) error {
+	if r == nil {
+		return nil
+	}
+	switch r.PromptMode {
+	case "",
+		asymptoteobserve.ContentRetentionFull,
+		asymptoteobserve.ContentRetentionRedacted,
+		asymptoteobserve.ContentRetentionMetadata:
+		return nil
+	default:
+		return fmt.Errorf("redaction.prompt_mode must be %q, %q, or %q",
+			asymptoteobserve.ContentRetentionFull,
+			asymptoteobserve.ContentRetentionRedacted,
+			asymptoteobserve.ContentRetentionMetadata)
+	}
+}
+
+// PromptRetentionMode returns the configured prompt retention mode, defaulting to
+// full when redaction is unset.
+func PromptRetentionMode(cfg Config) string {
+	if cfg.Redaction == nil {
+		return asymptoteobserve.ContentRetentionFull
+	}
+	return asymptoteobserve.NormalizePromptRetention(cfg.Redaction.PromptMode)
 }
 
 func HasSecretDestinations(cfg Config) bool {

--- a/cli/beacon/internal/endpoint/config/config_test.go
+++ b/cli/beacon/internal/endpoint/config/config_test.go
@@ -215,6 +215,61 @@ func TestLoadIgnoresLegacyContentRetention(t *testing.T) {
 	}
 }
 
+func TestRedactionRoundTripAndPromptRetentionMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := Default(true, "")
+	cfg.Redaction = &Redaction{PromptMode: "redacted"}
+	if _, err := Save(cfg); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+	loaded, err := Load(true)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if loaded.Redaction == nil || loaded.Redaction.PromptMode != "redacted" {
+		t.Fatalf("loaded redaction = %#v, want prompt_mode=redacted", loaded.Redaction)
+	}
+	if got := PromptRetentionMode(loaded); got != "redacted" {
+		t.Fatalf("PromptRetentionMode = %q, want redacted", got)
+	}
+}
+
+func TestPromptRetentionModeDefaultsToFull(t *testing.T) {
+	if got := PromptRetentionMode(Config{}); got != "full" {
+		t.Fatalf("PromptRetentionMode(nil redaction) = %q, want full", got)
+	}
+	if got := PromptRetentionMode(Config{Redaction: &Redaction{PromptMode: ""}}); got != "full" {
+		t.Fatalf("PromptRetentionMode(empty mode) = %q, want full", got)
+	}
+}
+
+func TestSaveRejectsUnknownPromptRetentionMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := Default(true, "")
+	cfg.Redaction = &Redaction{PromptMode: "bogus"}
+	if _, err := Save(cfg); err == nil {
+		t.Fatal("Save accepted unknown prompt_mode, want error")
+	}
+}
+
+func TestLoadRejectsUnknownPromptRetentionMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, UserConfigPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"user_mode":true,"redaction":{"prompt_mode":"bogus"}}`), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := Load(true); err == nil {
+		t.Fatal("Load accepted unknown prompt_mode, want error")
+	}
+}
+
 func TestLoadRejectsCorruptJSON(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	beaconauth "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/auth"
@@ -37,6 +38,7 @@ type InstallOptions struct {
 	StartService          bool
 	IncludeRuntimeMetrics bool
 	IncludeCodexSpans     bool
+	PromptRetention       string
 	SplunkHEC             *endpointconfig.SplunkHEC
 	FalconHEC             *endpointconfig.FalconHEC
 }
@@ -373,6 +375,9 @@ func buildConfig(opts InstallOptions) endpointconfig.Config {
 	cfg.Collector.BinaryPath = opts.CollectorPath
 	cfg.Collector.IncludeRuntimeMetrics = opts.IncludeRuntimeMetrics
 	cfg.Collector.IncludeCodexSpans = opts.IncludeCodexSpans
+	if mode := strings.TrimSpace(opts.PromptRetention); mode != "" {
+		cfg.Redaction = &endpointconfig.Redaction{PromptMode: mode}
+	}
 	if opts.SplunkHEC != nil {
 		if cfg.Destinations == nil {
 			cfg.Destinations = &endpointconfig.Destinations{}

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -86,6 +86,21 @@ func TestBuildConfigAppliesInstallOptions(t *testing.T) {
 	}
 }
 
+func TestBuildConfigSetsPromptRetention(t *testing.T) {
+	cfg := buildConfig(InstallOptions{UserMode: true, PromptRetention: "redacted"})
+	if cfg.Redaction == nil || cfg.Redaction.PromptMode != "redacted" {
+		t.Fatalf("Redaction = %#v, want prompt_mode=redacted", cfg.Redaction)
+	}
+	if got := endpointconfig.PromptRetentionMode(cfg); got != "redacted" {
+		t.Fatalf("PromptRetentionMode = %q, want redacted", got)
+	}
+
+	defaultCfg := buildConfig(InstallOptions{UserMode: true})
+	if defaultCfg.Redaction != nil {
+		t.Fatalf("default Redaction = %#v, want nil (full)", defaultCfg.Redaction)
+	}
+}
+
 func TestBuildConfigPreservesExplicitEmptyHarnesses(t *testing.T) {
 	cfg := buildConfig(InstallOptions{UserMode: true, Harnesses: []string{}})
 	if cfg.Harnesses == nil || len(cfg.Harnesses) != 0 {

--- a/cli/beacon/internal/endpoint/writer/writer.go
+++ b/cli/beacon/internal/endpoint/writer/writer.go
@@ -29,6 +29,9 @@ type Options struct {
 	MaxBytes       int
 	RotateSize     int64
 	RotateArchives int
+	// PromptRetention controls how prompt text is persisted: "" / "full" keeps the
+	// body, "redacted" replaces it with a placeholder, "metadata" drops the body.
+	PromptRetention string
 }
 
 func DefaultPath(userMode bool) string {
@@ -54,6 +57,13 @@ func AppendEvent(event schema.Event, opts Options) (string, error) {
 	}
 	if opts.RotateArchives < 1 {
 		opts.RotateArchives = DefaultRotateArchives
+	}
+	if event.Prompt != nil {
+		prompt, content := asymptoteobserve.RetainPrompt(opts.PromptRetention, event.Prompt.Text)
+		event.Prompt = prompt
+		if content != nil {
+			event.Content = content
+		}
 	}
 	event = SanitizeEvent(event, opts.MaxBytes)
 	if err := event.Validate(); err != nil {

--- a/cli/beacon/internal/endpoint/writer/writer_test.go
+++ b/cli/beacon/internal/endpoint/writer/writer_test.go
@@ -62,6 +62,60 @@ func TestAppendEventRedactsSecrets(t *testing.T) {
 	}
 }
 
+func TestAppendEventAppliesPromptRetention(t *testing.T) {
+	cases := []struct {
+		mode        string
+		wantText    string
+		wantDigest  bool
+		wantContent string // "" means no content marker expected
+	}{
+		{mode: "", wantText: "summarize the diff", wantDigest: false, wantContent: ""},
+		{mode: "full", wantText: "summarize the diff", wantDigest: false, wantContent: ""},
+		{mode: "redacted", wantText: "[REDACTED]", wantDigest: true, wantContent: "redacted"},
+		{mode: "metadata", wantText: "", wantDigest: true, wantContent: "metadata"},
+	}
+	for _, tc := range cases {
+		t.Run("mode="+tc.mode, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "runtime.jsonl")
+			event := schema.NewEvent(schema.NewEventOptions{
+				Action:  "prompt.submitted",
+				Harness: schema.HarnessInfo{Name: "test"},
+			})
+			event.Prompt = &schema.PromptInfo{Text: "summarize the diff"}
+			if _, err := AppendEvent(event, Options{Path: path, PromptRetention: tc.mode}); err != nil {
+				t.Fatalf("AppendEvent returned error: %v", err)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read log: %v", err)
+			}
+			var decoded map[string]interface{}
+			if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &decoded); err != nil {
+				t.Fatalf("line is not JSON: %v", err)
+			}
+			prompt, _ := decoded["prompt"].(map[string]interface{})
+			if prompt == nil {
+				t.Fatalf("prompt missing: %s", string(data))
+			}
+			if got, _ := prompt["text"].(string); got != tc.wantText {
+				t.Fatalf("prompt.text = %q, want %q", got, tc.wantText)
+			}
+			_, hasHash := prompt["hash"]
+			if hasHash != tc.wantDigest {
+				t.Fatalf("prompt.hash present = %v, want %v", hasHash, tc.wantDigest)
+			}
+			content, _ := decoded["content"].(map[string]interface{})
+			if tc.wantContent == "" {
+				if content != nil {
+					t.Fatalf("unexpected content marker: %#v", content)
+				}
+			} else if content == nil || content["retention"] != tc.wantContent {
+				t.Fatalf("content marker = %#v, want retention=%q", content, tc.wantContent)
+			}
+		})
+	}
+}
+
 func TestAppendEventRedactsNestedSlices(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "runtime.jsonl")
 	event := schema.NewEvent(schema.NewEventOptions{

--- a/docs/cli/endpoint-config.mdx
+++ b/docs/cli/endpoint-config.mdx
@@ -64,7 +64,21 @@ sudo beacon endpoint config show --system
 beacon endpoint config validate
 ```
 
-Validation checks endpoint and destination configuration. For example, Splunk HEC and Falcon LogScale HEC forwarding require both an endpoint URL and token when configured.
+Validation checks endpoint and destination configuration. For example, Splunk HEC and Falcon LogScale HEC forwarding require both an endpoint URL and token when configured, and `redaction.prompt_mode` must be `full`, `redacted`, or `metadata`.
+
+## Prompt Redaction
+
+The optional `redaction` block controls how much of the prompt body is persisted to the local runtime log. Set it during install with `beacon endpoint install --prompt-redaction <mode>`, or edit the config file directly:
+
+```json title="Redact prompt bodies in the local log"
+{
+  "redaction": {
+    "prompt_mode": "redacted"
+  }
+}
+```
+
+`prompt_mode` accepts `full` (default — retain the body, secrets redacted), `redacted` (replace the body with `[REDACTED]` and keep a hash/length digest), or `metadata` (drop the body, keep the digest). See [Redaction and Size Limits](/security/retention-redaction) for the full behavior.
 
 ### Examples
 

--- a/docs/cli/endpoint-install.mdx
+++ b/docs/cli/endpoint-install.mdx
@@ -27,6 +27,7 @@ By default, Beacon configures Claude Code and Codex CLI telemetry for local or c
 | `--no-start` | Write files without starting the launchd service |
 | `--include-runtime-metrics` | Include generic process, runtime, and harness operational OTLP metrics in Beacon JSONL. By default, low-signal metrics such as process CPU, memory, Node.js event loop, V8 heap, GitHub Copilot CLI, and OpenClaw operational metrics are filtered out |
 | `--include-codex-spans` | Include high-volume Codex OTLP spans for troubleshooting. By default, Beacon records Codex semantic logs and suppresses raw Codex spans |
+| `--prompt-redaction <mode>` | How much of the prompt body is persisted to the local log: `full` (default), `redacted` (replace the body with `[REDACTED]` and keep a hash/length digest), or `metadata` (drop the body, keep the digest). Secret-pattern redaction always applies regardless of mode |
 | `--splunk-hec-endpoint <url>` | Splunk HEC endpoint URL |
 | `--splunk-hec-token <token>` | Splunk HEC token |
 | `--splunk-index <index>` | Optional Splunk index |

--- a/docs/security/retention-redaction.mdx
+++ b/docs/security/retention-redaction.mdx
@@ -15,10 +15,35 @@ Beacon can write supported prompt, command, tool, file, approval, policy, and ru
 | Sanitization | Runtime payloads are normalized into typed event fields instead of storing source payloads verbatim wherever possible |
 | Truncation | Oversized fields are shortened and marked with truncation metadata |
 | Event-size limits | Events are bounded before they are written to `runtime.jsonl` or sent to configured destinations |
+| Prompt retention mode | An operator-selected mode controls how much of the prompt body is persisted |
+
+## Prompt Retention Mode
+
+Secret-pattern redaction always applies to prompt text as a floor. On top of that, operators can choose how much of the prompt body is persisted to the local runtime log with the `redaction.prompt_mode` endpoint config setting (or `beacon endpoint install --prompt-redaction <mode>`):
+
+| Mode | `prompt.text` | Digest (`prompt.hash` + `prompt.length`) | `content` marker |
+|------|---------------|------------------------------------------|------------------|
+| `full` (default) | Retained, secret-redacted | — | none |
+| `redacted` | Replaced with `[REDACTED]` | Retained | `retention: redacted`, `redacted: true` |
+| `metadata` | Dropped | Retained | `retention: metadata`, `included: false` |
+
+The digest is a SHA-256 hash and character length of the original prompt. It lets operators correlate and deduplicate prompts in `redacted` and `metadata` modes without retaining the prompt body.
+
+The mode is read from the trusted endpoint config file, not from process environment, so a monitored runtime cannot relax its own redaction. It applies to local hook telemetry and to CLI-side prompt events (such as the Devin Cloud connector) and their uploaded snapshots.
+
+Example endpoint config:
+
+```json
+{
+  "redaction": {
+    "prompt_mode": "redacted"
+  }
+}
+```
 
 ## Prompt Event Example
 
-Prompt content is included only when the source runtime emits it. Secret-like values are redacted before the event is written:
+Prompt content is included only when the source runtime emits it. Secret-like values are redacted before the event is written. In the default `full` mode, the prompt body is retained (with secrets redacted):
 
 ```json
 {
@@ -31,8 +56,25 @@ Prompt content is included only when the source runtime emits it. Secret-like va
   },
   "prompt": {
     "text": "Review this API client. Token: [REDACTED]"
+  }
+}
+```
+
+In `redacted` mode the body is replaced with a placeholder and a digest is retained so prompts can still be correlated:
+
+```json
+{
+  "event": {
+    "action": "prompt.submitted",
+    "category": "prompt"
+  },
+  "prompt": {
+    "text": "[REDACTED]",
+    "hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+    "length": 142
   },
   "content": {
+    "retention": "redacted",
     "included": true,
     "redacted": true
   }

--- a/pkg/asymptoteobserve/event.go
+++ b/pkg/asymptoteobserve/event.go
@@ -162,7 +162,9 @@ type PolicyInfo struct {
 }
 
 type PromptInfo struct {
-	Text string `json:"text,omitempty"`
+	Text   string `json:"text,omitempty"`
+	Hash   string `json:"hash,omitempty"`
+	Length int    `json:"length,omitempty"`
 }
 
 type ContentInfo struct {

--- a/pkg/asymptoteobserve/retention.go
+++ b/pkg/asymptoteobserve/retention.go
@@ -1,0 +1,62 @@
+package asymptoteobserve
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// PromptRedactionPlaceholder replaces prompt bodies when prompt retention runs in
+// "redacted" mode. It is a fixed marker so downstream readers can recognize that the
+// prompt body was intentionally withheld rather than empty.
+const PromptRedactionPlaceholder = "[REDACTED]"
+
+// NormalizePromptRetention returns a valid prompt retention mode, defaulting to
+// ContentRetentionFull for empty or unrecognized input. The modes reuse the
+// content.retention ladder so persisted events and the schema stay aligned.
+func NormalizePromptRetention(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case ContentRetentionMetadata:
+		return ContentRetentionMetadata
+	case ContentRetentionRedacted:
+		return ContentRetentionRedacted
+	default:
+		return ContentRetentionFull
+	}
+}
+
+// PromptDigest returns a stable sha256 hash (hex) and rune length of raw prompt text.
+// It lets operators correlate and dedupe prompts in redacted/metadata modes without
+// retaining the prompt body. Empty text yields an empty digest.
+func PromptDigest(raw string) (hash string, length int) {
+	if raw == "" {
+		return "", 0
+	}
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:]), len([]rune(raw))
+}
+
+// RetainPrompt applies a prompt retention mode to raw prompt text, returning the
+// PromptInfo to persist and the content marker that records how the body was handled.
+//
+//   - full (default, and any unknown mode): the body is kept verbatim and no content
+//     marker is added (callers still apply secret redaction and truncation downstream).
+//   - redacted: the body is replaced with PromptRedactionPlaceholder and a digest is
+//     retained; the marker reports redacted=true.
+//   - metadata: the body is dropped entirely and only the digest is retained.
+//
+// RetainPrompt never returns a nil PromptInfo so callers can persist the digest.
+func RetainPrompt(mode, raw string) (*PromptInfo, *ContentInfo) {
+	switch NormalizePromptRetention(mode) {
+	case ContentRetentionRedacted:
+		hash, length := PromptDigest(raw)
+		return &PromptInfo{Text: PromptRedactionPlaceholder, Hash: hash, Length: length},
+			&ContentInfo{Retention: ContentRetentionRedacted, Included: true, Redacted: true}
+	case ContentRetentionMetadata:
+		hash, length := PromptDigest(raw)
+		return &PromptInfo{Hash: hash, Length: length},
+			&ContentInfo{Retention: ContentRetentionMetadata, Included: false}
+	default:
+		return &PromptInfo{Text: raw}, nil
+	}
+}

--- a/pkg/asymptoteobserve/retention_test.go
+++ b/pkg/asymptoteobserve/retention_test.go
@@ -1,0 +1,76 @@
+package asymptoteobserve
+
+import "testing"
+
+func TestNormalizePromptRetention(t *testing.T) {
+	cases := map[string]string{
+		"":          ContentRetentionFull,
+		"full":      ContentRetentionFull,
+		"FULL":      ContentRetentionFull,
+		" redacted": ContentRetentionRedacted,
+		"metadata":  ContentRetentionMetadata,
+		"bogus":     ContentRetentionFull,
+	}
+	for input, want := range cases {
+		if got := NormalizePromptRetention(input); got != want {
+			t.Fatalf("NormalizePromptRetention(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestRetainPromptFullKeepsBodyAndAddsNoMarker(t *testing.T) {
+	info, content := RetainPrompt("full", "review token=secret")
+	if info == nil || info.Text != "review token=secret" {
+		t.Fatalf("full mode info = %#v, want verbatim text", info)
+	}
+	if info.Hash != "" || info.Length != 0 {
+		t.Fatalf("full mode should not add a digest: %#v", info)
+	}
+	if content != nil {
+		t.Fatalf("full mode should not add a content marker: %#v", content)
+	}
+}
+
+func TestRetainPromptRedactedReplacesBodyWithDigest(t *testing.T) {
+	raw := "deploy with api_key=hunter2"
+	info, content := RetainPrompt("redacted", raw)
+	if info.Text != PromptRedactionPlaceholder {
+		t.Fatalf("redacted mode text = %q, want placeholder", info.Text)
+	}
+	wantHash, wantLen := PromptDigest(raw)
+	if info.Hash != wantHash || info.Length != wantLen {
+		t.Fatalf("redacted digest = (%q,%d), want (%q,%d)", info.Hash, info.Length, wantHash, wantLen)
+	}
+	if content == nil || content.Retention != ContentRetentionRedacted || !content.Included || !content.Redacted {
+		t.Fatalf("redacted marker = %#v", content)
+	}
+}
+
+func TestRetainPromptMetadataDropsBody(t *testing.T) {
+	raw := "summarize this file"
+	info, content := RetainPrompt("metadata", raw)
+	if info.Text != "" {
+		t.Fatalf("metadata mode should drop body, got %q", info.Text)
+	}
+	wantHash, wantLen := PromptDigest(raw)
+	if info.Hash != wantHash || info.Length != wantLen {
+		t.Fatalf("metadata digest = (%q,%d), want (%q,%d)", info.Hash, info.Length, wantHash, wantLen)
+	}
+	if content == nil || content.Retention != ContentRetentionMetadata || content.Included {
+		t.Fatalf("metadata marker = %#v", content)
+	}
+}
+
+func TestPromptDigestStableAndEmpty(t *testing.T) {
+	if h, l := PromptDigest(""); h != "" || l != 0 {
+		t.Fatalf("empty digest = (%q,%d), want empty", h, l)
+	}
+	h1, l1 := PromptDigest("café")
+	h2, l2 := PromptDigest("café")
+	if h1 != h2 || l1 != l2 {
+		t.Fatalf("digest not stable: (%q,%d) vs (%q,%d)", h1, l1, h2, l2)
+	}
+	if l1 != 4 {
+		t.Fatalf("rune length = %d, want 4", l1)
+	}
+}

--- a/spec/threat-rules/FIELDS.md
+++ b/spec/threat-rules/FIELDS.md
@@ -100,6 +100,8 @@ Regenerate with `beacon rules fields --markdown > spec/threat-rules/FIELDS.md`.
 | `e.policy.name` | string |
 | `e.policy.reason` | string |
 | `e.product` | string |
+| `e.prompt.hash` | string |
+| `e.prompt.length` | int |
 | `e.prompt.text` | string |
 | `e.repository` | string |
 | `e.run.actor` | string |


### PR DESCRIPTION
## Summary

Adds an operator-selectable **prompt redaction mode** that controls how much of the prompt body is written to local endpoint logs, building on the existing `content.retention` schema ladder (which was previously only a passive marker). Default `full` preserves today's behavior exactly.

| Mode | `prompt.text` | digest (`prompt.hash` + `prompt.length`) | `content` marker |
|------|--------------|-------------------------------------------|------------------|
| `full` (default) | kept (secret-redacted) | – | none |
| `redacted` | `[REDACTED]` placeholder | yes | `retention: redacted`, `redacted: true` |
| `metadata` | dropped | yes | `retention: metadata`, `included: false` |

The digest is a SHA-256 hash + rune length of the original prompt, so operators can still correlate/deduplicate prompts in `redacted`/`metadata` modes without retaining the body. Secret-pattern redaction continues to apply as a floor in **every** mode.

## Design decisions

- **Config-driven, not env-driven.** The codebase deliberately ignores a legacy `BEACON_CONTENT_RETENTION` env (`TestGrokIgnoresLegacyRetentionEnv`) and ships a deprecated no-op `--content-retention` flag. The reason is sound: a monitored runtime must not be able to relax its own redaction by setting an env var. So the mode is read from the **trusted endpoint config file** (`redaction.prompt_mode`), and the legacy env stays ignored. A new, distinctly-named `--prompt-redaction` install flag writes it.
- **Both persistence paths enforced** through a single shared `RetainPrompt` helper in `pkg/asymptoteobserve`:
  - the hook `logging` chokepoint (covers all runtimes), reading the mode from the installer-set `BEACON_ENDPOINT_CONFIG`;
  - the CLI `writer` (covers the Devin Cloud connector and its uploaded snapshots, preserving the "upload never carries more than local" invariant).

## Changes

- `pkg/asymptoteobserve`: `RetainPrompt` / `NormalizePromptRetention` / `PromptDigest`; optional `prompt.hash` / `prompt.length` fields.
- `endpoint/config`: `redaction.prompt_mode` field, validation (fails closed on typos), `PromptRetentionMode` helper.
- Hook `logging`, CLI `writer`, Devin pull: apply the mode.
- `beacon endpoint install/repair --prompt-redaction <mode>` flag.
- Regenerated `spec/threat-rules/FIELDS.md`; updated `CLAUDE.md`, `README.md`, and the security/CLI docs.
- Tests at every layer: helper, config validation/round-trip, writer table test, hook end-to-end, lifecycle.

## Testing

All touched suites pass: `pkg/asymptoteobserve` (incl. threat-rules conformance), `cli/beacon-hooks`, and `cli/beacon` config/writer/lifecycle/devincloud/cmd, plus the collector exporter.

Two unrelated test failures observed locally are **pre-existing and environmental** — confirmed identical with these changes stashed:
- `harness` VS Code path test expects macOS paths (running on Linux);
- `hooks` factory test needs a real embedded `hooks.bin` (CI builds one; local uses a placeholder that fails arch validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT3qxCDeVEJG4CUNumkLmU

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT3qxCDeVEJG4CUNumkLmU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what sensitive prompt content is persisted and forwarded, but defaults are unchanged and policy is operator-controlled via trusted config with validation on install paths.
> 
> **Overview**
> Operators can control how much **prompt text** lands in `runtime.jsonl` (and matching uploads) via `redaction.prompt_mode` in the trusted endpoint config, or `beacon endpoint install|repair --prompt-redaction <mode>`. **Default `full`** keeps today’s behavior (body retained with secret-pattern redaction as a floor).
> 
> **`redacted`** replaces the body with `[REDACTED]` and keeps a SHA-256 hash plus rune length for correlation; **`metadata`** drops the body and keeps only that digest, with a `content` marker on non-`full` modes. The mode is read from the **config file** (hooks via `BEACON_ENDPOINT_CONFIG`), not process env, so monitored runtimes cannot weaken redaction.
> 
> Shared logic lives in `pkg/asymptoteobserve` (`RetainPrompt`, `PromptDigest`); it runs in hook `EndpointEvent`, `writer.AppendEvent`, and the Devin Cloud connector (local append and GCS session snapshots). Config **load/save rejects unknown modes**; malformed hook-side config falls back to full so logging does not stop. Docs and `spec/threat-rules/FIELDS.md` add `prompt.hash` / `prompt.length`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276225c5c8b9fc5240555f9276d4c4b7911241a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->