### PR TITLE
refactor(beaconevent): make NormalizeHarnessName table-driven

### DIFF
--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -1358,36 +1358,41 @@ func HarnessName(attrs map[string]interface{}, hints ...string) string {
 	return "otel"
 }
 
+// harnessNameRules maps substring aliases to a canonical harness name. Rules are
+// evaluated in order and the first whose lower-cased input contains any alias wins, so
+// more specific names (e.g. "claude_code", "copilot-chat") must precede the broader
+// catch-alls ("claude", "copilot"). This replaces a hand-written switch ladder; the
+// classification characterization tests pin the resulting mappings.
+var harnessNameRules = []struct {
+	aliases []string
+	name    string
+}{
+	{[]string{"cowork", "co-work"}, "claude_cowork"},
+	{[]string{"claude_agent_sdk", "claude-agent-sdk", "claude agent sdk"}, "claude_agent_sdk"},
+	{[]string{"claude_code", "claude-code", "claude code"}, "claude_code"},
+	{[]string{"claude"}, "claude_code"},
+	{[]string{"openclaw", "open-claw"}, "openclaw_gateway"},
+	{[]string{"antigravity", "anti-gravity"}, "antigravity_cli"},
+	{[]string{"codex"}, "codex_cli"},
+	{[]string{"gemini"}, "gemini_cli"},
+	{[]string{"copilot-chat"}, "vscode_copilot"},
+	{[]string{"github-copilot", "copilot_cli", "copilot"}, "copilot_cli"},
+}
+
 func NormalizeHarnessName(name string) string {
 	lower := strings.ToLower(strings.TrimSpace(name))
-	switch {
-	case lower == "":
-		return ""
-	case strings.Contains(lower, "cowork") || strings.Contains(lower, "co-work"):
-		return "claude_cowork"
-	case strings.Contains(lower, "claude_agent_sdk") || strings.Contains(lower, "claude-agent-sdk") || strings.Contains(lower, "claude agent sdk"):
-		return "claude_agent_sdk"
-	case strings.Contains(lower, "claude_code") || strings.Contains(lower, "claude-code") || strings.Contains(lower, "claude code") || strings.HasPrefix(lower, "claude_code."):
-		return "claude_code"
-	case lower == "claude" || strings.Contains(lower, "claude"):
-		return "claude_code"
-	case strings.Contains(lower, "openclaw") || strings.Contains(lower, "open-claw"):
-		return "openclaw_gateway"
-	case strings.Contains(lower, "antigravity") || strings.Contains(lower, "anti-gravity"):
-		return "antigravity_cli"
-	case strings.Contains(lower, "codex"):
-		return "codex_cli"
-	case strings.Contains(lower, "gemini"):
-		return "gemini_cli"
-	case strings.Contains(lower, "copilot-chat"):
-		return "vscode_copilot"
-	case strings.Contains(lower, "github-copilot") || strings.Contains(lower, "copilot_cli") || strings.Contains(lower, "copilot"):
-		return "copilot_cli"
-	case name != "":
-		return name
-	default:
+	if lower == "" {
 		return ""
 	}
+	for _, rule := range harnessNameRules {
+		for _, alias := range rule.aliases {
+			if strings.Contains(lower, alias) {
+				return rule.name
+			}
+		}
+	}
+	// Unrecognized but non-empty: return the original (untrimmed) name verbatim.
+	return name
 }
 
 func InferAction(attrs map[string]interface{}, fallback string) string {


### PR DESCRIPTION
## What

Replaces the 14-branch substring-matching `switch` ladder in `NormalizeHarnessName` with an ordered rule table (`harnessNameRules`: aliases → canonical harness name).

## Why

The hand-written switch was the kind of brittle, stringly-typed ladder the audit flagged (#1): order-dependent, easy to misorder, hard to extend. The table keeps the exact same first-match-wins ordering (specific names before catch-alls) while making the alias→name mapping declarative and reviewable in one place.

Also folded two provably-redundant conditions:
- `HasPrefix(lower, "claude_code.")` is subsumed by `Contains(lower, "claude_code")`
- `lower == "claude"` is subsumed by `Contains(lower, "claude")`

## Safety

Behavior-preserving. The PR 4 classification characterization tests (which pin every `NormalizeHarnessName` mapping, including verbatim passthrough of unrecognized names) stay green.

## Verification

- `go build ./...` and `go test ./...` in `collector-builder/exporter/beaconjsonexporter` — green.
- `gofmt -l` clean.

## Stacking

Based on #205 (PR 5) → #204 → #201 → #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure structural refactor of harness string classification with characterization tests guarding mappings; affects event labeling downstream only if ordering or aliases drift.
> 
> **Overview**
> Replaces the long `switch` in **`NormalizeHarnessName`** with an ordered **`harnessNameRules`** table (alias substrings → canonical harness IDs). Matching stays **first rule wins**, with the same ordering so specific tokens (e.g. `claude_code`, `copilot-chat`) beat broader ones (`claude`, `copilot`).
> 
> The fallback for unknown non-empty names is unchanged: return the **original** string (case preserved), not the lowercased form. A couple of redundant branches (`HasPrefix` for `claude_code.` and exact `claude`) are dropped because they were already covered by `Contains`.
> 
> No test changes in the diff; characterization tests are expected to keep the mapping contract locked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83a98804bff210fcba5cb1b6e6d8955cd8a04da9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->