### PR TITLE
refactor(beaconevent): extract InferAction substring fallback into a table

### DIFF
--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -1407,6 +1407,9 @@ func InferAction(attrs map[string]interface{}, fallback string) string {
 		mcpMethod,
 		FirstString(attrs, "event.name", "codex.op", "rpc.method"),
 	}, " "))
+	// Structured, heterogeneous matchers run first and short-circuit. Their order is
+	// significant relative to the keyword fallback below: e.g. the gemini_cli.file_operation
+	// case must precede the "file" keyword rule, which would otherwise claim it.
 	switch {
 	case harness == "copilot_cli" || harness == "vscode_copilot":
 		return CopilotAction(attrs, operation, text)
@@ -1426,21 +1429,31 @@ func InferAction(attrs map[string]interface{}, fallback string) string {
 		return GeminiToolAction(attrs)
 	case strings.Contains(text, "gemini_cli.file_operation"):
 		return GeminiFileAction(attrs)
-	case strings.Contains(text, "approval_mode_switch") || strings.Contains(text, "approval_mode_duration") || strings.Contains(text, "plan_execution"):
-		return ActionApprovalRequested
-	case strings.Contains(text, "prompt") || strings.Contains(text, "user_input"):
-		return ActionPromptSubmitted
-	case strings.Contains(text, "mcp"):
-		return ActionMCPToolInvoked
-	case strings.Contains(text, "command") || strings.Contains(text, "shell") || strings.Contains(text, "exec"):
-		return ActionCommandExecuted
-	case strings.Contains(text, "file") || strings.Contains(text, "write") || strings.Contains(text, "edit"):
-		return ActionFileModified
-	case strings.Contains(text, "approval"):
-		return ActionApprovalRequested
-	default:
-		return ActionToolInvoked
 	}
+
+	// Ordered substring fallback over the joined text. First rule with a matching keyword wins.
+	for _, rule := range textKeywordActionRules {
+		for _, keyword := range rule.keywords {
+			if strings.Contains(text, keyword) {
+				return rule.action
+			}
+		}
+	}
+	return ActionToolInvoked
+}
+
+// textKeywordActionRules is the ordered substring-match fallback for InferAction, applied
+// after the structured matchers above. Order matters: earlier rules take precedence.
+var textKeywordActionRules = []struct {
+	keywords []string
+	action   string
+}{
+	{[]string{"approval_mode_switch", "approval_mode_duration", "plan_execution"}, ActionApprovalRequested},
+	{[]string{"prompt", "user_input"}, ActionPromptSubmitted},
+	{[]string{"mcp"}, ActionMCPToolInvoked},
+	{[]string{"command", "shell", "exec"}, ActionCommandExecuted},
+	{[]string{"file", "write", "edit"}, ActionFileModified},
+	{[]string{"approval"}, ActionApprovalRequested},
 }
 
 func HasToolCall(attrs map[string]interface{}) bool {


### PR DESCRIPTION
## What

Extracts `InferAction`'s repetitive `strings.Contains` tail into an ordered keyword rule table (`textKeywordActionRules`) that is iterated after the structured matchers.

## Why

`InferAction` was the audit's #1 smell — a long switch mixing exact matches, helper delegations, and a run of near-identical substring checks. The substring tail is pure data, so it becomes a table; the heterogeneous early matchers stay an explicit switch.

Ordering is preserved and now documented: the early switch must run before the keyword table because, e.g., `gemini_cli.file_operation` has to be handled before the `"file"` keyword rule would otherwise claim it.

## Safety

Behavior-preserving. The PR 4 classification characterization tests (all 16 `InferAction` branches) stay green.

## Verification

- `go build ./...` and `go test ./...` in `collector-builder/exporter/beaconjsonexporter` — green.
- `gofmt -l` clean.

## Stacking

Based on #207 (PR 6) → #205 → #204 → #201 → #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of beacon event action inference; ordering is explicitly preserved and covered by existing characterization tests.
> 
> **Overview**
> Refactors **`InferAction`** so the tail of repeated `strings.Contains` checks is no longer inline `switch` cases. Those substring rules now live in an ordered **`textKeywordActionRules`** table, applied in a loop after the existing structured matchers (Copilot, MCP, Gemini, tool calls, etc.).
> 
> Comments clarify that **matcher order is unchanged**: structured cases still run first so paths like `gemini_cli.file_operation` are not swallowed by the generic `"file"` keyword rule. The default when nothing matches remains **`ActionToolInvoked`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de49e2bc64530cd967473cd3eb607be0eb1b5bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->