### PR TITLE
refactor(beaconevent): share gen_ai.usage field setters

### DIFF
--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -615,6 +615,23 @@ func (c Converter) usageEventFromDataPoint(resourceAttrs map[string]interface{},
 // Codex's "total" rollup type is left unmapped so it never sums on top of the
 // per-type counts. Unknown types only record the type so the raw value stays
 // inspectable without polluting usage totals.
+// gen_ai.usage field setters centralize how each canonical token type maps onto the
+// usage struct (including the nested cache/reasoning shapes and pointer handling). They
+// are shared by ApplyTokenUsage (metric datapoints, one token type per call) and
+// GenAIUsageFromAttrs (span/log attributes, all token types at once) so the mapping lives
+// in exactly one place. Each takes value by copy, so &v is safe per call.
+func setUsageInput(u *GenAIUsageInfo, v int64)  { u.InputTokens = &v }
+func setUsageOutput(u *GenAIUsageInfo, v int64) { u.OutputTokens = &v }
+func setUsageCacheRead(u *GenAIUsageInfo, v int64) {
+	u.CacheRead = &GenAIUsageCacheReadInfo{InputTokens: &v}
+}
+func setUsageCacheCreation(u *GenAIUsageInfo, v int64) {
+	u.CacheCreation = &GenAIUsageCacheCreationInfo{InputTokens: &v}
+}
+func setUsageReasoning(u *GenAIUsageInfo, v int64) {
+	u.Reasoning = &GenAIUsageReasoningInfo{OutputTokens: &v}
+}
+
 func ApplyTokenUsage(event *Event, tokenType string, value int64) {
 	if event.GenAI == nil {
 		event.GenAI = &GenAIInfo{}
@@ -625,15 +642,15 @@ func ApplyTokenUsage(event *Event, tokenType string, value int64) {
 	usage := event.GenAI.Usage
 	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(tokenType)), "_", "") {
 	case "input", "prompt":
-		usage.InputTokens = &value
+		setUsageInput(usage, value)
 	case "output", "completion":
-		usage.OutputTokens = &value
+		setUsageOutput(usage, value)
 	case "cacheread", "cachedinput":
-		usage.CacheRead = &GenAIUsageCacheReadInfo{InputTokens: &value}
+		setUsageCacheRead(usage, value)
 	case "cachecreation":
-		usage.CacheCreation = &GenAIUsageCacheCreationInfo{InputTokens: &value}
+		setUsageCacheCreation(usage, value)
 	case "reasoning", "reasoningoutput":
-		usage.Reasoning = &GenAIUsageReasoningInfo{OutputTokens: &value}
+		setUsageReasoning(usage, value)
 	default:
 		if event.GenAI.Token == nil && tokenType != "" {
 			event.GenAI.Token = &GenAITokenInfo{Type: tokenType}
@@ -880,19 +897,19 @@ func GenAIToolFromAttrs(attrs map[string]interface{}) *GenAIToolInfo {
 func GenAIUsageFromAttrs(attrs map[string]interface{}) *GenAIUsageInfo {
 	usage := &GenAIUsageInfo{}
 	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_creation.input_tokens", "gen_ai.usage.cache_creation_input_tokens", "cache_creation_tokens"); ok {
-		usage.CacheCreation = &GenAIUsageCacheCreationInfo{InputTokens: &value}
+		setUsageCacheCreation(usage, value)
 	}
 	if value, ok := Int64Attr(attrs, "gen_ai.usage.cache_read.input_tokens", "gen_ai.usage.cache_read_input_tokens", "cache_read_tokens"); ok {
-		usage.CacheRead = &GenAIUsageCacheReadInfo{InputTokens: &value}
+		setUsageCacheRead(usage, value)
 	}
 	if value, ok := Int64Attr(attrs, "gen_ai.usage.input_tokens", "llm.usage.prompt_tokens", "gen_ai.usage.prompt_tokens", "input_tokens"); ok {
-		usage.InputTokens = &value
+		setUsageInput(usage, value)
 	}
 	if value, ok := Int64Attr(attrs, "gen_ai.usage.output_tokens", "llm.usage.completion_tokens", "gen_ai.usage.completion_tokens", "output_tokens"); ok {
-		usage.OutputTokens = &value
+		setUsageOutput(usage, value)
 	}
 	if value, ok := Int64Attr(attrs, "gen_ai.usage.reasoning.output_tokens"); ok {
-		usage.Reasoning = &GenAIUsageReasoningInfo{OutputTokens: &value}
+		setUsageReasoning(usage, value)
 	}
 	if value, ok := FloatAttr(attrs, "gen_ai.usage.cost"); ok {
 		usage.CostUSD = &value


### PR DESCRIPTION
## What

Extracts shared `setUsage*` helpers (`setUsageInput`, `setUsageOutput`, `setUsageCacheRead`, `setUsageCacheCreation`, `setUsageReasoning`) and routes both `ApplyTokenUsage` and `GenAIUsageFromAttrs` through them.

## Why

The two functions independently encoded how each canonical token type maps onto the `gen_ai.usage` struct — including the nested `CacheRead`/`CacheCreation`/`Reasoning` shapes and the value-pointer handling. `CLAUDE.md` requires `gen_ai.usage` be the single canonical token representation; duplicated normalization invites divergence (audit #4). Centralizing the field mapping means a new token type or shape change is updated in exactly one place.

## Safety

Behavior-preserving. Setters take the value by copy so `&v` is safe and distinct per call (matching the previous block-scoped `&value`). Exporter tests stay green.

## Verification

- `go build ./...` and `go test ./...` in `collector-builder/exporter/beaconjsonexporter` — green.
- `gofmt -l` clean.

## Stacking

Based on #208 (PR 7) → #207 → #205 → #204 → #201 → #200. This is the last PR in the converter group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in exporter normalization only; tests reported green and no auth or data-path changes.
> 
> **Overview**
> **Deduplicates** how token counts land on the canonical `gen_ai.usage` struct in the beacon JSON exporter converter.
> 
> Adds small `setUsage*` helpers for input, output, cache read/creation, and reasoning (including nested shapes and pointer handling). **`ApplyTokenUsage`** (metric datapoints, one type per call) and **`GenAIUsageFromAttrs`** (span/log attributes) now both call those helpers instead of inlining the same assignments. **`CostUSD`** in `GenAIUsageFromAttrs` is unchanged and still set directly.
> 
> Documented intent: one place to update when token types or usage shapes change, without changing exporter output semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c426bab2b96f541f6f30df2ba3a3a30930934eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->