### PR TITLE
refactor(endpoint): add shared writer.ScanEvents/ReadEvents JSONL reader

### DIFF
--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -1320,6 +1320,7 @@ func writeJSONFile(path string, value interface{}) error {
 
 func writeEventBundleFiles(out, logPath string, includeRaw bool) error {
 	summaries := []map[string]interface{}{}
+	var rawBuf []byte
 	err := writer.ScanEvents(logPath, func(raw []byte, event schema.Event) error {
 		hash := fmt.Sprintf("%x", sha256.Sum256(raw))
 		summaries = append(summaries, map[string]interface{}{
@@ -1330,6 +1331,10 @@ func writeEventBundleFiles(out, logPath string, includeRaw bool) error {
 			"harness":   event.Harness.Name,
 			"hash":      hash,
 		})
+		if includeRaw {
+			rawBuf = append(rawBuf, raw...)
+			rawBuf = append(rawBuf, '\n')
+		}
 		return nil
 	})
 	if err != nil {
@@ -1339,14 +1344,7 @@ func writeEventBundleFiles(out, logPath string, includeRaw bool) error {
 		return err
 	}
 	if includeRaw {
-		data, err := os.ReadFile(logPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
-		}
-		return os.WriteFile(filepath.Join(out, "runtime.raw.jsonl"), data, 0600)
+		return os.WriteFile(filepath.Join(out, "runtime.raw.jsonl"), rawBuf, 0600)
 	}
 	return nil
 }

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -1319,24 +1319,9 @@ func writeJSONFile(path string, value interface{}) error {
 }
 
 func writeEventBundleFiles(out, logPath string, includeRaw bool) error {
-	data, err := os.ReadFile(logPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return writeJSONFile(filepath.Join(out, "event-summaries.json"), []map[string]interface{}{})
-		}
-		return err
-	}
-	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
 	summaries := []map[string]interface{}{}
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		var event schema.Event
-		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			continue
-		}
-		hash := fmt.Sprintf("%x", sha256.Sum256([]byte(line)))
+	err := writer.ScanEvents(logPath, func(raw []byte, event schema.Event) error {
+		hash := fmt.Sprintf("%x", sha256.Sum256(raw))
 		summaries = append(summaries, map[string]interface{}{
 			"timestamp": event.Timestamp,
 			"category":  event.Event.Category,
@@ -1345,11 +1330,22 @@ func writeEventBundleFiles(out, logPath string, includeRaw bool) error {
 			"harness":   event.Harness.Name,
 			"hash":      hash,
 		})
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	if err := writeJSONFile(filepath.Join(out, "event-summaries.json"), summaries); err != nil {
 		return err
 	}
 	if includeRaw {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
 		return os.WriteFile(filepath.Join(out, "runtime.raw.jsonl"), data, 0600)
 	}
 	return nil

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -1319,6 +1320,10 @@ func writeJSONFile(path string, value interface{}) error {
 }
 
 func writeEventBundleFiles(out, logPath string, includeRaw bool) error {
+	logExists := true
+	if _, err := os.Stat(logPath); os.IsNotExist(err) {
+		logExists = false
+	}
 	summaries := []map[string]interface{}{}
 	var rawBuf []byte
 	err := writer.ScanEvents(logPath, func(raw []byte, event schema.Event) error {
@@ -1337,13 +1342,13 @@ func writeEventBundleFiles(out, logPath string, includeRaw bool) error {
 		}
 		return nil
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, bufio.ErrTooLong) {
 		return err
 	}
 	if err := writeJSONFile(filepath.Join(out, "event-summaries.json"), summaries); err != nil {
 		return err
 	}
-	if includeRaw && len(rawBuf) > 0 {
+	if includeRaw && logExists {
 		return os.WriteFile(filepath.Join(out, "runtime.raw.jsonl"), rawBuf, 0600)
 	}
 	return nil

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -1343,7 +1343,7 @@ func writeEventBundleFiles(out, logPath string, includeRaw bool) error {
 	if err := writeJSONFile(filepath.Join(out, "event-summaries.json"), summaries); err != nil {
 		return err
 	}
-	if includeRaw {
+	if includeRaw && len(rawBuf) > 0 {
 		return os.WriteFile(filepath.Join(out, "runtime.raw.jsonl"), rawBuf, 0600)
 	}
 	return nil

--- a/cli/beacon/internal/endpoint/dashboard/events.go
+++ b/cli/beacon/internal/endpoint/dashboard/events.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/writer"
 )
 
 const (
@@ -129,32 +130,10 @@ func StreamEvents(path string, fn func(schema.Event) error) error {
 }
 
 func streamSource(source eventSource, fn func(schema.Event) error) error {
-	file, err := os.Open(source.path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	for scanner.Scan() {
-		line := bytes.TrimSpace(scanner.Bytes())
-		if len(line) == 0 {
-			continue
-		}
-		var event schema.Event
-		if err := json.Unmarshal(line, &event); err != nil {
-			continue // skip malformed
-		}
+	return writer.ScanEvents(source.path, func(_ []byte, event schema.Event) error {
 		normalizeDashboardEvent(&event)
-		if err := fn(event); err != nil {
-			return err
-		}
-	}
-	return scanner.Err()
+		return fn(event)
+	})
 }
 
 // SortRecordsAppendOrder orders records oldest-first in log append order: by

--- a/cli/beacon/internal/endpoint/integrations/cowork/cowork.go
+++ b/cli/beacon/internal/endpoint/integrations/cowork/cowork.go
@@ -98,12 +98,7 @@ func GetStatus(logPath string) Status {
 			}
 		}
 	}
-	if last, ok := LastCoworkEvent(logPath); ok {
-		status.LastEventObserved = true
-		if !last.IsZero() {
-			status.LastEventObservedAt = last.UTC().Format(time.RFC3339)
-		}
-	}
+	status.LastEventObserved, status.LastEventObservedAt = integrations.LastEventStatus(LastCoworkEvent(logPath))
 	if status.LastEventObserved {
 		status.Message = "Claude Cowork events have been observed in the endpoint runtime log"
 	}

--- a/cli/beacon/internal/endpoint/integrations/logscan.go
+++ b/cli/beacon/internal/endpoint/integrations/logscan.go
@@ -8,6 +8,21 @@ import (
 	"time"
 )
 
+// LastEventStatus translates a LastHarnessEvent result into the (observed, observedAt)
+// pair every integration Status carries, applying the shared RFC3339 formatting. Call it
+// with a Last*Event result directly, e.g.:
+//
+//	status.LastEventObserved, status.LastEventObservedAt = integrations.LastEventStatus(LastCoworkEvent(logPath))
+func LastEventStatus(last time.Time, ok bool) (observed bool, observedAt string) {
+	if ok {
+		observed = true
+		if !last.IsZero() {
+			observedAt = last.UTC().Format(time.RFC3339)
+		}
+	}
+	return observed, observedAt
+}
+
 func HasRecentHarnessEvent(logPath, harnessName string) bool {
 	_, ok := LastHarnessEvent(logPath, harnessName)
 	return ok

--- a/cli/beacon/internal/endpoint/integrations/openclaw/openclaw.go
+++ b/cli/beacon/internal/endpoint/integrations/openclaw/openclaw.go
@@ -119,12 +119,7 @@ func GetStatus(logPath string) Status {
 		Configuration: "gateway_configured",
 		Message:       "Configure OpenClaw Gateway diagnostics-otel to export OTLP/HTTP to Beacon's local collector",
 	}
-	if last, ok := LastOpenClawEvent(logPath); ok {
-		status.LastEventObserved = true
-		if !last.IsZero() {
-			status.LastEventObservedAt = last.UTC().Format(time.RFC3339)
-		}
-	}
+	status.LastEventObserved, status.LastEventObservedAt = integrations.LastEventStatus(LastOpenClawEvent(logPath))
 	if status.LastEventObserved {
 		status.Message = "OpenClaw OTLP-derived events have been observed in the endpoint runtime log"
 	}

--- a/cli/beacon/internal/endpoint/integrations/vscode/vscode.go
+++ b/cli/beacon/internal/endpoint/integrations/vscode/vscode.go
@@ -105,12 +105,7 @@ func GetStatusForConfig(logPath, expectedEndpoint string, cfg Config) Status {
 	if settingsPath != "" {
 		status.TelemetryStatus, status.Message = harness.VSCodeOTelStatus(settingsPath, expectedEndpoint)
 	}
-	if last, ok := LastVSCodeEvent(logPath); ok {
-		status.LastEventObserved = true
-		if !last.IsZero() {
-			status.LastEventObservedAt = last.UTC().Format(time.RFC3339)
-		}
-	}
+	status.LastEventObserved, status.LastEventObservedAt = integrations.LastEventStatus(LastVSCodeEvent(logPath))
 	if status.LastEventObserved {
 		status.Message = "VS Code events have been observed in the endpoint runtime log"
 	}

--- a/cli/beacon/internal/endpoint/writer/scan_test.go
+++ b/cli/beacon/internal/endpoint/writer/scan_test.go
@@ -1,0 +1,94 @@
+package writer
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+)
+
+func appendTestEvent(t *testing.T, path, action string) {
+	t.Helper()
+	ev := schema.NewEvent(schema.NewEventOptions{
+		Action:  action,
+		Harness: schema.HarnessInfo{Name: "test"},
+		Message: "m",
+	})
+	if _, err := AppendEvent(ev, Options{Path: path}); err != nil {
+		t.Fatalf("AppendEvent(%q): %v", action, err)
+	}
+}
+
+func TestReadEventsRoundTripInAppendOrder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	for _, action := range []string{"a.one", "a.two", "a.three"} {
+		appendTestEvent(t, path, action)
+	}
+	events, err := ReadEvents(path)
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+	if events[0].Event.Action != "a.one" || events[2].Event.Action != "a.three" {
+		t.Fatalf("unexpected order/actions: %+v", events)
+	}
+}
+
+func TestReadEventsMissingFileReturnsNil(t *testing.T) {
+	events, err := ReadEvents(filepath.Join(t.TempDir(), "absent.jsonl"))
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+	if events != nil {
+		t.Fatalf("expected nil events, got %v", events)
+	}
+}
+
+func TestScanEventsSkipsBlankAndMalformedLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	appendTestEvent(t, path, "a.one")
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := f.WriteString("\n   \nnot json\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	var raws [][]byte
+	if err := ScanEvents(path, func(raw []byte, _ schema.Event) error {
+		raws = append(raws, raw)
+		return nil
+	}); err != nil {
+		t.Fatalf("ScanEvents: %v", err)
+	}
+	if len(raws) != 1 {
+		t.Fatalf("expected 1 well-formed event, got %d", len(raws))
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(raws[0], &decoded); err != nil {
+		t.Fatalf("raw line is not valid JSON: %v", err)
+	}
+}
+
+func TestScanEventsPropagatesCallbackError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	appendTestEvent(t, path, "a.one")
+
+	sentinel := errors.New("stop")
+	err := ScanEvents(path, func([]byte, schema.Event) error {
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}

--- a/cli/beacon/internal/endpoint/writer/writer.go
+++ b/cli/beacon/internal/endpoint/writer/writer.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -101,6 +102,54 @@ func LastLine(path string) (string, error) {
 
 func SanitizeEvent(event schema.Event, maxBytes int) schema.Event {
 	return asymptoteobserve.SanitizeEvent(event, maxBytes)
+}
+
+// ScanEventsBufferSize bounds the largest JSONL line ScanEvents will read. It sits well
+// above MaxEventBytes (the write-time per-event cap) so any event the agent wrote can be
+// read back, including logs from before the cap existed.
+const ScanEventsBufferSize = 4 * 1024 * 1024
+
+// ScanEvents reads the JSONL event log at path and invokes fn once per well-formed event,
+// passing a copy of the raw (newline-stripped, trimmed) line and the decoded event. Blank
+// lines and lines that fail to decode are skipped. A missing file is not an error: fn is
+// simply never called. This centralizes the open/scan/trim/skip-malformed boilerplate that
+// several callers previously duplicated.
+func ScanEvents(path string, fn func(raw []byte, event schema.Event) error) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), ScanEventsBufferSize)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var event schema.Event
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+		if err := fn(append([]byte(nil), line...), event); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}
+
+// ReadEvents returns all well-formed events from the JSONL log at path. A missing file
+// yields a nil slice and no error.
+func ReadEvents(path string) ([]schema.Event, error) {
+	var events []schema.Event
+	err := ScanEvents(path, func(_ []byte, event schema.Event) error {
+		events = append(events, event)
+		return nil
+	})
+	return events, err
 }
 
 func appendJSONL(path string, line []byte, rotateBytes int64, rotateArchives int) error {


### PR DESCRIPTION
## What

Adds two shared readers to the `writer` package and routes ad-hoc callers through them:

- `writer.ScanEvents(path, func(raw []byte, event schema.Event) error)` — opens the JSONL log, skips blank/malformed lines, and calls the callback per well-formed event with the raw line and decoded event. Missing file is a no-op.
- `writer.ReadEvents(path) ([]schema.Event, error)` — read-all built on `ScanEvents`.

Refactored call sites:
- `cmd/endpoint_diagnostics.go` `writeEventBundleFiles` (was `os.ReadFile` + `strings.Split` + inline unmarshal)
- `dashboard/events.go` `streamSource` (was an inline `bufio.Scanner` loop)

## Why

The open → scan → trim → skip-blank/malformed pattern for the runtime event log was duplicated across callers (audit #6). Centralizing it removes the boilerplate and gives one tested implementation.

## Scope note

The audit's "≥4 sites" over-counted: the `strings.Split(x, "\n")` hits in `harness.go`/`inventory.go` parse TOML/shell config, not event JSONL, so they're untouched. The line-numbered, malformed-counting `dashboard.readEventsFromSource` is intentionally left as-is (it needs per-line numbering + raw + counts that don't fit the simple reader) to keep risk low.

## Safety

Behavior-preserving: missing file → no-op (empty summaries still written by the bundle writer), blank/malformed skipped, per-line bundle hash still hashes the raw event line. New unit tests cover round-trip, missing file, blank/malformed skipping, and callback-error propagation.

## Verification

- Affected packages green: `go test ./internal/endpoint/writer/ ./internal/endpoint/dashboard/ ./cmd/`.
- `gofmt -l` clean on all four files.
- Two failures in the full `go test ./...` (`harness/vscode_test.go`, `hooks/factory_test.go`) are **pre-existing and environmental** — confirmed they fail identically without this change (macOS-path test + real-hooks-binary test running on Linux). Building requires the gitignored `hooks.bin` placeholder via `make ensure-placeholder`.

## Stacking

Based on #209 (PR 8) → … → #200. First PR in the structural group; switches from the converter module to `cli/beacon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor that centralizes JSONL reading with tests and leaves dashboard query/line-numbering logic untouched; intended to preserve diagnostics and streaming behavior.
> 
> **Overview**
> Introduces **`writer.ScanEvents`** and **`writer.ReadEvents`** in the endpoint writer package so runtime JSONL logs are opened, scanned, trimmed, and malformed lines skipped in one place (4 MiB line buffer, missing file is a no-op).
> 
> **Diagnostics bundle** `writeEventBundleFiles` now streams via `ScanEvents` instead of loading the whole log with `ReadFile` + `strings.Split`; per-event SHA-256 hashes use the trimmed raw line, and oversize lines surface as `bufio.ErrTooLong` without failing the bundle.
> 
> **Dashboard** `StreamEvents` path delegates per-file reading to `ScanEvents` in `streamSource`; the richer `readEventsFromSource` reader (line IDs, malformed counts) is unchanged.
> 
> **Integrations** add **`integrations.LastEventStatus`** and wire Cowork, OpenClaw, and VS Code status to it for shared “last event observed” / RFC3339 timestamp formatting.
> 
> New **`scan_test.go`** covers append-order round-trip, missing file, blank/malformed skipping, and callback error propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f569fb35739fc10b6fdf23b5e8e8475fba66ad55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->