### PR TITLE
refactor(integrations): share last-event status helper

### DIFF
--- a/cli/beacon/internal/endpoint/integrations/cowork/cowork.go
+++ b/cli/beacon/internal/endpoint/integrations/cowork/cowork.go
@@ -98,12 +98,7 @@ func GetStatus(logPath string) Status {
 			}
 		}
 	}
-	if last, ok := LastCoworkEvent(logPath); ok {
-		status.LastEventObserved = true
-		if !last.IsZero() {
-			status.LastEventObservedAt = last.UTC().Format(time.RFC3339)
-		}
-	}
+	status.LastEventObserved, status.LastEventObservedAt = integrations.LastEventStatus(LastCoworkEvent(logPath))
 	if status.LastEventObserved {
 		status.Message = "Claude Cowork events have been observed in the endpoint runtime log"
 	}

--- a/cli/beacon/internal/endpoint/integrations/logscan.go
+++ b/cli/beacon/internal/endpoint/integrations/logscan.go
@@ -8,6 +8,21 @@ import (
 	"time"
 )
 
+// LastEventStatus translates a LastHarnessEvent result into the (observed, observedAt)
+// pair every integration Status carries, applying the shared RFC3339 formatting. Call it
+// with a Last*Event result directly, e.g.:
+//
+//	status.LastEventObserved, status.LastEventObservedAt = integrations.LastEventStatus(LastCoworkEvent(logPath))
+func LastEventStatus(last time.Time, ok bool) (observed bool, observedAt string) {
+	if ok {
+		observed = true
+		if !last.IsZero() {
+			observedAt = last.UTC().Format(time.RFC3339)
+		}
+	}
+	return observed, observedAt
+}
+
 func HasRecentHarnessEvent(logPath, harnessName string) bool {
 	_, ok := LastHarnessEvent(logPath, harnessName)
 	return ok

--- a/cli/beacon/internal/endpoint/integrations/openclaw/openclaw.go
+++ b/cli/beacon/internal/endpoint/integrations/openclaw/openclaw.go
@@ -119,12 +119,7 @@ func GetStatus(logPath string) Status {
 		Configuration: "gateway_configured",
 		Message:       "Configure OpenClaw Gateway diagnostics-otel to export OTLP/HTTP to Beacon's local collector",
 	}
-	if last, ok := LastOpenClawEvent(logPath); ok {
-		status.LastEventObserved = true
-		if !last.IsZero() {
-			status.LastEventObservedAt = last.UTC().Format(time.RFC3339)
-		}
-	}
+	status.LastEventObserved, status.LastEventObservedAt = integrations.LastEventStatus(LastOpenClawEvent(logPath))
 	if status.LastEventObserved {
 		status.Message = "OpenClaw OTLP-derived events have been observed in the endpoint runtime log"
 	}

--- a/cli/beacon/internal/endpoint/integrations/vscode/vscode.go
+++ b/cli/beacon/internal/endpoint/integrations/vscode/vscode.go
@@ -105,12 +105,7 @@ func GetStatusForConfig(logPath, expectedEndpoint string, cfg Config) Status {
 	if settingsPath != "" {
 		status.TelemetryStatus, status.Message = harness.VSCodeOTelStatus(settingsPath, expectedEndpoint)
 	}
-	if last, ok := LastVSCodeEvent(logPath); ok {
-		status.LastEventObserved = true
-		if !last.IsZero() {
-			status.LastEventObservedAt = last.UTC().Format(time.RFC3339)
-		}
-	}
+	status.LastEventObserved, status.LastEventObservedAt = integrations.LastEventStatus(LastVSCodeEvent(logPath))
 	if status.LastEventObserved {
 		status.Message = "VS Code events have been observed in the endpoint runtime log"
 	}


### PR DESCRIPTION
## What

Extracts `integrations.LastEventStatus(last time.Time, ok bool) (observed bool, observedAt string)` and uses it in the `cowork`, `openclaw`, and `vscode` `GetStatus` functions.

## Why

Each of the three integrations repeated the same six-line block converting a `Last*Event(logPath)` result into `Status.LastEventObserved` / `Status.LastEventObservedAt` with identical RFC3339 formatting (audit #6). Centralizing it removes the duplication and the formatting now lives in one place.

The call sites use Go's `f(g())` form, e.g. `status.LastEventObserved, status.LastEventObservedAt = integrations.LastEventStatus(LastCoworkEvent(logPath))`, so each integration keeps its own event source — notably `vscode` retains its combined hook + Copilot `LastVSCodeEvent`.

## Scope note

Only this shared sub-block is dedupable; the surrounding `GetStatus` bodies legitimately differ (cowork has Darwin app detection and extra fields; vscode resolves settings paths), so they're left intact. The thin `Has*/Last*` per-package wrappers are also left as public API.

## Safety

Behavior-preserving. All `integrations/...` package tests stay green.

## Verification

- `go build`/`go test ./internal/endpoint/integrations/...` — green.
- `gofmt -l` clean.

## Stacking

Based on #210 (PR 9) → … → #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with no API or logic changes beyond deduplicating identical status formatting.
> 
> **Overview**
> Adds **`integrations.LastEventStatus`** in `logscan.go` to turn a `(time.Time, ok)` from log scanning into **`LastEventObserved`** / **`LastEventObservedAt`** with shared UTC **RFC3339** formatting.
> 
> **Cowork**, **OpenClaw**, and **VS Code** `GetStatus` now assign those fields in one line via `integrations.LastEventStatus(Last*Event(logPath))` instead of repeating the same `if ok` / `IsZero` / `Format` block. Each package still uses its own **`Last*Event`** source (e.g. VS Code’s combined hook + Copilot logic is unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f105e3484659eb3301401e197c64074762d3ef97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->