### PR TITLE
fix(hooks): surface swallowed errors and wrap token-exchange errors

### DIFF
--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
@@ -226,19 +226,19 @@ func accessToken(ctx context.Context, credentialsB64 string) (string, error) {
 	}
 	assertion, err := signedJWT(account)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("sign GCS JWT: %w", err)
 	}
 	form := url.Values{}
 	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
 	form.Set("assertion", assertion)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, account.TokenURI, strings.NewReader(form.Encode()))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("build GCS token request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("GCS token request: %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))

--- a/cli/beacon-hooks/internal/logging/logging.go
+++ b/cli/beacon-hooks/internal/logging/logging.go
@@ -71,11 +71,13 @@ func (l *Logger) formatEntry(level, message string, fields ...interface{}) map[s
 func (l *Logger) write(entry map[string]interface{}) {
 	data, err := json.Marshal(entry)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "logging: failed to marshal log entry: %v\n", err)
 		return
 	}
 
 	f, err := os.OpenFile(l.logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "logging: failed to open log file %s: %v\n", l.logFile, err)
 		return
 	}
 	defer func() {


### PR DESCRIPTION
## What

Two error-handling hygiene fixes in `cli/beacon-hooks`:

1. `logging.Logger.write` now logs `json.Marshal` and `os.OpenFile` failures to stderr instead of swallowing them with bare `return`s. The method already logged Write/Close failures to stderr, so this makes all failure paths consistent. (The method is void by contract, so stderr — not an error return — is the right channel.)
2. `cloudshuttle.accessToken` wrapped most errors with context but returned the `signedJWT`, `http.NewRequestWithContext`, and `httpClient.Do` errors bare. They're now wrapped with `%w` for a consistent, contextful error chain.

## Why

Audit #7: swallowed errors hide a broken log path, and inconsistent wrapping loses context/breaks `errors.Is/As` chains.

## Safety

Behavior-preserving aside from added diagnostics. No control-flow changes.

## Verification

- `go build ./...` and `go test ./...` in `cli/beacon-hooks` — the touched code compiles and runs.
- `gofmt -l` clean.
- One failure in the logging package (`TestEndpointEventDoesNotInventCloudRunID`) is **pre-existing and environmental** — confirmed it fails identically without this change. The remote sandbox sets a cloud run-ID env var that `cloudRunFields` reads, leaking the session ID into the test; it would not be set in normal CI.

## Stacking

Based on #211 (PR 11) → … → #200. (Harness table-driving and the `endpoint_diagnostics.go` split are still pending in the series.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics and error-wrapping only; no auth or upload logic changes beyond clearer error messages.
> 
> **Overview**
> Improves error visibility in `cli/beacon-hooks` without changing control flow.
> 
> **Logging:** `Logger.write` now prints to **stderr** when `json.Marshal` or `os.OpenFile` fails, matching the existing behavior for write/close failures so a broken log path is easier to diagnose.
> 
> **Cloud shuttle:** `accessToken` wraps JWT signing, token HTTP request construction, and the token HTTP call with `%w` so failures carry consistent context and preserve `errors.Is` / `errors.As` chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f582247d5d4f53b7601e20550bf2a33c9cd4dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->