### PR TITLE
refactor(sdk): use named attribute constants in the TS SDK

### DIFF
--- a/packages/asymptote-sdk-js/src/constants.ts
+++ b/packages/asymptote-sdk-js/src/constants.ts
@@ -34,3 +34,5 @@ export const ATTR_BEACON_CONTENT_RETENTION = "beacon.content.retention";
 export const ATTR_ASYMPTOTE_INTEGRATION_NAME = "asymptote.observe.integration.name";
 export const ATTR_ASYMPTOTE_INTEGRATION_VERSION = "asymptote.observe.integration.version";
 export const ATTR_ASYMPTOTE_SDK_MODE = "asymptote.observe.sdk.mode";
+export const ATTR_ASYMPTOTE_INPUT_COUNT = "asymptote.observe.input.count";
+export const ATTR_ASYMPTOTE_OUTPUT_TYPE = "asymptote.observe.output.type";

--- a/packages/asymptote-sdk-js/src/index.ts
+++ b/packages/asymptote-sdk-js/src/index.ts
@@ -21,7 +21,11 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_TELEMETRY_SDK_NAME,
+  ATTR_TELEMETRY_SDK_VERSION,
+} from "@opentelemetry/semantic-conventions";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -35,6 +39,8 @@ import {
 } from "@traceloop/instrumentation-openai";
 
 import {
+  ATTR_ASYMPTOTE_INPUT_COUNT,
+  ATTR_ASYMPTOTE_OUTPUT_TYPE,
   ATTR_ASYMPTOTE_SDK_MODE,
   ATTR_BEACON_EVENT_ACTION,
   ATTR_BEACON_EVENT_CATEGORY,
@@ -197,8 +203,8 @@ export function initialize(options: InitializeOptions = {}): void {
   const provider = new NodeTracerProvider({
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: options.serviceName ?? process.env.OTEL_SERVICE_NAME ?? DEFAULT_SERVICE_NAME,
-      "telemetry.sdk.name": "asymptote-sdk-js",
-      "telemetry.sdk.version": SDK_VERSION,
+      [ATTR_TELEMETRY_SDK_NAME]: "asymptote-sdk-js",
+      [ATTR_TELEMETRY_SDK_VERSION]: SDK_VERSION,
       [ATTR_BEACON_ORIGIN]: "cloud",
       [ATTR_BEACON_HARNESS_NAME]: "asymptote_observe",
       [ATTR_ASYMPTOTE_SDK_MODE]: resolved.mode,
@@ -242,7 +248,7 @@ export function observe<T extends (...args: any[]) => any>(options: ObserveOptio
       },
     });
     if (!options.ignoreInput) {
-      span.setAttribute("asymptote.observe.input.count", args.length);
+      span.setAttribute(ATTR_ASYMPTOTE_INPUT_COUNT, args.length);
     }
     return context.with(trace.setSpan(context.active(), span), () => {
       try {
@@ -474,7 +480,7 @@ function finishResult<T>(result: T, span: Span, options?: ObserveOptions): unkno
     return result.then(
       value => {
         if (!options?.ignoreOutput) {
-          span.setAttribute("asymptote.observe.output.type", typeof value);
+          span.setAttribute(ATTR_ASYMPTOTE_OUTPUT_TYPE, typeof value);
         }
         span.setStatus({ code: SpanStatusCode.OK });
         span.end();
@@ -490,7 +496,7 @@ function finishResult<T>(result: T, span: Span, options?: ObserveOptions): unkno
     return finishAsyncIterable(result, span);
   }
   if (!options?.ignoreOutput) {
-    span.setAttribute("asymptote.observe.output.type", typeof result);
+    span.setAttribute(ATTR_ASYMPTOTE_OUTPUT_TYPE, typeof result);
   }
   span.setStatus({ code: SpanStatusCode.OK });
   span.end();


### PR DESCRIPTION
## What

Replaces inline attribute-name string literals in the TS SDK with named constants:

- Adds `ATTR_ASYMPTOTE_INPUT_COUNT` and `ATTR_ASYMPTOTE_OUTPUT_TYPE` to `constants.ts` and uses them at the `observe()`/result `setAttribute` sites.
- Uses the standard `ATTR_TELEMETRY_SDK_NAME` / `ATTR_TELEMETRY_SDK_VERSION` from `@opentelemetry/semantic-conventions` for the resource attributes (the file already imports `ATTR_SERVICE_NAME` from there).

## Why

Audit (TS): these attribute keys were hardcoded inline while the SDK already centralizes its other keys in `constants.ts`. One definition per key avoids drift and typos.

## Scope note — what was intentionally NOT changed

On inspection, several flagged TS items are load-bearing or already-intentional, so changing them would be churn or risk:
- `as unknown as Instrumentation` casts work around a real cross-package `Instrumentation` type mismatch (`@traceloop/*` vs `@opentelemetry/instrumentation`).
- The empty catches in `readSDKVersion` and `patchClaudeAgentSDK` already carry explanatory comments (intentional fallbacks).
- The `(...args: any[]) => any` wrapper generics preserve call-through typing for the public API; tightening them would regress ergonomics.

## Safety

Behavior-preserving — identical attribute keys emitted.

## Verification

- `npm run check` (tsc --noEmit) — clean.
- `npm test` — 22/22 pass.
- `npm run build` — succeeds, `dist/` emitted.

## Stacking

Based on #212 (PR 13) → … → #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of attribute key references only; no logic, export, or security changes.
> 
> **Overview**
> Centralizes OpenTelemetry attribute keys in the JS SDK so span and resource metadata stay consistent with the rest of `constants.ts`.
> 
> **Observe spans:** `observe()` and `finishResult()` now set input count and output type via new `ATTR_ASYMPTOTE_INPUT_COUNT` and `ATTR_ASYMPTOTE_OUTPUT_TYPE` instead of inline `"asymptote.observe.*"` strings.
> 
> **Tracer resource:** `initialize()` uses `ATTR_TELEMETRY_SDK_NAME` and `ATTR_TELEMETRY_SDK_VERSION` from `@opentelemetry/semantic-conventions` for the provider resource (alongside the existing `ATTR_SERVICE_NAME` import).
> 
> Emitted attribute names and values are unchanged; this is naming/organization only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be7cf1b167c8388ea6bbc54389ed8cff238d6874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->