### PR TITLE
refactor(harness): extract shared config-status tail in Discover*

### DIFF
--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -63,6 +63,18 @@ func DiscoverAll() []Harness {
 	}
 }
 
+// applyConfigStatus is the common tail shared by the file-based Discover* functions:
+// when ConfigPath exists it adopts the (status, message) reported by statusFn, otherwise
+// it marks the harness missing with missingMsg.
+func (h *Harness) applyConfigStatus(statusFn func(string) (TelemetryStatus, string), missingMsg string) {
+	if fileExists(h.ConfigPath) {
+		h.TelemetryStatus, h.Message = statusFn(h.ConfigPath)
+	} else {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = missingMsg
+	}
+}
+
 func DiscoverAntigravity() Harness {
 	h := Harness{Name: "antigravity_cli", DisplayName: "Antigravity CLI", Capability: "hooks"}
 	detectExecutable(&h, "antigravity", "antigravity-cli")
@@ -76,14 +88,7 @@ func DiscoverAntigravity() Harness {
 	if !h.Detected && (dirExists(filepath.Join(home, ".gemini", "config")) || dirExists(".agents")) {
 		h.Detected = true
 	}
-	if fileExists(h.ConfigPath) {
-		status, msg := antigravityStatus(h.ConfigPath)
-		h.TelemetryStatus = status
-		h.Message = msg
-	} else {
-		h.TelemetryStatus = TelemetryMissing
-		h.Message = "Antigravity hooks.json was not found"
-	}
+	h.applyConfigStatus(antigravityStatus, "Antigravity hooks.json was not found")
 	return h
 }
 
@@ -119,14 +124,7 @@ func DiscoverCodex() Harness {
 	detectExecutable(&h, "codex")
 	home, _ := os.UserHomeDir()
 	h.ConfigPath = filepath.Join(home, ".codex", "config.toml")
-	if fileExists(h.ConfigPath) {
-		status, msg := codexStatus(h.ConfigPath)
-		h.TelemetryStatus = status
-		h.Message = msg
-	} else {
-		h.TelemetryStatus = TelemetryMissing
-		h.Message = "Codex config file was not found"
-	}
+	h.applyConfigStatus(codexStatus, "Codex config file was not found")
 	return h
 }
 
@@ -135,14 +133,7 @@ func DiscoverFactory() Harness {
 	detectExecutable(&h, "droid")
 	home, _ := os.UserHomeDir()
 	h.ConfigPath = factoryProfilePath(home)
-	if fileExists(h.ConfigPath) {
-		status, msg := factoryStatus(h.ConfigPath)
-		h.TelemetryStatus = status
-		h.Message = msg
-	} else {
-		h.TelemetryStatus = TelemetryMissing
-		h.Message = "Factory Droid telemetry is configured by the launch environment; set OTEL_TELEMETRY_ENDPOINT to the local OTLP HTTP receiver"
-	}
+	h.applyConfigStatus(factoryStatus, "Factory Droid telemetry is configured by the launch environment; set OTEL_TELEMETRY_ENDPOINT to the local OTLP HTTP receiver")
 	return h
 }
 
@@ -179,14 +170,7 @@ func DiscoverHermes() Harness {
 	if !h.Detected && dirExists(filepath.Join(home, ".hermes")) {
 		h.Detected = true
 	}
-	if fileExists(h.ConfigPath) {
-		status, msg := hermesStatus(h.ConfigPath)
-		h.TelemetryStatus = status
-		h.Message = msg
-	} else {
-		h.TelemetryStatus = TelemetryMissing
-		h.Message = "Hermes config.yaml was not found"
-	}
+	h.applyConfigStatus(hermesStatus, "Hermes config.yaml was not found")
 	return h
 }
 
@@ -227,14 +211,10 @@ func DiscoverDevin() Harness {
 	if !h.Detected && (dirExists(filepath.Join(home, ".config", "devin")) || dirExists(".devin")) {
 		h.Detected = true
 	}
-	if fileExists(h.ConfigPath) {
-		status, msg := devinStatus(h.ConfigPath, "devin", "devin-cli")
-		h.TelemetryStatus = status
-		h.Message = msg
-	} else {
-		h.TelemetryStatus = TelemetryMissing
-		h.Message = "Devin CLI endpoint hooks were not found"
-	}
+	h.applyConfigStatus(
+		func(path string) (TelemetryStatus, string) { return devinStatus(path, "devin", "devin-cli") },
+		"Devin CLI endpoint hooks were not found",
+	)
 	return h
 }
 


### PR DESCRIPTION
## What

Extracts a `(*Harness).applyConfigStatus(statusFn, missingMsg)` helper for the config-status tail repeated across the file-based `Discover*` functions, and uses it in `DiscoverAntigravity`, `DiscoverCodex`, `DiscoverFactory`, `DiscoverHermes`, and `DiscoverDevin` (the last via a small closure for its variadic `platforms` arg).

## Why

Each of these repeated the identical tail: `if fileExists(ConfigPath) { status, msg = statusFn(...) } else { Missing + message }` (audit #6).

## Scope note — not a full table-drive

The original plan was to table-drive all `Discover*` functions. On inspection they're genuinely heterogeneous — different capabilities, path-resolution logic (managed vs user vs project), detection fallbacks, and inline content checks (Cursor, OpenCode, Claude) — so a data table would be *more* complex and less readable (over-engineering). Only the truly-identical status tail is shared, so that's what's extracted. The per-harness config paths each appear once, so they're not centralized (no real duplication).

## Safety

Behavior-preserving. Harness tests pass; the only failure is the pre-existing `vscode` macOS-path test that fails on Linux regardless of this change (confirmed earlier in the series).

## Verification

- `go build`/`go test ./internal/endpoint/harness/` — all `Discover*` tests green.
- `gofmt -l` clean.

## Stacking

Based on #214 (PR 12) → … → #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in harness discovery only; no API or security-sensitive logic changes.
> 
> **Overview**
> Adds **`(*Harness).applyConfigStatus`** to centralize the repeated “config file exists → run status fn; else `TelemetryMissing` + message” logic used at the end of several harness discoverers.
> 
> **Antigravity**, **Codex**, **Factory**, **Hermes**, and **Devin** now call this helper instead of duplicating the same `fileExists` / `TelemetryMissing` block; Devin passes a small closure so **`devinStatus`** still gets its platform arguments. Per-harness path resolution and detection stay unchanged; discoverers with different tails (e.g. Claude, Cursor, OpenCode) are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 468908da4404b5b88a850a9abfe0d4a78c1ceeee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->