### PR TITLE
refactor(cmd): move dashboard flags to a per-command options struct

### DIFF
--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -65,8 +65,6 @@ var endpointOpts struct {
 	falconSourcetype         string
 	falconInsecureSkipVerify bool
 	falconCAFile             string
-	dashboardAddr            string
-	dashboardOpen            bool
 	includeEventSummaries    bool
 	includeRawEvents         bool
 	writeInventoryEvent      bool
@@ -78,6 +76,14 @@ var endpointOpts struct {
 	inventoryWorkingDir      string
 	inventoryTrigger         string
 	inventoryTriggerHarness  string
+}
+
+// dashboardOpts holds the flags for the `endpoint dashboard` command. It is a per-command
+// options struct (rather than another field group on the monolithic endpointOpts) as the
+// first step of migrating CLI flags off the shared global.
+var dashboardOpts struct {
+	addr string
+	open bool
 }
 
 var endpointCmd = &cobra.Command{
@@ -422,8 +428,8 @@ func init() {
 	endpointDashboardCmd.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
 	endpointDashboardCmd.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 	endpointDashboardCmd.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
-	endpointDashboardCmd.Flags().StringVar(&endpointOpts.dashboardAddr, "addr", dashboard.DefaultAddr, "Local dashboard listen address")
-	endpointDashboardCmd.Flags().BoolVar(&endpointOpts.dashboardOpen, "open", false, "Open the dashboard in a browser")
+	endpointDashboardCmd.Flags().StringVar(&dashboardOpts.addr, "addr", dashboard.DefaultAddr, "Local dashboard listen address")
+	endpointDashboardCmd.Flags().BoolVar(&dashboardOpts.open, "open", false, "Open the dashboard in a browser")
 
 	endpointDiscoverCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print discovery as JSON")
 	endpointDiscoverCmd.Flags().BoolVar(&endpointOpts.allTargets, "all", false, "Discover all supported runtime targets")

--- a/cli/beacon/cmd/endpoint_install.go
+++ b/cli/beacon/cmd/endpoint_install.go
@@ -64,25 +64,25 @@ func runEndpointDashboard(cmd *cobra.Command, args []string) error {
 	runtimeLog := lifecycle.ResolveRuntimeLog(userMode, endpointOpts.logPath)
 	cfg.UserMode = runtimeLog.EffectiveUserMode
 	cfg.LogPath = runtimeLog.EffectiveLogPath
-	if endpointOpts.dashboardAddr == "" {
-		endpointOpts.dashboardAddr = dashboard.DefaultAddr
+	if dashboardOpts.addr == "" {
+		dashboardOpts.addr = dashboard.DefaultAddr
 	}
-	if err := dashboard.ValidateLoopbackAddr(endpointOpts.dashboardAddr); err != nil {
+	if err := dashboard.ValidateLoopbackAddr(dashboardOpts.addr); err != nil {
 		return err
 	}
-	url := dashboard.URL(endpointOpts.dashboardAddr)
+	url := dashboard.URL(dashboardOpts.addr)
 	fmt.Printf("Beacon endpoint dashboard: %s\n", url)
 	fmt.Printf("Runtime log: %s\n", cfg.LogPath)
 	if runtimeLog.Warning != "" {
 		fmt.Printf("Runtime log source: %s\n", runtimeLog.Warning)
 	}
-	if endpointOpts.dashboardOpen {
+	if dashboardOpts.open {
 		if err := dashboard.OpenBrowser(url); err != nil {
 			return err
 		}
 	}
 	return dashboardListenAndServe(dashboard.Options{
-		Addr:     endpointOpts.dashboardAddr,
+		Addr:     dashboardOpts.addr,
 		LogPath:  endpointOpts.logPath,
 		UserMode: userMode,
 	})

--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -680,7 +680,7 @@ func TestRunEndpointDashboardPassesRequestedLogPathToHandler(t *testing.T) {
 	endpointOpts.userMode = true
 	endpointOpts.systemMode = false
 	endpointOpts.logPath = ""
-	endpointOpts.dashboardAddr = "127.0.0.1:0"
+	dashboardOpts.addr = "127.0.0.1:0"
 
 	if err := runEndpointDashboard(nil, nil); err != nil {
 		t.Fatalf("runEndpointDashboard returned error: %v", err)


### PR DESCRIPTION
## What

First step of migrating CLI flags off the 62-field global `endpointOpts` (audit #2). The `endpoint dashboard` command's flags are self-contained, so they move to a dedicated `dashboardOpts` struct:

- removed `dashboardAddr`/`dashboardOpen` from `endpointOpts`
- added `var dashboardOpts struct { addr string; open bool }`
- bound the flags to it and read it in `runEndpointDashboard`
- updated the one test reference

`endpointOpts` drops from 62 → 60 fields.

## Why

The single 62-field global struct shared across the whole `cmd` package is the audit's #2 smell (testability/coupling). The fix is per-command option structs — but that's high blast-radius, so it's done **one command at a time** to keep each PR small, reviewable, and verifiable. This PR establishes the pattern with the smallest self-contained command; subsequent PRs migrate the remaining flag groups (cowork, splunk, falcon, inventory, …).

## Safety

Behavior-preserving — same flags, same defaults, same behavior. `go test ./cmd/` passes and no `dashboardAddr`/`dashboardOpen` references remain.

## Verification

- `go build ./...`, `go test ./cmd/` — green.
- `gofmt -l` clean.

## Stacking

Based on #215 (PR 10) → … → #200. This is the first of the `endpointOpts` migration series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with no user-facing CLI or dashboard behavior changes; limited to flag storage and wiring in the dashboard command path.
> 
> **Overview**
> Starts migrating CLI flags off the shared **`endpointOpts`** global by giving **`endpoint dashboard`** its own **`dashboardOpts`** struct (`addr`, `open`).
> 
> **`dashboardAddr`** / **`dashboardOpen`** are removed from **`endpointOpts`**; **`--addr`** and **`--open`** bind to **`dashboardOpts`**, and **`runEndpointDashboard`** reads those fields instead. The dashboard test sets **`dashboardOpts.addr`** accordingly. Flag names, defaults, and runtime behavior are unchanged; **`endpointOpts`** is two fields smaller as the first step toward per-command option structs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82934acc9626b7f8ca72e6c2c123b3c4589e55ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->