### PR TITLE
refactor(cmd): move claude-cowork flags to a per-command options struct

### DIFF
--- a/cli/beacon/cmd/endpoint.go
+++ b/cli/beacon/cmd/endpoint.go
@@ -36,12 +36,6 @@ var endpointOpts struct {
 	dryRun                   bool
 	fix                      bool
 	allTargets               bool
-	coworkHeaders            string
-	coworkEndpoint           string
-	coworkResourceAttributes string
-	coworkNgrok              bool
-	coworkOpen               bool
-	coworkSince              string
 	openClawEndpoint         string
 	openClawSince            string
 	vscodeEndpoint           string
@@ -84,6 +78,16 @@ var endpointOpts struct {
 var dashboardOpts struct {
 	addr string
 	open bool
+}
+
+// coworkOpts holds the flags for the `endpoint claude-cowork` subcommands.
+var coworkOpts struct {
+	headers            string
+	endpoint           string
+	resourceAttributes string
+	ngrok              bool
+	open               bool
+	since              string
 }
 
 var endpointCmd = &cobra.Command{
@@ -192,15 +196,15 @@ var endpointCoworkPrintConfigCmd = &cobra.Command{
 	Short: "Print Claude Cowork OTLP setup guidance",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := loadOrDefaultConfig()
-		endpoint := endpointOpts.coworkEndpoint
+		endpoint := coworkOpts.endpoint
 		if endpoint == "" {
 			endpoint = fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort)
 		}
 		fmt.Print(cowork.PrintConfig(cowork.Config{
 			Endpoint:           endpoint,
 			Protocol:           "HTTP/protobuf",
-			Headers:            endpointOpts.coworkHeaders,
-			ResourceAttributes: endpointOpts.coworkResourceAttributes,
+			Headers:            coworkOpts.headers,
+			ResourceAttributes: coworkOpts.resourceAttributes,
 		}))
 	},
 }
@@ -468,18 +472,18 @@ func init() {
 		c.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and launch daemon")
 		c.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
 	}
-	endpointCoworkPrintConfigCmd.Flags().StringVar(&endpointOpts.coworkHeaders, "headers", "", "Optional OTLP headers to show in setup guidance")
-	endpointCoworkPrintConfigCmd.Flags().StringVar(&endpointOpts.coworkEndpoint, "endpoint", "", "Public OTLP HTTPS endpoint to show in setup guidance")
-	endpointCoworkPrintConfigCmd.Flags().StringVar(&endpointOpts.coworkResourceAttributes, "resource-attributes", "", "Optional Claude Cowork resource attributes")
-	endpointCoworkSetupCmd.Flags().StringVar(&endpointOpts.coworkEndpoint, "endpoint", "", "Public OTLP HTTPS endpoint reachable by Claude Cowork")
-	endpointCoworkSetupCmd.Flags().StringVar(&endpointOpts.coworkHeaders, "headers", "", "Optional OTLP headers for the Claude admin settings")
-	endpointCoworkSetupCmd.Flags().StringVar(&endpointOpts.coworkResourceAttributes, "resource-attributes", "", "Optional Claude Cowork resource attributes")
-	endpointCoworkSetupCmd.Flags().BoolVar(&endpointOpts.coworkNgrok, "ngrok", false, "Create a temporary authenticated ngrok tunnel to the local OTLP HTTP receiver")
-	endpointCoworkSetupCmd.Flags().BoolVar(&endpointOpts.coworkOpen, "open", false, "Open Claude Cowork admin settings in a browser")
-	endpointCoworkValidateCmd.Flags().StringVar(&endpointOpts.coworkHeaders, "headers", "", "Optional OTLP headers to show when validation fails")
-	endpointCoworkValidateCmd.Flags().StringVar(&endpointOpts.coworkEndpoint, "endpoint", "", "Public OTLP HTTPS endpoint to show when validation fails")
-	endpointCoworkValidateCmd.Flags().StringVar(&endpointOpts.coworkResourceAttributes, "resource-attributes", "", "Optional Claude Cowork resource attributes")
-	endpointCoworkValidateCmd.Flags().StringVar(&endpointOpts.coworkSince, "since", "", "Require a Claude Cowork event within this duration, such as 10m")
+	endpointCoworkPrintConfigCmd.Flags().StringVar(&coworkOpts.headers, "headers", "", "Optional OTLP headers to show in setup guidance")
+	endpointCoworkPrintConfigCmd.Flags().StringVar(&coworkOpts.endpoint, "endpoint", "", "Public OTLP HTTPS endpoint to show in setup guidance")
+	endpointCoworkPrintConfigCmd.Flags().StringVar(&coworkOpts.resourceAttributes, "resource-attributes", "", "Optional Claude Cowork resource attributes")
+	endpointCoworkSetupCmd.Flags().StringVar(&coworkOpts.endpoint, "endpoint", "", "Public OTLP HTTPS endpoint reachable by Claude Cowork")
+	endpointCoworkSetupCmd.Flags().StringVar(&coworkOpts.headers, "headers", "", "Optional OTLP headers for the Claude admin settings")
+	endpointCoworkSetupCmd.Flags().StringVar(&coworkOpts.resourceAttributes, "resource-attributes", "", "Optional Claude Cowork resource attributes")
+	endpointCoworkSetupCmd.Flags().BoolVar(&coworkOpts.ngrok, "ngrok", false, "Create a temporary authenticated ngrok tunnel to the local OTLP HTTP receiver")
+	endpointCoworkSetupCmd.Flags().BoolVar(&coworkOpts.open, "open", false, "Open Claude Cowork admin settings in a browser")
+	endpointCoworkValidateCmd.Flags().StringVar(&coworkOpts.headers, "headers", "", "Optional OTLP headers to show when validation fails")
+	endpointCoworkValidateCmd.Flags().StringVar(&coworkOpts.endpoint, "endpoint", "", "Public OTLP HTTPS endpoint to show when validation fails")
+	endpointCoworkValidateCmd.Flags().StringVar(&coworkOpts.resourceAttributes, "resource-attributes", "", "Optional Claude Cowork resource attributes")
+	endpointCoworkValidateCmd.Flags().StringVar(&coworkOpts.since, "since", "", "Require a Claude Cowork event within this duration, such as 10m")
 	endpointCoworkStatusCmd.Flags().BoolVar(&endpointOpts.jsonOutput, "json", false, "Print status as JSON")
 	for _, c := range []*cobra.Command{endpointOpenClawPrintConfigCmd, endpointOpenClawStatusCmd, endpointOpenClawValidateCmd} {
 		c.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")

--- a/cli/beacon/cmd/endpoint_cowork.go
+++ b/cli/beacon/cmd/endpoint_cowork.go
@@ -32,9 +32,9 @@ var ngrokURLPattern = regexp.MustCompile(`url="?((?:https)://[^"\s]+)`)
 
 func runEndpointCoworkSetup(cmdCtx context.Context) error {
 	cfg := loadOrDefaultConfig()
-	resourceAttributes := endpointOpts.coworkResourceAttributes
-	if endpointOpts.coworkNgrok {
-		if endpointOpts.coworkEndpoint != "" {
+	resourceAttributes := coworkOpts.resourceAttributes
+	if coworkOpts.ngrok {
+		if coworkOpts.endpoint != "" {
 			return fmt.Errorf("--endpoint cannot be combined with --ngrok")
 		}
 		if resourceAttributes == "" {
@@ -58,7 +58,7 @@ func runEndpointCoworkSetup(cmdCtx context.Context) error {
 			Headers:            headers,
 			ResourceAttributes: resourceAttributes,
 		})
-		if endpointOpts.coworkOpen {
+		if coworkOpts.open {
 			if err := dashboard.OpenBrowser(cowork.AdminURL); err != nil {
 				_ = tunnel.Stop()
 				return err
@@ -68,22 +68,22 @@ func runEndpointCoworkSetup(cmdCtx context.Context) error {
 		return tunnel.Wait()
 	}
 
-	if endpointOpts.coworkEndpoint == "" {
+	if coworkOpts.endpoint == "" {
 		return fmt.Errorf("--endpoint is required unless --ngrok is set")
 	}
-	if !strings.HasPrefix(strings.ToLower(endpointOpts.coworkEndpoint), "https://") {
+	if !strings.HasPrefix(strings.ToLower(coworkOpts.endpoint), "https://") {
 		return fmt.Errorf("--endpoint must be a public HTTPS URL reachable by Claude Cowork")
 	}
 	if resourceAttributes == "" {
 		resourceAttributes = defaultCoworkProdResourceAttributes
 	}
 	printCoworkSetup(cowork.Config{
-		Endpoint:           endpointOpts.coworkEndpoint,
+		Endpoint:           coworkOpts.endpoint,
 		Protocol:           defaultCoworkProtocol,
-		Headers:            endpointOpts.coworkHeaders,
+		Headers:            coworkOpts.headers,
 		ResourceAttributes: resourceAttributes,
 	})
-	if endpointOpts.coworkOpen {
+	if coworkOpts.open {
 		return dashboard.OpenBrowser(cowork.AdminURL)
 	}
 	return nil
@@ -92,18 +92,18 @@ func runEndpointCoworkSetup(cmdCtx context.Context) error {
 func runEndpointCoworkValidate() error {
 	cfg := loadOrDefaultConfig()
 	status := cowork.GetStatus(cfg.LogPath)
-	if endpointOpts.coworkSince != "" {
-		duration, err := time.ParseDuration(endpointOpts.coworkSince)
+	if coworkOpts.since != "" {
+		duration, err := time.ParseDuration(coworkOpts.since)
 		if err != nil {
 			return fmt.Errorf("--since must be a duration such as 10m: %w", err)
 		}
 		since := time.Now().Add(-duration)
 		if !cowork.HasCoworkEventSince(cfg.LogPath, since) {
 			fmt.Print(cowork.PrintConfig(cowork.Config{
-				Endpoint:           endpointOpts.coworkEndpoint,
+				Endpoint:           coworkOpts.endpoint,
 				Protocol:           defaultCoworkProtocol,
-				Headers:            endpointOpts.coworkHeaders,
-				ResourceAttributes: endpointOpts.coworkResourceAttributes,
+				Headers:            coworkOpts.headers,
+				ResourceAttributes: coworkOpts.resourceAttributes,
 			}))
 			return fmt.Errorf("no Claude Cowork events observed in %s since %s", cfg.LogPath, since.UTC().Format(time.RFC3339))
 		}
@@ -112,10 +112,10 @@ func runEndpointCoworkValidate() error {
 	}
 	if !status.LastEventObserved {
 		fmt.Print(cowork.PrintConfig(cowork.Config{
-			Endpoint:           endpointOpts.coworkEndpoint,
+			Endpoint:           coworkOpts.endpoint,
 			Protocol:           defaultCoworkProtocol,
-			Headers:            endpointOpts.coworkHeaders,
-			ResourceAttributes: endpointOpts.coworkResourceAttributes,
+			Headers:            coworkOpts.headers,
+			ResourceAttributes: coworkOpts.resourceAttributes,
 		}))
 		return fmt.Errorf("no Claude Cowork events observed in %s", cfg.LogPath)
 	}


### PR DESCRIPTION
## What

Continues the `endpointOpts` migration (#2). The `endpoint claude-cowork` subcommands' six flags move from the global into a dedicated `coworkOpts` struct:

- removed `coworkHeaders`/`coworkEndpoint`/`coworkResourceAttributes`/`coworkNgrok`/`coworkOpen`/`coworkSince` from `endpointOpts`
- added `var coworkOpts struct { headers, endpoint, resourceAttributes, since string; ngrok, open bool }`
- rebound the flags and updated all readers in `endpoint_cowork.go`

`endpointOpts` drops from 60 → 54 fields.

## Safety

Behavior-preserving — same flags/defaults. `go test ./cmd/` passes; no `endpointOpts.cowork*` references remain.

## Verification

- `go build ./...`, `go test ./cmd/` — green.
- `gofmt -l` clean.

## Stacking

Based on #216 (PR 15a) → … → #200. Second PR in the `endpointOpts` migration series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving CLI refactor with no change to defaults or command semantics; risk is limited to missed references, which tests and grep confirm are cleared.
> 
> **Overview**
> Continues peeling flags off the shared `endpointOpts` global by introducing **`coworkOpts`** for `endpoint claude-cowork` (`print-config`, `setup`, `status`, `validate`).
> 
> Six Cowork-specific flags (`--headers`, `--endpoint`, `--resource-attributes`, `--ngrok`, `--open`, `--since`) are rebound to `coworkOpts`; setup/validate/print-config logic in `endpoint_cowork.go` reads from there instead of `endpointOpts.cowork*`. Shared flags like `--user`, `--log-path`, and `--json` stay on `endpointOpts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4066e874a0a10b48404a103ac5c13be5fca7ef0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->