### PR TITLE
refactor(cmd): flatten planDoctorFixes into per-check helpers

### DIFF
--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -639,34 +639,53 @@ func planDoctorFixes(result doctorResult, status lifecycle.Status) doctorFixPlan
 		}
 		switch check.Name {
 		case "runtime_log", "runtime_log_permissions", "last_event":
-			if check.Evidence == "missing_optional_file" || check.Evidence == "runtime_log_missing" {
-				addFix(plannedAction{Action: "create_runtime_log", Target: status.LogPath, Message: "create runtime log file and parent directory"})
-			} else if check.Evidence == "last_event_missing" {
-				addSkip(plannedAction{Action: "manual_fix", Target: check.Target, Message: "run beacon endpoint test-event or generate a runtime event"})
-			}
+			planRuntimeLogFix(check, status, addFix, addSkip)
 		case "collector_config", "launchd_plist", "collector_health", "collector_reachability", "service":
-			if runtime.GOOS != "darwin" {
-				addSkip(plannedAction{Action: "repair_collector_service", Target: endpointconfig.ConfigPath(status.RuntimeLog.EffectiveUserMode), Message: "launchd service repair is only available on macOS"})
-			} else if configUsable {
-				addFix(plannedAction{Action: "repair_collector_service", Target: endpointconfig.ConfigPath(status.RuntimeLog.EffectiveUserMode), Message: "recreate managed collector config and launchd service"})
-			} else {
-				addSkip(plannedAction{Action: "repair_collector_service", Target: endpointconfig.ConfigPath(status.RuntimeLog.EffectiveUserMode), Message: "skipped because endpoint config is invalid"})
-			}
+			planCollectorServiceFix(check, status, configUsable, addFix, addSkip)
 		case "config", "config_valid":
-			if check.Status == diagnostics.StatusFail {
-				addSkip(plannedAction{Action: "manual_fix", Target: check.Target, Message: "review endpoint config or run " + doctorInstallCommand(status.RuntimeLog.EffectiveUserMode)})
-			}
+			planConfigFix(check, status, addSkip)
 		case "harness":
-			message := "review harness configuration manually"
-			if check.Action != "" {
-				message = "run " + check.Action
-			}
-			addSkip(plannedAction{Action: "manual_fix", Target: check.Target, Message: message})
+			planHarnessFix(check, addSkip)
 		case "runtime_log_source":
 			addSkip(plannedAction{Action: "manual_fix", Target: check.Target, Message: check.Action})
 		}
 	}
 	return plan
+}
+
+func planRuntimeLogFix(check diagnostics.Check, status lifecycle.Status, addFix, addSkip func(plannedAction)) {
+	switch check.Evidence {
+	case "missing_optional_file", "runtime_log_missing":
+		addFix(plannedAction{Action: "create_runtime_log", Target: status.LogPath, Message: "create runtime log file and parent directory"})
+	case "last_event_missing":
+		addSkip(plannedAction{Action: "manual_fix", Target: check.Target, Message: "run beacon endpoint test-event or generate a runtime event"})
+	}
+}
+
+func planCollectorServiceFix(check diagnostics.Check, status lifecycle.Status, configUsable bool, addFix, addSkip func(plannedAction)) {
+	target := endpointconfig.ConfigPath(status.RuntimeLog.EffectiveUserMode)
+	switch {
+	case runtime.GOOS != "darwin":
+		addSkip(plannedAction{Action: "repair_collector_service", Target: target, Message: "launchd service repair is only available on macOS"})
+	case configUsable:
+		addFix(plannedAction{Action: "repair_collector_service", Target: target, Message: "recreate managed collector config and launchd service"})
+	default:
+		addSkip(plannedAction{Action: "repair_collector_service", Target: target, Message: "skipped because endpoint config is invalid"})
+	}
+}
+
+func planConfigFix(check diagnostics.Check, status lifecycle.Status, addSkip func(plannedAction)) {
+	if check.Status == diagnostics.StatusFail {
+		addSkip(plannedAction{Action: "manual_fix", Target: check.Target, Message: "review endpoint config or run " + doctorInstallCommand(status.RuntimeLog.EffectiveUserMode)})
+	}
+}
+
+func planHarnessFix(check diagnostics.Check, addSkip func(plannedAction)) {
+	message := "review harness configuration manually"
+	if check.Action != "" {
+		message = "run " + check.Action
+	}
+	addSkip(plannedAction{Action: "manual_fix", Target: check.Target, Message: message})
 }
 
 func applyDoctorFixes(plan doctorFixPlan, status lifecycle.Status) error {


### PR DESCRIPTION
## What

Flattens `planDoctorFixes` (a ~60-line `for → switch → if/else` block nested four deep) by extracting per-check-group helpers that take the `addFix`/`addSkip` closures:

- `planRuntimeLogFix`, `planCollectorServiceFix`, `planConfigFix`, `planHarnessFix`

The main loop now just dispatches by check name.

## Why

Audit #5/#8: the deep nesting made the fix-planning logic hard to follow and extend.

## Safety

Behavior-preserving — the same fixes/skips are produced. The `runtime_log` `if/else-if` becomes a `switch` on `check.Evidence`; the collector `if/else-if/else` becomes a `switch`. Existing doctor tests pass.

## Verification

- `go build ./...`, `go test ./cmd/` — green.
- `gofmt -l` clean.

## Stacking

Based on #223 (PR 18) → … → #200. First PR of round-2 Group B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving structural refactor in CLI doctor fix planning only; no new logic paths beyond equivalent switch forms.
> 
> **Overview**
> **Refactors** `planDoctorFixes` in `endpoint_diagnostics.go` so the main loop only dispatches on check name instead of holding nested `if/else` for each case.
> 
> Runtime log, collector/service, config, and harness fix planning move into **`planRuntimeLogFix`**, **`planCollectorServiceFix`**, **`planConfigFix`**, and **`planHarnessFix`**, each taking the existing `addFix` / `addSkip` closures. Runtime log branching uses a **`switch` on `check.Evidence`**; collector repair uses a **`switch`** on OS, `configUsable`, and default skip paths.
> 
> **No change** to which fixes or skips are emitted or to `applyDoctorFixes`; existing doctor tests against `planDoctorFixes` still apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24df82a19b3900fa1a35f2d2264be2aef5108b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->