### PR TITLE
Add agent-permission-bypass-spawn detect rule

### DIFF
--- a/rules/agent-control/agent-permission-bypass-spawn.rule.yaml
+++ b/rules/agent-control/agent-permission-bypass-spawn.rule.yaml
@@ -1,0 +1,90 @@
+id: agent-permission-bypass-spawn
+version: 1
+title: Agent runtime spawned with permission/approval gating disabled
+description: >
+  A command.executed event launches a known AI agent runtime CLI (Claude Code, Codex,
+  Cursor Agent, Aider, Goose, OpenCode, Gemini) with a flag that disables the runtime's
+  own permission/approval gate — for example --dangerously-skip-permissions,
+  --dangerously-bypass-approvals-and-sandbox, --permission-mode bypassPermissions,
+  --sandbox danger-full-access, --ask-for-approval never, --full-auto, or --yolo.
+  Spawning a nested agent with its approval gate turned off is a control-bypass signal:
+  whatever guardrails the parent runtime enforces (interactive approvals, sandboxing) do
+  not apply inside the spawned agent, so the child can run arbitrary tools and commands
+  unattended. This is the detect twin of the enforce-side bypass-spawn control; it flags
+  the pattern in the runtime log without blocking anything.
+severity: high
+status: stable
+posture: detect
+taxonomy:
+  owasp_llm: LLM06
+
+# The agent binary must appear as a command head (start of line, after a shell
+# separator, or after a launcher like sudo/env/npx) AND the command must carry a
+# permission-bypass flag. Requiring both keeps the rule off ordinary uses of a bare
+# --force on non-agent commands (e.g. git push --force, npm install --force).
+match: >
+  e.event.action == "command.executed" &&
+  e.command.command.matches("(?i)(^|[;&|]|&&|\\|\\||\\bsudo\\s+|\\benv\\s+|\\bnpx\\s+)\\s*(claude|codex|cursor-agent|aider|goose|opencode|gemini)\\b") &&
+  e.command.command.matches("(?i)(--dangerously-skip-permissions|--dangerously-bypass-approvals-and-sandbox|--permission-mode[ =]+bypasspermissions|--sandbox[ =]+danger-full-access|--ask-for-approval[ =]+never|--full-auto|--yolo|(^|\\s)-a[ =]+never\\b|--force\\b)")
+
+emit:
+  reason: "AI agent runtime spawned with its permission/approval gate disabled"
+
+tests:
+  - name: claude_dangerously_skip_permissions
+    verdict: match
+    events:
+      - timestamp: "2026-06-13T10:00:00Z"
+        event: { action: command.executed }
+        command: { command: "claude --dangerously-skip-permissions -p \"refactor the repo\"" }
+        session: { id: s1 }
+  - name: codex_full_auto_via_npx
+    verdict: match
+    events:
+      - timestamp: "2026-06-13T10:01:00Z"
+        event: { action: command.executed }
+        command: { command: "npx codex exec --full-auto \"apply the patch\"" }
+        session: { id: s1 }
+  - name: cursor_agent_force
+    verdict: match
+    events:
+      - timestamp: "2026-06-13T10:02:00Z"
+        event: { action: command.executed }
+        command: { command: "cursor-agent --force -m \"do the thing\"" }
+        session: { id: s1 }
+  - name: codex_bypass_approvals_and_sandbox
+    verdict: match
+    events:
+      - timestamp: "2026-06-13T10:03:00Z"
+        event: { action: command.executed }
+        command: { command: "codex --dangerously-bypass-approvals-and-sandbox" }
+        session: { id: s1 }
+  - name: claude_permission_mode_bypass
+    verdict: match
+    events:
+      - timestamp: "2026-06-13T10:04:00Z"
+        event: { action: command.executed }
+        command: { command: "claude -p --permission-mode bypassPermissions \"go\"" }
+        session: { id: s1 }
+  - name: claude_normal_invocation_no_bypass
+    verdict: no_match
+    events:
+      - timestamp: "2026-06-13T10:05:00Z"
+        event: { action: command.executed }
+        command: { command: "claude -p \"summarize the diff\"" }
+        session: { id: s1 }
+  - name: non_agent_command_with_force
+    verdict: no_match
+    events:
+      - timestamp: "2026-06-13T10:06:00Z"
+        event: { action: command.executed }
+        command: { command: "git push --force origin main" }
+        session: { id: s1 }
+  - name: bypass_flag_text_but_not_a_command_execution
+    verdict: no_match
+    events:
+      - timestamp: "2026-06-13T10:07:00Z"
+        event: { action: file.read }
+        command: { command: "claude --dangerously-skip-permissions" }
+        file: { path: "/notes/agent-cheatsheet.md" }
+        session: { id: s1 }


### PR DESCRIPTION
## What

Adds a new `rules/agent-control/` category with a single detect-posture rule, **`agent-permission-bypass-spawn`**.

This is the second of three standalone PRs for the optional **policy seam**. It is pure rules-corpus data — no code changes — and is fully independent of the other two PRs.

## Why

When an agent runtime is spawned with its own permission/approval gate turned off (e.g. `claude --dangerously-skip-permissions`, `codex --full-auto`), whatever guardrails the parent enforces don't apply inside the child, which can then run arbitrary tools unattended. This rule is the **open detect twin** of the enforce-side bypass-spawn control: it surfaces the pattern in the runtime JSONL via `beacon scan` without blocking anything. (Audit/enforce behavior stays entirely in the managed provider per the agreed posture.)

## How

- Matches `command.executed` events where the command both (a) launches a known agent runtime CLI at a command head — start of line, after a shell separator, or after `sudo`/`env`/`npx` — and (b) carries a permission-bypass flag.
- Requiring **both** clauses keeps the rule off ordinary uses of a bare `--force` on non-agent commands (`git push --force`, `npm install --force`).
- `status: stable`, `posture: detect`, `severity: high`, taxonomy `owasp_llm: LLM06` (Excessive Agency).

## Verification

- Ships 5 `match` + 3 `no_match` conformance fixtures (incl. a normal `claude -p` invocation, a non-agent `--force` command, and a `file.read` carrying the bypass text but not executing it).
- `TestPackConformance` in `pkg/asymptoteobserve/threatrules` recursively loads the repo `rules/` tree, so the new category is picked up automatically — `go test -count=1 ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rnRZDFHmjWsVrUaL6QurM

---
_Generated by [Claude Code](https://claude.ai/code/session_013rnRZDFHmjWsVrUaL6QurM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rules-corpus YAML only; no runtime or enforcement code changes, and behavior is limited to detection in existing scan flows.
> 
> **Overview**
> Introduces a new **`rules/agent-control/`** category with a **detect-only** rule **`agent-permission-bypass-spawn`** that flags when a `command.executed` event launches a known agent runtime CLI (Claude, Codex, `cursor-agent`, etc.) together with a permission/approval bypass flag (`--dangerously-skip-permissions`, `--full-auto`, `--permission-mode bypassPermissions`, `--force` on the agent, and similar).
> 
> The match logic requires **both** an agent binary at a command head (line start, shell separator, or after `sudo`/`env`/`npx`) **and** a bypass flag, so non-agent uses like `git push --force` are excluded. Posture is **detect** (high severity, OWASP LLM06); it surfaces the pattern in scans without blocking.
> 
> The rule ships **eight embedded conformance tests** (five match, three no_match), including normal `claude -p` invocations and non-`command.executed` events. Existing `TestPackConformance` loads the `rules/` tree recursively, so no test harness changes are required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd93ec7627bbdbebe95e6d9a986ae7c84441c565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->