### PR TITLE
Add read-only permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   typescript-sdk:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add explicit `contents: read` permission to the GitHub Actions CI workflow to follow the principle of least privilege and improve security posture.

## Changes

- Added `permissions` block to `.github/workflows/ci.yml` with `contents: read` permission
- This restricts the workflow to read-only access to repository contents, preventing unintended write operations

## Details

This change aligns with GitHub Actions security best practices by explicitly declaring minimal required permissions. The CI workflow only needs to read repository contents to run tests and checks; it does not require write access to contents, deployments, or other resources.

https://claude.ai/code/session_01SwVjLEcpmzLkp1GU379Ymq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only permission tightening with no application or runtime behavior changes; CI jobs that only checkout and test should remain unaffected.
> 
> **Overview**
> Adds a workflow-level **`permissions`** block to **`.github/workflows/ci.yml`** with **`contents: read`**, matching the pattern already used in **`release-check`** and **`npm-publish-sdk`**.
> 
> This explicitly caps the CI run to read-only repo access instead of relying on the default GITHUB_TOKEN scope, which aligns with least-privilege for checkout/build/test jobs that do not need to write repository contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b34b2be16acf04f1fee7894626af2587be503134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->