### PR TITLE
refactor(hooks): dedupe devin/windsurf marshal and drop dead helper

### DIFF
--- a/cli/beacon/internal/endpoint/hooks/devin.go
+++ b/cli/beacon/internal/endpoint/hooks/devin.go
@@ -235,20 +235,7 @@ func readWindsurfHooks(path string) (windsurfHooksFile, error) {
 }
 
 func (config windsurfHooksFile) marshal() ([]byte, error) {
-	out := make(map[string]json.RawMessage, len(config.values)+1)
-	for key, value := range config.values {
-		if key != "hooks" {
-			out[key] = value
-		}
-	}
-	if len(config.hooks) > 0 {
-		data, err := json.Marshal(config.hooks)
-		if err != nil {
-			return nil, err
-		}
-		out["hooks"] = data
-	}
-	return json.MarshalIndent(out, "", "  ")
+	return marshalHookConfig(config.values, config.hooks, len(config.hooks) > 0)
 }
 
 func (config devinConfig) marshal() ([]byte, error) {
@@ -258,14 +245,21 @@ func (config devinConfig) marshal() ([]byte, error) {
 		}
 		return json.MarshalIndent(config.hooks, "", "  ")
 	}
-	out := make(map[string]json.RawMessage, len(config.values)+1)
-	for key, value := range config.values {
+	return marshalHookConfig(config.values, config.hooks, len(config.hooks) > 0)
+}
+
+// marshalHookConfig re-marshals a hook config file's preserved top-level values,
+// replacing the "hooks" key with the freshly marshaled hooks when present. It is
+// shared by the windsurf and devin (non-standalone) marshalers.
+func marshalHookConfig(values map[string]json.RawMessage, hooks any, hasHooks bool) ([]byte, error) {
+	out := make(map[string]json.RawMessage, len(values)+1)
+	for key, value := range values {
 		if key != "hooks" {
 			out[key] = value
 		}
 	}
-	if len(config.hooks) > 0 {
-		data, err := json.Marshal(config.hooks)
+	if hasHooks {
+		data, err := json.Marshal(hooks)
 		if err != nil {
 			return nil, err
 		}
@@ -402,10 +396,6 @@ func filterDevinEndpointHooks(group devinHookGroup, platforms ...string) (devinH
 		filtered.Hooks = append(filtered.Hooks, hook)
 	}
 	return filtered, changed
-}
-
-func isDevinInstalledAt(path string) bool {
-	return isDevinInstalledAtPlatforms(path, "devin")
 }
 
 func isDevinCLIInstalledAt(path string) bool {


### PR DESCRIPTION
## What

Two small, verified cleanups in `hooks/devin.go` surfaced by a follow-up audit:

1. **Dedupe marshal logic.** `windsurfHooksFile.marshal` and the non-standalone path of `devinConfig.marshal` were byte-identical 14-line blocks. Extract a shared `marshalHookConfig(values, hooks, hasHooks)` helper.
2. **Remove dead code.** `isDevinInstalledAt` was an unused wrapper around `isDevinInstalledAtPlatforms` (only the CLI/Desktop variants are called) — confirmed no callers across the repo.

## Safety

Behavior-preserving. The devin/windsurf install/remove/marshal tests pass (including the config-preservation tests that exercise the marshal path).

> Note: the unrelated `TestInstallFactoryUsesSystemConfigForSystemLog` requires a real embedded `hooks.bin` that isn't present in this checkout; it fails identically with and without this change.

## Verification

- `go build ./...` — green.
- `go test ./internal/endpoint/hooks/ -run 'Devin|Windsurf'` — all pass.
- `gofmt -l` clean.

## Audit context

This is the only PR I'm opening from the follow-up audit of the 5 previously-unreviewed files. The other findings were either false positives (e.g. a flagged "ignored error" that is actually `return true, os.Remove(path)`) or intentional/marginal (see the session summary) and are left as-is.

## Stacking

Based on #231 (PR 22) → … → #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZg4Mc8rDoryH88rXsmhwM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in hook config serialization only; no auth, security, or API surface changes.
> 
> **Overview**
> Refactors hook config serialization in `devin.go` without changing install/remove behavior.
> 
> **Windsurf** and **non-standalone Devin** `marshal` paths now call a shared **`marshalHookConfig`**, which copies preserved top-level JSON keys, omits the old `hooks` entry from `values`, and re-injects freshly marshaled hooks when `hasHooks` is true. Standalone Devin marshaling is unchanged.
> 
> Removes the unused **`isDevinInstalledAt`** wrapper; CLI/Desktop still use **`isDevinInstalledAtPlatforms`** directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff8aa59b8d1ff0432a50dfc7b4e6bd4a93e9c3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->