### PR TITLE
Update onboarding tag

### DIFF
--- a/docs/manage/configure-s3-data-connector.mdx
+++ b/docs/manage/configure-s3-data-connector.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Configure S3 Data Connector"
 description: "Configure read-only S3 access for Asymptote ingestion."
-tag: "Enterprise"
 ---
 
 ## Overview

--- a/docs/manage/connect-okta.mdx
+++ b/docs/manage/connect-okta.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Connect Okta"
 description: "Connect Okta to populate identity and device inventory in Asymptote."
-tag: "Enterprise"
 ---
 
 ## Overview


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation frontmatter-only edits with no application or security behavior impact.
> 
> **Overview**
> Removes the **`tag: "Enterprise"`** frontmatter field from the **Connect Okta** and **Configure S3 Data Connector** onboarding guides so those pages are no longer labeled as Enterprise in docs metadata/navigation.
> 
> No body content or setup steps change—only YAML frontmatter on those two MDX files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a9a9a68d194ceeba34e5d9eb22747f3b09f28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->