### PR TITLE
Update agent instructions to include packaging vector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,13 @@ cd ../..
 sh packaging/macos/test-endpoint-scripts.sh
 ```
 
+When building macOS `.pkg` artifacts, always include the Vector binary by
+setting `BEACON_VECTOR_BIN` (or `VECTOR_BIN`) to the release Vector executable
+before running `packaging/macos/build-pkg.sh` or
+`packaging/macos/build-signed-notarized-pkg.sh`. The package should install
+`/opt/beacon/bin/vector` so packaged Jamf/Fleet forwarder helpers work without a
+separate Vector install.
+
 ### Preferred CI Release
 
 CI release automation should:

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -35,7 +35,8 @@ The endpoint install creates system configuration and runtime state:
 
 ## Build A Test Package
 
-Build Beacon and `beacon-otelcol`, then assemble the macOS package:
+Build Beacon, `beacon-otelcol`, and have the release Vector binary available,
+then assemble the macOS package:
 
 ```bash
 cd cli/beacon
@@ -46,13 +47,15 @@ cd collector-builder
 ocb --config builder.yaml
 cd ..
 
-sh packaging/macos/build-pkg.sh
+BEACON_VECTOR_BIN="$(command -v vector)" \
+  sh packaging/macos/build-pkg.sh
 ```
 
 Set `BEACON_APP_SIGN_IDENTITY` to sign payload binaries with a Developer ID
 Application certificate, set `PKG_SIGN_IDENTITY` to sign the package with a
-Developer ID Installer certificate, and set `NOTARYTOOL_PROFILE` to submit and
-staple the package with Apple's notary service.
+Developer ID Installer certificate, set `BEACON_VECTOR_BIN` to include the
+Vector binary at `/opt/beacon/bin/vector`, and set `NOTARYTOOL_PROFILE` to
+submit and staple the package with Apple's notary service.
 
 For release artifacts, use the signing wrapper so required identities are checked
 up front and the final package signature, stapled ticket, Gatekeeper assessment,
@@ -61,6 +64,7 @@ and checksum are verified:
 ```bash
 BEACON_APP_SIGN_IDENTITY="Developer ID Application: Example Corp (TEAMID)" \
 PKG_SIGN_IDENTITY="Developer ID Installer: Example Corp (TEAMID)" \
+BEACON_VECTOR_BIN="$(command -v vector)" \
 NOTARYTOOL_PROFILE="beacon-notary-profile" \
   sh packaging/macos/build-signed-notarized-pkg.sh
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or packaging script modifications.
> 
> **Overview**
> Documents that macOS `.pkg` builds should bundle the **Vector** binary so Jamf/Fleet forwarder helpers work without a separate Vector install.
> 
> **`CLAUDE.md`** adds release guidance: set `BEACON_VECTOR_BIN` (or `VECTOR_BIN`) to the release Vector executable before running `build-pkg.sh` or `build-signed-notarized-pkg.sh`, targeting install path `/opt/beacon/bin/vector`.
> 
> **`packaging/macos/README.md`** updates the test and signed/notarized build examples to require a release Vector binary up front, export `BEACON_VECTOR_BIN="$(command -v vector)"` in the sample commands, and call out `BEACON_VECTOR_BIN` alongside signing/notarization env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8143f84e0db6011490bfd95f64608dfa88c45cc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->