### PR TITLE
ci(release): publish signed macOS packages from tags

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,10 +1,18 @@
 name: Release Check
 
+# Validates that the release build is healthy WITHOUT publishing. The real
+# release now runs from release.yml on a v* tag, so this only needs to guard
+# against release-config breakage before a tag is cut: it runs on PRs that touch
+# release-relevant paths and on manual dispatch.
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "v*"
+  pull_request:
+    paths:
+      - "cli/beacon/.goreleaser.yaml"
+      - "collector-builder/**"
+      - "packaging/macos/**"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-check.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,234 @@
+name: Release
+
+# Full hands-off release on a pushed v* tag:
+#   1. goreleaser  — builds tarballs, publishes the GitHub release + changelog,
+#                    and updates the Homebrew tap.
+#   2. package     — (after goreleaser) builds, signs, notarizes, and staples the
+#                    macOS .pkg for both arches and attaches them plus the
+#                    package update manifest to the same release.
+#
+# Triggered only by pushed version tags, so outside contributors (whose fork PRs
+# never receive secrets) cannot run it. All release secrets live in the protected
+# `release` environment, restricted to v* tags.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/beacon/go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "v2.13.3"
+          install-only: true
+
+      - name: Install OpenTelemetry Collector Builder
+        run: go install go.opentelemetry.io/collector/cmd/builder@v0.121.0
+
+      - name: Build collector distributions
+        run: bash collector-builder/build-release-collectors.sh
+
+      - name: Validate native collector binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          collector=collector-builder/dist/beacon-otelcol/linux_amd64/beacon-otelcol
+          test -x "$collector"
+          "$collector" components | awk '
+            /name: beaconjson/ { beaconjson = 1 }
+            /name: falcon_hec/ { falcon_hec = 1 }
+            END { exit !(beaconjson && falcon_hec) }
+          '
+
+      - name: Check GoReleaser config
+        working-directory: cli/beacon
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: goreleaser check
+
+      # Run from cli/beacon because the release pre-hook writes target-specific
+      # beacon-hooks binaries to a shared embedded path; --parallelism 1 avoids
+      # racing on it.
+      - name: Publish release (tarballs, GitHub release, Homebrew tap)
+        working-directory: cli/beacon
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: goreleaser release --clean --parallelism 1
+
+  package:
+    needs: goreleaser
+    runs-on: macos-latest
+    environment: release
+    env:
+      REPO: ${{ github.repository }}
+      TAG: ${{ github.ref_name }}
+      NOTARYTOOL_PROFILE: beacon-notary-ci
+      BEACON_APP_SIGN_IDENTITY: ${{ vars.DEVELOPER_ID_APP_IDENTITY }}
+      PKG_SIGN_IDENTITY: ${{ vars.DEVELOPER_ID_INSTALLER_IDENTITY }}
+      APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+      VECTOR_VERSION: "0.56.0"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/beacon/go.mod
+
+      - name: Compute version
+        id: ver
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install OpenTelemetry Collector Builder
+        run: go install go.opentelemetry.io/collector/cmd/builder@v0.121.0
+
+      - name: Build collector distributions
+        run: bash collector-builder/build-release-collectors.sh
+
+      - name: Download Vector binaries (per arch)
+        run: |
+          set -euo pipefail
+          mkdir -p dist/vector
+          curl -fsSLO "https://packages.timber.io/vector/${VECTOR_VERSION}/vector-${VECTOR_VERSION}-SHA256SUMS"
+          for ARCH in arm64 amd64; do
+            case "$ARCH" in
+              arm64) VECTOR_ARCH="arm64" ;;
+              amd64) VECTOR_ARCH="x86_64" ;;
+              *) echo "unsupported Vector arch: $ARCH" >&2; exit 1 ;;
+            esac
+            archive="vector-${VECTOR_VERSION}-${VECTOR_ARCH}-apple-darwin.tar.gz"
+            curl -fsSLO "https://packages.timber.io/vector/${VECTOR_VERSION}/${archive}"
+            checksum_line="$(awk -v archive="$archive" '$2 == archive { print }' "vector-${VECTOR_VERSION}-SHA256SUMS")"
+            if [ -z "$checksum_line" ]; then
+              echo "checksum not found for $archive" >&2
+              exit 1
+            fi
+            printf '%s\n' "$checksum_line" | shasum -a 256 -c -
+            mkdir -p "dist/vector/${ARCH}"
+            tar -xzf "$archive" -C "dist/vector/${ARCH}" --strip-components=2 "./vector-${VECTOR_ARCH}-apple-darwin/bin/vector"
+            "dist/vector/${ARCH}/vector" --version
+          done
+
+      - name: Build beacon binaries (per arch, with embedded hooks)
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          BEACON_LD="github.com/asymptote-labs/agent-beacon/cli/beacon/internal/version"
+          HOOKS_LD="github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/version"
+          mkdir -p dist/pkgbins
+          for ARCH in arm64 amd64; do
+            # Embed the arch-matched hooks binary, then build beacon for that arch.
+            (cd cli/beacon-hooks && GOOS=darwin GOARCH="$ARCH" \
+              go build -ldflags "-s -w -X ${HOOKS_LD}.Version=${VERSION}" \
+              -o ../beacon/internal/embedded/hooks.bin .)
+            (cd cli/beacon && GOOS=darwin GOARCH="$ARCH" CGO_ENABLED=0 \
+              go build -a -ldflags "-s -w -X ${BEACON_LD}.Version=${VERSION} -X ${BEACON_LD}.GitCommit=$(git rev-parse --short HEAD) -X ${BEACON_LD}.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              -o "../../dist/pkgbins/beacon-${ARCH}" .)
+          done
+
+      - name: Set up signing keychain
+        env:
+          DEVELOPER_ID_APP_CERT_P12: ${{ secrets.DEVELOPER_ID_APP_CERT_P12 }}
+          DEVELOPER_ID_APP_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_APP_CERT_PASSWORD }}
+          DEVELOPER_ID_INSTALLER_CERT_P12: ${{ secrets.DEVELOPER_ID_INSTALLER_CERT_P12 }}
+          DEVELOPER_ID_INSTALLER_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_INSTALLER_CERT_PASSWORD }}
+          NOTARY_API_KEY_P8: ${{ secrets.NOTARY_API_KEY_P8 }}
+          NOTARY_API_KEY_ID: ${{ secrets.NOTARY_API_KEY_ID }}
+          NOTARY_API_ISSUER: ${{ secrets.NOTARY_API_ISSUER }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/beacon-signing.keychain-db"
+          KEYCHAIN_PW="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          # Make the new keychain searchable while keeping the login keychain.
+          security list-keychains -d user -s "$KEYCHAIN" "$(security default-keychain -d user | tr -d ' "')"
+
+          echo "$DEVELOPER_ID_APP_CERT_P12" | base64 --decode > "$RUNNER_TEMP/app.p12"
+          echo "$DEVELOPER_ID_INSTALLER_CERT_P12" | base64 --decode > "$RUNNER_TEMP/installer.p12"
+          security import "$RUNNER_TEMP/app.p12" -k "$KEYCHAIN" -P "$DEVELOPER_ID_APP_CERT_PASSWORD" -T /usr/bin/codesign
+          security import "$RUNNER_TEMP/installer.p12" -k "$KEYCHAIN" -P "$DEVELOPER_ID_INSTALLER_CERT_PASSWORD" -T /usr/bin/pkgbuild
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PW" "$KEYCHAIN"
+
+          # Store notarization credentials as the profile build-pkg.sh expects.
+          echo "$NOTARY_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/notary.p8"
+          xcrun notarytool store-credentials "$NOTARYTOOL_PROFILE" \
+            --key "$RUNNER_TEMP/notary.p8" \
+            --key-id "$NOTARY_API_KEY_ID" \
+            --issuer "$NOTARY_API_ISSUER" \
+            --keychain "$KEYCHAIN"
+          rm -f "$RUNNER_TEMP/app.p12" "$RUNNER_TEMP/installer.p12" "$RUNNER_TEMP/notary.p8"
+          echo "BEACON_SIGNING_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+          # Carry the keychain password so later steps can keep it unlocked.
+          echo "::add-mask::$KEYCHAIN_PW"
+          echo "BEACON_SIGNING_KEYCHAIN_PW=$KEYCHAIN_PW" >> "$GITHUB_ENV"
+
+      - name: Build, sign, notarize, and staple packages (per arch)
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          security unlock-keychain -p "$BEACON_SIGNING_KEYCHAIN_PW" "$BEACON_SIGNING_KEYCHAIN"
+          for ARCH in arm64 amd64; do
+            BEACON_VERSION="$VERSION" \
+            BEACON_PKG_ARCH="$ARCH" \
+            BEACON_BIN="$PWD/dist/pkgbins/beacon-${ARCH}" \
+            BEACON_COLLECTOR="$PWD/collector-builder/dist/beacon-otelcol/darwin_${ARCH}/beacon-otelcol" \
+            BEACON_VECTOR_BIN="$PWD/dist/vector/${ARCH}/vector" \
+            OUT_DIR="$PWD/dist/macos" \
+              sh packaging/macos/build-signed-notarized-pkg.sh
+          done
+          ls -la dist/macos
+
+      - name: Generate update manifest
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          ARM_PKG="$(ls dist/macos/*-${VERSION}-arm64.pkg)"
+          AMD_PKG="$(ls dist/macos/*-${VERSION}-amd64.pkg)"
+          sh packaging/macos/gen-update-manifest.sh \
+            "$VERSION" "$TAG" "$REPO" "$APPLE_TEAM_ID" \
+            "arm64=$ARM_PKG" "amd64=$AMD_PKG" > dist/macos/update-manifest.json
+          cat dist/macos/update-manifest.json
+
+      - name: Attach packages + manifest to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # goreleaser (the needs: dependency) has already created the release.
+          # create-if-missing is a safety net for a re-run before goreleaser.
+          if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$TAG" --repo "$REPO" --title "$TAG" \
+              --notes "Release $TAG" --verify-tag
+          fi
+          gh release upload "$TAG" \
+            dist/macos/*.pkg \
+            dist/macos/*.pkg.sha256 \
+            dist/macos/update-manifest.json \
+            --repo "$REPO" --clobber
+
+      - name: Clean up signing keychain
+        if: always()
+        run: |
+          security delete-keychain "$BEACON_SIGNING_KEYCHAIN" 2>/dev/null || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,26 @@ Prefer a CI-based release workflow triggered by an annotated version tag. Use a
 local GoReleaser publish only as a fallback when CI release automation is not
 available or the maintainer explicitly asks for a local release.
 
+A pushed `v*` tag runs the full release end-to-end via
+`.github/workflows/release.yml` (no local publish steps required), with two jobs
+in the protected `release` GitHub Environment:
+
+1. `goreleaser` (ubuntu) builds the collector dists, publishes the GitHub release
+   + changelog and tarballs, and updates the Homebrew tap.
+2. `package` (macOS, `needs: goreleaser`) builds `beacon`/`beacon-hooks` plus
+   arch-matched collector and Vector binaries for `darwin_arm64` and
+   `darwin_amd64`, then signs, notarizes, staples, and uploads the `.pkg`
+   artifacts, `.sha256`s, and `update-manifest.json`.
+
+Required `release`-environment secrets: `HOMEBREW_TAP_TOKEN`,
+`DEVELOPER_ID_APP_CERT_P12`, `DEVELOPER_ID_APP_CERT_PASSWORD`,
+`DEVELOPER_ID_INSTALLER_CERT_P12`, `DEVELOPER_ID_INSTALLER_CERT_PASSWORD`,
+`NOTARY_API_KEY_P8`, `NOTARY_API_KEY_ID`, `NOTARY_API_ISSUER`; plus Variables
+`DEVELOPER_ID_APP_IDENTITY`, `DEVELOPER_ID_INSTALLER_IDENTITY`, `APPLE_TEAM_ID`.
+Keep one-time Apple-side onboarding steps out of the repo and share them with
+the release maintainer directly. Never use `pull_request_target` or build
+untrusted PR code in the signing job.
+
 Use the next semver tag requested by the maintainer, usually the next `v0.0.x`
 tag unless they explicitly decide Beacon is ready for `v1.0.0`.
 
@@ -181,20 +201,21 @@ CI release automation should:
 - Provide `GITHUB_TOKEN` for the GitHub release and `HOMEBREW_TAP_TOKEN` with
   write access to `asymptote-labs/homebrew-tap`.
 
-Once release CI exists, the normal deployment flow is:
+The normal deployment flow is:
 
 ```bash
 git fetch --tags origin
 git status -sb --untracked-files=all
 git tag -a <tag> -m "<tag>"
 git push origin <tag>
-gh run list --workflow <release-workflow-name> --limit 5
+gh run list --workflow release.yml --limit 5
 ```
 
-After the workflow succeeds, verify both the GitHub release and the Homebrew tap:
+After the workflow succeeds, verify the GitHub release assets and the Homebrew
+tap:
 
 ```bash
-gh release view <tag> --json url,tagName,assets --jq '.tagName + " " + .url + " assets=" + (.assets | length | tostring)'
+gh release view <tag> --json url,tagName,assets --jq '.tagName + " " + .url + " assets=" + (.assets | map(.name) | join(","))'
 gh api repos/Asymptote-Labs/homebrew-tap/contents/Formula/beacon.rb --jq '.content' | base64 --decode | sed -n '1,70p'
 gh api repos/Asymptote-Labs/homebrew-tap/commits/main --jq '.sha + " " + .commit.message'
 ```

--- a/cli/beacon/.goreleaser.yaml
+++ b/cli/beacon/.goreleaser.yaml
@@ -129,6 +129,10 @@ release:
     name: agent-beacon
   draft: false
   prerelease: auto
+  # The macOS package job in .github/workflows/release.yml attaches signed .pkg
+  # assets + update-manifest.json to the same release. append keeps reruns or
+  # future job ordering changes from failing on an existing release.
+  mode: append
   name_template: "v{{.Version}}"
   extra_files:
     # The threat-rule pack ships as a separate asset, not embedded in the binary,

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -10,13 +10,26 @@ trap 'rm -rf "$WORK_DIR"' EXIT INT TERM
 VERSION="${BEACON_VERSION:-$(cd "$ROOT_DIR" && git describe --tags --always --dirty 2>/dev/null || echo dev)}"
 PKG_IDENTIFIER="${PKG_IDENTIFIER:-ai.asymptote.beacon.endpoint}"
 PKG_NAME="${PKG_NAME:-BeaconEndpointAgent}"
+# When BEACON_PKG_ARCH is set (e.g. arm64/amd64 in CI), default the collector
+# target to that arch and append the arch to the package name so a release can
+# carry one package per Mac architecture. The caller is responsible for passing
+# an arch-matched BEACON_BIN. Unset preserves the host-arch default and name.
+ARCH="${BEACON_PKG_ARCH:-}"
 BEACON_BIN="${BEACON_BIN:-$ROOT_DIR/cli/beacon/beacon}"
-COLLECTOR_TARGET="${BEACON_COLLECTOR_TARGET:-$(go env GOOS)_$(go env GOARCH)}"
+DEFAULT_COLLECTOR_TARGET="$(go env GOOS)_$(go env GOARCH)"
+if [ -n "$ARCH" ]; then
+  DEFAULT_COLLECTOR_TARGET="darwin_$ARCH"
+fi
+COLLECTOR_TARGET="${BEACON_COLLECTOR_TARGET:-$DEFAULT_COLLECTOR_TARGET}"
 COLLECTOR_BIN="${BEACON_COLLECTOR:-$ROOT_DIR/collector-builder/dist/beacon-otelcol/$COLLECTOR_TARGET/beacon-otelcol}"
 VECTOR_BIN="${BEACON_VECTOR_BIN:-${VECTOR_BIN:-}}"
 PKG_ROOT="$WORK_DIR/pkgroot"
 PKG_SCRIPTS="$WORK_DIR/scripts"
-PKG_PATH="$OUT_DIR/$PKG_NAME-$VERSION.pkg"
+if [ -n "$ARCH" ]; then
+  PKG_PATH="$OUT_DIR/$PKG_NAME-$VERSION-$ARCH.pkg"
+else
+  PKG_PATH="$OUT_DIR/$PKG_NAME-$VERSION.pkg"
+fi
 
 copy_file() {
   if cp -X "$1" "$2" 2>/dev/null; then

--- a/packaging/macos/gen-update-manifest.sh
+++ b/packaging/macos/gen-update-manifest.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Generate the package update manifest (update-manifest.json) for a release.
+#
+# Usage:
+#   gen-update-manifest.sh VERSION TAG REPO TEAM_ID \
+#     arm64=/path/Beacon-...-arm64.pkg amd64=/path/Beacon-...-amd64.pkg
+#
+# Emits JSON to stdout. Download URLs point at the GitHub release assets for TAG.
+set -eu
+
+if [ "$#" -lt 5 ]; then
+  echo "usage: $0 VERSION TAG REPO TEAM_ID arch=pkgpath [arch=pkgpath ...]" >&2
+  exit 2
+fi
+
+VERSION="$1"; TAG="$2"; REPO="$3"; TEAM_ID="$4"
+shift 4
+
+MIN_SUPPORTED="${BEACON_MIN_SUPPORTED_VERSION:-}"
+PKG_IDENTIFIER="${PKG_IDENTIFIER:-ai.asymptote.beacon.endpoint}"
+
+artifacts=""
+for pair in "$@"; do
+  arch="${pair%%=*}"
+  pkg="${pair#*=}"
+  if [ ! -f "$pkg" ]; then
+    echo "package not found: $pkg" >&2
+    exit 1
+  fi
+  sha="$(shasum -a 256 "$pkg" | awk '{print $1}')"
+  base="$(basename "$pkg")"
+  url="https://github.com/$REPO/releases/download/$TAG/$base"
+  entry="\"darwin_$arch\":{\"url\":\"$url\",\"sha256\":\"$sha\"}"
+  if [ -z "$artifacts" ]; then
+    artifacts="$entry"
+  else
+    artifacts="$artifacts,$entry"
+  fi
+done
+
+min_field=""
+if [ -n "$MIN_SUPPORTED" ]; then
+  min_field="\"min_supported_version\":\"$MIN_SUPPORTED\","
+fi
+
+printf '{"schema":1,"version":"%s",%s"team_id":"%s","pkg_identifier":"%s","artifacts":{%s}}\n' \
+  "$VERSION" "$min_field" "$TEAM_ID" "$PKG_IDENTIFIER" "$artifacts"


### PR DESCRIPTION
## Summary
- Add a tag-driven release workflow that runs GoReleaser, then builds, signs, notarizes, staples, and uploads per-arch macOS `.pkg` artifacts plus `.sha256`s and `update-manifest.json`.
- Keep this PR limited to release artifact production, without shipping the self-updater CLI/runtime/daemon changes from PR #240.
- Fix package assembly in CI to embed arch-matched Vector binaries, verified against upstream SHA256SUMS, so packaged Jamf/Fleet forwarders have `/opt/beacon/bin/vector`.

## Test plan
- `sh packaging/macos/test-endpoint-scripts.sh`
- `GOBIN=$(mktemp -d) go install github.com/goreleaser/goreleaser/v2@v2.13.3 && <tmp>/goreleaser check` from `cli/beacon`
- Smoke-tested `packaging/macos/gen-update-manifest.sh` with fake arm64/amd64 package files

## Follow-up
After this lands, push a `v*` tag to validate the protected release environment produces signed/notarized/stapled packages. The self-updater branch can then consume that real signed artifact locally before its own PR merges.

Made with [Cursor](https://cursor.com)