### PR TITLE
fix(hooks): correct Cursor payload platform attribution

### DIFF
--- a/cli/beacon-hooks/cmd/helpers.go
+++ b/cli/beacon-hooks/cmd/helpers.go
@@ -11,6 +11,9 @@ import (
 func readStdinJSON() (map[string]interface{}, error) {
 	var input map[string]interface{}
 	err := json.NewDecoder(os.Stdin).Decode(&input)
+	if err == nil {
+		applyPayloadPlatformOverride(input)
+	}
 	return input, err
 }
 
@@ -34,6 +37,28 @@ func isDevinLikePlatform(platform string) bool {
 
 func isCascadePlatform(platform string) bool {
 	return platform == "devin-desktop"
+}
+
+func applyPayloadPlatformOverride(input map[string]interface{}) {
+	if platformFlag != "claude" || !looksLikeCursorPayload(input) {
+		return
+	}
+	platformFlag = "cursor"
+}
+
+func looksLikeCursorPayload(input map[string]interface{}) bool {
+	if getFirstStr(input, "conversation_id", "parent_conversation_id", "cursor_version", "generation_id") != "" {
+		return true
+	}
+	if _, ok := input["workspace_roots"]; ok {
+		return true
+	}
+	switch getFirstStr(input, "hook_event_name", "hookEventName") {
+	case "beforeSubmitPrompt", "beforeShellExecution", "afterShellExecution", "beforeReadFile", "afterFileEdit", "postToolUse", "postToolUseFailure", "preCompact", "subagentStart", "subagentStop":
+		return true
+	default:
+		return false
+	}
 }
 
 // getFirstStr returns the first non-empty string value from input for the given keys.
@@ -60,7 +85,7 @@ func resolveSessionID(input map[string]interface{}, platform string) string {
 		}
 		return getFirstStr(input, "sessionId", "session_id")
 	case "cursor":
-		return getFirstStr(input, "conversation_id", "parent_conversation_id")
+		return getFirstStr(input, "conversation_id", "parent_conversation_id", "session_id", "sessionId")
 	case "vscode":
 		return getFirstStr(input, "sessionId", "session_id", "conversation_id", "gen_ai.conversation.id")
 	case "devin", "devin-cli":
@@ -95,7 +120,7 @@ func resolveSessionIDWithTranscript(input map[string]interface{}, platform strin
 		}
 		return
 	case "cursor":
-		sessionID = getFirstStr(input, "conversation_id", "parent_conversation_id")
+		sessionID = getFirstStr(input, "conversation_id", "parent_conversation_id", "session_id", "sessionId")
 		transcriptPath = getFirstStr(input, "transcript_path")
 		return
 	case "vscode":

--- a/cli/beacon-hooks/cmd/post_tool_test.go
+++ b/cli/beacon-hooks/cmd/post_tool_test.go
@@ -114,6 +114,35 @@ func TestRunPostToolEmitsCursorAfterShellExecution(t *testing.T) {
 	}
 }
 
+func TestRunPostToolCorrectsCursorPayloadWithDefaultPlatform(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "claude"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPostTool, map[string]interface{}{
+		"hook_event_name": "afterShellExecution",
+		"session_id":      "conv-shell",
+		"command":         "go test ./...",
+		"output":          "ok",
+		"cwd":             "/repo",
+	})
+	if len(out) != 0 {
+		t.Fatalf("post-tool response = %#v, want empty response", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if harness := event["harness"].(map[string]interface{})["name"]; harness != "cursor" {
+		t.Fatalf("harness = %q, want cursor", harness)
+	}
+	if action := event["event"].(map[string]interface{})["action"]; action != "command.executed" {
+		t.Fatalf("event.action = %q, want command.executed", action)
+	}
+	if sessionID := event["session"].(map[string]interface{})["id"]; sessionID != "conv-shell" {
+		t.Fatalf("session.id = %q, want conv-shell", sessionID)
+	}
+}
+
 func TestRunPostToolEmitsCursorMCPGenAIFields(t *testing.T) {
 	setupHookConfigDirs(t)
 	platformFlag = "cursor"
@@ -273,7 +302,7 @@ func TestRunPostToolEmitsCursorMCPFailureResponseFields(t *testing.T) {
 			"jsonrpc_request_id": "req-1",
 		},
 		"tool_response": map[string]interface{}{
-			"error": true,
+			"error":      true,
 			"mcp_server": "linear",
 			"mcp_tool":   "get_organizations",
 		},

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -94,6 +94,34 @@ func TestRunPreToolEmitsCursorBeforeShellExecution(t *testing.T) {
 	}
 }
 
+func TestRunPreToolCorrectsCursorPayloadWithDefaultPlatform(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "claude"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPreTool, map[string]interface{}{
+		"conversation_id": "conv-shell",
+		"hook_event_name": "beforeShellExecution",
+		"command":         "npm test",
+		"cwd":             "/repo",
+	})
+	if out["permission"] != "allow" {
+		t.Fatalf("beforeShellExecution response = %#v, want permission allow", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if harness := event["harness"].(map[string]interface{})["name"]; harness != "cursor" {
+		t.Fatalf("harness = %q, want cursor", harness)
+	}
+	if action := event["event"].(map[string]interface{})["action"]; action != "approval.allowed" {
+		t.Fatalf("event.action = %q, want approval.allowed", action)
+	}
+	if sessionID := event["session"].(map[string]interface{})["id"]; sessionID != "conv-shell" {
+		t.Fatalf("session.id = %q, want conv-shell", sessionID)
+	}
+}
+
 func TestRunPreToolEmitsCursorBeforeReadFile(t *testing.T) {
 	setupHookConfigDirs(t)
 	platformFlag = "cursor"


### PR DESCRIPTION
## Summary
- Detect Cursor-shaped hook payloads that arrive through the default `claude` platform path and attribute them to Cursor before logging.
- Allow Cursor session extraction to fall back to `session_id` / `sessionId` for legacy or no-platform hook payloads.
- Add regressions for pre-tool and post-tool Cursor payloads invoked with the default platform.

## Verification
- Verified the reported local session ID appeared in `/var/log/beacon-agent/runtime.jsonl` with both `harness.name=claude` and `harness.name=cursor`.
- `go test ./...` in `cli/beacon-hooks`
- `go test ./internal/endpoint/dashboard` in `cli/beacon`
- `go test ./threatrules` in `pkg/asymptoteobserve`


Made with [Cursor](https://cursor.com)