### PR TITLE
docs: document v0.0.76 release workflow and package notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,23 @@ gh api repos/Asymptote-Labs/homebrew-tap/contents/Formula/beacon.rb --jq '.conte
 gh api repos/Asymptote-Labs/homebrew-tap/commits/main --jq '.sha + " " + .commit.message'
 ```
 
+The release should include the four GoReleaser CLI archives, `checksums.txt`,
+`threat-rules.tar.gz`, `BeaconEndpointAgent-<version>-arm64.pkg`, its `.sha256`,
+and `update-manifest.json`. Verify the package before announcing the release:
+
+```bash
+tmpdir="$(mktemp -d)"
+cd "$tmpdir"
+gh release download <tag> --repo Asymptote-Labs/agent-beacon --pattern 'BeaconEndpointAgent-*-arm64.pkg*' --pattern update-manifest.json
+expected="$(awk '{print $1}' BeaconEndpointAgent-*-arm64.pkg.sha256)"
+actual="$(shasum -a 256 BeaconEndpointAgent-*-arm64.pkg | awk '{print $1}')"
+test "$expected" = "$actual"
+pkgutil --check-signature BeaconEndpointAgent-*-arm64.pkg
+xcrun stapler validate BeaconEndpointAgent-*-arm64.pkg
+spctl --assess --type install -vv BeaconEndpointAgent-*-arm64.pkg
+jq . update-manifest.json
+```
+
 If the workflow fails after the tag is pushed, do not create a second tag until
 the failure is understood. Fix the release workflow or source issue, then rerun
 the failed workflow for the same tag when possible. Delete and recreate a pushed

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ management (SIEM), log aggregation, and object storage destinations.
 Agent Beacon is designed for Security and IT teams to deploy and validate
 through standard MDM workflows.
 
+Version tags publish a signed, notarized, and stapled Apple Silicon endpoint
+`.pkg` to GitHub Releases for MDM/manual download. Homebrew and release archives
+remain available for CLI installs across supported macOS/Linux architectures.
+
 | MDM platform | Support path |
 | --- | --- |
 | [Fleet](https://docs.asymptotelabs.ai/cli/fleet) | macOS package and user-context deployment helpers |

--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -11,6 +11,12 @@ Stay up to date with the latest changes to the Agent Beacon CLI.
 
 ## June 2026
 
+### v0.0.76 · June 24, 2026
+
+- **Signed Apple Silicon endpoint package releases** · A pushed version tag now runs the release pipeline end-to-end: GoReleaser publishes CLI archives and updates Homebrew, then CI builds, signs, notarizes, staples, and uploads the Apple Silicon endpoint `.pkg`, `.sha256`, and `update-manifest.json` assets to GitHub Releases for direct MDM/manual download.
+- **Current bundled Vector in the macOS package** · The signed endpoint package includes `/opt/beacon/bin/vector` for Jamf/Fleet forwarder helpers and now targets Apple Silicon so Beacon can ship the current Vector macOS distribution rather than pinning all packages to an older dual-arch Vector release.
+- **Cursor and Claude session attribution fix** · Fixed a hook attribution edge case where Cursor-shaped hook payloads invoked through the default hook platform could be stamped as Claude, making a single Cursor session UUID appear under both Cursor and Claude in runtime logs and managed dashboards.
+
 ### v0.0.73 · June 21, 2026
 
 - **S3 token and cost analytics fields** · The S3 Vector forwarding template now preserves canonical `gen_ai.usage` and also emits top-level `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `reasoning_output_tokens`, and `cost_usd` fields so downstream warehouses can persist usage attribution reliably.

--- a/docs/cli/install.mdx
+++ b/docs/cli/install.mdx
@@ -24,6 +24,11 @@ beacon version 0.0.66
 
 Beacon releases publish macOS and Linux archives for `amd64` and `arm64` alongside Homebrew builds. For archive-based installs or source builds, see [Manual CLI Installation](/cli/manual-install).
 
+Apple Silicon endpoint package releases are attached to GitHub Releases as
+signed, notarized, and stapled `.pkg` assets for MDM or manual system installs.
+Use those package assets when you want `/opt/beacon`, the local collector
+LaunchDaemon, and the bundled Vector forwarder helpers installed together.
+
 ## Next steps
 
 After installing Beacon, configure the workflow you need:

--- a/docs/cli/manual-install.mdx
+++ b/docs/cli/manual-install.mdx
@@ -7,6 +7,12 @@ description: "Install the Beacon CLI from platform archives or build it from sou
 
 Beacon releases publish platform archives for macOS and Linux on `amd64` and `arm64`. Each archive includes the `beacon` CLI and the matching `beacon-otelcol` collector binary, with SHA-256 checksums published alongside the release.
 
+For managed endpoint rollouts on Apple Silicon Macs, GitHub Releases also attach
+a signed, notarized, and stapled `BeaconEndpointAgent-<version>-arm64.pkg`. The
+package installs Beacon under `/opt/beacon`, includes the collector and Vector
+binary, and is intended for MDM or root-managed system deployments rather than
+per-user CLI installs.
+
 ## Build from source
 
 To build the CLI directly from the Beacon repository:

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -16,6 +16,7 @@ The package builder assembles this payload:
 ```text
 /opt/beacon/bin/beacon
 /opt/beacon/bin/beacon-otelcol
+/opt/beacon/bin/vector
 /opt/beacon/scripts/install-endpoint.sh
 /opt/beacon/scripts/uninstall-endpoint.sh
 /opt/beacon/jamf/extension-attributes/*.sh
@@ -68,6 +69,13 @@ BEACON_VECTOR_BIN="$(command -v vector)" \
 NOTARYTOOL_PROFILE="beacon-notary-profile" \
   sh packaging/macos/build-signed-notarized-pkg.sh
 ```
+
+The CI release workflow publishes the signed endpoint package from pushed `v*`
+tags. GoReleaser still publishes multi-arch CLI tarballs for Homebrew and manual
+archive installs, while the signed/notarized/stapled endpoint `.pkg` is currently
+Apple Silicon only (`BeaconEndpointAgent-<version>-arm64.pkg`) so the package can
+include the current Vector macOS distribution. The workflow also uploads the
+package `.sha256` and `update-manifest.json` assets to the GitHub release.
 
 ## Manual Install
 


### PR DESCRIPTION
## Summary
- Document the validated tag-driven release workflow and package verification checklist.
- Add v0.0.76 CLI changelog notes for the Cursor/Claude attribution fix and signed Apple Silicon package assets.
- Clarify install/package docs around Homebrew/archive installs versus the signed Apple Silicon endpoint `.pkg` with bundled Vector.

## Verification
- Docs-only change; no code tests run.
- Read lints reported no diagnostics on edited docs.


Made with [Cursor](https://cursor.com)