### PR TITLE
Update s3 forwarding docs

### DIFF
--- a/docs/guides/jamf-anthropic-openai-cursor-mdm.mdx
+++ b/docs/guides/jamf-anthropic-openai-cursor-mdm.mdx
@@ -440,6 +440,23 @@ sudo launchctl print system/com.beacon.endpoint.s3-forwarder
 sudo tail -n 100 /tmp/com.beacon.endpoint.s3-forwarder.err
 ```
 
+If `launchctl` reports `Could not find service "com.beacon.endpoint.s3-forwarder"`,
+the S3 files may still be present but the optional LaunchDaemon is not loaded.
+When the saved S3 environment exists, rerun the packaged installer to rewrite
+the Vector config and plist and start the service:
+
+```bash
+sudo sh -c '. "/Library/Application Support/Beacon/Forwarders/s3-vector.env"; /opt/beacon/jamf/claude/s3/install-forwarder.sh'
+sudo launchctl print system/com.beacon.endpoint.s3-forwarder | egrep 'state =|pid =|last exit code'
+```
+
+Use the same command as a Jamf remediation policy for devices where this health
+check fails:
+
+```bash
+sudo launchctl print system/com.beacon.endpoint.s3-forwarder >/dev/null 2>&1
+```
+
 Verify that the env file has non-secret settings without printing credentials:
 
 ```bash

--- a/docs/guides/jamf-s3-mdm.mdx
+++ b/docs/guides/jamf-s3-mdm.mdx
@@ -446,13 +446,71 @@ sudo tail -n 100 /tmp/com.beacon.endpoint.s3-forwarder.err
 
 ### Forwarder Is Not Loaded
 
-Load it manually:
+If `launchctl` reports `Could not find service "com.beacon.endpoint.s3-forwarder"`,
+first confirm the managed files are still present:
+
+```bash
+ls -l /opt/beacon/bin/vector
+ls -l /opt/beacon/jamf/claude/s3/install-forwarder.sh
+ls -l "/Library/LaunchDaemons/com.beacon.endpoint.s3-forwarder.plist"
+ls -l "/Library/Application Support/Beacon/Forwarders/s3-vector.toml" \
+      "/Library/Application Support/Beacon/Forwarders/s3-vector.env"
+```
+
+If the plist exists, load it:
 
 ```bash
 sudo launchctl bootstrap system /Library/LaunchDaemons/com.beacon.endpoint.s3-forwarder.plist
+sudo launchctl print system/com.beacon.endpoint.s3-forwarder | egrep 'state =|pid =|last exit code'
 ```
 
-If launchd remains opaque, run Vector in the foreground:
+If the LaunchDaemon files exist but you want an idempotent repair, rerun the
+packaged S3 installer using the saved environment. This rewrites the Vector
+config, environment file, and plist, then starts the forwarder:
+
+```bash
+sudo sh -c '. "/Library/Application Support/Beacon/Forwarders/s3-vector.env"; /opt/beacon/jamf/claude/s3/install-forwarder.sh'
+```
+
+For Jamf remediation, scope a policy to devices where the S3 forwarder is not
+loaded:
+
+```bash
+sudo launchctl print system/com.beacon.endpoint.s3-forwarder >/dev/null 2>&1
+```
+
+Then run this script on those devices, or on all Beacon devices if the original
+S3 env file should already exist everywhere:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+ENV_PATH="/Library/Application Support/Beacon/Forwarders/s3-vector.env"
+INSTALLER="/opt/beacon/jamf/claude/s3/install-forwarder.sh"
+LABEL="com.beacon.endpoint.s3-forwarder"
+
+if [ ! -x "$INSTALLER" ]; then
+  echo "Beacon S3 installer missing: $INSTALLER" >&2
+  exit 1
+fi
+
+if [ ! -f "$ENV_PATH" ]; then
+  echo "S3 env file missing: $ENV_PATH; rerun the original S3 configuration policy" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+. "$ENV_PATH"
+set +a
+
+"$INSTALLER"
+
+launchctl print "system/$LABEL" | egrep 'state =|pid =|last exit code' || true
+```
+
+If launchd remains opaque after the repair, run Vector in the foreground:
 
 ```bash
 sudo /opt/beacon/jamf/claude/s3/run-forwarder.sh


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to operational runbooks; no application or infrastructure code is modified.
> 
> **Overview**
> Expands **Jamf S3 forwarder** troubleshooting when `launchctl` reports the `com.beacon.endpoint.s3-forwarder` service is missing—clarifying that on-disk S3/Vector files may still exist while the LaunchDaemon simply isn’t loaded.
> 
> Both **jamf-s3-mdm** and **jamf-anthropic-openai-cursor-mdm** now document rerunning `install-forwarder.sh` after sourcing `s3-vector.env` for an idempotent repair, optional `launchctl bootstrap`, and a one-liner health check suitable for scoping Jamf remediation policies. The Claude-focused S3 guide adds the shorter repair/remediation snippet; the dedicated **jamf-s3** guide adds file-presence checks and a full Jamf remediation bash script that validates installer/env paths before re-running the installer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e6bb49c36ac600d1812d00346245e8184139e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->