### PR TITLE
Update guide

### DIFF
--- a/docs/guides/jamf-anthropic-openai-cursor-mdm.mdx
+++ b/docs/guides/jamf-anthropic-openai-cursor-mdm.mdx
@@ -457,6 +457,37 @@ check fails:
 sudo launchctl print system/com.beacon.endpoint.s3-forwarder >/dev/null 2>&1
 ```
 
+Then run this script on those devices, or on all Beacon devices if the original
+S3 env file should already exist everywhere:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+ENV_PATH="/Library/Application Support/Beacon/Forwarders/s3-vector.env"
+INSTALLER="/opt/beacon/jamf/claude/s3/install-forwarder.sh"
+LABEL="com.beacon.endpoint.s3-forwarder"
+
+if [ ! -x "$INSTALLER" ]; then
+  echo "Beacon S3 installer missing: $INSTALLER" >&2
+  exit 1
+fi
+
+if [ ! -f "$ENV_PATH" ]; then
+  echo "S3 env file missing: $ENV_PATH; rerun the original S3 configuration policy" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+. "$ENV_PATH"
+set +a
+
+"$INSTALLER"
+
+launchctl print "system/$LABEL" | egrep 'state =|pid =|last exit code' || true
+```
+
 Verify that the env file has non-secret settings without printing credentials:
 
 ```bash


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no application or deployment logic modifications.
> 
> **Overview**
> The Jamf Anthropic/OpenAI/Cursor MDM guide’s **No S3 Objects** troubleshooting section now tells operators to run a follow-up script after the existing `launchctl` health check (or on all Beacon Macs when `s3-vector.env` should already be present).
> 
> The new bash snippet sources `/Library/Application Support/Beacon/Forwarders/s3-vector.env`, verifies `install-forwarder.sh` and the env file exist, reruns the packaged S3 forwarder installer, and prints forwarder `state`/`pid`/`last exit code` for validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265523ec8dd09950914d510695363fb7e61f9234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->