### PR TITLE
docs: add v0.0.78 self-update release notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,17 @@ spctl --assess --type install -vv BeaconEndpointAgent-*-arm64.pkg
 jq . update-manifest.json
 ```
 
+For releases that include endpoint self-update changes, validate the manual apply
+path from the prior installed package on an Apple Silicon Mac:
+
+```bash
+/opt/beacon/bin/beacon version
+sudo /opt/beacon/bin/beacon endpoint update --apply
+/opt/beacon/bin/beacon version
+/opt/beacon/bin/beacon endpoint status --system
+sudo tail -n 20 /var/log/beacon-agent/system.jsonl
+```
+
 If the workflow fails after the tag is pushed, do not create a second tag until
 the failure is understood. Fix the release workflow or source issue, then rerun
 the failed workflow for the same tag when possible. Delete and recreate a pushed

--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -11,7 +11,7 @@ Stay up to date with the latest changes to the Agent Beacon CLI.
 
 ## June 2026
 
-### Unreleased
+### v0.0.78 · June 25, 2026
 
 - **Check-only endpoint update monitoring** · Apple Silicon package installs can opt into a local `launchd` job that checks the release manifest every 10 minutes and writes local-only update status events to `system.jsonl`. This phase does not download or apply packages.
 - **Manual endpoint package apply** · Apple Silicon package installs can explicitly run `sudo /opt/beacon/bin/beacon endpoint update --apply` to download the signed package from the release manifest, verify its checksum/signature/notarization/staple, install it with Apple's `installer`, health-check it, and roll back the `/opt/beacon` tree if the new install is unhealthy.


### PR DESCRIPTION
## Summary
- Move the check-only/manual self-update notes into a v0.0.78 changelog entry.
- Add a release validation checklist for manual endpoint self-update apply.

## Verification
- Docs-only change; no code tests run.

Made with [Cursor](https://cursor.com)