### PR TITLE
feat(endpoint): enable auto updater daemon lifecycle

### DIFF
--- a/cli/beacon/cmd/endpoint_test.go
+++ b/cli/beacon/cmd/endpoint_test.go
@@ -1198,6 +1198,11 @@ func TestAutoUpdateModeIgnoresDestinationValidation(t *testing.T) {
 	if err := setConfigAutoUpdateModeAt(path, "off"); err != nil {
 		t.Fatalf("setConfigAutoUpdateModeAt: %v", err)
 	}
+	if info, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	} else if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("config permissions = %v, want 0600", got)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)

--- a/cli/beacon/cmd/endpoint_update_service.go
+++ b/cli/beacon/cmd/endpoint_update_service.go
@@ -228,6 +228,20 @@ func runScheduledUpdate(parent context.Context) error {
 		return nil
 	}
 	sleepJitter()
+	mode = selfupdate.ResolveMode(configAutoUpdateMode())
+	if mode == selfupdate.ModeOff {
+		current := version.GetVersion()
+		res := selfupdate.CheckResult{Mode: mode}
+		_ = selfupdate.EmitCheckEvent(selfupdate.CheckEventOptions{
+			Result:       res,
+			Action:       selfupdate.EventUnsupported,
+			Reason:       "mode_off_after_jitter",
+			LogPath:      endpointSystemLogPath(),
+			AgentVersion: current,
+		})
+		fmt.Println("Update checks were disabled during jitter; nothing to do.")
+		return nil
+	}
 
 	current := version.GetVersion()
 	if mode == selfupdate.ModeAuto {

--- a/cli/beacon/cmd/endpoint_update_service.go
+++ b/cli/beacon/cmd/endpoint_update_service.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -22,9 +24,14 @@ var endpointUpdateServiceOpts struct {
 	scheduled bool
 }
 
+// jitterEnv overrides the maximum scheduled-run jitter (seconds). Default 1800;
+// 0 disables jitter for tests/manual diagnostics.
+const jitterEnv = "BEACON_UPDATE_JITTER_SECONDS"
+const defaultJitterSeconds = 1800
+
 var endpointUpdateEnableCmd = &cobra.Command{
 	Use:          "enable",
-	Short:        "Enable check-only update monitoring",
+	Short:        "Enable endpoint update monitoring",
 	SilenceUsage: true,
 	RunE:         runUpdateEnable,
 }
@@ -43,13 +50,25 @@ var endpointUpdateStatusCmd = &cobra.Command{
 	RunE:         runUpdateStatus,
 }
 
+// endpointUpdateInstallDaemonCmd is invoked by package postinstall. It
+// reconciles the launchd job with the resolved mode without changing stored
+// config, so explicit off/check-only/auto choices survive package upgrades.
+var endpointUpdateInstallDaemonCmd = &cobra.Command{
+	Use:          "install-daemon",
+	Short:        "Internal: reconcile the updater launchd job with configured mode",
+	Hidden:       true,
+	SilenceUsage: true,
+	RunE:         runUpdateInstallDaemon,
+}
+
 func init() {
 	endpointUpdateCmd.AddCommand(endpointUpdateEnableCmd)
 	endpointUpdateCmd.AddCommand(endpointUpdateDisableCmd)
 	endpointUpdateCmd.AddCommand(endpointUpdateStatusCmd)
+	endpointUpdateCmd.AddCommand(endpointUpdateInstallDaemonCmd)
 	endpointUpdateEnableCmd.Flags().BoolVar(&endpointUpdateServiceOpts.checkOnly, "check-only", false, "Enable periodic checks without applying updates")
-	// The launchd job runs `update --scheduled`; Phase 1 is check-only. Hidden
-	// from the user-facing help.
+	// The launchd job runs `update --scheduled`; it resolves the mode and either
+	// checks only or applies. Hidden from user-facing help.
 	endpointUpdateCmd.Flags().BoolVar(&endpointUpdateServiceOpts.scheduled, "scheduled", false, "Internal: run as the scheduled updater job")
 	_ = endpointUpdateCmd.Flags().MarkHidden("scheduled")
 }
@@ -81,6 +100,10 @@ func setConfigAutoUpdateModeAt(path, mode string) error {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
+	perm := os.FileMode(0644)
+	if info, err := os.Stat(path); err == nil {
+		perm = info.Mode().Perm()
+	}
 	autoUpdate, err := json.Marshal(endpointconfig.AutoUpdate{Mode: mode})
 	if err != nil {
 		return err
@@ -90,7 +113,7 @@ func setConfigAutoUpdateModeAt(path, mode string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, out, 0644)
+	return os.WriteFile(path, out, perm)
 }
 
 func requireRootForUpdater() error {
@@ -107,10 +130,10 @@ func runUpdateEnable(cmd *cobra.Command, args []string) error {
 	if err := requireSystemPackageForUpdater(detectUpdateInstall()); err != nil {
 		return err
 	}
-	if !endpointUpdateServiceOpts.checkOnly {
-		return fmt.Errorf("phase 1 supports check-only monitoring only; rerun with --check-only")
+	mode := selfupdate.ModeAuto
+	if endpointUpdateServiceOpts.checkOnly {
+		mode = selfupdate.ModeCheckOnly
 	}
-	mode := selfupdate.ModeCheckOnly
 	if err := setConfigAutoUpdateMode(string(mode)); err != nil {
 		return fmt.Errorf("write auto-update config: %w", err)
 	}
@@ -121,7 +144,7 @@ func runUpdateEnable(cmd *cobra.Command, args []string) error {
 	if err := mgr.Load(); err != nil {
 		return fmt.Errorf("load updater job: %w", err)
 	}
-	fmt.Printf("Update checks enabled (mode: %s).\n", mode)
+	fmt.Printf("Endpoint updater enabled (mode: %s).\n", mode)
 	return nil
 }
 
@@ -161,8 +184,34 @@ func runUpdateStatus(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runScheduledUpdate is the entrypoint the launchd job calls. Phase 1 only
-// performs check-only monitoring and writes a local system-log event.
+func runUpdateInstallDaemon(cmd *cobra.Command, args []string) error {
+	if err := requireRootForUpdater(); err != nil {
+		return err
+	}
+	if err := requireSystemPackageForUpdater(detectUpdateInstall()); err != nil {
+		return err
+	}
+	mode := selfupdate.ResolveMode(configAutoUpdateMode())
+	mgr := service.UpdaterManager{}
+	if mode == selfupdate.ModeOff {
+		_ = mgr.Unload()
+		_ = os.Remove(mgr.PlistPath())
+		fmt.Println("Auto-update is off; updater daemon not installed.")
+		return nil
+	}
+	if _, err := mgr.WritePlist(selfupdate.SystemBeaconPath()); err != nil {
+		return fmt.Errorf("write updater plist: %w", err)
+	}
+	if err := mgr.Load(); err != nil {
+		return fmt.Errorf("load updater job: %w", err)
+	}
+	fmt.Printf("Background updater installed (mode: %s).\n", mode)
+	return nil
+}
+
+// runScheduledUpdate is the entrypoint the launchd job calls. It resolves the
+// effective mode and either checks only or applies, after a randomized delay to
+// spread fleet-wide release-manifest/package fetches.
 func runScheduledUpdate(parent context.Context) error {
 	mode := selfupdate.ResolveMode(configAutoUpdateMode())
 	if mode == selfupdate.ModeOff {
@@ -178,23 +227,15 @@ func runScheduledUpdate(parent context.Context) error {
 		fmt.Println("Update checks are off; nothing to do.")
 		return nil
 	}
-	if mode != selfupdate.ModeCheckOnly {
-		current := version.GetVersion()
-		res := selfupdate.CheckResult{Mode: mode}
-		if err := selfupdate.EmitCheckEvent(selfupdate.CheckEventOptions{
-			Result:       res,
-			Action:       selfupdate.EventUnsupported,
-			Reason:       "mode_not_supported_in_phase1",
-			LogPath:      endpointSystemLogPath(),
-			AgentVersion: current,
-		}); err != nil {
-			return fmt.Errorf("write update check event: %w", err)
-		}
-		fmt.Printf("Phase 1 scheduled updater supports check-only mode only (resolved: %s).\n", mode)
-		return nil
-	}
+	sleepJitter()
 
 	current := version.GetVersion()
+	if mode == selfupdate.ModeAuto {
+		return applyUpdate(parent, current)
+	}
+	if mode != selfupdate.ModeCheckOnly {
+		return fmt.Errorf("unsupported update mode %q", mode)
+	}
 	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	defer cancel()
 	res, err := selfupdate.CheckWithMode(ctx, current, configAutoUpdateMode())
@@ -222,6 +263,19 @@ func runScheduledUpdate(parent context.Context) error {
 		fmt.Printf("Update available: %s (current %s). check-only mode; not applying.\n", res.LatestVersion, res.CurrentVersion)
 	}
 	return nil
+}
+
+func sleepJitter() {
+	max := defaultJitterSeconds
+	if v := os.Getenv(jitterEnv); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			max = n
+		}
+	}
+	if max <= 0 {
+		return
+	}
+	time.Sleep(time.Duration(rand.Intn(max)) * time.Second)
 }
 
 func endpointSystemLogPath() string {

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -14,6 +14,7 @@ import (
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/diagnostics"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/harness"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/selfupdate"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/service"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/writer"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/ingest"
@@ -283,8 +284,33 @@ func Repair(opts InstallOptions) (InstallResult, error) {
 	result, err := Install(opts)
 	if err != nil {
 		restoreFile(configPath, configSnapshot)
+		return result, err
 	}
-	return result, err
+	if !opts.UserMode {
+		if err := reconcileUpdaterFromConfig(opts.LogPath); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func reconcileUpdaterFromConfig(logPath string) error {
+	cfg := loadOrDefault(false, logPath)
+	localMode := ""
+	if cfg.AutoUpdate != nil {
+		localMode = cfg.AutoUpdate.Mode
+	}
+	mode := selfupdate.ResolveMode(localMode)
+	mgr := service.UpdaterManager{}
+	if mode == selfupdate.ModeOff {
+		_ = mgr.Unload()
+		_ = os.Remove(mgr.PlistPath())
+		return nil
+	}
+	if _, err := mgr.WritePlist(selfupdate.SystemBeaconPath()); err != nil {
+		return err
+	}
+	return mgr.Load()
 }
 
 func GetStatus(userMode bool, logPath string) Status {

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -280,6 +280,12 @@ func Uninstall(opts UninstallOptions) error {
 func Repair(opts InstallOptions) (InstallResult, error) {
 	configPath := endpointconfig.ConfigPath(opts.UserMode)
 	configSnapshot := snapshotFile(configPath)
+	priorAutoUpdateMode := ""
+	if !opts.UserMode {
+		if mode, err := autoUpdateModeFromConfigFile(configPath); err == nil {
+			priorAutoUpdateMode = mode
+		}
+	}
 	_ = Uninstall(UninstallOptions{UserMode: opts.UserMode, LogPath: opts.LogPath, KeepLogs: true, KeepConfig: true, KeepUpdater: true})
 	result, err := Install(opts)
 	if err != nil {
@@ -287,6 +293,11 @@ func Repair(opts InstallOptions) (InstallResult, error) {
 		return result, err
 	}
 	if !opts.UserMode {
+		if priorAutoUpdateMode != "" {
+			if err := setAutoUpdateModeInConfigFile(configPath, priorAutoUpdateMode); err != nil {
+				return result, err
+			}
+		}
 		if err := reconcileUpdaterFromConfig(opts.LogPath); err != nil {
 			return result, err
 		}
@@ -327,6 +338,31 @@ func autoUpdateModeFromConfigFile(path string) (string, error) {
 		return "", nil
 	}
 	return partial.AutoUpdate.Mode, nil
+}
+
+func setAutoUpdateModeInConfigFile(path, mode string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	autoUpdate, err := json.Marshal(endpointconfig.AutoUpdate{Mode: mode})
+	if err != nil {
+		return err
+	}
+	raw["auto_update"] = autoUpdate
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return err
+	}
+	perm := os.FileMode(0644)
+	if info, err := os.Stat(path); err == nil {
+		perm = info.Mode().Perm()
+	}
+	return os.WriteFile(path, out, perm)
 }
 
 func GetStatus(userMode bool, logPath string) Status {

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -25,6 +25,11 @@ var (
 	writeCollectorConfig = endpointcollector.WriteConfig
 	saveEndpointConfig   = endpointconfig.Save
 	appendInstallEvent   = writer.AppendEvent
+	removeUpdaterJob     = func() {
+		updater := service.UpdaterManager{}
+		_ = updater.Unload()
+		_ = os.Remove(updater.PlistPath())
+	}
 )
 
 type InstallOptions struct {
@@ -42,10 +47,11 @@ type InstallOptions struct {
 }
 
 type UninstallOptions struct {
-	UserMode   bool
-	LogPath    string
-	KeepLogs   bool
-	KeepConfig bool
+	UserMode    bool
+	LogPath     string
+	KeepLogs    bool
+	KeepConfig  bool
+	KeepUpdater bool
 }
 
 type InstallResult struct {
@@ -246,10 +252,8 @@ func Uninstall(opts UninstallOptions) error {
 	cfg := loadOrDefault(opts.UserMode, opts.LogPath)
 	manager := service.Manager{UserMode: cfg.UserMode}
 	_ = manager.Unload()
-	if !cfg.UserMode {
-		updater := service.UpdaterManager{}
-		_ = updater.Unload()
-		_ = os.Remove(updater.PlistPath())
+	if !cfg.UserMode && !opts.KeepUpdater {
+		removeUpdaterJob()
 	}
 	manifest, _ := ReadManifest(cfg.UserMode)
 	if !opts.KeepConfig {
@@ -275,7 +279,7 @@ func Uninstall(opts UninstallOptions) error {
 func Repair(opts InstallOptions) (InstallResult, error) {
 	configPath := endpointconfig.ConfigPath(opts.UserMode)
 	configSnapshot := snapshotFile(configPath)
-	_ = Uninstall(UninstallOptions{UserMode: opts.UserMode, LogPath: opts.LogPath, KeepLogs: true, KeepConfig: true})
+	_ = Uninstall(UninstallOptions{UserMode: opts.UserMode, LogPath: opts.LogPath, KeepLogs: true, KeepConfig: true, KeepUpdater: true})
 	result, err := Install(opts)
 	if err != nil {
 		restoreFile(configPath, configSnapshot)

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -246,6 +246,11 @@ func Uninstall(opts UninstallOptions) error {
 	cfg := loadOrDefault(opts.UserMode, opts.LogPath)
 	manager := service.Manager{UserMode: cfg.UserMode}
 	_ = manager.Unload()
+	if !cfg.UserMode {
+		updater := service.UpdaterManager{}
+		_ = updater.Unload()
+		_ = os.Remove(updater.PlistPath())
+	}
 	manifest, _ := ReadManifest(cfg.UserMode)
 	if !opts.KeepConfig {
 		restoreBackups(manifest.Backups)

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -26,6 +26,7 @@ var (
 	writeCollectorConfig = endpointcollector.WriteConfig
 	saveEndpointConfig   = endpointconfig.Save
 	appendInstallEvent   = writer.AppendEvent
+	detectUpdaterInstall = selfupdate.DetectInstall
 	removeUpdaterJob     = func() {
 		updater := service.UpdaterManager{}
 		_ = updater.Unload()
@@ -306,6 +307,9 @@ func Repair(opts InstallOptions) (InstallResult, error) {
 }
 
 func reconcileUpdaterFromConfig(logPath string) error {
+	if !detectUpdaterInstall().SupportsSeamlessUpdate() {
+		return nil
+	}
 	localMode := ""
 	if mode, err := autoUpdateModeFromConfigFile(endpointconfig.ConfigPath(false)); err == nil {
 		localMode = mode

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -295,10 +295,9 @@ func Repair(opts InstallOptions) (InstallResult, error) {
 }
 
 func reconcileUpdaterFromConfig(logPath string) error {
-	cfg := loadOrDefault(false, logPath)
 	localMode := ""
-	if cfg.AutoUpdate != nil {
-		localMode = cfg.AutoUpdate.Mode
+	if mode, err := autoUpdateModeFromConfigFile(endpointconfig.ConfigPath(false)); err == nil {
+		localMode = mode
 	}
 	mode := selfupdate.ResolveMode(localMode)
 	mgr := service.UpdaterManager{}
@@ -311,6 +310,23 @@ func reconcileUpdaterFromConfig(logPath string) error {
 		return err
 	}
 	return mgr.Load()
+}
+
+func autoUpdateModeFromConfigFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	var partial struct {
+		AutoUpdate *endpointconfig.AutoUpdate `json:"auto_update"`
+	}
+	if err := json.Unmarshal(data, &partial); err != nil {
+		return "", err
+	}
+	if partial.AutoUpdate == nil {
+		return "", nil
+	}
+	return partial.AutoUpdate.Mode, nil
 }
 
 func GetStatus(userMode bool, logPath string) Status {

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -452,6 +452,9 @@ func buildConfig(opts InstallOptions) endpointconfig.Config {
 		logPath = writer.DefaultPath(opts.UserMode)
 	}
 	cfg := endpointconfig.Default(opts.UserMode, logPath)
+	if mode, err := autoUpdateModeFromConfigFile(endpointconfig.ConfigPath(opts.UserMode)); err == nil && mode != "" {
+		cfg.AutoUpdate = &endpointconfig.AutoUpdate{Mode: mode}
+	}
 	if opts.Harnesses != nil {
 		cfg.Harnesses = opts.Harnesses
 	}

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -16,6 +16,7 @@ import (
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/harness"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/selfupdate"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/service"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/writer"
 )
@@ -344,6 +345,17 @@ func TestAutoUpdateModeFromConfigFileIgnoresDestinationValidation(t *testing.T) 
 	}
 	if mode != "check-only" {
 		t.Fatalf("mode after set = %q, want check-only", mode)
+	}
+}
+
+func TestReconcileUpdaterSkipsNonPackageInstalls(t *testing.T) {
+	oldDetect := detectUpdaterInstall
+	t.Cleanup(func() { detectUpdaterInstall = oldDetect })
+	detectUpdaterInstall = func() selfupdate.Install {
+		return selfupdate.Install{Kind: selfupdate.InstallHomebrew, BinaryPath: "/opt/homebrew/bin/beacon"}
+	}
+	if err := reconcileUpdaterFromConfig(filepath.Join(t.TempDir(), "runtime.jsonl")); err != nil {
+		t.Fatalf("reconcileUpdaterFromConfig should ignore non-package install, got %v", err)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -299,6 +299,27 @@ func TestWriteReadManifestRoundTrip(t *testing.T) {
 	}
 }
 
+func TestAutoUpdateModeFromConfigFileIgnoresDestinationValidation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{
+  "user_mode": false,
+  "log_path": "/var/log/beacon-agent/runtime.jsonl",
+  "collector": {"grpc_port":4317,"http_port":4318},
+  "harnesses": ["claude"],
+  "destinations": {"splunk_hec": {"endpoint": "https://splunk.example"}},
+  "auto_update": {"mode": "auto"}
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mode, err := autoUpdateModeFromConfigFile(path)
+	if err != nil {
+		t.Fatalf("autoUpdateModeFromConfigFile: %v", err)
+	}
+	if mode != "auto" {
+		t.Fatalf("mode = %q, want auto", mode)
+	}
+}
+
 func TestDiscoverAndRestoreBackups(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "settings.json")

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -1,6 +1,7 @@
 package lifecycle
 
 import (
+	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
@@ -317,6 +318,32 @@ func TestAutoUpdateModeFromConfigFileIgnoresDestinationValidation(t *testing.T) 
 	}
 	if mode != "auto" {
 		t.Fatalf("mode = %q, want auto", mode)
+	}
+	if err := setAutoUpdateModeInConfigFile(path, "check-only"); err != nil {
+		t.Fatalf("setAutoUpdateModeInConfigFile: %v", err)
+	}
+	if info, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	} else if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("permissions = %v, want 0600", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := raw["destinations"]; !ok {
+		t.Fatalf("destinations were not preserved: %s", data)
+	}
+	mode, err = autoUpdateModeFromConfigFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode != "check-only" {
+		t.Fatalf("mode after set = %q, want check-only", mode)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -88,6 +88,22 @@ func TestBuildConfigAppliesInstallOptions(t *testing.T) {
 	}
 }
 
+func TestBuildConfigPreservesAutoUpdateMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configPath := endpointconfig.ConfigPath(true)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"auto_update":{"mode":"check-only"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := buildConfig(InstallOptions{UserMode: true})
+	if cfg.AutoUpdate == nil || cfg.AutoUpdate.Mode != "check-only" {
+		t.Fatalf("AutoUpdate = %#v, want check-only", cfg.AutoUpdate)
+	}
+}
+
 func TestBuildConfigPreservesExplicitEmptyHarnesses(t *testing.T) {
 	cfg := buildConfig(InstallOptions{UserMode: true, Harnesses: []string{}})
 	if cfg.Harnesses == nil || len(cfg.Harnesses) != 0 {

--- a/cli/beacon/internal/endpoint/service/updater.go
+++ b/cli/beacon/internal/endpoint/service/updater.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 )
 
-// UpdaterLabel is the launchd label for the periodic update-check job. Phase 1
-// is check-only and does not apply package updates.
+// UpdaterLabel is the launchd label for the periodic endpoint updater job.
 const UpdaterLabel = "com.beacon.endpoint.updater"
 
-// UpdaterManager manages the update-check launchd job. Unlike the collector
+// UpdaterManager manages the endpoint updater launchd job. Unlike the collector
 // service it is system-only and runs on a schedule rather than KeepAlive.
 type UpdaterManager struct{}
 
@@ -78,9 +77,8 @@ func (m UpdaterManager) Status() Status {
 	return status
 }
 
-// updaterPlist renders the check-only LaunchDaemon. Phase 1 runs every ten
-// minutes so update detection can be dogfooded quickly without install risk.
-// It does not RunAtLoad and is not KeepAlive (one-shot scheduled job).
+// updaterPlist renders the updater LaunchDaemon. It runs daily and does not
+// RunAtLoad or KeepAlive; each invocation resolves the configured mode.
 func updaterPlist(label, program string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -93,11 +91,15 @@ func updaterPlist(label, program string) string {
     <string>%s</string>
     <string>endpoint</string>
     <string>update</string>
-    <string>--check</string>
     <string>--scheduled</string>
   </array>
-  <key>StartInterval</key>
-  <integer>600</integer>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>3</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
   <key>RunAtLoad</key>
   <false/>
   <key>StandardOutPath</key>

--- a/cli/beacon/internal/endpoint/service/updater_test.go
+++ b/cli/beacon/internal/endpoint/service/updater_test.go
@@ -11,10 +11,12 @@ func TestUpdaterPlistContent(t *testing.T) {
 	for _, want := range []string{
 		"<string>com.beacon.endpoint.updater</string>",
 		"<string>/opt/beacon/bin/beacon</string>",
-		"<string>--check</string>",
 		"<string>--scheduled</string>",
-		"<key>StartInterval</key>",
-		"<integer>600</integer>",
+		"<key>StartCalendarInterval</key>",
+		"<key>Hour</key>",
+		"<integer>3</integer>",
+		"<key>Minute</key>",
+		"<integer>0</integer>",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("plist missing %q", want)
@@ -23,6 +25,9 @@ func TestUpdaterPlistContent(t *testing.T) {
 	// One-shot scheduled job: must not RunAtLoad or KeepAlive.
 	if strings.Contains(out, "<key>KeepAlive</key>") {
 		t.Errorf("updater plist should not set KeepAlive")
+	}
+	if strings.Contains(out, "<string>--check</string>") {
+		t.Errorf("updater plist should let scheduled mode resolve check/apply behavior")
 	}
 	if !strings.Contains(out, "<key>RunAtLoad</key>\n  <false/>") {
 		t.Errorf("updater plist should set RunAtLoad false")

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -40,7 +40,10 @@ if command -v launchctl >/dev/null 2>&1; then
   }
   restart_optional_forwarder "com.beacon.endpoint.falcon-forwarder" "/Library/LaunchDaemons/com.beacon.endpoint.falcon-forwarder.plist"
   restart_optional_forwarder "com.beacon.endpoint.s3-forwarder" "/Library/LaunchDaemons/com.beacon.endpoint.s3-forwarder.plist"
-  "${BEACON_BIN:-/opt/beacon/bin/beacon}" endpoint update install-daemon >/dev/null 2>&1 || true
+  "${BEACON_BIN:-/opt/beacon/bin/beacon}" endpoint update install-daemon || {
+    echo "Error: could not reconcile Beacon endpoint updater daemon" >&2
+    exit 1
+  }
 fi
 
 exit 0

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -40,6 +40,7 @@ if command -v launchctl >/dev/null 2>&1; then
   }
   restart_optional_forwarder "com.beacon.endpoint.falcon-forwarder" "/Library/LaunchDaemons/com.beacon.endpoint.falcon-forwarder.plist"
   restart_optional_forwarder "com.beacon.endpoint.s3-forwarder" "/Library/LaunchDaemons/com.beacon.endpoint.s3-forwarder.plist"
+  "${BEACON_BIN:-/opt/beacon/bin/beacon}" endpoint update install-daemon >/dev/null 2>&1 || true
 fi
 
 exit 0

--- a/packaging/macos/scripts/preinstall
+++ b/packaging/macos/scripts/preinstall
@@ -6,6 +6,7 @@ set -eu
 if command -v launchctl >/dev/null 2>&1; then
   launchctl bootout system/com.beacon.endpoint.collector >/dev/null 2>&1 || true
   launchctl bootout system/com.beacon.endpoint.falcon-forwarder >/dev/null 2>&1 || true
+  launchctl bootout system/com.beacon.endpoint.updater >/dev/null 2>&1 || true
 fi
 
 exit 0

--- a/packaging/macos/scripts/preinstall
+++ b/packaging/macos/scripts/preinstall
@@ -6,7 +6,6 @@ set -eu
 if command -v launchctl >/dev/null 2>&1; then
   launchctl bootout system/com.beacon.endpoint.collector >/dev/null 2>&1 || true
   launchctl bootout system/com.beacon.endpoint.falcon-forwarder >/dev/null 2>&1 || true
-  launchctl bootout system/com.beacon.endpoint.updater >/dev/null 2>&1 || true
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
- Allow `beacon endpoint update enable` to opt into apply-capable `auto` mode while preserving `--check-only`.
- Change the updater LaunchDaemon from 10-minute check-only polling to a daily scheduled job with in-process jitter that resolves `off` / `check-only` / `auto` at runtime.
- Add package lifecycle reconciliation: preinstall boots out the updater, postinstall reconciles it based on configured mode, and endpoint uninstall removes the updater job/plist.

## Scope boundaries
- Default remains `off`; package installs do not enable the updater unless config/managed profile already says `check-only` or `auto`.
- No docs/runbook changes in this PR.

## Verification
- `cd cli/beacon && go test ./cmd -run 'TestEndpointUpdate|TestRequireSystemPackageForUpdater|TestAutoUpdateMode|TestRunEndpointUpdate|TestCompletionAndDocsCommandsRegistered'`
- `cd cli/beacon && go test ./internal/endpoint/service ./internal/endpoint/lifecycle ./internal/endpoint/selfupdate`
- `sh packaging/macos/test-endpoint-scripts.sh`
- `cd cli/beacon && go test ./internal/endpoint/...`

Note: an attempted `go test ./cmd -run '^$'` hung in the shell harness before starting `go test` (stuck in shell `cat`), so it was terminated; focused command tests passed.

Made with [Cursor](https://cursor.com)