### PR TITLE
fix(endpoint): tolerate CLT-only stapler during self-update

### DIFF
--- a/cli/beacon/internal/endpoint/selfupdate/apply.go
+++ b/cli/beacon/internal/endpoint/selfupdate/apply.go
@@ -291,8 +291,10 @@ func verifySHA256(path, want string) error {
 	return nil
 }
 
-// verifyGatekeeper confirms the .pkg is a Developer ID Installer-signed,
-// notarized, and stapled package before it is run.
+// verifyGatekeeper confirms the .pkg is Developer ID Installer-signed and
+// accepted by Gatekeeper before it is run. stapler validation is best-effort:
+// endpoint machines commonly have only Command Line Tools installed, where the
+// stapler shim exists but refuses to run without full Xcode.
 func (a *Applier) verifyGatekeeper(ctx context.Context, pkgPath, teamID string) error {
 	run := a.runner()
 	out, err := run(ctx, "pkgutil", "--check-signature", pkgPath)
@@ -303,12 +305,22 @@ func (a *Applier) verifyGatekeeper(ctx context.Context, pkgPath, teamID string) 
 		return fmt.Errorf("package signature does not match expected team id %s", teamID)
 	}
 	if out, err := run(ctx, "stapler", "validate", pkgPath); err != nil {
-		return fmt.Errorf("stapler validate: %s: %w", strings.TrimSpace(out), err)
+		if !staplerUnavailable(out, err) {
+			return fmt.Errorf("stapler validate: %s: %w", strings.TrimSpace(out), err)
+		}
 	}
 	if out, err := run(ctx, "spctl", "--assess", "--type", "install", "-vv", pkgPath); err != nil {
 		return fmt.Errorf("spctl assessment failed: %s: %w", strings.TrimSpace(out), err)
 	}
 	return nil
+}
+
+func staplerUnavailable(out string, err error) bool {
+	msg := strings.ToLower(strings.TrimSpace(out + " " + err.Error()))
+	return strings.Contains(msg, "requires xcode") ||
+		strings.Contains(msg, "command line tools instance") ||
+		strings.Contains(msg, "executable file not found") ||
+		strings.Contains(msg, "no such file or directory")
 }
 
 // install applies the package. Production runs the macOS installer into "/";

--- a/cli/beacon/internal/endpoint/selfupdate/apply_test.go
+++ b/cli/beacon/internal/endpoint/selfupdate/apply_test.go
@@ -217,6 +217,50 @@ func TestApplyGatekeeperAbortsBeforeInstall(t *testing.T) {
 	}
 }
 
+func TestVerifyGatekeeperSkipsUnavailableStapler(t *testing.T) {
+	a := NewApplier("0.0.1")
+	var calls []string
+	a.run = func(ctx context.Context, name string, args ...string) (string, error) {
+		calls = append(calls, name)
+		switch name {
+		case "pkgutil":
+			return "Developer ID Installer: Example (TEAMID)", nil
+		case "stapler":
+			return "xcode-select: error: tool 'stapler' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance", fmt.Errorf("exit status 1")
+		case "spctl":
+			return "accepted", nil
+		default:
+			return "", nil
+		}
+	}
+
+	if err := a.verifyGatekeeper(context.Background(), filepath.Join(t.TempDir(), "Beacon.pkg"), "TEAMID"); err != nil {
+		t.Fatalf("verifyGatekeeper should skip unavailable stapler, got %v", err)
+	}
+	if strings.Join(calls, ",") != "pkgutil,stapler,spctl" {
+		t.Fatalf("calls = %v, want pkgutil, stapler, spctl", calls)
+	}
+}
+
+func TestVerifyGatekeeperFailsStaplerValidationFailure(t *testing.T) {
+	a := NewApplier("0.0.1")
+	a.run = func(ctx context.Context, name string, args ...string) (string, error) {
+		switch name {
+		case "pkgutil":
+			return "Developer ID Installer: Example (TEAMID)", nil
+		case "stapler":
+			return "The validate action worked! The staple and validate action failed!", fmt.Errorf("exit status 65")
+		default:
+			return "", nil
+		}
+	}
+
+	err := a.verifyGatekeeper(context.Background(), filepath.Join(t.TempDir(), "Beacon.pkg"), "TEAMID")
+	if err == nil || !strings.Contains(err.Error(), "stapler validate") {
+		t.Fatalf("verifyGatekeeper error = %v, want stapler validation failure", err)
+	}
+}
+
 func TestApplyRestartsCollectorBeforeHealthCheck(t *testing.T) {
 	artifact, sha := makeBeaconTarball(t, "9.9.9")
 	srv := manifestServer(t, "9.9.9", sha, artifact)


### PR DESCRIPTION
## Summary
- Treat unavailable `stapler` on Command Line Tools-only Macs as a best-effort validation skip.
- Keep `pkgutil --check-signature` and `spctl --assess --type install` as required package checks.
- Add regression tests for CLT-only stapler output and real stapler validation failures.

## Test plan
- `cd cli/beacon && go test ./internal/endpoint/selfupdate`


Made with [Cursor](https://cursor.com)