### PR TITLE
fix(endpoint): make launchd restarts idempotent

### DIFF
--- a/cli/beacon/internal/endpoint/selfupdate/apply.go
+++ b/cli/beacon/internal/endpoint/selfupdate/apply.go
@@ -445,9 +445,7 @@ func (a *Applier) restartCollector() error {
 	if a.restart != nil {
 		return a.restart()
 	}
-	mgr := service.Manager{UserMode: false}
-	_ = mgr.Unload()
-	return mgr.Load()
+	return service.Manager{UserMode: false}.Restart()
 }
 
 // versionLineMatches reports whether `beacon version` output

--- a/cli/beacon/internal/endpoint/service/service.go
+++ b/cli/beacon/internal/endpoint/service/service.go
@@ -72,20 +72,7 @@ func (m Manager) Load() error {
 	if err != nil {
 		return err
 	}
-	domain := serviceDomain(m.UserMode)
-	out, err := runLaunchctlCommand("bootstrap", domain, path)
-	if err == nil {
-		return nil
-	}
-	text := strings.TrimSpace(out)
-	if strings.Contains(text, "already bootstrapped") {
-		target := domain + "/" + m.Label()
-		if err := runLaunchctlWithContext(domain, m.Label(), "", "bootout", target); err != nil {
-			return err
-		}
-		return runLaunchctlWithContext(domain, m.Label(), path, "bootstrap", domain, path)
-	}
-	return launchctlError(text, err, domain, m.Label(), path, "bootstrap", domain, path)
+	return loadLaunchdJob(serviceDomain(m.UserMode), m.Label(), path)
 }
 
 func (m Manager) Unload() error {
@@ -94,6 +81,24 @@ func (m Manager) Unload() error {
 	}
 	target := serviceDomain(m.UserMode) + "/" + m.Label()
 	return runLaunchctlWithContext(serviceDomain(m.UserMode), m.Label(), "", "bootout", target)
+}
+
+func (m Manager) Restart() error {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+	domain := serviceDomain(m.UserMode)
+	label := m.Label()
+	target := domain + "/" + label
+	out, err := runLaunchctlCommand("kickstart", "-k", target)
+	if err == nil {
+		return nil
+	}
+	text := strings.TrimSpace(out)
+	if launchctlNoSuchProcess(text) {
+		return m.Load()
+	}
+	return launchctlError(text, err, domain, label, "", "kickstart", "-k", target)
 }
 
 func (m Manager) Status() Status {
@@ -123,10 +128,49 @@ func runLaunchctlWithContext(domain, label, plistPath string, args ...string) er
 		return nil
 	}
 	text := strings.TrimSpace(out)
-	if strings.Contains(text, "No such process") {
+	if launchctlNoSuchProcess(text) {
 		return nil
 	}
 	return launchctlError(text, err, domain, label, plistPath, args...)
+}
+
+func launchctlNoSuchProcess(text string) bool {
+	return strings.Contains(text, "No such process") || strings.Contains(text, "Could not find service")
+}
+
+func loadLaunchdJob(domain, label, plistPath string) error {
+	out, err := runLaunchctlCommand("bootstrap", domain, plistPath)
+	if err == nil {
+		return nil
+	}
+	text := strings.TrimSpace(out)
+	if !launchdJobAppearsLoaded(text, domain, label) {
+		return launchctlError(text, err, domain, label, plistPath, "bootstrap", domain, plistPath)
+	}
+	target := domain + "/" + label
+	if err := runLaunchctlWithContext(domain, label, "", "bootout", target); err != nil {
+		return err
+	}
+	if out, err := runLaunchctlCommand("bootstrap", domain, plistPath); err != nil {
+		text := strings.TrimSpace(out)
+		if launchdJobAppearsLoaded(text, domain, label) {
+			return nil
+		}
+		return launchctlError(text, err, domain, label, plistPath, "bootstrap", domain, plistPath)
+	}
+	return nil
+}
+
+func launchdJobAppearsLoaded(bootstrapOutput, domain, label string) bool {
+	text := strings.TrimSpace(bootstrapOutput)
+	if strings.Contains(text, "already bootstrapped") {
+		return true
+	}
+	if !strings.Contains(text, "Bootstrap failed: 5") && !strings.Contains(text, "Input/output error") {
+		return false
+	}
+	out, err := runLaunchctlCommand("print", domain+"/"+label)
+	return err == nil && strings.TrimSpace(out) != ""
 }
 
 func launchctlError(text string, err error, domain, label, plistPath string, args ...string) error {

--- a/cli/beacon/internal/endpoint/service/service_test.go
+++ b/cli/beacon/internal/endpoint/service/service_test.go
@@ -129,12 +129,7 @@ func TestRunLaunchctlWithContextExplainsBootstrapIOError(t *testing.T) {
 	}
 }
 
-func TestManagerLoadReloadsAlreadyBootstrappedJob(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("launchd reload is macOS-only")
-	}
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+func TestLoadLaunchdJobReloadsAlreadyBootstrappedJob(t *testing.T) {
 	var calls []string
 	oldRun := runLaunchctlCommand
 	runLaunchctlCommand = func(args ...string) (string, error) {
@@ -152,8 +147,8 @@ func TestManagerLoadReloadsAlreadyBootstrappedJob(t *testing.T) {
 		runLaunchctlCommand = oldRun
 	})
 
-	if err := (Manager{UserMode: true}).Load(); err != nil {
-		t.Fatalf("Load returned error: %v", err)
+	if err := loadLaunchdJob("gui/501", UserLabel, "/Users/test/Library/LaunchAgents/"+UserLabel+".plist"); err != nil {
+		t.Fatalf("loadLaunchdJob returned error: %v", err)
 	}
 	if len(calls) != 3 {
 		t.Fatalf("launchctl calls = %#v, want bootstrap/bootout/bootstrap", calls)
@@ -163,26 +158,138 @@ func TestManagerLoadReloadsAlreadyBootstrappedJob(t *testing.T) {
 	}
 }
 
-func TestManagerLoadReturnsBootoutFailureWhenReloadFails(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("launchd reload is macOS-only")
-	}
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+func TestLoadLaunchdJobReloadsBootstrapIOErrorWhenJobPrints(t *testing.T) {
+	var calls []string
 	oldRun := runLaunchctlCommand
 	runLaunchctlCommand = func(args ...string) (string, error) {
-		if len(args) > 0 && args[0] == "bootstrap" {
-			return "Bootstrap failed: 5: already bootstrapped", errors.New("exit status 5")
+		calls = append(calls, strings.Join(args, " "))
+		switch strings.Join(args, " ") {
+		case "bootstrap system /Library/LaunchDaemons/" + SystemLabel + ".plist":
+			if len(calls) == 1 {
+				return "Bootstrap failed: 5: Input/output error", errors.New("exit status 5")
+			}
+			return "", nil
+		case "print system/" + SystemLabel:
+			return "state = running\npid = 123\n", nil
+		case "bootout system/" + SystemLabel:
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl call: %s", strings.Join(args, " "))
 		}
-		return "Boot-out failed", errors.New("exit status 5")
 	}
 	t.Cleanup(func() {
 		runLaunchctlCommand = oldRun
 	})
 
-	err := (Manager{UserMode: true}).Load()
+	if err := loadLaunchdJob("system", SystemLabel, "/Library/LaunchDaemons/"+SystemLabel+".plist"); err != nil {
+		t.Fatalf("loadLaunchdJob returned error: %v", err)
+	}
+	if len(calls) != 4 {
+		t.Fatalf("launchctl calls = %#v, want bootstrap/print/bootout/bootstrap", calls)
+	}
+}
+
+func TestLoadLaunchdJobTreatsPostBootstrapLoadedStateAsSuccess(t *testing.T) {
+	var calls []string
+	oldRun := runLaunchctlCommand
+	runLaunchctlCommand = func(args ...string) (string, error) {
+		calls = append(calls, strings.Join(args, " "))
+		switch strings.Join(args, " ") {
+		case "bootstrap system /Library/LaunchDaemons/" + SystemLabel + ".plist":
+			return "Bootstrap failed: 5: Input/output error", errors.New("exit status 5")
+		case "print system/" + SystemLabel:
+			return "state = running\npid = 123\n", nil
+		case "bootout system/" + SystemLabel:
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl call: %s", strings.Join(args, " "))
+		}
+	}
+	t.Cleanup(func() {
+		runLaunchctlCommand = oldRun
+	})
+
+	if err := loadLaunchdJob("system", SystemLabel, "/Library/LaunchDaemons/"+SystemLabel+".plist"); err != nil {
+		t.Fatalf("loadLaunchdJob returned error: %v", err)
+	}
+	if len(calls) != 5 {
+		t.Fatalf("launchctl calls = %#v, want bootstrap/print/bootout/bootstrap/print", calls)
+	}
+}
+
+func TestLoadLaunchdJobReturnsBootoutFailureWhenReloadFails(t *testing.T) {
+	oldRun := runLaunchctlCommand
+	runLaunchctlCommand = func(args ...string) (string, error) {
+		switch args[0] {
+		case "bootstrap":
+			return "Bootstrap failed: 5: already bootstrapped", errors.New("exit status 5")
+		case "bootout":
+			return "Boot-out failed", errors.New("exit status 5")
+		default:
+			return "", fmt.Errorf("unexpected launchctl call: %s", strings.Join(args, " "))
+		}
+	}
+	t.Cleanup(func() {
+		runLaunchctlCommand = oldRun
+	})
+
+	err := loadLaunchdJob("gui/501", UserLabel, "/Users/test/Library/LaunchAgents/"+UserLabel+".plist")
 	if err == nil || !strings.Contains(err.Error(), "Boot-out failed") {
-		t.Fatalf("Load error = %v, want bootout failure", err)
+		t.Fatalf("loadLaunchdJob error = %v, want bootout failure", err)
+	}
+}
+
+func TestManagerRestartKickstartsLoadedJob(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchd restart is macOS-only")
+	}
+	var calls []string
+	oldRun := runLaunchctlCommand
+	runLaunchctlCommand = func(args ...string) (string, error) {
+		calls = append(calls, strings.Join(args, " "))
+		return "", nil
+	}
+	t.Cleanup(func() {
+		runLaunchctlCommand = oldRun
+	})
+
+	if err := (Manager{UserMode: false}).Restart(); err != nil {
+		t.Fatalf("Restart returned error: %v", err)
+	}
+	want := "kickstart -k system/" + SystemLabel
+	if len(calls) != 1 || calls[0] != want {
+		t.Fatalf("launchctl calls = %#v, want %q", calls, want)
+	}
+}
+
+func TestManagerRestartLoadsMissingJob(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchd restart is macOS-only")
+	}
+	var calls []string
+	oldRun := runLaunchctlCommand
+	runLaunchctlCommand = func(args ...string) (string, error) {
+		calls = append(calls, strings.Join(args, " "))
+		switch args[0] {
+		case "kickstart":
+			return "Could not find service \"system/" + SystemLabel + "\" in domain for system", errors.New("exit status 113")
+		case "bootstrap":
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected launchctl call: %s", strings.Join(args, " "))
+		}
+	}
+	t.Cleanup(func() {
+		runLaunchctlCommand = oldRun
+	})
+
+	if err := (Manager{UserMode: false}).Restart(); err != nil {
+		t.Fatalf("Restart returned error: %v", err)
+	}
+	if len(calls) != 2 ||
+		calls[0] != "kickstart -k system/"+SystemLabel ||
+		calls[1] != "bootstrap system /Library/LaunchDaemons/"+SystemLabel+".plist" {
+		t.Fatalf("launchctl calls = %#v, want kickstart/bootstrap", calls)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/service/updater.go
+++ b/cli/beacon/internal/endpoint/service/updater.go
@@ -38,18 +38,7 @@ func (m UpdaterManager) Load() error {
 		return nil
 	}
 	path := m.PlistPath()
-	out, err := runLaunchctlCommand("bootstrap", "system", path)
-	if err == nil {
-		return nil
-	}
-	if strings.Contains(strings.TrimSpace(out), "already bootstrapped") {
-		target := "system/" + UpdaterLabel
-		if err := runLaunchctlWithContext("system", UpdaterLabel, "", "bootout", target); err != nil {
-			return err
-		}
-		return runLaunchctlWithContext("system", UpdaterLabel, path, "bootstrap", "system", path)
-	}
-	return launchctlError(strings.TrimSpace(out), err, "system", UpdaterLabel, path, "bootstrap", "system", path)
+	return loadLaunchdJob("system", UpdaterLabel, path)
 }
 
 // Unload boots the updater job out of the system domain.


### PR DESCRIPTION
## Summary
- Use `launchctl kickstart -k` for collector restarts during self-update instead of bootout/bootstrap, avoiding races with package postinstall that has already loaded the collector.
- Centralize launchd load recovery for collector and updater jobs so `Bootstrap failed: 5` with an already loaded job triggers bootout/bootstrap recovery instead of a hard failure.
- Add regression tests for already-bootstrapped, input/output stale-loaded, post-bootstrap-loaded, and missing-service restart cases.

## Test plan
- `cd cli/beacon && go test ./internal/endpoint/service ./internal/endpoint/selfupdate`
- `cd cli/beacon && go test ./internal/endpoint/...`
- `cd cli/beacon && go test ./cmd -run 'TestEndpointUpdate|TestAutoUpdateMode|TestRequireSystemPackageForUpdater|TestEndpointSystemLogPath'`
- `sh packaging/macos/test-endpoint-scripts.sh`


Made with [Cursor](https://cursor.com)