### PR TITLE
Add CLI banner

### DIFF
--- a/cli/beacon/cmd/root.go
+++ b/cli/beacon/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -18,15 +19,62 @@ local telemetry, and writes Wazuh-compatible JSON logs without requiring an
 Beacon-hosted backend.`,
 	Version: version.GetVersion(),
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Beacon Endpoint Agent")
-		fmt.Println()
-		fmt.Println("Start with:")
-		fmt.Println("  beacon endpoint install")
-		fmt.Println("  beacon endpoint status")
-		fmt.Println("  beacon endpoint wazuh print-config")
-		fmt.Println()
-		cmd.Usage()
+		printRootSplash(cmd)
 	},
+}
+
+const (
+	beaconPurple = "\x1b[38;5;141m"
+	resetColor   = "\x1b[0m"
+)
+
+var beaconBanner = []string{
+	"██████╗ ███████╗ █████╗  ██████╗ ██████╗ ███╗   ██╗",
+	"██╔══██╗██╔════╝██╔══██╗██╔════╝██╔═══██╗████╗  ██║",
+	"██████╔╝█████╗  ███████║██║     ██║   ██║██╔██╗ ██║",
+	"██╔══██╗██╔══╝  ██╔══██║██║     ██║   ██║██║╚██╗██║",
+	"██████╔╝███████╗██║  ██║╚██████╗╚██████╔╝██║ ╚████║",
+	"╚═════╝ ╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚═╝  ╚═══╝",
+}
+
+func printRootSplash(cmd *cobra.Command) {
+	out := cmd.OutOrStdout()
+	printBeaconBanner(out, shouldUseColor(out))
+	fmt.Fprintln(out, "Open-source telemetry layer for AI agents.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Start with:")
+	fmt.Fprintln(out, "  beacon endpoint install")
+	fmt.Fprintln(out, "  beacon endpoint status")
+	fmt.Fprintln(out, "  beacon endpoint wazuh print-config")
+	fmt.Fprintln(out)
+	_ = cmd.Usage()
+}
+
+func printBeaconBanner(out io.Writer, color bool) {
+	if color {
+		fmt.Fprint(out, beaconPurple)
+	}
+	for _, line := range beaconBanner {
+		fmt.Fprintln(out, line)
+	}
+	if color {
+		fmt.Fprint(out, resetColor)
+	}
+}
+
+func shouldUseColor(out io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	file, ok := out.(*os.File)
+	if !ok {
+		return false
+	}
+	stat, err := file.Stat()
+	if err != nil {
+		return false
+	}
+	return stat.Mode()&os.ModeCharDevice != 0
 }
 
 var completionCmd = &cobra.Command{

--- a/cli/beacon/cmd/root.go
+++ b/cli/beacon/cmd/root.go
@@ -39,6 +39,7 @@ var beaconBanner = []string{
 
 func printRootSplash(cmd *cobra.Command) {
 	out := cmd.OutOrStdout()
+	cmd.SetOut(out)
 	printBeaconBanner(out, shouldUseColor(out))
 	fmt.Fprintln(out, "Open-source telemetry layer for AI agents.")
 	fmt.Fprintln(out)

--- a/cli/beacon/cmd/root_test.go
+++ b/cli/beacon/cmd/root_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestPrintRootSplash(t *testing.T) {
+	cmd := &cobra.Command{Use: "beacon"}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	printRootSplash(cmd)
+
+	got := out.String()
+	for _, want := range []string{
+		"██████╗ ███████╗ █████╗  ██████╗ ██████╗ ███╗   ██╗",
+		"Open-source telemetry layer for AI agents.",
+		"Start with:",
+		"beacon endpoint install",
+		"beacon endpoint status",
+		"beacon endpoint wazuh print-config",
+		"Usage:",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("root splash missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "\x1b[") {
+		t.Fatalf("root splash written to a buffer should not include ANSI escapes:\n%q", got)
+	}
+	for _, line := range beaconBanner {
+		if len([]rune(line)) > 64 {
+			t.Fatalf("banner line %q is too wide: got %d columns", line, len(line))
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add a compact filled Beacon wordmark to the root CLI output.
- Color the banner purple for interactive terminals while respecting non-interactive output, `NO_COLOR`, and `TERM=dumb`.
- Add coverage for the root splash content and ANSI suppression in captured output.

## Test plan
- `go test ./cmd`
- `make build`
- `./beacon`


Made with [Cursor](https://cursor.com)