### PR TITLE
fix(endpoint): preserve updater daemon after self-update

### DIFF
--- a/cli/beacon/internal/endpoint/service/updater.go
+++ b/cli/beacon/internal/endpoint/service/updater.go
@@ -37,6 +37,9 @@ func (m UpdaterManager) Load() error {
 	if runtime.GOOS != "darwin" {
 		return nil
 	}
+	if status := m.Status(); status.Loaded && status.Running {
+		return nil
+	}
 	path := m.PlistPath()
 	return loadLaunchdJob("system", UpdaterLabel, path)
 }

--- a/cli/beacon/internal/endpoint/service/updater_test.go
+++ b/cli/beacon/internal/endpoint/service/updater_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"runtime"
 	"strings"
 	"testing"
@@ -46,5 +47,30 @@ func TestUpdaterWritePlistNonDarwinContract(t *testing.T) {
 	}
 	if _, err := (UpdaterManager{}).WritePlist("/opt/beacon/bin/beacon"); err == nil {
 		t.Error("expected error writing updater plist on non-darwin")
+	}
+}
+
+func TestUpdaterLoadDoesNotUnloadRunningUpdater(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchd updater load is macOS-only")
+	}
+	var calls []string
+	oldRun := runLaunchctlCommand
+	runLaunchctlCommand = func(args ...string) (string, error) {
+		calls = append(calls, strings.Join(args, " "))
+		if strings.Join(args, " ") == "print system/"+UpdaterLabel {
+			return "state = running\npid = 123\n", nil
+		}
+		return "", errors.New("unexpected launchctl call")
+	}
+	t.Cleanup(func() {
+		runLaunchctlCommand = oldRun
+	})
+
+	if err := (UpdaterManager{}).Load(); err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(calls) != 1 || calls[0] != "print system/"+UpdaterLabel {
+		t.Fatalf("launchctl calls = %#v, want only status print", calls)
 	}
 }


### PR DESCRIPTION
## Summary
- Avoid booting out the updater launchd job when package postinstall reconciles while the updater is the currently running scheduled job.
- Preserve `auto` mode's loaded daemon state after a successful self-update.
- Add a regression test that ensures `UpdaterManager.Load` does not unload/bootstrap a running updater job.

## Test plan
- `cd cli/beacon && go test ./internal/endpoint/service ./internal/endpoint/selfupdate`
- `cd cli/beacon && go test ./cmd -run 'TestEndpointUpdate|TestAutoUpdateMode|TestRequireSystemPackageForUpdater|TestEndpointSystemLogPath'`
- `cd cli/beacon && go test ./internal/endpoint/...`
- `sh packaging/macos/test-endpoint-scripts.sh`


Made with [Cursor](https://cursor.com)