### PR TITLE
fix(endpoint): clean self-update staging after success

### DIFF
--- a/cli/beacon/internal/endpoint/selfupdate/apply.go
+++ b/cli/beacon/internal/endpoint/selfupdate/apply.go
@@ -215,6 +215,7 @@ func (a *Applier) Apply(ctx context.Context) (ApplyResult, error) {
 
 	result.Applied = true
 	result.Message = fmt.Sprintf("updated %s -> %s", a.CurrentVersion, manifest.Version)
+	a.cleanupSuccessfulUpdate()
 	a.emit(true, result, result.Message)
 	return result, nil
 }
@@ -231,6 +232,22 @@ func (a *Applier) stageDir() string {
 		return a.StageDir
 	}
 	return StateDir()
+}
+
+func (a *Applier) cleanupSuccessfulUpdate() {
+	stage := a.stageDir()
+	for _, pattern := range []string{
+		filepath.Join(stage, "download*"),
+		filepath.Join(stage, "rollback"),
+	} {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+		for _, match := range matches {
+			_ = os.RemoveAll(match)
+		}
+	}
 }
 
 func (a *Applier) prefix() string {

--- a/cli/beacon/internal/endpoint/selfupdate/apply_test.go
+++ b/cli/beacon/internal/endpoint/selfupdate/apply_test.go
@@ -95,6 +95,52 @@ func TestApplyHappyPath(t *testing.T) {
 	}
 }
 
+func TestApplyCleansSuccessfulUpdateStaging(t *testing.T) {
+	artifact, sha := makeBeaconTarball(t, "9.9.9")
+	srv := manifestServer(t, "9.9.9", sha, artifact)
+	defer srv.Close()
+
+	a := testApplier(t, "0.0.1", srv)
+	oldBin := filepath.Join(a.InstallPrefix, "opt/beacon/bin/beacon")
+	if err := os.MkdirAll(filepath.Dir(oldBin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldBin, []byte("#!/bin/sh\necho \"beacon version 0.0.1 (old) built on test\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	staleDownload := filepath.Join(a.StageDir, "download.pkg")
+	if err := os.WriteFile(staleDownload, []byte("stale package"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staleRollback := filepath.Join(a.StageDir, "rollback", "beacon", "bin", "old")
+	if err := os.MkdirAll(filepath.Dir(staleRollback), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(staleRollback, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := a.Apply(context.Background())
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !res.Applied {
+		t.Fatalf("expected update applied: %+v", res)
+	}
+	for _, path := range []string{
+		staleDownload,
+		filepath.Join(a.StageDir, "download.tar.gz"),
+		filepath.Join(a.StageDir, "rollback"),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s still exists or unexpected error: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(a.StageDir, ".update.lock")); err != nil {
+		t.Fatalf("lock file should remain reusable: %v", err)
+	}
+}
+
 func TestApplySHA256Mismatch(t *testing.T) {
 	artifact, _ := makeBeaconTarball(t, "9.9.9")
 	srv := manifestServer(t, "9.9.9", "deadbeefbad", artifact)


### PR DESCRIPTION
## Summary
- Remove staged update downloads after a successful self-update.
- Remove rollback snapshots once the new package has passed restart and health checks.
- Keep the update lock file in place for reuse and leave failure artifacts available for failed-update debugging.

## Test plan
- `cd cli/beacon && go test ./internal/endpoint/selfupdate`
- `cd cli/beacon && go test ./internal/endpoint/...`


Made with [Cursor](https://cursor.com)