### PR TITLE
fix(endpoint): defer updater reload after self-update

### DIFF
--- a/cli/beacon/internal/endpoint/service/updater.go
+++ b/cli/beacon/internal/endpoint/service/updater.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -14,6 +15,17 @@ const UpdaterLabel = "com.beacon.endpoint.updater"
 // UpdaterManager manages the endpoint updater launchd job. Unlike the collector
 // service it is system-only and runs on a schedule rather than KeepAlive.
 type UpdaterManager struct{}
+
+var startDeferredUpdaterReload = func(path string) error {
+	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf(
+		"sleep 75; /bin/launchctl bootout system/%s >/dev/null 2>&1 || true; /bin/launchctl bootstrap system %s >/dev/null 2>&1",
+		UpdaterLabel,
+		shellQuote(path),
+	))
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Start()
+}
 
 // PlistPath returns the LaunchDaemon plist path for the updater job.
 func (UpdaterManager) PlistPath() string {
@@ -37,10 +49,10 @@ func (m UpdaterManager) Load() error {
 	if runtime.GOOS != "darwin" {
 		return nil
 	}
-	if status := m.Status(); status.Loaded && status.Running {
-		return nil
-	}
 	path := m.PlistPath()
+	if status := m.Status(); status.Loaded && status.Running {
+		return startDeferredUpdaterReload(path)
+	}
 	return loadLaunchdJob("system", UpdaterLabel, path)
 }
 
@@ -102,4 +114,8 @@ func updaterPlist(label, program string) string {
 </dict>
 </plist>
 `, label, program, label, label)
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }

--- a/cli/beacon/internal/endpoint/service/updater.go
+++ b/cli/beacon/internal/endpoint/service/updater.go
@@ -17,14 +17,19 @@ const UpdaterLabel = "com.beacon.endpoint.updater"
 type UpdaterManager struct{}
 
 var startDeferredUpdaterReload = func(path string) error {
-	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf(
-		"sleep 75; /bin/launchctl bootout system/%s >/dev/null 2>&1 || true; /bin/launchctl bootstrap system %s >/dev/null 2>&1",
-		UpdaterLabel,
-		shellQuote(path),
-	))
+	cmd := exec.Command("/bin/sh", "-c", deferredUpdaterReloadScript(os.Getpid(), path))
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Start()
+}
+
+func deferredUpdaterReloadScript(pid int, path string) string {
+	return fmt.Sprintf(
+		"deadline=$((SECONDS+600)); while /bin/kill -0 %d >/dev/null 2>&1 && [ \"$SECONDS\" -lt \"$deadline\" ]; do sleep 2; done; /bin/launchctl bootout system/%s >/dev/null 2>&1 || true; /bin/launchctl bootstrap system %s >/dev/null 2>&1",
+		pid,
+		UpdaterLabel,
+		shellQuote(path),
+	)
 }
 
 // PlistPath returns the LaunchDaemon plist path for the updater job.

--- a/cli/beacon/internal/endpoint/service/updater_test.go
+++ b/cli/beacon/internal/endpoint/service/updater_test.go
@@ -50,12 +50,13 @@ func TestUpdaterWritePlistNonDarwinContract(t *testing.T) {
 	}
 }
 
-func TestUpdaterLoadDoesNotUnloadRunningUpdater(t *testing.T) {
+func TestUpdaterLoadDefersReloadForRunningUpdater(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("launchd updater load is macOS-only")
 	}
 	var calls []string
 	oldRun := runLaunchctlCommand
+	oldDeferred := startDeferredUpdaterReload
 	runLaunchctlCommand = func(args ...string) (string, error) {
 		calls = append(calls, strings.Join(args, " "))
 		if strings.Join(args, " ") == "print system/"+UpdaterLabel {
@@ -63,8 +64,14 @@ func TestUpdaterLoadDoesNotUnloadRunningUpdater(t *testing.T) {
 		}
 		return "", errors.New("unexpected launchctl call")
 	}
+	var deferredPath string
+	startDeferredUpdaterReload = func(path string) error {
+		deferredPath = path
+		return nil
+	}
 	t.Cleanup(func() {
 		runLaunchctlCommand = oldRun
+		startDeferredUpdaterReload = oldDeferred
 	})
 
 	if err := (UpdaterManager{}).Load(); err != nil {
@@ -72,5 +79,8 @@ func TestUpdaterLoadDoesNotUnloadRunningUpdater(t *testing.T) {
 	}
 	if len(calls) != 1 || calls[0] != "print system/"+UpdaterLabel {
 		t.Fatalf("launchctl calls = %#v, want only status print", calls)
+	}
+	if deferredPath != (UpdaterManager{}).PlistPath() {
+		t.Fatalf("deferred reload path = %q, want updater plist", deferredPath)
 	}
 }

--- a/cli/beacon/internal/endpoint/service/updater_test.go
+++ b/cli/beacon/internal/endpoint/service/updater_test.go
@@ -84,3 +84,18 @@ func TestUpdaterLoadDefersReloadForRunningUpdater(t *testing.T) {
 		t.Fatalf("deferred reload path = %q, want updater plist", deferredPath)
 	}
 }
+
+func TestDeferredUpdaterReloadScriptWaitsForParentExit(t *testing.T) {
+	script := deferredUpdaterReloadScript(12345, "/Library/LaunchDaemons/com.beacon.endpoint.updater.plist")
+	for _, want := range []string{
+		"/bin/kill -0 12345",
+		"SECONDS+600",
+		"do sleep 2; done",
+		"/bin/launchctl bootout system/" + UpdaterLabel,
+		"/bin/launchctl bootstrap system '/Library/LaunchDaemons/com.beacon.endpoint.updater.plist'",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("deferred reload script missing %q:\n%s", want, script)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- When package postinstall reconciles the updater while the updater job itself is running, schedule a delayed launchd reload instead of leaving the old in-memory calendar trigger active.
- Preserve the current updater process so the self-update can finish cleanly, then bootout/bootstrap the LaunchDaemon after a short delay.
- Add regression coverage for the deferred-reload path.

## Test plan
- `cd cli/beacon && go test ./internal/endpoint/service`
- `cd cli/beacon && go test ./cmd -run 'TestEndpointUpdate|TestAutoUpdateMode|TestRequireSystemPackageForUpdater'`
- `sh packaging/macos/test-endpoint-scripts.sh`
- `cd cli/beacon && go test ./internal/endpoint/...`


Made with [Cursor](https://cursor.com)