### PR TITLE
fix(endpoint): wait on updater job before deferred reload

### DIFF
--- a/cli/beacon/internal/endpoint/service/updater.go
+++ b/cli/beacon/internal/endpoint/service/updater.go
@@ -17,16 +17,16 @@ const UpdaterLabel = "com.beacon.endpoint.updater"
 type UpdaterManager struct{}
 
 var startDeferredUpdaterReload = func(path string) error {
-	cmd := exec.Command("/bin/sh", "-c", deferredUpdaterReloadScript(os.Getpid(), path))
+	cmd := exec.Command("/bin/sh", "-c", deferredUpdaterReloadScript(path))
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Start()
 }
 
-func deferredUpdaterReloadScript(pid int, path string) string {
+func deferredUpdaterReloadScript(path string) string {
 	return fmt.Sprintf(
-		"deadline=$((SECONDS+600)); while /bin/kill -0 %d >/dev/null 2>&1 && [ \"$SECONDS\" -lt \"$deadline\" ]; do sleep 2; done; /bin/launchctl bootout system/%s >/dev/null 2>&1 || true; /bin/launchctl bootstrap system %s >/dev/null 2>&1",
-		pid,
+		"deadline=$((SECONDS+600)); while [ \"$SECONDS\" -lt \"$deadline\" ] && /bin/launchctl print system/%s 2>/dev/null | /usr/bin/grep -Eq 'state = running|pid ='; do sleep 2; done; /bin/launchctl bootout system/%s >/dev/null 2>&1 || true; /bin/launchctl bootstrap system %s >/dev/null 2>&1",
+		UpdaterLabel,
 		UpdaterLabel,
 		shellQuote(path),
 	)

--- a/cli/beacon/internal/endpoint/service/updater_test.go
+++ b/cli/beacon/internal/endpoint/service/updater_test.go
@@ -86,9 +86,10 @@ func TestUpdaterLoadDefersReloadForRunningUpdater(t *testing.T) {
 }
 
 func TestDeferredUpdaterReloadScriptWaitsForParentExit(t *testing.T) {
-	script := deferredUpdaterReloadScript(12345, "/Library/LaunchDaemons/com.beacon.endpoint.updater.plist")
+	script := deferredUpdaterReloadScript("/Library/LaunchDaemons/com.beacon.endpoint.updater.plist")
 	for _, want := range []string{
-		"/bin/kill -0 12345",
+		"/bin/launchctl print system/" + UpdaterLabel,
+		"/usr/bin/grep -Eq 'state = running|pid ='",
 		"SECONDS+600",
 		"do sleep 2; done",
 		"/bin/launchctl bootout system/" + UpdaterLabel,


### PR DESCRIPTION
## Summary
- Change deferred updater LaunchDaemon reload to poll the actual launchd updater job state instead of waiting on the short-lived `install-daemon` process PID.
- Avoid interrupting slow self-update health checks while still reloading launchd after the scheduled updater exits.
- Add test coverage for the launchd-state polling reload script.

## Test plan
- `cd cli/beacon && go test ./internal/endpoint/service`
- `cd cli/beacon && go test ./cmd -run 'TestEndpointUpdate|TestAutoUpdateMode|TestRequireSystemPackageForUpdater'`
- `cd cli/beacon && go test ./internal/endpoint/...`
- `sh packaging/macos/test-endpoint-scripts.sh`


Made with [Cursor](https://cursor.com)