### PR TITLE
fix(endpoint): restore Vector forwarders during package update

### DIFF
--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -17,20 +17,51 @@ BEACON_SPLUNK_CA_FILE="${BEACON_SPLUNK_CA_FILE:-}" \
 BEACON_NO_START=1 \
   /opt/beacon/scripts/install-endpoint.sh
 
-restart_optional_forwarder() {
+forwarder_running() {
+  label="$1"
+
+  launchctl print "system/$label" 2>/dev/null | grep -Eq 'state = running|pid ='
+}
+
+restore_existing_forwarder() {
   label="$1"
   plist_path="$2"
+  target="system/$label"
 
+  # No plist means the customer has not installed this optional forwarder.
   if [ ! -f "$plist_path" ]; then
     return 0
   fi
 
-  launchctl bootout "system/$label" >/dev/null 2>&1 || true
-  launchctl bootstrap system "$plist_path" >/dev/null 2>&1 || {
-    if ! launchctl print "system/$label" >/dev/null 2>&1; then
-      echo "Warning: could not restart optional forwarder $label" >&2
+  if forwarder_running "$label"; then
+    out="$(launchctl kickstart -k "$target" 2>&1)" || {
+      echo "Warning: launchctl kickstart failed for $label: $out" >&2
+    }
+    if forwarder_running "$label"; then
+      return 0
     fi
-  }
+  fi
+
+  for delay in 1 2 4 8 16; do
+    out="$(launchctl bootstrap system "$plist_path" 2>&1)" || {
+      echo "Warning: launchctl bootstrap failed for $label: $out" >&2
+    }
+    if forwarder_running "$label"; then
+      return 0
+    fi
+
+    out="$(launchctl kickstart -k "$target" 2>&1)" || {
+      echo "Warning: launchctl kickstart retry failed for $label: $out" >&2
+    }
+    if forwarder_running "$label"; then
+      return 0
+    fi
+    sleep "$delay"
+  done
+
+  out="$(launchctl print "$target" 2>&1)" || true
+  echo "Error: could not restore existing forwarder $label after package install. launchctl print: $out" >&2
+  return 1
 }
 
 if command -v launchctl >/dev/null 2>&1; then
@@ -38,8 +69,8 @@ if command -v launchctl >/dev/null 2>&1; then
   launchctl bootstrap system /Library/LaunchDaemons/com.beacon.endpoint.collector.plist >/dev/null 2>&1 || {
     launchctl print system/com.beacon.endpoint.collector >/dev/null 2>&1 || exit 1
   }
-  restart_optional_forwarder "com.beacon.endpoint.falcon-forwarder" "/Library/LaunchDaemons/com.beacon.endpoint.falcon-forwarder.plist"
-  restart_optional_forwarder "com.beacon.endpoint.s3-forwarder" "/Library/LaunchDaemons/com.beacon.endpoint.s3-forwarder.plist"
+  restore_existing_forwarder "com.beacon.endpoint.falcon-forwarder" "/Library/LaunchDaemons/com.beacon.endpoint.falcon-forwarder.plist"
+  restore_existing_forwarder "com.beacon.endpoint.s3-forwarder" "/Library/LaunchDaemons/com.beacon.endpoint.s3-forwarder.plist"
   "${BEACON_BIN:-/opt/beacon/bin/beacon}" endpoint update install-daemon || {
     echo "Error: could not reconcile Beacon endpoint updater daemon" >&2
     exit 1

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -50,6 +50,16 @@ restore_existing_forwarder() {
       return 0
     fi
 
+    out="$(launchctl bootout "$target" 2>&1)" || {
+      echo "Warning: launchctl bootout retry failed for $label: $out" >&2
+    }
+    out="$(launchctl bootstrap system "$plist_path" 2>&1)" || {
+      echo "Warning: launchctl bootstrap after bootout failed for $label: $out" >&2
+    }
+    if forwarder_running "$label"; then
+      return 0
+    fi
+
     out="$(launchctl kickstart -k "$target" 2>&1)" || {
       echo "Warning: launchctl kickstart retry failed for $label: $out" >&2
     }

--- a/packaging/macos/test-endpoint-scripts.sh
+++ b/packaging/macos/test-endpoint-scripts.sh
@@ -37,6 +37,10 @@ if ! grep -q 'launchctl kickstart -k' "$ROOT_DIR/packaging/macos/scripts/postins
   echo "postinstall should kickstart already-loaded forwarders" >&2
   exit 1
 fi
+if ! grep -q 'launchctl bootout "$target"' "$ROOT_DIR/packaging/macos/scripts/postinstall"; then
+  echo "postinstall should recover loaded-but-stuck forwarders with bootout" >&2
+  exit 1
+fi
 if ! grep -q 'could not restore existing forwarder' "$ROOT_DIR/packaging/macos/scripts/postinstall"; then
   echo "postinstall should fail loudly when an existing forwarder cannot be restored" >&2
   exit 1

--- a/packaging/macos/test-endpoint-scripts.sh
+++ b/packaging/macos/test-endpoint-scripts.sh
@@ -29,6 +29,22 @@ if ! grep -q 'INVENTORY_STATE' "$ROOT_DIR/packaging/macos/jamf/claude/common/rep
   echo "repair-hooks should prepare inventory heartbeat state files" >&2
   exit 1
 fi
+if ! grep -q 'restore_existing_forwarder' "$ROOT_DIR/packaging/macos/scripts/postinstall"; then
+  echo "postinstall should restore existing optional forwarders" >&2
+  exit 1
+fi
+if ! grep -q 'launchctl kickstart -k' "$ROOT_DIR/packaging/macos/scripts/postinstall"; then
+  echo "postinstall should kickstart already-loaded forwarders" >&2
+  exit 1
+fi
+if ! grep -q 'could not restore existing forwarder' "$ROOT_DIR/packaging/macos/scripts/postinstall"; then
+  echo "postinstall should fail loudly when an existing forwarder cannot be restored" >&2
+  exit 1
+fi
+if ! grep -q 'launchctl bootstrap failed' "$ROOT_DIR/packaging/macos/scripts/postinstall"; then
+  echo "postinstall should preserve launchctl bootstrap diagnostics" >&2
+  exit 1
+fi
 
 PKG_TEST_BIN="$TMP_DIR/pkg-bin"
 PKG_TEST_ROOT="$TMP_DIR/pkg-root"


### PR DESCRIPTION
## Summary
- Restore existing Falcon/S3 Vector forwarders during package postinstall with retry and running-state verification.
- Preserve launchctl diagnostics when restore attempts fail.
- Fail package/self-update if a previously configured forwarder cannot be restored, instead of silently dropping customer log forwarding.

## Test plan
- `sh packaging/macos/test-endpoint-scripts.sh`


Made with [Cursor](https://cursor.com)