### PR TITLE
chore(endpoint): run updater across business hours

### DIFF
--- a/cli/beacon/internal/endpoint/service/updater.go
+++ b/cli/beacon/internal/endpoint/service/updater.go
@@ -86,8 +86,8 @@ func (m UpdaterManager) Status() Status {
 	return status
 }
 
-// updaterPlist renders the updater LaunchDaemon. It runs daily at 2 PM local
-// time and does not
+// updaterPlist renders the updater LaunchDaemon. It runs at business-hour
+// intervals in local time and does not
 // RunAtLoad or KeepAlive; each invocation resolves the configured mode.
 func updaterPlist(label, program string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
@@ -104,12 +104,38 @@ func updaterPlist(label, program string) string {
     <string>--scheduled</string>
   </array>
   <key>StartCalendarInterval</key>
+  <array>
   <dict>
     <key>Hour</key>
-    <integer>14</integer>
+    <integer>9</integer>
     <key>Minute</key>
     <integer>0</integer>
   </dict>
+  <dict>
+    <key>Hour</key>
+    <integer>12</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <dict>
+    <key>Hour</key>
+    <integer>15</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <dict>
+    <key>Hour</key>
+    <integer>18</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <dict>
+    <key>Hour</key>
+    <integer>21</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  </array>
   <key>RunAtLoad</key>
   <false/>
   <key>StandardOutPath</key>

--- a/cli/beacon/internal/endpoint/service/updater_test.go
+++ b/cli/beacon/internal/endpoint/service/updater_test.go
@@ -14,13 +14,17 @@ func TestUpdaterPlistContent(t *testing.T) {
 		"<string>/opt/beacon/bin/beacon</string>",
 		"<string>--scheduled</string>",
 		"<key>StartCalendarInterval</key>",
-		"<key>Hour</key>",
-		"<integer>14</integer>",
+		"<array>",
 		"<key>Minute</key>",
 		"<integer>0</integer>",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("plist missing %q", want)
+		}
+	}
+	for _, hour := range []string{"9", "12", "15", "18", "21"} {
+		if !strings.Contains(out, "<integer>"+hour+"</integer>") {
+			t.Errorf("plist missing hour %s", hour)
 		}
 	}
 	// One-shot scheduled job: must not RunAtLoad or KeepAlive.


### PR DESCRIPTION
## Summary
- Change the updater LaunchDaemon from one daily 2 PM run to five local-time windows: 9 AM, noon, 3 PM, 6 PM, and 9 PM.
- Keep each scheduled invocation as a one-shot job that resolves the configured mode and still applies jitter.
- Update plist tests for the multi-window schedule.

## Test plan
- `cd cli/beacon && go test ./internal/endpoint/service`
- `cd cli/beacon && go test ./cmd -run 'TestEndpointUpdate|TestAutoUpdateMode|TestRequireSystemPackageForUpdater'`
- `sh packaging/macos/test-endpoint-scripts.sh`


Made with [Cursor](https://cursor.com)