### PR TITLE
docs: document endpoint self-update operations

### DIFF
--- a/docs/cli/upgrade.mdx
+++ b/docs/cli/upgrade.mdx
@@ -23,12 +23,45 @@ brew upgrade beacon
 beacon version
 ```
 
-## Check-only endpoint update monitoring
+## Self-updating endpoint packages
 
 For Apple Silicon systems installed from the signed endpoint package, Beacon can
-periodically check the GitHub Release manifest without downloading or applying
-updates. This writes local-only update status events to `system.jsonl` beside the
-runtime log.
+check the GitHub Release manifest and optionally apply newer signed packages.
+Self-update is **off by default** and is available only for the system package
+install under `/opt/beacon`. Homebrew and archive installs should continue to use
+their normal upgrade flow.
+
+Behind the scenes, `beacon endpoint update` reads `update-manifest.json`, selects
+the package artifact for the local architecture, downloads it into the endpoint
+update staging directory, verifies the manifest checksum, Developer ID Installer
+signature, and Gatekeeper install assessment, then runs Apple's `installer`. The
+package postinstall restarts the local collector, restores configured Vector
+forwarders, reconciles the updater LaunchDaemon, and the updater health-checks
+the new install. If the new install is unhealthy, Beacon restores the previous
+`/opt/beacon` tree.
+
+Update activity is written to the local system log beside the runtime log:
+
+```text
+/var/log/beacon-agent/system.jsonl
+```
+
+### Modes
+
+Beacon supports three endpoint update modes:
+
+| Mode | Behavior |
+| --- | --- |
+| `off` | Default. No background update job applies updates. |
+| `check-only` | Periodically checks for newer compatible packages and writes local system-log events, but never downloads or installs packages. |
+| `auto` | Periodically checks for newer compatible packages, then downloads, verifies, installs, health-checks, and rolls back on failure. |
+
+Scheduled checks run from the root `launchd` job
+`com.beacon.endpoint.updater`. The default package schedule uses local business
+hours with jitter, so devices do not all fetch and install at exactly the same
+time.
+
+### Check-only monitoring
 
 ```bash title="Enable check-only endpoint update monitoring"
 sudo /opt/beacon/bin/beacon endpoint update enable --check-only
@@ -41,16 +74,79 @@ Disable the background check job with:
 sudo /opt/beacon/bin/beacon endpoint update disable
 ```
 
+### Auto apply mode
+
+Enable full automatic package updates with:
+
+```bash title="Enable automatic endpoint package updates"
+sudo /opt/beacon/bin/beacon endpoint update enable
+sudo /opt/beacon/bin/beacon endpoint update status
+```
+
+The status output should show:
+
+```text
+Update mode:      auto
+Install kind:     system_pkg
+Updater daemon:   loaded=true running=false
+```
+
+Disable automatic updates and remove the updater LaunchDaemon with:
+
+```bash title="Disable automatic endpoint package updates"
+sudo /opt/beacon/bin/beacon endpoint update disable
+```
+
+### Manual apply
+
 When a newer signed endpoint package is available, apply it manually with:
 
 ```bash title="Manually apply an endpoint package update"
 sudo /opt/beacon/bin/beacon endpoint update --apply
 ```
 
-Manual apply downloads the package from the release manifest, verifies the
-checksum, Developer ID signature, stapled notarization ticket, and Gatekeeper
-assessment, then installs it with Apple's `installer`. If the updated install is
-unhealthy, Beacon restores the previous `/opt/beacon` tree.
+### Troubleshooting self-update
+
+Check installed version and updater state:
+
+```bash title="Inspect updater state"
+/opt/beacon/bin/beacon version
+/opt/beacon/bin/beacon endpoint update status
+sudo tail -n 30 /var/log/beacon-agent/system.jsonl
+```
+
+Check the updater LaunchDaemon:
+
+```bash title="Inspect updater launchd job"
+launchctl print system/com.beacon.endpoint.updater
+```
+
+Run the scheduled updater path immediately for testing:
+
+```bash title="Run scheduled updater immediately"
+sudo BEACON_UPDATE_JITTER_SECONDS=0 /opt/beacon/bin/beacon endpoint update --scheduled
+```
+
+Common states:
+
+| Symptom | What to check |
+| --- | --- |
+| `mode=off` or `Updater daemon: loaded=false` | Re-enable with `sudo /opt/beacon/bin/beacon endpoint update enable` or `--check-only`. |
+| `homebrew_install` or `not_system_package` | The seamless updater applies only to the signed system package install. Use `brew upgrade beacon` for Homebrew. |
+| Manual non-root check cannot write `system.jsonl` | Run manual system checks with `sudo`, or rely on the root scheduled updater. |
+| Package apply fails before install | Check checksum, signature, Gatekeeper, manifest URL, and network access to the package URL. |
+| Package apply fails after install | Beacon should roll back and write `update.failed` to `system.jsonl`; inspect `/Library/Application Support/Beacon/Endpoint/updates/last_failure.json` if present. |
+| S3/Falcon forwarding stops after update | Check `launchctl print system/com.beacon.endpoint.s3-forwarder` or `...falcon-forwarder`; package postinstall restores pre-existing forwarders and fails loudly if they cannot be restored. |
+
+Successful updates clean staging state under:
+
+```text
+/Library/Application Support/Beacon/Endpoint/updates
+```
+
+Only `.update.lock` should remain after a healthy update. If a future update
+fails and rollback succeeds, Beacon keeps a small `last_failure.json` diagnostic
+instead of retaining a full old install tree.
 
 ## Repair endpoint configuration
 

--- a/docs/mdm/fleet.mdx
+++ b/docs/mdm/fleet.mdx
@@ -52,11 +52,34 @@ Upload the signed and notarized `.pkg` as Fleet software and scope it to a pilot
   <Step title="Add policies or labels">
     Add queries from `/opt/beacon/fleet/queries` as Fleet policies or labels to track install state, service health, log freshness, config state, and runtime log writability.
   </Step>
+  <Step title="Optionally enable endpoint self-updates">
+    Beacon package self-updates are off by default. To opt in during rollout,
+    add a Fleet script or policy command that runs one of the following after the
+    package install completes:
+
+    ```bash title="Enable automatic package self-updates"
+    /opt/beacon/bin/beacon endpoint update enable
+    ```
+
+    For visibility without automatic package installation, enable check-only
+    mode instead:
+
+    ```bash title="Enable check-only update monitoring"
+    /opt/beacon/bin/beacon endpoint update enable --check-only
+    ```
+
+    Both commands require root and are intended for the system package install.
+    `auto` mode installs newer compatible signed packages from the release
+    manifest after package verification and health checks. `check-only` mode
+    writes local update status events to `/var/log/beacon-agent/system.jsonl` but
+    does not download or apply packages.
+  </Step>
   <Step title="Validate the deployment">
     Run the Fleet validation helper on a managed Mac:
 
     ```bash
     /opt/beacon/fleet/scripts/validate.sh
+    sudo /opt/beacon/bin/beacon endpoint update status
     ```
   </Step>
 </Steps>
@@ -174,6 +197,29 @@ Use `/opt/beacon/fleet/scripts/uninstall.sh` to remove endpoint service files. S
 
     ```bash
     sudo /opt/beacon/bin/beacon endpoint status --system --json
+    ```
+  </Accordion>
+  <Accordion title="Endpoint self-update is not running">
+    Check update mode, launchd state, and local system update events:
+
+    ```bash
+    sudo /opt/beacon/bin/beacon endpoint update status
+    sudo launchctl print system/com.beacon.endpoint.updater
+    sudo tail -n 30 /var/log/beacon-agent/system.jsonl
+    ```
+
+    If the updater is disabled or missing, run the Fleet script or policy command
+    that enables the desired mode:
+
+    ```bash
+    sudo /opt/beacon/bin/beacon endpoint update enable
+    ```
+
+    To trigger an urgent update check from Fleet, run the scheduled updater path
+    immediately:
+
+    ```bash
+    sudo BEACON_UPDATE_JITTER_SECONDS=0 /opt/beacon/bin/beacon endpoint update --scheduled
     ```
   </Accordion>
 </AccordionGroup>

--- a/docs/mdm/index.mdx
+++ b/docs/mdm/index.mdx
@@ -7,7 +7,7 @@ description: "Plan managed macOS deployment of Beacon with Jamf Pro, Fleet, or a
 
 Beacon's macOS package is designed for security and IT rollout through MDM. A signed and notarized `.pkg` installs Beacon under `/opt/beacon`, creates system endpoint configuration, loads the local collector LaunchDaemon, and writes endpoint events to `/var/log/beacon-agent/runtime.jsonl`. Optional Splunk HEC or Falcon LogScale HEC settings add collector destinations while preserving the local runtime log.
 
-The package installs and inventories a local-only endpoint agent. Beacon does not require a hosted account, remote policy fetch, or MDM API credentials for normal collection. During package postinstall, Beacon tolerates a transient `launchctl bootstrap` failure when the LaunchDaemon is already registered and continues validation against the existing service registration.
+The package installs and inventories a local-only endpoint agent. Beacon does not require a hosted account, remote policy fetch, or MDM API credentials for normal collection. During package postinstall, Beacon tolerates a transient `launchctl bootstrap` failure when the LaunchDaemon is already registered and continues validation against the existing service registration. Endpoint package self-updates are available for Apple Silicon system package installs, but remain off by default; IT admins can opt into `check-only` monitoring or `auto` package updates during Jamf or Fleet rollout.
 
 ## Package layout
 
@@ -30,7 +30,9 @@ The endpoint install creates system configuration and runtime state:
 /Library/Application Support/Beacon/Endpoint/config.json
 /Library/Application Support/Beacon/Endpoint/otelcol.yaml
 /Library/LaunchDaemons/com.beacon.endpoint.collector.plist
+/Library/LaunchDaemons/com.beacon.endpoint.updater.plist
 /var/log/beacon-agent/runtime.jsonl
+/var/log/beacon-agent/system.jsonl
 ```
 
 ## Deployment model

--- a/docs/mdm/jamf.mdx
+++ b/docs/mdm/jamf.mdx
@@ -71,11 +71,35 @@ Build or obtain a signed and notarized Beacon macOS package, upload it to Jamf P
     | 14 | Splunk TLS skip-verify flag, accepts `1`, `true`, or `yes`; use only for testing. |
     | 15 | Optional Splunk HEC CA certificate path. |
   </Step>
+  <Step title="Optionally enable endpoint self-updates">
+    Beacon package self-updates are off by default. To opt in during rollout,
+    add a Jamf Files and Processes payload, or a post-install policy command,
+    that runs one of the following after the package install completes:
+
+    ```bash title="Enable automatic package self-updates"
+    /opt/beacon/bin/beacon endpoint update enable
+    ```
+
+    For visibility without automatic package installation, enable check-only
+    mode instead:
+
+    ```bash title="Enable check-only update monitoring"
+    /opt/beacon/bin/beacon endpoint update enable --check-only
+    ```
+
+    Both commands require root and are intended for the system package install.
+    `auto` mode installs newer compatible signed packages from the release
+    manifest after verifying checksum, Developer ID signature, and Gatekeeper
+    assessment. `check-only` mode writes local update status events to
+    `/var/log/beacon-agent/system.jsonl` but does not download or apply
+    packages.
+  </Step>
   <Step title="Validate the deployment">
     After the package deploys, validate the endpoint state on a managed Mac:
 
     ```bash
     sudo /opt/beacon/bin/beacon endpoint status --json
+    sudo /opt/beacon/bin/beacon endpoint update status
     sudo /opt/beacon/bin/beacon endpoint wazuh validate
     sudo launchctl print system/com.beacon.endpoint.collector
     ```
@@ -168,6 +192,30 @@ Use `/opt/beacon/jamf/scripts/install-cursor-hooks.sh` as a separate user-contex
 
     ```bash
     sudo /opt/beacon/bin/beacon endpoint status --system --json
+    ```
+  </Accordion>
+  <Accordion title="Endpoint self-update is not running">
+    Check the configured update mode and updater LaunchDaemon state:
+
+    ```bash
+    sudo /opt/beacon/bin/beacon endpoint update status
+    sudo launchctl print system/com.beacon.endpoint.updater
+    sudo tail -n 30 /var/log/beacon-agent/system.jsonl
+    ```
+
+    `auto` mode applies newer compatible signed packages. `check-only` mode
+    reports update availability without installing. If the updater is disabled
+    or missing, re-run the Jamf policy command that enables the desired mode:
+
+    ```bash
+    sudo /opt/beacon/bin/beacon endpoint update enable
+    ```
+
+    For urgent remediation, a Jamf policy can trigger the scheduled updater path
+    immediately:
+
+    ```bash
+    sudo BEACON_UPDATE_JITTER_SECONDS=0 /opt/beacon/bin/beacon endpoint update --scheduled
     ```
   </Accordion>
 </AccordionGroup>

--- a/docs/security/endpoint-operations.mdx
+++ b/docs/security/endpoint-operations.mdx
@@ -77,9 +77,15 @@ Optional network behavior is customer configured:
 | Sumo Logic | Customer-managed Sumo forwarding reads local JSONL and sends to a Hosted Collector HTTP Source |
 | Splunk HEC | Optional collector exporter sends events to the configured Splunk HEC endpoint |
 | Falcon LogScale HEC | Optional collector exporter sends events to the configured Falcon LogScale HEC endpoint |
+| Endpoint self-update | Optional updater mode fetches the release manifest and signed package assets when manually invoked or explicitly enabled |
 | Customer-managed forwarding | Customer shipper, agent, or SIEM pipeline reads local JSONL |
 
 Beacon itself does not store Elastic cluster URLs or credentials, Datadog API keys or site configuration, Sumo Source URLs, tokens, collector configuration, or Rapid7 webhook URLs. Splunk HEC and Falcon LogScale HEC tokens are stored only in local collector configuration when those optional destinations are enabled.
+
+Endpoint package self-updates are off by default. When an admin enables
+`check-only` or `auto`, the updater's network access is limited to the configured
+release manifest and package asset URLs; normal runtime hook execution remains
+local-only.
 
 ## Uninstall Guarantees
 

--- a/docs/support/troubleshooting.mdx
+++ b/docs/support/troubleshooting.mdx
@@ -57,6 +57,19 @@ description: "Solutions for common issues when setting up and using Asymptote."
 
     After uninstalling hooks, restart the affected agent or IDE so new sessions pick up the updated hook configuration. See the [hook command docs](/cli/hooks#beacon-endpoint-hooks-uninstall) for supported harness names and flags.
   </Accordion>
+  <Accordion title="Endpoint package self-update is not running">
+    For signed macOS package installs, self-update is off by default. Check the
+    configured mode, updater LaunchDaemon state, and local update events:
+
+    ```bash
+    sudo /opt/beacon/bin/beacon endpoint update status
+    sudo launchctl print system/com.beacon.endpoint.updater
+    sudo tail -n 30 /var/log/beacon-agent/system.jsonl
+    ```
+
+    See [Troubleshooting self-update](/cli/upgrade#troubleshooting-self-update)
+    for mode explanations, manual apply, and scheduled updater checks.
+  </Accordion>
 </AccordionGroup>
 
 <Info icon="circle-question" title="Still stuck?">


### PR DESCRIPTION
## Summary
- Document endpoint package self-update modes, behind-the-scenes behavior, troubleshooting, and staging cleanup expectations.
- Add Jamf deployment guidance for optionally enabling `auto` or `check-only` update mode during rollout.
- Add Jamf troubleshooting steps for updater launchd state and urgent scheduled updater runs.

## Test plan
- Docs-only; checked diagnostics for edited MDX files.


Made with [Cursor](https://cursor.com)