### PR TITLE
fix(endpoint): detect nested MCP inventory

### DIFF
--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -408,16 +408,38 @@ func parseMCPServers(item candidate, data []byte, redaction string, co contentOp
 }
 
 func serversFromMap(item candidate, root map[string]interface{}, redaction string, co contentOptions) []MCPServer {
-	var servers []MCPServer
-	for _, key := range []string{"mcpServers", "mcp_servers", "servers"} {
-		if raw, ok := root[key]; ok {
-			servers = append(servers, serversFromBlock(item, raw, redaction, co)...)
-		}
-	}
-	if raw, ok := root["mcp"]; ok {
+	servers := serversFromNestedMCPBlocks(item, root, redaction, co)
+	if raw, ok := root["servers"]; ok {
 		servers = append(servers, serversFromBlock(item, raw, redaction, co)...)
 	}
 	return dedupeServers(servers)
+}
+
+func serversFromNestedMCPBlocks(item candidate, value interface{}, redaction string, co contentOptions) []MCPServer {
+	var servers []MCPServer
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		for key, nested := range typed {
+			if isMCPServerBlockKey(key) {
+				servers = append(servers, serversFromBlock(item, nested, redaction, co)...)
+			}
+			servers = append(servers, serversFromNestedMCPBlocks(item, nested, redaction, co)...)
+		}
+	case []interface{}:
+		for _, nested := range typed {
+			servers = append(servers, serversFromNestedMCPBlocks(item, nested, redaction, co)...)
+		}
+	}
+	return servers
+}
+
+func isMCPServerBlockKey(key string) bool {
+	switch key {
+	case "mcpServers", "mcp_servers", "mcp":
+		return true
+	default:
+		return false
+	}
 }
 
 func serversFromBlock(item candidate, raw interface{}, redaction string, co contentOptions) []MCPServer {

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -131,6 +131,88 @@ func TestScanClaudeJSONMCPInventory(t *testing.T) {
 	}
 }
 
+func TestScanClaudeJSONNestedProjectMCPInventory(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	writeFile(t, filepath.Join(home, ".claude.json"), `{
+  "projects": {
+    "/repo/one": {
+      "mcpServers": {
+        "beacon-dummy-test": {
+          "command": "/bin/echo",
+          "args": ["beacon-dummy-test"]
+        }
+      }
+    },
+    "/repo/two": {
+      "mcpServers": {
+        "remote": {
+          "url": "https://example.test/mcp",
+          "transport": "http"
+        }
+      }
+    }
+  }
+}`)
+
+	result := Scan(Options{
+		HomeDir:    home,
+		WorkingDir: work,
+		Runtimes:   []string{"claude_code"},
+		Now:        fixedNow,
+	})
+
+	if got, want := len(result.MCPServers), 2; got != want {
+		t.Fatalf("MCPServers len = %d, want %d: %#v", got, want, result.MCPServers)
+	}
+	assertServer(t, result.MCPServers, "claude_code", "beacon-dummy-test", TransportStdio, true, 1, 0, 0)
+	assertServer(t, result.MCPServers, "claude_code", "remote", TransportHTTP, false, 0, 0, 0)
+	config := findConfig(result.Configs, "claude_code", filepath.Join(home, ".claude.json"))
+	if config == nil {
+		t.Fatalf("Claude ~/.claude.json config not found in %#v", result.Configs)
+	}
+	if config.MCPServerCount != 2 || config.ParserStatus != StatusOK {
+		t.Fatalf("Claude ~/.claude.json status = %#v, want nested MCP servers", config)
+	}
+}
+
+func TestScanNestedMCPBlocksAcrossConfigFormats(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	writeFile(t, filepath.Join(home, ".cursor", "mcp.json"), `{
+  "profiles": {
+    "default": {
+      "mcp_servers": {
+        "cursor-nested": {"command": "node"}
+      }
+    }
+  }
+}`)
+	writeFile(t, filepath.Join(home, ".codex", "config.toml"), `
+[profiles.default.mcp_servers.codex_nested]
+command = "python3"
+args = ["server.py"]
+`)
+
+	result := Scan(Options{
+		HomeDir:    home,
+		WorkingDir: work,
+		Runtimes:   []string{"cursor", "codex_cli"},
+		Now:        fixedNow,
+	})
+
+	assertServer(t, result.MCPServers, "cursor", "cursor-nested", TransportStdio, true, 0, 0, 0)
+	assertServer(t, result.MCPServers, "codex_cli", "codex_nested", TransportStdio, true, 1, 0, 0)
+	cursorConfig := findConfig(result.Configs, "cursor", filepath.Join(home, ".cursor", "mcp.json"))
+	if cursorConfig == nil || cursorConfig.MCPServerCount != 1 {
+		t.Fatalf("Cursor nested MCP count = %#v, want one server", cursorConfig)
+	}
+	codexConfig := findConfig(result.Configs, "codex_cli", filepath.Join(home, ".codex", "config.toml"))
+	if codexConfig == nil || codexConfig.MCPServerCount != 1 {
+		t.Fatalf("Codex nested MCP count = %#v, want one server", codexConfig)
+	}
+}
+
 func TestScanFiltersRuntimes(t *testing.T) {
 	home := t.TempDir()
 	work := t.TempDir()


### PR DESCRIPTION
## Summary
- Recursively detect MCP server blocks named `mcpServers`, `mcp_servers`, or `mcp` inside inventory config files.
- Capture Claude project-scoped MCP servers from `~/.claude.json` and nested MCP blocks in other harness configs.
- Add regression coverage for nested Claude, Cursor, and Codex MCP inventory shapes.

## Test plan
- `cd cli/beacon && go test ./internal/endpoint/inventory`
- `cd cli/beacon && go test ./internal/endpoint/...`
- End-to-end verified `go run . endpoint inventory heartbeat --user --force` writes a snapshot containing a nested Claude `projects.*.mcpServers` server.


Made with [Cursor](https://cursor.com)