### PR TITLE
Add S3 upload GitHub Actions reference workflow

### DIFF
--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -369,7 +369,9 @@ credentials at the job level and set `upload`:
 
 See [`examples/github-actions/claude-code-telemetry.yml`](../../examples/github-actions/claude-code-telemetry.yml),
 [`examples/github-actions/claude-security-review-session.yml`](../../examples/github-actions/claude-security-review-session.yml),
-and [`examples/github-actions/codex-action-session.yml`](../../examples/github-actions/codex-action-session.yml)
+[`examples/github-actions/codex-action-session.yml`](../../examples/github-actions/codex-action-session.yml),
+[`examples/github-actions/s3-upload-telemetry.yml`](../../examples/github-actions/s3-upload-telemetry.yml),
+and [`examples/github-actions/gcs-upload-telemetry.yml`](../../examples/github-actions/gcs-upload-telemetry.yml)
 for complete reference workflows.
 
 ## Wazuh

--- a/docs/log-forwarding/ci-telemetry-exports.mdx
+++ b/docs/log-forwarding/ci-telemetry-exports.mdx
@@ -92,6 +92,10 @@ Configure cloud credentials at the job level, then pass the upload destination t
     upload: s3
 ```
 
+See the sample workflow:
+
+- [S3 upload telemetry workflow](https://github.com/Asymptote-Labs/agent-beacon/blob/main/examples/github-actions/s3-upload-telemetry.yml)
+
 For GCS, authenticate with your normal Google Cloud CI mechanism and set `BEACON_CI_GCS_BUCKET` plus optional `BEACON_CI_GCS_PREFIX`:
 
 ```yaml
@@ -109,6 +113,10 @@ For GCS, authenticate with your normal Google Cloud CI mechanism and set `BEACON
     command: claude --print "Review this pull request"
     upload: gcs
 ```
+
+See the sample workflow:
+
+- [GCS upload telemetry workflow](https://github.com/Asymptote-Labs/agent-beacon/blob/main/examples/github-actions/gcs-upload-telemetry.yml)
 
 ## Object Layout
 

--- a/docs/runtimes/claude-code-ci.mdx
+++ b/docs/runtimes/claude-code-ci.mdx
@@ -104,6 +104,24 @@ See the sample workflow:
 
 Use `--upload` when the completed `runtime.jsonl` should be handed off through object storage after validation.
 
+Upload to Amazon S3:
+
+```yaml
+- uses: aws-actions/configure-aws-credentials@v4
+  with:
+    role-to-assume: ${{ secrets.BEACON_TELEMETRY_ROLE_ARN }}
+    aws-region: us-east-1
+
+- name: Run an agent with Asymptote telemetry
+  uses: asymptote-labs/agent-beacon@v0.0.66
+  env:
+    BEACON_CI_S3_BUCKET: my-beacon-telemetry
+    BEACON_CI_S3_PREFIX: github-actions
+  with:
+    command: claude --print "Review this pull request"
+    upload: s3
+```
+
 Upload to Google Cloud Storage:
 
 ```yaml
@@ -122,8 +140,9 @@ Upload to Google Cloud Storage:
     upload: gcs
 ```
 
-See the sample workflow:
+See the sample workflows:
 
+- [S3 upload telemetry workflow](https://github.com/Asymptote-Labs/agent-beacon/blob/main/examples/github-actions/s3-upload-telemetry.yml)
 - [GCS upload telemetry workflow](https://github.com/Asymptote-Labs/agent-beacon/blob/main/examples/github-actions/gcs-upload-telemetry.yml)
 
 ## Validation Behavior

--- a/examples/github-actions/s3-upload-telemetry.yml
+++ b/examples/github-actions/s3-upload-telemetry.yml
@@ -1,0 +1,43 @@
+# Reference workflow for testing Agent Beacon CI telemetry with direct S3
+# upload. Copy this file to .github/workflows/ in a test repository and update
+# the bucket, AWS role, region, and action ref.
+#
+# This file lives under examples/ (not .github/workflows/) so it is a reference
+# only and does not run in this repository.
+# Replace <tag> with the Beacon release tag you want to run (v0.0.44 or newer).
+
+name: Test Agent Beacon S3 upload
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  beacon-s3-upload:
+    runs-on: ubuntu-latest
+    env:
+      BEACON_CI_S3_BUCKET: ${{ vars.BEACON_CI_S3_BUCKET }}
+      BEACON_CI_S3_PREFIX: github-actions/test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.BEACON_TELEMETRY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run Agent Beacon with S3 upload
+        uses: asymptote-labs/agent-beacon@<tag>
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          command: claude --print "Say hello from Agent Beacon CI telemetry"
+          upload: s3
+          upload-artifact: "true"


### PR DESCRIPTION
## Summary
- Add `examples/github-actions/s3-upload-telemetry.yml`, mirroring the existing GCS CI upload reference workflow with AWS OIDC credentials, `BEACON_CI_S3_*` env vars, and `upload: s3`.
- Link the new example from CI telemetry export docs, Claude Code CI docs, and `cli/beacon/README.md`.

## Background
GCS already has a full copy-paste workflow under `examples/github-actions/`. S3 upload is documented inline in docs/README but had no matching reference file. No open issues or PRs target this gap.

## Test plan
- [x] Verified `examples/github-actions/s3-upload-telemetry.yml` parses as valid YAML
- [x] Compared structure against `gcs-upload-telemetry.yml` and confirmed inputs match `action.yml` (`upload: s3`, `BEACON_CI_S3_BUCKET`, `BEACON_CI_S3_PREFIX`)
- [x] Ran `go test ./internal/ci/... -run 'Upload|S3'` in `cli/beacon`
- [x] Maintainer can copy the workflow into a test repo, set `BEACON_TELEMETRY_ROLE_ARN`, `BEACON_CI_S3_BUCKET`, and run `workflow_dispatch`