### PR TITLE
Add Splunk HEC forward GitHub Actions reference workflow

### DIFF
--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -371,7 +371,8 @@ See [`examples/github-actions/claude-code-telemetry.yml`](../../examples/github-
 [`examples/github-actions/claude-security-review-session.yml`](../../examples/github-actions/claude-security-review-session.yml),
 [`examples/github-actions/codex-action-session.yml`](../../examples/github-actions/codex-action-session.yml),
 [`examples/github-actions/s3-upload-telemetry.yml`](../../examples/github-actions/s3-upload-telemetry.yml),
-and [`examples/github-actions/gcs-upload-telemetry.yml`](../../examples/github-actions/gcs-upload-telemetry.yml)
+[`examples/github-actions/gcs-upload-telemetry.yml`](../../examples/github-actions/gcs-upload-telemetry.yml),
+and [`examples/github-actions/splunk-forward-telemetry.yml`](../../examples/github-actions/splunk-forward-telemetry.yml)
 for complete reference workflows.
 
 ## Wazuh

--- a/docs/log-forwarding/ci-telemetry-exports.mdx
+++ b/docs/log-forwarding/ci-telemetry-exports.mdx
@@ -72,6 +72,36 @@ beacon ci exec --upload s3 --upload gcs -- claude --print "Review this repositor
 
 S3 upload uses `aws s3 cp` and the standard AWS credential provider chain. GCS upload uses `gcloud storage cp` when available, falling back to `gsutil cp`.
 
+### GitHub Actions SIEM Forwarding
+
+Set the Splunk or Falcon ingest token at the job or workflow level from a secret, then pass `forward` and `forward-endpoint` to the Agent Beacon action:
+
+```yaml
+jobs:
+  claude-telemetry:
+    runs-on: ubuntu-latest
+    env:
+      BEACON_CI_SPLUNK_HEC_TOKEN: ${{ secrets.SPLUNK_HEC_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Claude with Beacon telemetry
+        uses: asymptote-labs/agent-beacon@v0.0.66
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          command: claude --print "Review this pull request"
+          forward: splunk
+          forward-endpoint: https://splunk.example:8088/services/collector
+          upload-artifact: "true"
+```
+
+See the sample workflow:
+
+- [Splunk forward telemetry workflow](https://github.com/Asymptote-Labs/agent-beacon/blob/main/examples/github-actions/splunk-forward-telemetry.yml)
+
+For Falcon LogScale HEC, set `BEACON_CI_FALCON_HEC_TOKEN` and use `forward: falcon`.
+
 ### GitHub Actions Object Storage
 
 Configure cloud credentials at the job level, then pass the upload destination to the Agent Beacon action:

--- a/examples/github-actions/claude-code-telemetry.yml
+++ b/examples/github-actions/claude-code-telemetry.yml
@@ -19,7 +19,6 @@ jobs:
     # exposing secrets to the Claude child process. Omit this block if you only
     # upload the default GitHub artifact.
     env:
-      BEACON_CI_SPLUNK_HEC_TOKEN: ${{ secrets.SPLUNK_HEC_TOKEN }}
       BEACON_CI_S3_BUCKET: ${{ vars.BEACON_CI_S3_BUCKET }}
       BEACON_CI_S3_PREFIX: github-actions
     steps:
@@ -44,8 +43,9 @@ jobs:
           command: claude --print "Summarize the changes in this pull request"
           # Optional: forward to a customer-managed SIEM before teardown.
           # Requires a Beacon release that includes ci exec --forward.
-          forward: splunk
-          forward-endpoint: https://splunk.example:8088/services/collector
+          # See examples/github-actions/splunk-forward-telemetry.yml.
+          # forward: splunk
+          # forward-endpoint: https://splunk.example:8088/services/collector
           # Optional: upload the completed runtime JSONL to object storage.
           # Supported values: s3, gcs, or s3,gcs.
           # upload: s3

--- a/examples/github-actions/splunk-forward-telemetry.yml
+++ b/examples/github-actions/splunk-forward-telemetry.yml
@@ -1,0 +1,38 @@
+# Reference workflow for testing Agent Beacon CI telemetry with direct Splunk
+# HEC forwarding. Copy this file to .github/workflows/ in a test repository
+# and update the Splunk endpoint, secret names, and action ref.
+#
+# This file lives under examples/ (not .github/workflows/) so it is a reference
+# only and does not run in this repository.
+# Replace <tag> with the Beacon release tag you want to run (v0.0.39 or newer).
+
+name: Test Agent Beacon Splunk forward
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  beacon-splunk-forward:
+    runs-on: ubuntu-latest
+    # Keep the Splunk token at the job level so Beacon can forward events
+    # without exposing the secret to the Claude child process.
+    env:
+      BEACON_CI_SPLUNK_HEC_TOKEN: ${{ secrets.SPLUNK_HEC_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run Agent Beacon with Splunk forwarding
+        uses: asymptote-labs/agent-beacon@<tag>
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          command: claude --print "Say hello from Agent Beacon CI telemetry"
+          forward: splunk
+          forward-endpoint: https://splunk.example:8088/services/collector
+          upload-artifact: "true"


### PR DESCRIPTION
## Summary
- Add `examples/github-actions/splunk-forward-telemetry.yml` as a dedicated Splunk HEC CI forwarding reference workflow with job-level `BEACON_CI_SPLUNK_HEC_TOKEN`, `forward: splunk`, and `forward-endpoint`.
- Document the pattern in `docs/log-forwarding/ci-telemetry-exports.mdx` and link the example from `cli/beacon/README.md`.
- Point `claude-code-telemetry.yml` at the dedicated Splunk workflow instead of enabling forwarding inline.

## Background
Splunk CI forwarding is supported by `action.yml` and documented inline, but there was no copy-paste reference workflow comparable to the GCS upload example. No open issues or PRs target this gap.

## Test plan
- [x] Verified `examples/github-actions/splunk-forward-telemetry.yml` parses as valid YAML
- [x] Confirmed inputs match `action.yml` (`forward: splunk`, `BEACON_CI_SPLUNK_HEC_TOKEN`, `forward-endpoint`)
- [x] Ran `go test ./internal/ci/... -run 'Forward|Splunk'` in `cli/beacon`
- [x] Maintainer can copy the workflow into a test repo, set `SPLUNK_HEC_TOKEN`, and run `workflow_dispatch`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example YAML only; no runtime or forwarding logic changes.
> 
> **Overview**
> Adds a **copy-paste reference workflow** for Agent Beacon CI telemetry with **Splunk HEC forwarding** (`examples/github-actions/splunk-forward-telemetry.yml`), including job-level `BEACON_CI_SPLUNK_HEC_TOKEN`, `forward: splunk`, and `forward-endpoint`.
> 
> Documents the same pattern in **CI telemetry exports** docs and links the example from the **beacon CLI README**. The general **Claude Code telemetry** example no longer enables Splunk inline; it comments forwarding and points readers at the dedicated Splunk workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23d5e1c5e213dbcf92bc6efb1eb44724c84bac7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->