### PR TITLE
Add IAM user configuration step to docs

### DIFF
--- a/docs/guides/claude-s3-system.mdx
+++ b/docs/guides/claude-s3-system.mdx
@@ -60,6 +60,24 @@ aws iam create-policy \
 
 If your bucket requires KMS or object tags, add the required `kms:*` or `s3:PutObjectTagging` permissions in AWS.
 
+### Create or choose IAM credentials
+
+You get the access key and secret key from AWS IAM, but ideally use temporary credentials instead of long-lived access keys.
+
+For a quick setup:
+
+1. Open the AWS Console.
+2. Go to IAM.
+3. Go to Users.
+4. Select the IAM user you want Vector to use, or create one named `beacon-endpoint-writer`.
+5. Attach the `BeaconEndpointWriteOnly` policy to that IAM user.
+6. Open the Security credentials tab.
+7. Under Access keys, click Create access key.
+8. Choose the use case, such as Command Line Interface (CLI).
+9. AWS will show `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+
+AWS only shows the secret access key once. Copy it immediately or download the `.csv`.
+
 For a quick local setup, have these values ready:
 
 ```bash


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or application code impact.
> 
> **Overview**
> The **Claude System Mode with S3** guide now documents how to obtain `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` after creating the write-only IAM policy.
> 
> A new **Create or choose IAM credentials** subsection walks through the AWS Console: pick or create a user (e.g. `beacon-endpoint-writer`), attach `BeaconEndpointWriteOnly`, create an access key, and copy the secret once. It also nudges readers toward temporary credentials over long-lived keys before the existing `export` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dae453cd082770282eb17ce204c8a849d41ad3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->