### PR TITLE
Add CurrentBranch() to read git branch without git binary

### DIFF
--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -65,19 +65,28 @@ func resolveBranch(input map[string]interface{}, cwd string) string {
 	return git.CurrentBranch(cwd)
 }
 
-// applyBranchField fills fields["branch"] for emitters that write endpoint
-// events without going through emitHookEvent. fallbackDir seeds branch
-// resolution when the payload carries no working directory, such as a file
-// edit identified only by its path.
-func applyBranchField(fields map[string]interface{}, input map[string]interface{}, fallbackDir string) {
+// applyWorkspaceFields fills workspace context (session.working_directory,
+// repository, branch) for emitters that write endpoint events without going
+// through emitHookEvent, mirroring emitHookEvent's enrichment. fallbackDir
+// seeds branch resolution when the payload carries no working directory,
+// such as a file edit identified only by its path; it is never used for
+// repository, which must reflect the actual workspace path.
+func applyWorkspaceFields(fields map[string]interface{}, input map[string]interface{}, fallbackDir string) {
+	cwd := resolveCwd(input, platformFlag)
+	if cwd != "" {
+		fields["session"] = mergeNested(fields["session"], map[string]interface{}{"working_directory": cwd})
+		if existing, ok := fields["repository"]; !ok || existing == "" {
+			fields["repository"] = cwd
+		}
+	}
 	if existing, ok := fields["branch"]; ok && existing != "" {
 		return
 	}
-	cwd := resolveCwd(input, platformFlag)
-	if cwd == "" {
-		cwd = fallbackDir
+	branchDir := cwd
+	if branchDir == "" {
+		branchDir = fallbackDir
 	}
-	if branch := resolveBranch(input, cwd); branch != "" {
+	if branch := resolveBranch(input, branchDir); branch != "" {
 		fields["branch"] = branch
 	}
 }

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -65,6 +65,23 @@ func resolveBranch(input map[string]interface{}, cwd string) string {
 	return git.CurrentBranch(cwd)
 }
 
+// applyBranchField fills fields["branch"] for emitters that write endpoint
+// events without going through emitHookEvent. fallbackDir seeds branch
+// resolution when the payload carries no working directory, such as a file
+// edit identified only by its path.
+func applyBranchField(fields map[string]interface{}, input map[string]interface{}, fallbackDir string) {
+	if existing, ok := fields["branch"]; ok && existing != "" {
+		return
+	}
+	cwd := resolveCwd(input, platformFlag)
+	if cwd == "" {
+		cwd = fallbackDir
+	}
+	if branch := resolveBranch(input, cwd); branch != "" {
+		fields["branch"] = branch
+	}
+}
+
 // gitMetadataDisabled accepts 1/true/yes, matching other Beacon disable flags.
 func gitMetadataDisabled() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("BEACON_DISABLE_GIT_METADATA"))) {

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/cloudshuttle"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/git"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
 )
 
@@ -38,16 +39,39 @@ func emitHookEvent(logger *logging.Logger, action, category, severity, message s
 	if model := getFirstStr(input, "model"); model != "" {
 		fields["model"] = model
 	}
-	if cwd := resolveCwd(input, platformFlag); cwd != "" {
+	cwd := resolveCwd(input, platformFlag)
+	if cwd != "" {
 		fields["session"] = mergeNested(fields["session"], map[string]interface{}{"working_directory": cwd})
 		fields["repository"] = cwd
 	}
-	if branch := getFirstStr(input, "branch", "git_branch"); branch != "" {
+	if branch := resolveBranch(input, cwd); branch != "" {
 		fields["branch"] = branch
 	}
 	if err := logger.EndpointEvent(action, category, severity, message, fields); err != nil {
 		logger.Error("Failed to write endpoint event", "error", err.Error(), "action", action)
 	}
+}
+
+// resolveBranch prefers a runtime-provided branch and otherwise derives the
+// checked-out branch from the event's working directory. Runtime-provided
+// values pass through even when local git metadata enrichment is disabled.
+func resolveBranch(input map[string]interface{}, cwd string) string {
+	if branch := getFirstStr(input, "branch", "git_branch"); branch != "" {
+		return branch
+	}
+	if cwd == "" || gitMetadataDisabled() {
+		return ""
+	}
+	return git.CurrentBranch(cwd)
+}
+
+// gitMetadataDisabled accepts 1/true/yes, matching other Beacon disable flags.
+func gitMetadataDisabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("BEACON_DISABLE_GIT_METADATA"))) {
+	case "1", "true", "yes":
+		return true
+	}
+	return false
 }
 
 func uploadCloudTelemetry(logger *logging.Logger, force bool) {

--- a/cli/beacon-hooks/cmd/endpoint_events_test.go
+++ b/cli/beacon-hooks/cmd/endpoint_events_test.go
@@ -116,6 +116,58 @@ func TestRunPromptSubmitOmitsBranchOutsideRepo(t *testing.T) {
 	}
 }
 
+func TestRunOpenCodeEventEmitsLocalGitBranch(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "opencode"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	repo := t.TempDir()
+	writeGitHead(t, repo, "ref: refs/heads/feature/opencode\n")
+
+	runHookWithInput(t, runOpenCodeEvent, map[string]interface{}{
+		"type":       "command.executed",
+		"session_id": "oc-branch",
+		"cwd":        repo,
+		"command":    "ls",
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := event["branch"]; got != "feature/opencode" {
+		t.Fatalf("branch = %q, want feature/opencode", got)
+	}
+}
+
+func TestRunPostToolFileEditEmitsLocalGitBranch(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	repo := t.TempDir()
+	writeGitHead(t, repo, "ref: refs/heads/feature/edit\n")
+	editedFile := filepath.Join(repo, "pkg", "main.go")
+
+	// No workspace_roots or cwd in the payload: branch must resolve from the
+	// edited file's own directory.
+	runHookWithInput(t, runPostTool, map[string]interface{}{
+		"conversation_id": "conv-edit",
+		"hook_event_name": "afterFileEdit",
+		"file_path":       editedFile,
+		"edits": []interface{}{
+			map[string]interface{}{"old_string": "old line", "new_string": "new line"},
+		},
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "file.modified" {
+		t.Fatalf("event.action = %q, want file.modified", action)
+	}
+	if got := event["branch"]; got != "feature/edit" {
+		t.Fatalf("branch = %q, want feature/edit", got)
+	}
+}
+
 func TestToolFieldsMapsMCPGenAIStandardFields(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/cli/beacon-hooks/cmd/endpoint_events_test.go
+++ b/cli/beacon-hooks/cmd/endpoint_events_test.go
@@ -4,11 +4,117 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
 )
+
+func writeGitHead(t *testing.T, repo, head string) {
+	t.Helper()
+	gitDir := filepath.Join(repo, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", gitDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte(head), 0o644); err != nil {
+		t.Fatalf("write HEAD: %v", err)
+	}
+}
+
+func TestResolveBranchPrefersRuntimeProvidedBranch(t *testing.T) {
+	repo := t.TempDir()
+	writeGitHead(t, repo, "ref: refs/heads/local-branch\n")
+
+	got := resolveBranch(map[string]interface{}{"git_branch": "cloud-branch"}, repo)
+	if got != "cloud-branch" {
+		t.Fatalf("resolveBranch = %q, want runtime-provided cloud-branch", got)
+	}
+}
+
+func TestResolveBranchReadsLocalCheckout(t *testing.T) {
+	repo := t.TempDir()
+	writeGitHead(t, repo, "ref: refs/heads/feature/local\n")
+
+	got := resolveBranch(map[string]interface{}{}, repo)
+	if got != "feature/local" {
+		t.Fatalf("resolveBranch = %q, want feature/local", got)
+	}
+}
+
+func TestResolveBranchOutsideRepo(t *testing.T) {
+	if got := resolveBranch(map[string]interface{}{}, t.TempDir()); got != "" {
+		t.Fatalf("resolveBranch = %q, want empty outside a repo", got)
+	}
+	if got := resolveBranch(map[string]interface{}{}, ""); got != "" {
+		t.Fatalf("resolveBranch = %q, want empty without cwd", got)
+	}
+}
+
+func TestResolveBranchDisabledByEnv(t *testing.T) {
+	repo := t.TempDir()
+	writeGitHead(t, repo, "ref: refs/heads/feature/local\n")
+
+	for _, value := range []string{"1", "true", "YES"} {
+		t.Setenv("BEACON_DISABLE_GIT_METADATA", value)
+		if got := resolveBranch(map[string]interface{}{}, repo); got != "" {
+			t.Fatalf("resolveBranch = %q, want empty with BEACON_DISABLE_GIT_METADATA=%s", got, value)
+		}
+		// Runtime-provided branch still passes through when disabled.
+		if got := resolveBranch(map[string]interface{}{"git_branch": "cloud-branch"}, repo); got != "cloud-branch" {
+			t.Fatalf("resolveBranch = %q, want runtime-provided branch to pass through", got)
+		}
+	}
+
+	t.Setenv("BEACON_DISABLE_GIT_METADATA", "0")
+	if got := resolveBranch(map[string]interface{}{}, repo); got != "feature/local" {
+		t.Fatalf("resolveBranch = %q, want feature/local with disable flag off", got)
+	}
+}
+
+func TestRunPromptSubmitEmitsLocalGitBranch(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	repo := t.TempDir()
+	writeGitHead(t, repo, "ref: refs/heads/feature/local\n")
+
+	runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"conversation_id": "conv-branch",
+		"hook_event_name": "beforeSubmitPrompt",
+		"workspace_roots": []interface{}{repo},
+		"prompt":          "hello",
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := event["branch"]; got != "feature/local" {
+		t.Fatalf("branch = %q, want feature/local", got)
+	}
+	if got := event["repository"]; got != repo {
+		t.Fatalf("repository = %q, want %q", got, repo)
+	}
+}
+
+func TestRunPromptSubmitOmitsBranchOutsideRepo(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"conversation_id": "conv-no-repo",
+		"hook_event_name": "beforeSubmitPrompt",
+		"workspace_roots": []interface{}{t.TempDir()},
+		"prompt":          "hello",
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if branch, ok := event["branch"]; ok {
+		t.Fatalf("branch = %q, want no branch field outside a repo", branch)
+	}
+}
 
 func TestToolFieldsMapsMCPGenAIStandardFields(t *testing.T) {
 	tests := []struct {

--- a/cli/beacon-hooks/cmd/endpoint_events_test.go
+++ b/cli/beacon-hooks/cmd/endpoint_events_test.go
@@ -166,6 +166,46 @@ func TestRunPostToolFileEditEmitsLocalGitBranch(t *testing.T) {
 	if got := event["branch"]; got != "feature/edit" {
 		t.Fatalf("branch = %q, want feature/edit", got)
 	}
+	// The file-dir fallback must not masquerade as the workspace path.
+	if repository, ok := event["repository"]; ok {
+		t.Fatalf("repository = %q, want no repository without a payload cwd", repository)
+	}
+}
+
+func TestRunPostToolFileEditEmitsWorkspaceFields(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	repo := t.TempDir()
+	writeGitHead(t, repo, "ref: refs/heads/feature/edit\n")
+	editedFile := filepath.Join(repo, "pkg", "main.go")
+
+	runHookWithInput(t, runPostTool, map[string]interface{}{
+		"conversation_id": "conv-edit-ws",
+		"hook_event_name": "afterFileEdit",
+		"workspace_roots": []interface{}{repo},
+		"file_path":       editedFile,
+		"edits": []interface{}{
+			map[string]interface{}{"old_string": "old line", "new_string": "new line"},
+		},
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := event["repository"]; got != repo {
+		t.Fatalf("repository = %q, want %q", got, repo)
+	}
+	session := event["session"].(map[string]interface{})
+	if got := session["working_directory"]; got != repo {
+		t.Fatalf("session.working_directory = %q, want %q", got, repo)
+	}
+	if got := session["id"]; got != "conv-edit-ws" {
+		t.Fatalf("session.id = %q, want conv-edit-ws", got)
+	}
+	if got := event["branch"]; got != "feature/edit" {
+		t.Fatalf("branch = %q, want feature/edit", got)
+	}
 }
 
 func TestToolFieldsMapsMCPGenAIStandardFields(t *testing.T) {

--- a/cli/beacon-hooks/cmd/opencode_event.go
+++ b/cli/beacon-hooks/cmd/opencode_event.go
@@ -44,6 +44,7 @@ func runOpenCodeEvent(cmd *cobra.Command, args []string) {
 func opencodeEndpointEvent(input map[string]interface{}, sessionID string) (string, string, string, string, map[string]interface{}) {
 	eventType := getFirstStr(input, "type", "event_type", "hook")
 	fields := sessionFields(sessionID, input)
+	applyBranchField(fields, input, "")
 	fields["raw"] = map[string]interface{}{
 		"opencode": input,
 	}

--- a/cli/beacon-hooks/cmd/opencode_event.go
+++ b/cli/beacon-hooks/cmd/opencode_event.go
@@ -44,7 +44,7 @@ func runOpenCodeEvent(cmd *cobra.Command, args []string) {
 func opencodeEndpointEvent(input map[string]interface{}, sessionID string) (string, string, string, string, map[string]interface{}) {
 	eventType := getFirstStr(input, "type", "event_type", "hook")
 	fields := sessionFields(sessionID, input)
-	applyBranchField(fields, input, "")
+	applyWorkspaceFields(fields, input, "")
 	fields["raw"] = map[string]interface{}{
 		"opencode": input,
 	}

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -210,7 +210,7 @@ func recordLocalEdit(params *evaluationParams, input map[string]interface{}, log
 	if params.sessionID != "" {
 		fields["session"] = mergeNested(fields["session"], map[string]interface{}{"id": params.sessionID})
 	}
-	applyBranchField(fields, input, filepath.Dir(params.filePath))
+	applyWorkspaceFields(fields, input, filepath.Dir(params.filePath))
 	logger.EndpointEvent("file.modified", "file", "info", "File edit observed", fields)
 }
 

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -85,7 +86,7 @@ func runPostTool(cmd *cobra.Command, args []string) {
 	}
 
 	seedCursorCloudRunID(input)
-	recordLocalEdit(params, logger)
+	recordLocalEdit(params, input, logger)
 	maybeUploadCursorCloudTelemetry(logger)
 	outputJSON(emptyResponse)
 }
@@ -196,7 +197,7 @@ func parseClaudeCopilotInput(input map[string]interface{}, logger *logging.Logge
 }
 
 // recordLocalEdit logs file-edit metadata without sending code or diffs to a hosted service.
-func recordLocalEdit(params *evaluationParams, logger *logging.Logger) {
+func recordLocalEdit(params *evaluationParams, input map[string]interface{}, logger *logging.Logger) {
 	logger.Info("File edit observed", "file_path", params.filePath, "tool_name", params.toolName)
 	fields := map[string]interface{}{}
 	for key, value := range params.extraFields {
@@ -209,6 +210,7 @@ func recordLocalEdit(params *evaluationParams, logger *logging.Logger) {
 	if params.sessionID != "" {
 		fields["session"] = mergeNested(fields["session"], map[string]interface{}{"id": params.sessionID})
 	}
+	applyBranchField(fields, input, filepath.Dir(params.filePath))
 	logger.EndpointEvent("file.modified", "file", "info", "File edit observed", fields)
 }
 

--- a/cli/beacon-hooks/internal/git/git.go
+++ b/cli/beacon-hooks/internal/git/git.go
@@ -2,11 +2,125 @@ package git
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 )
+
+// maxGitMetadataBytes caps reads of repository metadata files so hostile or
+// corrupt .git contents cannot balloon hook memory or telemetry.
+const maxGitMetadataBytes = 4096
+
+// CurrentBranch returns the branch checked out in the repository containing
+// cwd, reading HEAD directly so no git binary is required. It returns "" when
+// cwd is not inside a git repository, HEAD is detached, or HEAD does not
+// parse as a local branch ref.
+func CurrentBranch(cwd string) string {
+	headPath := findHeadFile(cwd)
+	if headPath == "" {
+		return ""
+	}
+	ref, ok := strings.CutPrefix(firstNonEmptyLine(readCapped(headPath)), "ref:")
+	if !ok {
+		return ""
+	}
+	branch, ok := strings.CutPrefix(strings.TrimSpace(ref), "refs/heads/")
+	if !ok || !isValidBranchName(branch) {
+		return ""
+	}
+	return branch
+}
+
+// findHeadFile walks up from cwd to the HEAD file of the innermost checkout.
+// Unlike findGitDir, a worktree ".git" pointer file resolves to the
+// per-worktree gitdir, which holds this checkout's HEAD; the shared commondir
+// HEAD would report another worktree's branch.
+func findHeadFile(cwd string) string {
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return ""
+		}
+	}
+
+	dir := cwd
+	for {
+		gitPath := filepath.Join(dir, ".git")
+		if info, err := os.Stat(gitPath); err == nil {
+			if info.IsDir() {
+				return filepath.Join(gitPath, "HEAD")
+			}
+			if gitdir := parseGitDirPointer(gitPath); gitdir != "" {
+				head := filepath.Join(gitdir, "HEAD")
+				if _, err := os.Stat(head); err == nil {
+					return head
+				}
+			}
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// parseGitDirPointer reads a ".git" pointer file ("gitdir: <path>") and
+// returns the referenced gitdir as an absolute cleaned path, or "".
+func parseGitDirPointer(dotGitFile string) string {
+	gitdir, ok := strings.CutPrefix(firstNonEmptyLine(readCapped(dotGitFile)), "gitdir:")
+	if !ok {
+		return ""
+	}
+	gitdir = strings.TrimSpace(gitdir)
+	if gitdir == "" {
+		return ""
+	}
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(filepath.Dir(dotGitFile), gitdir)
+	}
+	return filepath.Clean(gitdir)
+}
+
+func readCapped(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, maxGitMetadataBytes))
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func firstNonEmptyLine(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// isValidBranchName rejects ref names git itself would refuse, so malformed
+// or hostile HEAD content never reaches telemetry.
+func isValidBranchName(branch string) bool {
+	if branch == "" || len(branch) > 255 {
+		return false
+	}
+	for _, r := range branch {
+		if r < 0x20 || r == 0x7f || r == ' ' {
+			return false
+		}
+	}
+	return true
+}
 
 // GetRemoteInfo returns the owner and repository name from the git remote origin.
 // Returns empty strings if not in a git repo or no origin remote is configured.
@@ -71,26 +185,10 @@ func findGitDir(cwd string) string {
 // extracts the gitdir path, and resolves the common git directory
 // that contains the config with remote URLs.
 func resolveWorktreeGitDir(dotGitFile string) string {
-	data, err := os.ReadFile(dotGitFile)
-	if err != nil {
-		return ""
-	}
-
-	// Parse "gitdir: <path>" from the .git file
-	line := strings.TrimSpace(string(data))
-	if !strings.HasPrefix(line, "gitdir:") {
-		return ""
-	}
-	gitdir := strings.TrimSpace(strings.TrimPrefix(line, "gitdir:"))
+	gitdir := parseGitDirPointer(dotGitFile)
 	if gitdir == "" {
 		return ""
 	}
-
-	// Resolve relative paths against the .git file's parent directory
-	if !filepath.IsAbs(gitdir) {
-		gitdir = filepath.Join(filepath.Dir(dotGitFile), gitdir)
-	}
-	gitdir = filepath.Clean(gitdir)
 
 	// In a worktree, gitdir points to e.g. /repo/.git/worktrees/foo
 	// which contains a "commondir" file with a relative path to the shared .git dir

--- a/cli/beacon-hooks/internal/git/git.go
+++ b/cli/beacon-hooks/internal/git/git.go
@@ -54,10 +54,14 @@ func findHeadFile(cwd string) string {
 				return filepath.Join(gitPath, "HEAD")
 			}
 			if gitdir := parseGitDirPointer(gitPath); gitdir != "" {
+				// A parsed pointer marks this directory as its own
+				// checkout. A missing HEAD means the checkout is broken;
+				// walking on would misattribute an enclosing repo's branch.
 				head := filepath.Join(gitdir, "HEAD")
 				if _, err := os.Stat(head); err == nil {
 					return head
 				}
+				return ""
 			}
 		}
 

--- a/cli/beacon-hooks/internal/git/git_test.go
+++ b/cli/beacon-hooks/internal/git/git_test.go
@@ -103,6 +103,20 @@ func TestCurrentBranchWorktreeRelativeGitDirPointer(t *testing.T) {
 	}
 }
 
+func TestCurrentBranchBrokenWorktreeDoesNotReportParentBranch(t *testing.T) {
+	parent := t.TempDir()
+	writeTestFile(t, filepath.Join(parent, ".git", "HEAD"), "ref: refs/heads/parent-branch\n")
+
+	// The pointer parses but the referenced gitdir has no HEAD: the checkout
+	// is broken, so no branch should be reported — least of all the parent's.
+	broken := filepath.Join(parent, "broken-worktree")
+	writeTestFile(t, filepath.Join(broken, ".git"), "gitdir: "+filepath.Join(parent, ".git", "worktrees", "missing")+"\n")
+
+	if got := CurrentBranch(broken); got != "" {
+		t.Fatalf("CurrentBranch = %q, want empty for a broken worktree", got)
+	}
+}
+
 func TestCurrentBranchRejectsMalformedHead(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cli/beacon-hooks/internal/git/git_test.go
+++ b/cli/beacon-hooks/internal/git/git_test.go
@@ -1,0 +1,129 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestCurrentBranchNormalRepo(t *testing.T) {
+	repo := t.TempDir()
+	writeTestFile(t, filepath.Join(repo, ".git", "HEAD"), "ref: refs/heads/main\n")
+
+	if got := CurrentBranch(repo); got != "main" {
+		t.Fatalf("CurrentBranch = %q, want main", got)
+	}
+}
+
+func TestCurrentBranchWithSlashes(t *testing.T) {
+	repo := t.TempDir()
+	writeTestFile(t, filepath.Join(repo, ".git", "HEAD"), "ref: refs/heads/feature/custom-fields\n")
+
+	if got := CurrentBranch(repo); got != "feature/custom-fields" {
+		t.Fatalf("CurrentBranch = %q, want feature/custom-fields", got)
+	}
+}
+
+func TestCurrentBranchWalksUpFromSubdirectory(t *testing.T) {
+	repo := t.TempDir()
+	writeTestFile(t, filepath.Join(repo, ".git", "HEAD"), "ref: refs/heads/main\n")
+	nested := filepath.Join(repo, "pkg", "internal", "deep")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+
+	if got := CurrentBranch(nested); got != "main" {
+		t.Fatalf("CurrentBranch = %q, want main", got)
+	}
+}
+
+func TestCurrentBranchDetachedHead(t *testing.T) {
+	repo := t.TempDir()
+	writeTestFile(t, filepath.Join(repo, ".git", "HEAD"), "0123456789abcdef0123456789abcdef01234567\n")
+
+	if got := CurrentBranch(repo); got != "" {
+		t.Fatalf("CurrentBranch = %q, want empty for detached HEAD", got)
+	}
+}
+
+func TestCurrentBranchOutsideRepo(t *testing.T) {
+	if got := CurrentBranch(t.TempDir()); got != "" {
+		t.Fatalf("CurrentBranch = %q, want empty outside a repo", got)
+	}
+}
+
+func TestCurrentBranchWorktreeUsesPerWorktreeHead(t *testing.T) {
+	base := t.TempDir()
+	mainRepo := filepath.Join(base, "main-repo")
+	worktree := filepath.Join(base, "wt")
+
+	writeTestFile(t, filepath.Join(mainRepo, ".git", "HEAD"), "ref: refs/heads/main\n")
+	writeTestFile(t, filepath.Join(mainRepo, ".git", "config"), "[remote \"origin\"]\n\turl = git@github.com:asymptote-labs/agent-beacon.git\n")
+	worktreeGitDir := filepath.Join(mainRepo, ".git", "worktrees", "wt")
+	writeTestFile(t, filepath.Join(worktreeGitDir, "HEAD"), "ref: refs/heads/feature/wt-branch\n")
+	writeTestFile(t, filepath.Join(worktreeGitDir, "commondir"), "../..\n")
+	writeTestFile(t, filepath.Join(worktree, ".git"), "gitdir: "+worktreeGitDir+"\n")
+
+	if got := CurrentBranch(worktree); got != "feature/wt-branch" {
+		t.Fatalf("CurrentBranch = %q, want the worktree's own branch", got)
+	}
+	if got := CurrentBranch(mainRepo); got != "main" {
+		t.Fatalf("CurrentBranch = %q, want the main checkout's branch", got)
+	}
+	// The commondir path used by GetRemoteInfo must keep working after the
+	// shared pointer-parsing refactor.
+	owner, name := GetRemoteInfo(worktree)
+	if owner != "asymptote-labs" || name != "agent-beacon" {
+		t.Fatalf("GetRemoteInfo = %q/%q, want asymptote-labs/agent-beacon", owner, name)
+	}
+}
+
+func TestCurrentBranchWorktreeRelativeGitDirPointer(t *testing.T) {
+	base := t.TempDir()
+	mainRepo := filepath.Join(base, "main-repo")
+	worktree := filepath.Join(base, "wt")
+
+	worktreeGitDir := filepath.Join(mainRepo, ".git", "worktrees", "wt")
+	writeTestFile(t, filepath.Join(worktreeGitDir, "HEAD"), "ref: refs/heads/relative-branch\n")
+	writeTestFile(t, filepath.Join(worktree, ".git"), "gitdir: ../main-repo/.git/worktrees/wt\n")
+
+	if got := CurrentBranch(worktree); got != "relative-branch" {
+		t.Fatalf("CurrentBranch = %q, want relative-branch", got)
+	}
+}
+
+func TestCurrentBranchRejectsMalformedHead(t *testing.T) {
+	tests := []struct {
+		name string
+		head string
+	}{
+		{"empty", ""},
+		{"non-branch ref", "ref: refs/remotes/origin/main\n"},
+		{"missing name", "ref: refs/heads/\n"},
+		{"embedded space", "ref: refs/heads/bad name\n"},
+		{"control character", "ref: refs/heads/bad\x01name\n"},
+		{"overlong name", "ref: refs/heads/" + strings.Repeat("a", 300) + "\n"},
+		{"garbage", "not a head file\n"},
+		{"oversized garbage", strings.Repeat("x", 2*maxGitMetadataBytes)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeTestFile(t, filepath.Join(repo, ".git", "HEAD"), tt.head)
+			if got := CurrentBranch(repo); got != "" {
+				t.Fatalf("CurrentBranch = %q, want empty for %s HEAD", got, tt.name)
+			}
+		})
+	}
+}

--- a/docs/runtimes/cursor.mdx
+++ b/docs/runtimes/cursor.mdx
@@ -49,6 +49,7 @@ beacon endpoint hooks install --harness cursor --level project
 |------|---------|
 | Prompt telemetry | Supported for local Cursor through `beforeSubmitPrompt` hooks; not available in Cursor Cloud Agents because Cursor submits the prompt before the cloud VM exists. See [Cursor's Cloud Agent hook support matrix](https://cursor.com/docs/hooks#cloud-agent-support). |
 | Command, tool, and file telemetry | Supported for tool, shell command, MCP-like, approval, and file edit payloads where Cursor exposes them; Cursor Cloud support is limited to Cursor's [cloud-supported command hooks](https://cursor.com/docs/hooks#cloud-agent-support). |
+| Repository and branch context | Events include the workspace path as `repository`, and `branch` is resolved from the workspace's local git checkout (`.git/HEAD`) when Cursor does not supply one; disable local git resolution with `BEACON_DISABLE_GIT_METADATA=1` |
 | Local JSONL and dashboard | Supported |
 | MDM deployment | Supported for the endpoint agent; Cursor hooks are installed separately in the logged-in user's context |
 

--- a/docs/security/data-inventory.mdx
+++ b/docs/security/data-inventory.mdx
@@ -80,6 +80,8 @@ By default, snapshots include config-file metadata, MCP server metadata, skill m
 
 Top-level `model`, `repository`, `branch`, `message`, `raw`, and `field_truncated` fields can add shared context across entities. Content-bearing fields follow the configured retention mode.
 
+For hook-based runtimes, `branch` is derived locally from the workspace's `.git/HEAD` file when the runtime payload does not provide one. This is a local file read only — no git command runs and nothing leaves the machine — and it can be disabled with `BEACON_DISABLE_GIT_METADATA=1`.
+
 ## Related
 
 <Columns cols={2}>

--- a/docs/telemetry-schema/fields.mdx
+++ b/docs/telemetry-schema/fields.mdx
@@ -36,6 +36,8 @@ Beacon models each event as an action plus a set of typed entities. The [`event`
 
 Top-level `model`, `repository`, `branch`, `message`, `raw`, and `field_truncated` fields add shared context that can apply across multiple entities. For example, a command event can include both `tool` and `command`; a file edit can include `file`, `session`, `repository`, and `branch`; a CI event can include `origin` and `run`; and a GenAI tool call can include both `tool` and nested `gen_ai.tool` metadata.
 
+For hook-based runtimes, when the runtime payload does not supply a branch, Beacon fills `branch` from the working directory's git checkout by reading `.git/HEAD` directly — no git binary is required, and the field is omitted when the directory is not a git repository or HEAD is detached. Set `BEACON_DISABLE_GIT_METADATA=1` (accepts `1`, `true`, or `yes`) in the runtime's environment to turn off local git metadata enrichment; runtime-provided branch values still pass through.
+
 ## GenAI context
 
 When a runtime emits OpenTelemetry GenAI semantic convention attributes, Beacon preserves them under `gen_ai` while also projecting commonly queried values into top-level fields such as `model`, `tool.name`, or `prompt.text`.


### PR DESCRIPTION
## Summary

Adds a new `CurrentBranch()` function to the git package that reads the checked-out branch directly from the `.git/HEAD` file without requiring a git binary. This enables branch enrichment in hook telemetry while respecting security constraints around hostile or corrupt git metadata.

## Key Changes

- **New `git.CurrentBranch()` function**: Walks up from a working directory to find the innermost git repository and reads its HEAD file to determine the checked-out branch. Returns empty string when outside a repo, HEAD is detached, or the branch name is invalid.

- **Worktree support**: Correctly handles git worktrees by resolving `.git` pointer files to the per-worktree gitdir (which holds the correct HEAD), rather than the shared commondir.

- **Security hardening**:
  - Caps metadata file reads to 4096 bytes to prevent memory exhaustion from hostile `.git` contents
  - Validates branch names against git's own rules (rejects control characters, spaces, overlong names, non-branch refs)
  - Refactored `parseGitDirPointer()` helper to safely parse `.git` pointer files with the same size limits

- **Hook integration**: Updated `endpoint_events.go` to call `git.CurrentBranch()` when resolving branch telemetry, with a new `BEACON_DISABLE_GIT_METADATA` environment variable to opt out of local git metadata enrichment. Runtime-provided branch values always pass through regardless of the disable flag.

- **Comprehensive test coverage**: Added 129 lines of tests covering normal repos, worktrees (both absolute and relative gitdir pointers), detached HEAD, subdirectory traversal, and rejection of malformed HEAD content.

## Implementation Details

- `findHeadFile()` walks the directory tree to locate `.git` and handles both directory repos and worktree pointer files
- `readCapped()` uses `io.LimitReader` to enforce the 4KB metadata size limit
- `isValidBranchName()` rejects names with control characters (0x00-0x1f, 0x7f), spaces, or length > 255
- The refactored `parseGitDirPointer()` is now used by both `CurrentBranch()` and the existing `resolveWorktreeGitDir()` function, eliminating duplication

https://claude.ai/code/session_015FodhguTi7VVFaan7Crgkq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to optional local metadata on hook JSONL events with validation, size limits, and an env disable; no auth, network, or git subprocess execution.
> 
> **Overview**
> Hook endpoint telemetry now fills **`branch`** from the workspace’s local **`.git/HEAD`** when the runtime does not send `branch` / `git_branch`, using a new **`git.CurrentBranch()`** path that does not invoke the git binary. Runtime-provided branch values still win; **`BEACON_DISABLE_GIT_METADATA`** (`1` / `true` / `yes`) turns off local resolution only.
> 
> **`emitHookEvent`** uses **`resolveBranch`**; **`applyWorkspaceFields`** mirrors the same **`repository`**, **`session.working_directory`**, and **`branch`** rules for direct **`EndpointEvent`** writers (OpenCode events and Cursor **`afterFileEdit`** via **`recordLocalEdit`**), with branch fallback from the edited file’s directory when there is no cwd—without setting **`repository`** from that fallback.
> 
> **`CurrentBranch`** walks up to the innermost checkout, handles worktree **`.git`** pointers to per-worktree HEAD, caps metadata reads at 4KB, validates branch names, and shares **`parseGitDirPointer`** with existing worktree remote resolution. Docs for Cursor, schema fields, and data inventory describe the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd13f66af2166df44a2ccea2576630e60a6cff28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->