### PR TITLE
Add dedicated Hook Inventory page and fix summary aggregation

### DIFF
--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -121,7 +121,12 @@ func Handler(opts Options) (http.Handler, error) {
 			methodNotAllowed(w)
 			return
 		}
-		events, err := ReadEvents(opts.LogPath, parseQuery(r, maxEventLimit))
+		// Summary cards must describe the same dataset as total_events, so
+		// aggregate over every matched event rather than the page-limited
+		// slice a small ?limit= would leave behind.
+		query := parseQuery(r, maxEventLimit)
+		query.NoLimit = true
+		events, err := ReadEvents(opts.LogPath, query)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err)
 			return

--- a/cli/beacon/internal/endpoint/dashboard/server_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/server_test.go
@@ -118,6 +118,58 @@ func TestStatusUsesRequestedRuntimeLogSource(t *testing.T) {
 	}
 }
 
+// TestSummaryEndpointAggregatesAllMatchedEvents guards /api/summary against
+// truncated aggregation: total_events comes from the full match count, so the
+// breakdown counts must be computed over the same full set even when the
+// request carries a small ?limit= from the Log Search view.
+func TestSummaryEndpointAggregatesAllMatchedEvents(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	mk := func(minute int) string {
+		return `{"timestamp":"2026-06-11T10:` + itoa2(minute) + `:00Z","vendor":"beacon","product":"endpoint-agent","schema_version":"1.0","event":{"kind":"agent_runtime","action":"command.executed","category":"command"},"severity":"info","endpoint":{"os":"darwin"},"harness":{"name":"cursor"},"session":{"id":"s1"},"command":{"command":"ls"},"message":"command.executed"}`
+	}
+	var lines []string
+	for i := 0; i < 12; i++ {
+		lines = append(lines, mk(i))
+	}
+	if err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatalf("write fixture log: %v", err)
+	}
+	handler, err := Handler(Options{UserMode: true, LogPath: logPath})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/summary?limit=5", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var summary Summary
+	if err := json.Unmarshal(rec.Body.Bytes(), &summary); err != nil {
+		t.Fatalf("unmarshal summary: %v", err)
+	}
+	if summary.TotalEvents != 12 {
+		t.Fatalf("total_events = %d, want 12", summary.TotalEvents)
+	}
+	if summary.CountsByHarness["cursor"] != 12 {
+		t.Fatalf("counts_by_harness[cursor] = %d, want 12 (must not be capped by ?limit=5)", summary.CountsByHarness["cursor"])
+	}
+	if summary.CommandEvents != 12 {
+		t.Fatalf("command_events = %d, want 12", summary.CommandEvents)
+	}
+	if len(summary.TopHarnesses) != 1 || summary.TopHarnesses[0].Count != 12 {
+		t.Fatalf("top_harnesses = %#v, want cursor with 12 events", summary.TopHarnesses)
+	}
+}
+
+func itoa2(v int) string {
+	if v < 10 {
+		return "0" + strconv.Itoa(v)
+	}
+	return strconv.Itoa(v)
+}
+
 func TestTokensEndpointAggregatesUsage(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
 	lines := []string{
@@ -517,6 +569,7 @@ func TestStaticDashboardPagesServe(t *testing.T) {
 		{path: "/detections.html", want: "Beacon Endpoint Detections"},
 		{path: "/findings.html", want: "Beacon Endpoint Findings"},
 		{path: "/inventory.html", want: "Beacon Endpoint Agent Inventory"},
+		{path: "/inventory-hooks.html", want: "Beacon Endpoint Hook Inventory"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.path, func(t *testing.T) {

--- a/cli/beacon/internal/endpoint/dashboard/static/app.js
+++ b/cli/beacon/internal/endpoint/dashboard/static/app.js
@@ -21,7 +21,9 @@ const isOverviewPage = document.body.dataset.page === "overview";
 const isTokensPage = document.body.dataset.page === "tokens";
 const isDetectionsPage = document.body.dataset.page === "detections";
 const isFindingsPage = document.body.dataset.page === "findings";
-const isInventoryPage = document.body.dataset.page === "inventory";
+// Both inventory pages share loadInventory(); each renderer targets its own
+// page's elements and no-ops when they are absent.
+const isInventoryPage = document.body.dataset.page === "inventory" || document.body.dataset.page === "inventory-hooks";
 const formFields = [
   "q",
   "harness",
@@ -86,8 +88,25 @@ function hydrateFiltersFromURL() {
   for (const field of formFields) {
     const input = $(`[name="${field}"]`);
     if (!input) continue;
-    if (params.has(field)) input.value = params.get(field);
+    if (!params.has(field)) continue;
+    const value = params.get(field);
+    if (field === "limit") ensureLimitOption(input, value);
+    input.value = value;
   }
+}
+
+// The limit control is a fixed <select>; a URL like ?limit=5 would otherwise
+// silently deselect it and the query would fall back to the server default,
+// so add the requested limit as a selectable option.
+function ensureLimitOption(select, value) {
+  if (!(select instanceof HTMLSelectElement)) return;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return;
+  if (Array.from(select.options).some((option) => option.value === value)) return;
+  const option = document.createElement("option");
+  option.value = value;
+  option.textContent = `${value} events`;
+  select.append(option);
 }
 
 function updateURL(query) {
@@ -283,6 +302,9 @@ function renderInventory(resp) {
   renderInventoryMCP(servers, configs);
   renderInventorySkills(existingSkills);
   renderInventoryHooks(hooks, hookConfigs);
+  renderHookInventoryCards(hooks, hookConfigs);
+  renderHookTargets(hooks, configs);
+  renderHookManifests(hookConfigs);
   renderInventoryScope(resp?.user_scope || {});
 }
 
@@ -447,6 +469,78 @@ function renderInventoryHooks(hooks, configs = []) {
         </tr>
       `;
     })
+    .join("");
+}
+
+// Renderers for the dedicated Hook Inventory page (inventory-hooks.html).
+
+function renderHookInventoryCards(hooks, hookConfigs) {
+  const el = $("#hook-inventory-cards");
+  if (!el) return;
+  const installed = hooks.filter((hook) => hook.installed).length;
+  const managed = hookConfigs.filter((config) => config.beacon_managed).length;
+  const cards = [
+    { label: "Hook Targets", value: hooks.length, hint: "runtimes probed" },
+    { label: "Hooks Installed", value: installed, hint: "reporting to Beacon" },
+    { label: "Hook Manifests", value: hookConfigs.length, hint: "discovered files" },
+    { label: "Beacon Managed", value: managed, hint: "managed manifests" },
+  ];
+  el.innerHTML = cards
+    .map((card) => `
+      <div class="card">
+        <span class="muted">${escapeHTML(card.label)}</span>
+        <span class="value">${escapeHTML(card.value)}</span>
+        ${card.hint ? `<span class="muted">${escapeHTML(card.hint)}</span>` : ""}
+      </div>
+    `)
+    .join("");
+}
+
+function renderHookTargets(hooks, configs = []) {
+  const tbody = $("#hook-targets");
+  if (!tbody) return;
+  if (!hooks.length) {
+    tbody.innerHTML = `<tr><td colspan="7" class="muted">No hook targets probed.</td></tr>`;
+    return;
+  }
+  const configByPath = configsByPath(configs);
+  tbody.innerHTML = hooks
+    .map((hook) => {
+      const config = configByPath.get(hook.path) || {};
+      return `
+        <tr class="${hook.installed ? "" : "row-absent"}">
+          <td>${escapeHTML(runtimeLabel(hook.target))}</td>
+          <td>${badge(hook.status || (hook.installed ? "configured" : "not_installed"), hook.installed ? "badge-ok" : "badge-muted")}</td>
+          <td>${config.scope ? badge(config.scope, "badge-muted") : `<span class="muted">-</span>`}</td>
+          <td>${config.beacon_managed ? badge("managed", "badge-ok") : `<span class="muted">no</span>`}</td>
+          <td class="mono path-cell">${hook.binary_path ? escapeHTML(hook.binary_path) : `<span class="muted">-</span>`}</td>
+          <td class="mono path-cell">${hook.path ? escapeHTML(hook.path) : `<span class="muted">-</span>`}</td>
+          <td>${hook.message ? `<span class="muted">${escapeHTML(hook.message)}</span>` : `<span class="muted">-</span>`}</td>
+        </tr>
+      `;
+    })
+    .join("");
+}
+
+function renderHookManifests(hookConfigs) {
+  const tbody = $("#hook-manifests");
+  if (!tbody) return;
+  if (!hookConfigs.length) {
+    tbody.innerHTML = `<tr><td colspan="7" class="muted">No hook configuration manifests discovered.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = hookConfigs
+    .map((config) => `
+      <tr>
+        <td>${escapeHTML(runtimeLabel(config.runtime))}</td>
+        <td>${badge(config.scope || "unknown", "badge-muted")}</td>
+        <td>${parserBadge(config)}</td>
+        <td>${config.beacon_managed ? badge("managed", "badge-ok") : `<span class="muted">no</span>`}</td>
+        <td class="nowrap">${config.modified_at ? escapeHTML(formatTime(config.modified_at)) : `<span class="muted">-</span>`}</td>
+        <td class="mono sha-cell">${hashCell(config.file_sha256)}</td>
+        <td class="mono path-cell">${escapeHTML(config.path || config.path_hash || "")}</td>
+      </tr>
+    `)
     .join("");
 }
 
@@ -618,8 +712,19 @@ function patchEvents(previousEvents, nextEvents) {
     if (existing.has(record.id)) break;
     newest.push(record);
   }
-  if (!newest.length) return;
-  prependEventRows(newest);
+  if (newest.length) prependEventRows(newest);
+  trimEventRows(nextEvents.length);
+}
+
+// trimEventRows drops trailing rows so the poll path's prepends never grow the
+// table past the active limit; nextEvents is the server's limited slice, so its
+// length is the row budget for the current view.
+function trimEventRows(maxRows) {
+  const tbody = $("#events");
+  if (!tbody || !(maxRows > 0)) return;
+  while (tbody.children.length > maxRows) {
+    tbody.removeChild(tbody.lastElementChild);
+  }
 }
 
 function prependEventRows(records) {


### PR DESCRIPTION
## Summary

This change adds a dedicated Hook Inventory page (`inventory-hooks.html`) to the dashboard with specialized views for hook targets and manifests, and fixes a bug where the `/api/summary` endpoint was truncating aggregation counts when a small `?limit=` parameter was present.

## Key Changes

- **New Hook Inventory Page**: Added `inventory-hooks.html` support with three new renderer functions:
  - `renderHookInventoryCards()`: Displays summary cards for hook targets, installed hooks, manifests, and beacon-managed count
  - `renderHookTargets()`: Renders a detailed table of hook targets with status, scope, binary path, and manifest path
  - `renderHookManifests()`: Renders a table of discovered hook configuration manifests with runtime, scope, parser, and file hash information

- **Fixed Summary Aggregation Bug**: Modified `/api/summary` endpoint to aggregate over the full matched event set rather than the page-limited slice. The `query.NoLimit = true` flag ensures summary cards (total_events, counts_by_harness, command_events, top_harnesses) reflect the complete dataset even when the UI requests a small `?limit=` for pagination.

- **Improved URL Parameter Handling**: 
  - Added `ensureLimitOption()` function to dynamically add requested limit values to the fixed `<select>` control, preventing silent deselection when a URL like `?limit=5` is used
  - Refactored `hydrateFiltersFromURL()` for clarity with early continues

- **Event Table Trimming**: Added `trimEventRows()` function to prevent the event table from growing unbounded during polling by dropping trailing rows when new events are prepended, respecting the active limit.

- **Updated Page Detection**: Modified `isInventoryPage` check to include both `inventory` and `inventory-hooks` pages so shared `loadInventory()` logic applies to both, with individual renderers no-opping when their target elements are absent.

## Implementation Details

- The summary aggregation fix ensures that dashboard summary cards always show accurate totals across the entire matched dataset, while the UI's `?limit=` parameter only affects which rows are displayed in paginated views.
- Hook inventory renderers follow the existing pattern of checking for element existence and returning early if not present, allowing the same data load to serve both the overview inventory section and the dedicated hooks page.
- Added test coverage (`TestSummaryEndpointAggregatesAllMatchedEvents`) to guard against regression of the truncated aggregation bug.

https://claude.ai/code/session_016VDGw9z4vzLDAmE6BjgTvP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local loopback dashboard changes only; the summary fix corrects misleading metrics without altering event pagination behavior.
> 
> **Overview**
> Adds a **Hook Inventory** dashboard view (`inventory-hooks.html`) that reuses `loadInventory()` and new client renderers for hook summary cards, per-runtime hook targets, and hook manifest tables.
> 
> **Fixes `/api/summary`** so breakdown metrics (`total_events`, harness counts, etc.) are built from **all** events matching the current filters by setting `query.NoLimit = true`, while `?limit=` still only caps the event list from `/api/events`. Regression coverage is added in `TestSummaryEndpointAggregatesAllMatchedEvents`.
> 
> **Log Search UX:** `ensureLimitOption()` keeps URL `?limit=` values on the fixed limit `<select>`, and **`trimEventRows()`** stops the live-poll prepend path from growing the table past the active row budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fefdcd0eeadffb5accbe9216d7c5c5779916057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->