### PR TITLE
Add agent reasoning telemetry capture via afterAgentThought hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Do not recreate or depend on removed `asymptote` mirror trees. Keep new work foc
 Supported runtime surfaces today:
 
 - Claude Code and Codex CLI telemetry configuration through local OpenTelemetry settings.
-- Cursor hook telemetry for sessions, prompt submission, tool use, command execution, MCP-like tool activity, approval decisions, and file edits where hook payloads expose those fields.
+- Cursor hook telemetry for sessions, prompt submission, tool use, command execution, MCP-like tool activity, approval decisions, file edits, and agent reasoning (`afterAgentThought` thinking text recorded as `agent.reasoning` events in the OTel GenAI `gen_ai.output.messages` reasoning-part shape) where hook payloads expose those fields.
 - Claude Cowork admin-configured OpenTelemetry setup guidance and local validation.
 - `beaconjson` OpenTelemetry Collector exporter that converts OTLP logs, traces, metrics, and resource attributes into Beacon endpoint JSONL.
 - Asymptote Observe TypeScript SDK instrumentation for cloud applications, starting from OpenTelemetry/OpenLLMetry patterns and `observe()` wrappers.

--- a/cli/beacon-hooks/cmd/agent_thought.go
+++ b/cli/beacon-hooks/cmd/agent_thought.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/spf13/cobra"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+)
+
+var agentThoughtCmd = &cobra.Command{
+	Use:   "agent-thought",
+	Short: "Record agent reasoning output for local endpoint telemetry",
+	Long: `afterAgentThought hook - triggered when the agent completes a thinking block.
+Records the aggregated reasoning text as local endpoint telemetry.`,
+	Run: runAgentThought,
+}
+
+func init() {
+	rootCmd.AddCommand(agentThoughtCmd)
+}
+
+func runAgentThought(cmd *cobra.Command, args []string) {
+	input, err := readStdinJSON()
+	if err != nil {
+		outputJSON(hookNoopResponse())
+		return
+	}
+
+	sessionID := resolveSessionID(input, platformFlag)
+	logger := newHookLogger("agent-thought", platformFlag, sessionID)
+	logger.Debug("Agent thought observed")
+
+	text := getFirstStr(input, "text", "thought", "thinking")
+	if text == "" {
+		outputJSON(hookNoopResponse())
+		return
+	}
+
+	fields := sessionFields(sessionID, input)
+	fields["gen_ai"] = map[string]interface{}{
+		"output": map[string]interface{}{
+			"messages": reasoningOutputMessages(text),
+		},
+	}
+	fields["content"] = retainedContentFields(text)
+	if meta := thoughtMetadataFields(input); len(meta) > 0 {
+		fields["raw"] = map[string]interface{}{platformFlag: meta}
+	}
+	emitHookEvent(logger, "agent.reasoning", "session", "info", "Agent reasoning captured", input, fields)
+	outputJSON(hookNoopResponse())
+}
+
+// reasoningOutputMessages wraps reasoning text in the OpenTelemetry GenAI
+// output-messages shape (a single assistant message with a reasoning part), so
+// hook-captured reasoning matches what semconv-native OTLP sources emit.
+func reasoningOutputMessages(text string) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"role": "assistant",
+			"parts": []interface{}{
+				map[string]interface{}{"type": "reasoning", "content": text},
+			},
+		},
+	}
+}
+
+// retainedContentFields builds the content marker for an event that retains
+// raw text, computed against the original text so hash and byte count stay
+// stable even after the sink redacts or truncates the stored copy.
+func retainedContentFields(text string) map[string]interface{} {
+	sum := sha256.Sum256([]byte(text))
+	fields := map[string]interface{}{
+		"retention": asymptoteobserve.ContentRetentionFull,
+		"included":  true,
+		"hash":      hex.EncodeToString(sum[:]),
+		"bytes":     len(text),
+	}
+	if len(text) > asymptoteobserve.DefaultStringLimit {
+		fields["truncated"] = true
+	}
+	if asymptoteobserve.RedactString(text) != text {
+		fields["redacted"] = true
+	}
+	return fields
+}
+
+// thoughtMetadataFields extracts the non-content afterAgentThought payload
+// metadata worth retaining; the reasoning text itself is excluded because it
+// already lives in gen_ai.output.messages.
+func thoughtMetadataFields(input map[string]interface{}) map[string]interface{} {
+	meta := map[string]interface{}{}
+	if duration, ok := firstToolIntAcross([]map[string]interface{}{input}, "duration_ms", "durationMs"); ok {
+		meta["duration_ms"] = duration
+	}
+	if generationID := getFirstStr(input, "generation_id", "generationId"); generationID != "" {
+		meta["generation_id"] = generationID
+	}
+	return meta
+}

--- a/cli/beacon-hooks/cmd/agent_thought_test.go
+++ b/cli/beacon-hooks/cmd/agent_thought_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+)
+
+func TestRunAgentThoughtEmitsReasoningEvent(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	thought := "The failing test writes to a read-only dir; I should use t.TempDir() instead."
+	out := runHookWithInput(t, runAgentThought, map[string]interface{}{
+		"hook_event_name": "afterAgentThought",
+		"conversation_id": "conv-thought",
+		"generation_id":   "gen-42",
+		"model":           "gpt-5.5",
+		"text":            thought,
+		"duration_ms":     float64(5000),
+		"workspace_roots": []interface{}{"/repo"},
+	})
+	if out["continue"] != true {
+		t.Fatalf("cursor agent-thought response = %#v, want continue=true", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	eventInfo := event["event"].(map[string]interface{})
+	if eventInfo["action"] != "agent.reasoning" || eventInfo["category"] != "session" {
+		t.Fatalf("event = %#v, want agent.reasoning session", eventInfo)
+	}
+	if session := event["session"].(map[string]interface{}); session["id"] != "conv-thought" {
+		t.Fatalf("session = %#v, want id conv-thought", session)
+	}
+	if event["model"] != "gpt-5.5" {
+		t.Fatalf("model = %v, want gpt-5.5", event["model"])
+	}
+
+	genAI := event["gen_ai"].(map[string]interface{})
+	messages := genAI["output"].(map[string]interface{})["messages"].([]interface{})
+	if len(messages) != 1 {
+		t.Fatalf("output messages = %#v, want one assistant message", messages)
+	}
+	message := messages[0].(map[string]interface{})
+	if message["role"] != "assistant" {
+		t.Fatalf("message role = %v, want assistant", message["role"])
+	}
+	part := message["parts"].([]interface{})[0].(map[string]interface{})
+	if part["type"] != "reasoning" || part["content"] != thought {
+		t.Fatalf("reasoning part = %#v", part)
+	}
+
+	sum := sha256.Sum256([]byte(thought))
+	content := event["content"].(map[string]interface{})
+	if content["retention"] != "full" || content["included"] != true {
+		t.Fatalf("content marker = %#v", content)
+	}
+	if content["hash"] != hex.EncodeToString(sum[:]) {
+		t.Fatalf("content hash = %v, want %s", content["hash"], hex.EncodeToString(sum[:]))
+	}
+	if content["bytes"] != float64(len(thought)) {
+		t.Fatalf("content bytes = %v, want %d", content["bytes"], len(thought))
+	}
+	if _, ok := content["truncated"]; ok {
+		t.Fatalf("short thought should not be marked truncated: %#v", content)
+	}
+
+	raw := event["raw"].(map[string]interface{})["cursor"].(map[string]interface{})
+	if raw["duration_ms"] != float64(5000) || raw["generation_id"] != "gen-42" {
+		t.Fatalf("raw cursor metadata = %#v", raw)
+	}
+	if _, ok := raw["text"]; ok {
+		t.Fatalf("raw metadata must not duplicate reasoning text: %#v", raw)
+	}
+}
+
+func TestRunAgentThoughtSkipsEventWithoutText(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runAgentThought, map[string]interface{}{
+		"hook_event_name": "afterAgentThought",
+		"conversation_id": "conv-empty",
+	})
+	if out["continue"] != true {
+		t.Fatalf("cursor agent-thought response = %#v, want continue=true", out)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("no endpoint event should be written without text: %v", err)
+	}
+}
+
+func TestRunAgentThoughtCorrectsCursorPayloadWithDefaultPlatform(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "claude"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runAgentThought, map[string]interface{}{
+		"hook_event_name": "afterAgentThought",
+		"conversation_id": "conv-override",
+		"text":            "reasoning through the plan",
+	})
+	if out["continue"] != true {
+		t.Fatalf("response after cursor payload override = %#v, want continue=true", out)
+	}
+	event := lastEndpointEvent(t, logPath)
+	if harness := event["harness"].(map[string]interface{}); harness["name"] != "cursor" {
+		t.Fatalf("harness = %#v, want cursor", harness)
+	}
+}
+
+func TestRunAgentThoughtMarksLongAndSecretBearingText(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	long := "api_key=sk-abcdefghijklmnopqrstuvwxyz123456 " + strings.Repeat("reasoning ", asymptoteobserve.DefaultStringLimit/8)
+	runHookWithInput(t, runAgentThought, map[string]interface{}{
+		"hook_event_name": "afterAgentThought",
+		"conversation_id": "conv-long",
+		"text":            long,
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	content := event["content"].(map[string]interface{})
+	if content["truncated"] != true {
+		t.Fatalf("content marker should flag truncation: %#v", content)
+	}
+	if content["redacted"] != true {
+		t.Fatalf("content marker should flag redaction: %#v", content)
+	}
+	if content["bytes"] != float64(len(long)) {
+		t.Fatalf("content bytes = %v, want original length %d", content["bytes"], len(long))
+	}
+
+	part := event["gen_ai"].(map[string]interface{})["output"].(map[string]interface{})["messages"].([]interface{})[0].(map[string]interface{})["parts"].([]interface{})[0].(map[string]interface{})
+	stored := part["content"].(string)
+	if strings.Contains(stored, "sk-abcdefghijklmnopqrstuvwxyz123456") {
+		t.Fatalf("stored reasoning text was not redacted")
+	}
+	if len(stored) > asymptoteobserve.DefaultStringLimit+64 {
+		t.Fatalf("stored reasoning text was not truncated: %d bytes", len(stored))
+	}
+}

--- a/cli/beacon-hooks/cmd/cursor_event.go
+++ b/cli/beacon-hooks/cmd/cursor_event.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
 )
 
 var cursorEventCmd = &cobra.Command{
@@ -23,12 +21,7 @@ func runCursorEvent(cmd *cobra.Command, args []string) {
 		return
 	}
 	sessionID := resolveSessionID(input, platformFlag)
-	var logger *logging.Logger
-	if sessionID != "" {
-		logger = logging.NewSessionLogger("cursor-event", platformFlag, sessionID)
-	} else {
-		logger = logging.NewLoggerForPlatform("cursor-event", platformFlag)
-	}
+	logger := newHookLogger("cursor-event", platformFlag, sessionID)
 	switch getFirstStr(input, "hook_event_name", "hookEventName") {
 	case "preCompact":
 		emitHookEvent(logger, "session.compacting", "session", "info", "Context compaction observed", input, sessionFields(sessionID, input))

--- a/cli/beacon-hooks/cmd/helpers.go
+++ b/cli/beacon-hooks/cmd/helpers.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
 )
 
 // readStdinJSON decodes JSON from stdin into a map.
@@ -31,6 +33,24 @@ func outputJSONAndExit(data map[string]interface{}) {
 // emptyResponse is a reusable empty JSON response.
 var emptyResponse = map[string]interface{}{}
 
+// hookNoopResponse returns the platform's expected no-op hook reply. Call it
+// after readStdinJSON so payload-based platform overrides have been applied.
+func hookNoopResponse() map[string]interface{} {
+	if platformFlag == "cursor" {
+		return map[string]interface{}{"continue": true}
+	}
+	return emptyResponse
+}
+
+// newHookLogger returns a per-session logger when a session ID is known and a
+// per-platform logger otherwise.
+func newHookLogger(hookName, platform, sessionID string) *logging.Logger {
+	if sessionID != "" {
+		return logging.NewSessionLogger(hookName, platform, sessionID)
+	}
+	return logging.NewLoggerForPlatform(hookName, platform)
+}
+
 func isDevinLikePlatform(platform string) bool {
 	return platform == "devin" || platform == "devin-cli"
 }
@@ -54,7 +74,7 @@ func looksLikeCursorPayload(input map[string]interface{}) bool {
 		return true
 	}
 	switch getFirstStr(input, "hook_event_name", "hookEventName") {
-	case "beforeSubmitPrompt", "beforeShellExecution", "afterShellExecution", "beforeReadFile", "afterFileEdit", "postToolUse", "postToolUseFailure", "preCompact", "subagentStart", "subagentStop":
+	case "beforeSubmitPrompt", "beforeShellExecution", "afterShellExecution", "beforeReadFile", "afterFileEdit", "afterAgentThought", "postToolUse", "postToolUseFailure", "preCompact", "subagentStart", "subagentStop":
 		return true
 	default:
 		return false

--- a/cli/beacon-hooks/cmd/opencode_event.go
+++ b/cli/beacon-hooks/cmd/opencode_event.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-
-	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
 )
 
 var opencodeEventCmd = &cobra.Command{
@@ -26,12 +24,7 @@ func runOpenCodeEvent(cmd *cobra.Command, args []string) {
 		return
 	}
 	sessionID := resolveSessionID(input, "opencode")
-	var logger *logging.Logger
-	if sessionID != "" {
-		logger = logging.NewSessionLogger("opencode-event", "opencode", sessionID)
-	} else {
-		logger = logging.NewLoggerForPlatform("opencode-event", "opencode")
-	}
+	logger := newHookLogger("opencode-event", "opencode", sessionID)
 	action, category, severity, message, fields := opencodeEndpointEvent(input, sessionID)
 	if action == "" {
 		outputJSON(emptyResponse)

--- a/cli/beacon-hooks/cmd/permission_request.go
+++ b/cli/beacon-hooks/cmd/permission_request.go
@@ -32,12 +32,7 @@ func runPermissionRequest(cmd *cobra.Command, args []string) {
 	}
 
 	sessionID := resolveSessionID(input, platformFlag)
-	var logger *logging.Logger
-	if sessionID != "" {
-		logger = logging.NewSessionLogger("permission-request", platformFlag, sessionID)
-	} else {
-		logger = logging.NewLoggerForPlatform("permission-request", platformFlag)
-	}
+	logger := newHookLogger("permission-request", platformFlag, sessionID)
 
 	if deny, denied := enforcePolicy(logger, input, sessionID, policycontract.PhasePermissionRequest); denied {
 		outputJSON(deny)

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -42,12 +42,7 @@ func runPostTool(cmd *cobra.Command, args []string) {
 
 	// Resolve session ID early so we can use per-session logger
 	sessionID := resolveSessionID(input, platformFlag)
-	var logger *logging.Logger
-	if sessionID != "" {
-		logger = logging.NewSessionLogger("post-tool-async-scan", platformFlag, sessionID)
-	} else {
-		logger = logging.NewLoggerForPlatform("post-tool-async-scan", platformFlag)
-	}
+	logger := newHookLogger("post-tool-async-scan", platformFlag, sessionID)
 
 	var params *evaluationParams
 

--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -37,12 +37,7 @@ func runPreTool(cmd *cobra.Command, args []string) {
 	}
 
 	sessionID := resolveSessionID(input, platformFlag)
-	var logger *logging.Logger
-	if sessionID != "" {
-		logger = logging.NewSessionLogger("pre-tool", platformFlag, sessionID)
-	} else {
-		logger = logging.NewLoggerForPlatform("pre-tool", platformFlag)
-	}
+	logger := newHookLogger("pre-tool", platformFlag, sessionID)
 
 	logger.Debug("Pre-tool observed")
 	if deny, denied := enforcePolicy(logger, input, sessionID, policycontract.PhasePreTool); denied {

--- a/cli/beacon-hooks/cmd/prompt_submit.go
+++ b/cli/beacon-hooks/cmd/prompt_submit.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/state"
 )
 
@@ -20,24 +19,14 @@ func init() {
 }
 
 func runPromptSubmit(cmd *cobra.Command, args []string) {
-	noopResponse := emptyResponse
-	if platformFlag == "cursor" {
-		noopResponse = map[string]interface{}{"continue": true}
-	}
-
 	input, err := readStdinJSON()
 	if err != nil {
-		outputJSON(noopResponse)
+		outputJSON(hookNoopResponse())
 		return
 	}
 
 	sessionID := resolveSessionID(input, platformFlag)
-	var logger *logging.Logger
-	if sessionID != "" {
-		logger = logging.NewSessionLogger("prompt-submit", platformFlag, sessionID)
-	} else {
-		logger = logging.NewLoggerForPlatform("prompt-submit", platformFlag)
-	}
+	logger := newHookLogger("prompt-submit", platformFlag, sessionID)
 
 	logger.Debug("Prompt submit observed")
 	maybeEmitInventoryHeartbeat(logger, input)
@@ -65,5 +54,5 @@ func runPromptSubmit(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	outputJSON(noopResponse)
+	outputJSON(hookNoopResponse())
 }

--- a/cli/beacon-hooks/cmd/stop.go
+++ b/cli/beacon-hooks/cmd/stop.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/config"
-	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/state"
 )
 
@@ -38,12 +37,7 @@ func runStop(cmd *cobra.Command, args []string) {
 
 	sessionID, transcriptPath := resolveSessionIDWithTranscript(input, platformFlag)
 
-	var logger *logging.Logger
-	if sessionID != "" {
-		logger = logging.NewSessionLogger("stop", platformFlag, sessionID)
-	} else {
-		logger = logging.NewLoggerForPlatform("stop", platformFlag)
-	}
+	logger := newHookLogger("stop", platformFlag, sessionID)
 
 	logger.Debug("Stop hook called", "session_id", sessionID, "has_transcript", transcriptPath != "", "platform", platformFlag)
 	if sessionID == "" {

--- a/cli/beacon-hooks/cmd/subagent.go
+++ b/cli/beacon-hooks/cmd/subagent.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/logging"
 )
 
 var subagentStartCmd = &cobra.Command{
@@ -34,12 +32,7 @@ func runSubagentLifecycle(action, message string) {
 		return
 	}
 	sessionID := resolveSessionID(input, platformFlag)
-	var logger *logging.Logger
-	if sessionID != "" {
-		logger = logging.NewSessionLogger("subagent", platformFlag, sessionID)
-	} else {
-		logger = logging.NewLoggerForPlatform("subagent", platformFlag)
-	}
+	logger := newHookLogger("subagent", platformFlag, sessionID)
 	fields := sessionFields(sessionID, input)
 	subagent := map[string]interface{}{
 		"id":   getFirstStr(input, "subagent_id", "agent_id", "agentId"),

--- a/cli/beacon-hooks/internal/logging/endpoint_event_test.go
+++ b/cli/beacon-hooks/internal/logging/endpoint_event_test.go
@@ -111,6 +111,9 @@ func TestEndpointEventDoesNotInventCloudRunID(t *testing.T) {
 	t.Setenv("BEACON_RUN_PROVIDER", "claude_code_web")
 	t.Setenv("BEACON_CLOUD_GCS_BUCKET", "bucket")
 	t.Setenv("BEACON_CLOUD_GCS_CREDENTIALS_B64", "credentials")
+	// cloudRunFields falls back to this env var; clear it so the test stays
+	// hermetic when it runs inside a Claude Code remote session.
+	t.Setenv("CLAUDE_CODE_REMOTE_SESSION_ID", "")
 
 	logger := NewLoggerForPlatform("session-start", "claude")
 	if err := logger.EndpointEvent("session.started", "session", "info", "Session started", nil); err != nil {

--- a/cli/beacon/internal/endpoint/hooks/cursor.go
+++ b/cli/beacon/internal/endpoint/hooks/cursor.go
@@ -95,6 +95,7 @@ func installCursorHooksJSON(path, binaryPath, logPath, configPath string) error 
 		"sessionStart":       {Command: commandPrefix + " session-start"},
 		"beforeSubmitPrompt": {Command: commandPrefix + " prompt-submit", Timeout: 30},
 		"preToolUse":         {Command: commandPrefix + " pre-tool", Matcher: "Write|Edit|MultiEdit|Shell|MCP"},
+		"afterAgentThought":  {Command: commandPrefix + " agent-thought"},
 		"afterFileEdit":      {Command: commandPrefix + " post-tool"},
 		"postToolUse":        {Command: commandPrefix + " post-tool"},
 		"postToolUseFailure": {Command: commandPrefix + " post-tool"},

--- a/cli/beacon/internal/endpoint/hooks/cursor_test.go
+++ b/cli/beacon/internal/endpoint/hooks/cursor_test.go
@@ -35,6 +35,9 @@ func TestInstallCursorHooksJSONPreservesNonBeaconHooks(t *testing.T) {
 	if !strings.Contains(text, "BEACON_ENDPOINT_CONFIG='/tmp/config.json'") {
 		t.Fatalf("endpoint config env was not added: %s", text)
 	}
+	if !strings.Contains(text, `"afterAgentThought"`) || !strings.Contains(text, "agent-thought") {
+		t.Fatalf("afterAgentThought reasoning hook was not installed: %s", text)
+	}
 }
 
 func TestRemoveEndpointHooksPreservesOtherHooks(t *testing.T) {

--- a/docs/runtimes/cursor.mdx
+++ b/docs/runtimes/cursor.mdx
@@ -49,6 +49,7 @@ beacon endpoint hooks install --harness cursor --level project
 |------|---------|
 | Prompt telemetry | Supported for local Cursor through `beforeSubmitPrompt` hooks; not available in Cursor Cloud Agents because Cursor submits the prompt before the cloud VM exists. See [Cursor's Cloud Agent hook support matrix](https://cursor.com/docs/hooks#cloud-agent-support). |
 | Command, tool, and file telemetry | Supported for tool, shell command, MCP-like, approval, and file edit payloads where Cursor exposes them; Cursor Cloud support is limited to Cursor's [cloud-supported command hooks](https://cursor.com/docs/hooks#cloud-agent-support). |
+| Agent reasoning telemetry | Supported for local Cursor through `afterAgentThought` hooks. Each completed thinking block is recorded as an `agent.reasoning` event carrying the reasoning text in the OpenTelemetry GenAI output-messages shape (`gen_ai.output.messages` with a `reasoning` part), plus a `content` marker with the original text's hash and byte count. Reasoning is only available for models/modes where Cursor exposes visible thinking text. |
 | Repository and branch context | Events include the workspace path as `repository`, and `branch` is resolved from the workspace's local git checkout (`.git/HEAD`) when Cursor does not supply one; disable local git resolution with `BEACON_DISABLE_GIT_METADATA=1` |
 | Local JSONL and dashboard | Supported |
 | MDM deployment | Supported for the endpoint agent; Cursor hooks are installed separately in the logged-in user's context |
@@ -57,7 +58,7 @@ beacon endpoint hooks install --harness cursor --level project
 
 Restart Cursor after installing or removing hooks so the updated hook configuration is picked up by new sessions.
 
-Hook events include metadata such as file path, operation, language, diff hash, and diff byte count. Raw diffs are subject to Asymptote's redaction, sanitization, truncation, and event-size limits before writing.
+Hook events include metadata such as file path, operation, language, diff hash, and diff byte count. Raw diffs and reasoning text are subject to Asymptote's redaction, sanitization, truncation, and event-size limits before writing.
 
 ## Related
 

--- a/pkg/asymptoteobserve/event.go
+++ b/pkg/asymptoteobserve/event.go
@@ -200,11 +200,16 @@ type PromptInfo struct {
 	Text string `json:"text,omitempty"`
 }
 
+// ContentInfo marks how an event's retained raw content was handled. Hash and
+// Bytes describe the original content before redaction/truncation, so events
+// keep a stable identifier and size even when the stored text was cut down.
 type ContentInfo struct {
 	Retention string `json:"retention"`
 	Included  bool   `json:"included"`
 	Redacted  bool   `json:"redacted,omitempty"`
 	Truncated bool   `json:"truncated,omitempty"`
+	Hash      string `json:"hash,omitempty"`
+	Bytes     int    `json:"bytes,omitempty"`
 }
 
 const (

--- a/spec/threat-rules/FIELDS.md
+++ b/spec/threat-rules/FIELDS.md
@@ -15,6 +15,8 @@ Regenerate with `beacon rules fields --markdown > spec/threat-rules/FIELDS.md`.
 | `e.command.command` | string |
 | `e.command.duration_ms` | int |
 | `e.command.exit_code` | int |
+| `e.content.bytes` | int |
+| `e.content.hash` | string |
 | `e.content.included` | bool |
 | `e.content.redacted` | bool |
 | `e.content.retention` | string |


### PR DESCRIPTION
## Summary

Adds support for capturing agent reasoning output from Cursor's `afterAgentThought` hook as local endpoint telemetry. This enables visibility into agent thinking blocks and internal reasoning processes.

## Key Changes

- **New `agent-thought` hook command** (`cli/beacon-hooks/cmd/agent_thought.go`): Processes `afterAgentThought` hook events from Cursor, wraps reasoning text in OpenTelemetry GenAI output-messages format (assistant message with reasoning part), and emits `agent.reasoning` session events with content markers.

- **Content tracking for reasoning text**: Implements `retainedContentFields()` to compute SHA256 hash and byte count against original text before redaction/truncation, enabling stable event identifiers and size tracking even when stored text is modified by the sink.

- **Metadata extraction**: Captures non-content payload fields (`duration_ms`, `generation_id`) in raw platform metadata while excluding the reasoning text itself (already in `gen_ai.output.messages`).

- **Comprehensive test coverage** (`cli/beacon-hooks/cmd/agent_thought_test.go`): 
  - Validates reasoning event structure and GenAI message format
  - Verifies content markers (hash, bytes, truncation, redaction flags)
  - Tests skip behavior when text is absent
  - Confirms platform override handling (Claude payload corrected to Cursor)
  - Validates redaction and truncation of long/secret-bearing text

- **Helper refactoring**: Extracted `hookNoopResponse()` and `newHookLogger()` helpers in `helpers.go` to reduce duplication across hook commands (`prompt_submit`, `cursor_event`, `opencode_event`, `subagent`, `stop`, `permission_request`, `post_tool`, `pre_tool`).

- **Schema updates**: Added `hash` and `bytes` fields to `ContentInfo` struct in `pkg/asymptoteobserve/event.go` with documentation explaining they describe original content before sink modifications.

- **Hook registration**: Updated Cursor hook installation to register `afterAgentThought` → `agent-thought` command mapping and added event name to platform detection logic.

- **Documentation**: Updated Cursor runtime docs and threat-rules field reference to include new content tracking fields.

## Implementation Details

- Reasoning text is wrapped in the standard OpenTelemetry GenAI semconv shape (single assistant message with reasoning-typed part) for consistency with native OTLP sources.
- Content markers use the original text for hash/byte computation so events maintain stable identifiers even when the sink redacts secrets or truncates long text.
- Metadata extraction skips the reasoning text itself to avoid duplication since it's already captured in structured `gen_ai.output.messages`.
- Hook returns platform-appropriate no-op response (`{"continue": true}` for Cursor, empty for others).

https://claude.ai/code/session_01CpJTLucos2j9RzdH9SXidk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds retention of agent reasoning text (sensitive internal thinking) to local JSONL with redaction/truncation, plus optional schema fields for threat rules; hook-path changes are additive and well-tested.
> 
> **Overview**
> Adds **Cursor `afterAgentThought`** handling so completed thinking blocks become local **`agent.reasoning`** session events, with reasoning text in **`gen_ai.output.messages`** (assistant message + **`reasoning`** part) and **`content`** markers (SHA-256 **hash**, **bytes**, truncation/redaction flags computed from the original text).
> 
> Introduces the **`beacon-hooks agent-thought`** command, wires it in **`beacon endpoint hooks install`** for Cursor, and extends Cursor payload detection to recognize **`afterAgentThought`**. Refactors shared hook helpers (**`hookNoopResponse`**, **`newHookLogger`**) across existing commands.
> 
> Extends **`ContentInfo`** with optional **`hash`** / **`bytes`**, documents Cursor reasoning coverage, and updates threat-rule field reference for **`e.content.hash`** and **`e.content.bytes`**. Includes tests for event shape, empty text, platform override, and redaction/truncation; clears **`CLAUDE_CODE_REMOTE_SESSION_ID`** in one cloud logging test for hermeticity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c68fe92ffdf90e95c99e2bdcee1cc1ebeb3b836b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->