### PR TITLE
Update docs with latest release notes

### DIFF
--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -9,6 +9,28 @@ Stay up to date with the latest changes to the Agent Beacon CLI.
 
 ---
 
+## July 2026
+
+### v0.0.95 · July 10, 2026
+
+- **Cursor telemetry docs polish** · Fixed punctuation and grammar in the Cursor telemetry support table so local and cloud hook coverage is easier to scan.
+
+### v0.0.94 · July 10, 2026
+
+- **Cursor agent reasoning telemetry** · Local Cursor hooks now capture completed `afterAgentThought` thinking blocks as `agent.reasoning` events, preserving the text in the OpenTelemetry GenAI `gen_ai.output.messages` reasoning-part shape when Cursor exposes visible thinking text.
+- **Hook inventory dashboard fixes** · Added a dedicated Hook Inventory dashboard page and fixed summary aggregation and poll-path row limits so inventory coverage is easier to inspect locally.
+
+### v0.0.93 · July 9, 2026
+
+- **Branch attribution without git execution** · Hook events can now fill `branch` from the local checkout by reading `.git/HEAD` directly when the runtime payload does not provide one, avoiding broken-worktree walks and keeping branch context paired with workspace fields.
+- **CI export reference workflows** · Added GitHub Actions examples for forwarding CI telemetry to Splunk HEC and uploading completed runtime JSONL to S3.
+- **S3 setup doc updates** · Clarified IAM user configuration and AWS S3 setup steps for customer-managed telemetry upload paths.
+
+### v0.0.92 · July 1, 2026
+
+- **Package install repair for active users** · macOS package installs now repair the active user's runtime configuration after package updates, helping user-context hooks keep pointing at the current packaged binaries.
+- **Codex hook docs alignment** · Updated Codex hook guidance after reverting the in-progress Codex session token attribution changes, preserving the current contract where Codex token usage has model, harness, repository, and run attribution but no per-session rollup.
+
 ## June 2026
 
 ### v0.0.91 · June 29, 2026

--- a/docs/cli/ci-finish.mdx
+++ b/docs/cli/ci-finish.mdx
@@ -43,7 +43,7 @@ beacon ci finish --upload gcs
 ```yaml
 - name: Start Beacon telemetry
   id: beacon
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   with:
     mode: start
     harnesses: codex
@@ -56,7 +56,7 @@ beacon ci finish --upload gcs
 
 - name: Finish Beacon telemetry
   if: always()
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   with:
     mode: finish
     min-events: "1"

--- a/docs/cli/ci.mdx
+++ b/docs/cli/ci.mdx
@@ -39,7 +39,7 @@ Some workflows call a third-party action that launches the agent internally. In 
 
 ```yaml title="Wrap a CI action that launches an agent"
 - name: Start Beacon telemetry
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   with:
     mode: start
     harnesses: claude
@@ -54,7 +54,7 @@ Some workflows call a third-party action that launches the agent internally. In 
 
 - name: Finish Beacon telemetry
   if: always()
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   with:
     mode: finish
     min-events: "1"

--- a/docs/cli/cloud-claude-web-print-setup.mdx
+++ b/docs/cli/cloud-claude-web-print-setup.mdx
@@ -18,7 +18,7 @@ Paste the generated script into the Claude Code cloud environment setup field. I
 Print setup for a specific Beacon release:
 
 ```bash title="Print setup for a specific Beacon release"
-beacon cloud claude-web print-setup --version v0.0.66
+beacon cloud claude-web print-setup --version v0.0.95
 ```
 
 ## Related

--- a/docs/cli/cloud-cursor-print-setup.mdx
+++ b/docs/cli/cloud-cursor-print-setup.mdx
@@ -31,7 +31,7 @@ for the current platform support list.
 Print setup for a specific Beacon release:
 
 ```bash title="Print setup for a specific Beacon release"
-beacon cloud cursor print-setup --version v0.0.66
+beacon cloud cursor print-setup --version v0.0.95
 ```
 
 ## Related

--- a/docs/cli/rules-pull.mdx
+++ b/docs/cli/rules-pull.mdx
@@ -30,7 +30,7 @@ Downloaded tarballs only install `.rule.yaml` entries. Archive entries containin
 Pull a rule pack:
 
 ```bash title="Pull a rule pack"
-beacon rules pull https://github.com/asymptote-labs/agent-beacon/releases/download/v0.0.66/threat-rules.tar.gz
+beacon rules pull https://github.com/asymptote-labs/agent-beacon/releases/download/v0.0.95/threat-rules.tar.gz
 ```
 
 Pull one rule file:
@@ -42,13 +42,13 @@ beacon rules pull https://example.com/rules/suspicious-egress-command.rule.yaml
 Overwrite an existing rule with the same id:
 
 ```bash title="Overwrite existing rules"
-beacon rules pull https://github.com/asymptote-labs/agent-beacon/releases/download/v0.0.66/threat-rules.tar.gz --force
+beacon rules pull https://github.com/asymptote-labs/agent-beacon/releases/download/v0.0.95/threat-rules.tar.gz --force
 ```
 
 Install into the system-mode rule store:
 
 ```bash title="Pull system-mode rules"
-sudo beacon rules pull https://github.com/asymptote-labs/agent-beacon/releases/download/v0.0.66/threat-rules.tar.gz --system
+sudo beacon rules pull https://github.com/asymptote-labs/agent-beacon/releases/download/v0.0.95/threat-rules.tar.gz --system
 ```
 
 ## Flags

--- a/docs/cli/rules.mdx
+++ b/docs/cli/rules.mdx
@@ -108,7 +108,7 @@ beacon rules remove suspicious-egress-command
 Fetch a `.rule.yaml`, `.tar.gz`, or `.tgz` rule pack from an explicit URL and install valid rules into the store.
 
 ```bash title="Pull a rule pack"
-beacon rules pull https://github.com/asymptote-labs/agent-beacon/releases/download/v0.0.66/threat-rules.tar.gz
+beacon rules pull https://github.com/asymptote-labs/agent-beacon/releases/download/v0.0.95/threat-rules.tar.gz
 ```
 
 Downloaded tarballs only install `.rule.yaml` entries. Archive entries containing path traversal elements are rejected before install.

--- a/docs/cli/version.mdx
+++ b/docs/cli/version.mdx
@@ -15,7 +15,7 @@ beacon version
 ```bash title="Example output"
 $ beacon version
 
-beacon version 0.0.66 (c618237) built on 2026-06-13T23:01:46Z
+beacon version 0.0.95 (fc83f7d) built on 2026-07-10T06:07:46Z
 ```
 </Accordion>
 
@@ -33,9 +33,9 @@ When an update is available, Beacon prints the latest version, the installed ver
 ```bash title="Example output"
 $ beacon version check
 
-Beacon v0.0.66 is available. Current version: v0.0.65
+Beacon v0.0.95 is available. Current version: v0.0.94
 If installed with Homebrew: brew upgrade beacon
-Download: https://github.com/Asymptote-Labs/agent-beacon/releases/tag/v0.0.66
+Download: https://github.com/Asymptote-Labs/agent-beacon/releases/tag/v0.0.95
 ```
 </Accordion>
 

--- a/docs/detections/index.mdx
+++ b/docs/detections/index.mdx
@@ -32,7 +32,7 @@ beacon scan --json
 Install the full maintained rule pack from a Beacon release:
 
 ```bash title="Install the full threat-rule pack"
-beacon rules pull https://github.com/asymptote-labs/agent-beacon/releases/download/v0.0.66/threat-rules.tar.gz
+beacon rules pull https://github.com/asymptote-labs/agent-beacon/releases/download/v0.0.95/threat-rules.tar.gz
 ```
 
 List the active rules Beacon will use:

--- a/docs/log-forwarding/ci-telemetry-exports.mdx
+++ b/docs/log-forwarding/ci-telemetry-exports.mdx
@@ -31,7 +31,7 @@ The **Agent Beacon CI Telemetry** GitHub Action uploads the CI runtime log as a 
 
 ```yaml
 - name: Run Claude with Beacon telemetry
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   with:
     command: claude --print "Review this pull request"
     upload-artifact: "true"
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Claude with Beacon telemetry
-        uses: asymptote-labs/agent-beacon@v0.0.66
+        uses: asymptote-labs/agent-beacon@v0.0.95
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -113,7 +113,7 @@ Configure cloud credentials at the job level, then pass the upload destination t
     aws-region: us-east-1
 
 - name: Run Claude with Beacon telemetry
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   env:
     BEACON_CI_S3_BUCKET: my-beacon-telemetry
     BEACON_CI_S3_PREFIX: github-actions
@@ -135,7 +135,7 @@ For GCS, authenticate with your normal Google Cloud CI mechanism and set `BEACON
     service_account: ${{ secrets.BEACON_GCP_SERVICE_ACCOUNT }}
 
 - name: Run Claude with Beacon telemetry
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   env:
     BEACON_CI_GCS_BUCKET: my-beacon-telemetry
     BEACON_CI_GCS_PREFIX: github-actions

--- a/docs/runtimes/claude-code-ci.mdx
+++ b/docs/runtimes/claude-code-ci.mdx
@@ -67,7 +67,7 @@ Use the Asymptote GitHub Action when you want the workflow to install the CI col
 
 ```yaml
 - name: Run an agent with Asymptote telemetry
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   with:
     command: claude --print "Review this pull request"
     upload-artifact: "true"
@@ -78,7 +78,7 @@ To wrap a third-party action that launches an agent internally, start and finish
 
 ```yaml
 - name: Start Asymptote telemetry
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   with:
     mode: start
     harnesses: claude
@@ -89,7 +89,7 @@ To wrap a third-party action that launches an agent internally, start and finish
 
 - name: Finish Asymptote telemetry
   if: always()
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   with:
     mode: finish
     min-events: "1"
@@ -113,7 +113,7 @@ Upload to Amazon S3:
     aws-region: us-east-1
 
 - name: Run an agent with Asymptote telemetry
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   env:
     BEACON_CI_S3_BUCKET: my-beacon-telemetry
     BEACON_CI_S3_PREFIX: github-actions
@@ -131,7 +131,7 @@ Upload to Google Cloud Storage:
     service_account: ${{ secrets.BEACON_GCP_SERVICE_ACCOUNT }}
 
 - name: Run an agent with Asymptote telemetry
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   env:
     BEACON_CI_GCS_BUCKET: my-beacon-telemetry
     BEACON_CI_GCS_PREFIX: github-actions

--- a/docs/runtimes/claude-code-cloud-agents.mdx
+++ b/docs/runtimes/claude-code-cloud-agents.mdx
@@ -173,7 +173,7 @@ BEACON_CLOUD_GCS_CREDENTIALS_B64=<base64-service-account-json>
 Generate the setup script for your Beacon release:
 
 ```bash
-beacon cloud claude-web print-setup --version v0.0.66
+beacon cloud claude-web print-setup --version v0.0.95
 ```
 
 Paste the generated script into the Claude environment **Setup script** field.

--- a/docs/runtimes/codex-cli.mdx
+++ b/docs/runtimes/codex-cli.mdx
@@ -40,7 +40,7 @@ Asymptote can also capture Codex telemetry in CI with `beacon ci start` and `bea
 ```yaml
 - name: Start Asymptote telemetry
   id: beacon
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   with:
     mode: start
     harnesses: codex
@@ -53,7 +53,7 @@ Asymptote can also capture Codex telemetry in CI with `beacon ci start` and `bea
 
 - name: Finish Asymptote telemetry
   if: always()
-  uses: asymptote-labs/agent-beacon@v0.0.66
+  uses: asymptote-labs/agent-beacon@v0.0.95
   with:
     mode: finish
 ```

--- a/docs/runtimes/cursor-cloud-agents.mdx
+++ b/docs/runtimes/cursor-cloud-agents.mdx
@@ -190,7 +190,7 @@ git push
 Generate the setup script for your Beacon release:
 
 ```bash
-beacon cloud cursor print-setup --version v0.0.66
+beacon cloud cursor print-setup --version v0.0.95
 ```
 
 Paste the generated script into the Cursor cloud environment setup step. The


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes (changelog and example version strings); no runtime or application code is modified.
> 
> **Overview**
> Updates documentation to **v0.0.95** and documents **July 2026** CLI releases **v0.0.92–v0.0.95** in the CLI changelog.
> 
> The changelog adds entries for Cursor reasoning telemetry and hook-inventory dashboard work, branch attribution via `.git/HEAD`, CI export/S3 doc examples, macOS package install repair, and related fixes. Across the docs site, example pins move from **v0.0.66** to **v0.0.95** for the GitHub Action `asymptote-labs/agent-beacon`, `beacon cloud … print-setup --version`, `beacon rules pull` threat-rule URLs, and `beacon version` / `beacon version check` sample output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ace35626d2ccdd4cd33073170c5defd41e81a16b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->