### PR TITLE
Fix runtime logs perms mismatch

### DIFF
--- a/cli/beacon-hooks/internal/logging/endpoint_event_test.go
+++ b/cli/beacon-hooks/internal/logging/endpoint_event_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -38,6 +39,31 @@ func TestEndpointEventStillWritesStructuredTelemetry(t *testing.T) {
 
 	if data, err := os.ReadFile(logPath); err != nil || len(data) == 0 {
 		t.Fatalf("expected structured endpoint event, len=%d err=%v", len(data), err)
+	}
+}
+
+func TestEndpointEventCreatesSharedRuntimeFilesDespiteUmask(t *testing.T) {
+	oldUmask := syscall.Umask(0022)
+	t.Cleanup(func() {
+		syscall.Umask(oldUmask)
+	})
+
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	logger := NewLoggerForPlatform("agent-thought", "cursor")
+	if err := logger.EndpointEvent("agent.reasoning", "session", "info", "Agent reasoning captured", nil); err != nil {
+		t.Fatalf("EndpointEvent returned error: %v", err)
+	}
+
+	for _, target := range []string{logPath, logPath + ".lock"} {
+		info, err := os.Stat(target)
+		if err != nil {
+			t.Fatalf("stat %s: %v", target, err)
+		}
+		if got := info.Mode().Perm(); got != endpointRuntimeFileMode {
+			t.Fatalf("%s mode = %o, want %o", target, got, endpointRuntimeFileMode)
+		}
 	}
 }
 

--- a/cli/beacon-hooks/internal/logging/logging.go
+++ b/cli/beacon-hooks/internal/logging/logging.go
@@ -18,6 +18,7 @@ import (
 const (
 	defaultEndpointRotateBytes    = 10 * 1024 * 1024
 	defaultEndpointRotateArchives = 5
+	endpointRuntimeFileMode       = 0666
 )
 
 // Logger provides structured JSON logging for hook events
@@ -273,7 +274,7 @@ func appendEndpointJSONL(path string, line []byte, rotateBytes int64, rotateArch
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	lock, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0644)
+	lock, err := openEndpointRuntimeFile(path+".lock", os.O_CREATE|os.O_RDWR)
 	if err != nil {
 		return err
 	}
@@ -289,13 +290,32 @@ func appendEndpointJSONL(path string, line []byte, rotateBytes int64, rotateArch
 	if err := rotateEndpointLogIfNeeded(path, rotateBytes, rotateArchives, int64(len(line))); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := openEndpointRuntimeFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 	_, err = f.Write(line)
 	return err
+}
+
+func openEndpointRuntimeFile(path string, flag int) (*os.File, error) {
+	existed := true
+	if _, err := os.Stat(path); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		existed = false
+	}
+	f, err := os.OpenFile(path, flag, endpointRuntimeFileMode)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, endpointRuntimeFileMode); err != nil && !existed {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
 }
 
 func rotateEndpointLogIfNeeded(path string, maxSize int64, archives int, nextWriteBytes int64) error {

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -974,7 +974,7 @@ func actionForCheck(check diagnostics.Check, runtimeLog lifecycle.RuntimeLogSour
 		if check.Evidence == "runtime_log_missing" || check.Evidence == "missing_optional_file" {
 			return "beacon endpoint doctor --fix"
 		}
-		return "chmod 644 " + check.Target
+		return "chmod 666 " + check.Target
 	case "runtime_log_source":
 		if runtimeLog.RequestedUserMode && !runtimeLog.EffectiveUserMode {
 			return "stop the system collector or run beacon endpoint install --user"

--- a/cli/beacon/cmd/endpoint_elastic.go
+++ b/cli/beacon/cmd/endpoint_elastic.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/elastic"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/writer"
 )
 
 func runEndpointElasticUp(ctx context.Context) error {
@@ -85,14 +86,7 @@ func ensureLogFile(path string) error {
 	if path == "" {
 		return nil
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
-	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND, 0644)
-	if err != nil {
-		return err
-	}
-	return file.Close()
+	return writer.EnsureRuntimeFile(path)
 }
 
 func runDockerCompose(ctx context.Context, dir string, env []string, args ...string) error {

--- a/cli/beacon/internal/endpoint/diagnostics/diagnostics.go
+++ b/cli/beacon/internal/endpoint/diagnostics/diagnostics.go
@@ -87,8 +87,8 @@ func checkLogPermissions(path string) Check {
 		return Check{Name: "runtime_log_permissions", Target: path, Status: StatusWarn, Severity: SeverityLow, Message: "runtime log not created yet", Evidence: "runtime_log_missing"}
 	}
 	mode := info.Mode().Perm()
-	if mode&0022 != 0 {
-		return Check{Name: "runtime_log_permissions", Target: path, Status: StatusFail, Severity: SeverityHigh, Message: fmt.Sprintf("runtime log is group/world writable: %o", mode), Evidence: "group_or_world_writable"}
+	if mode&0222 == 0 {
+		return Check{Name: "runtime_log_permissions", Target: path, Status: StatusFail, Severity: SeverityHigh, Message: fmt.Sprintf("runtime log is not writable: %o", mode), Evidence: "not_writable"}
 	}
 	if mode&0044 == 0 {
 		return Check{Name: "runtime_log_permissions", Target: path, Status: StatusWarn, Severity: SeverityLow, Message: fmt.Sprintf("runtime log may not be readable by Wazuh: %o", mode), Evidence: "not_group_or_world_readable"}

--- a/cli/beacon/internal/endpoint/diagnostics/diagnostics_test.go
+++ b/cli/beacon/internal/endpoint/diagnostics/diagnostics_test.go
@@ -51,7 +51,7 @@ func TestCheckLogPermissions(t *testing.T) {
 	if err := os.Chmod(logPath, 0666); err != nil {
 		t.Fatalf("chmod writable log: %v", err)
 	}
-	if check := checkLogPermissions(logPath); check.Status != "fail" || check.Severity != "high" {
+	if check := checkLogPermissions(logPath); check.Status != "ok" {
 		t.Fatalf("0666 log permissions check = %#v", check)
 	}
 
@@ -60,6 +60,13 @@ func TestCheckLogPermissions(t *testing.T) {
 	}
 	if check := checkLogPermissions(logPath); check.Status != "warn" || check.Severity != "low" {
 		t.Fatalf("0200 log permissions check = %#v", check)
+	}
+
+	if err := os.Chmod(logPath, 0444); err != nil {
+		t.Fatalf("chmod non-writable log: %v", err)
+	}
+	if check := checkLogPermissions(logPath); check.Status != "fail" || check.Severity != "high" || check.Evidence != "not_writable" {
+		t.Fatalf("0444 log permissions check = %#v", check)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/writer/writer.go
+++ b/cli/beacon/internal/endpoint/writer/writer.go
@@ -21,6 +21,7 @@ const (
 	DefaultRotateBytes    = 10 * 1024 * 1024
 	DefaultRotateArchives = 5
 	RotateBytes           = DefaultRotateBytes
+	runtimeFileMode       = 0666
 )
 
 type Options struct {
@@ -107,7 +108,7 @@ func appendJSONL(path string, line []byte, rotateBytes int64, rotateArchives int
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	lock, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0644)
+	lock, err := openRuntimeFile(path+".lock", os.O_CREATE|os.O_RDWR)
 	if err != nil {
 		return err
 	}
@@ -123,13 +124,32 @@ func appendJSONL(path string, line []byte, rotateBytes int64, rotateArchives int
 	if err := rotateIfNeeded(path, rotateBytes, rotateArchives, int64(len(line))); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := openRuntimeFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 	_, err = f.Write(line)
 	return err
+}
+
+func openRuntimeFile(path string, flag int) (*os.File, error) {
+	existed := true
+	if _, err := os.Stat(path); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		existed = false
+	}
+	f, err := os.OpenFile(path, flag, runtimeFileMode)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, runtimeFileMode); err != nil && !existed {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
 }
 
 func rotateIfNeeded(path string, maxSize int64, archives int, nextWriteBytes int64) error {

--- a/cli/beacon/internal/endpoint/writer/writer.go
+++ b/cli/beacon/internal/endpoint/writer/writer.go
@@ -82,6 +82,20 @@ func AppendEvent(event schema.Event, opts Options) (string, error) {
 	return opts.Path, nil
 }
 
+// EnsureRuntimeFile creates the shared runtime log with the shared writable
+// mode without appending an event, for doctor --fix and setup flows that
+// pre-create the log so user-run hooks can append to it later.
+func EnsureRuntimeFile(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	f, err := openRuntimeFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
 func LastLine(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/cli/beacon/internal/endpoint/writer/writer_test.go
+++ b/cli/beacon/internal/endpoint/writer/writer_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
@@ -40,6 +41,33 @@ func TestAppendEventWritesSingleJSONLine(t *testing.T) {
 	}
 	if decoded["vendor"] != schema.Vendor {
 		t.Fatalf("unexpected vendor: %v", decoded["vendor"])
+	}
+}
+
+func TestAppendEventCreatesSharedRuntimeFilesDespiteUmask(t *testing.T) {
+	oldUmask := syscall.Umask(0022)
+	t.Cleanup(func() {
+		syscall.Umask(oldUmask)
+	})
+
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	event := schema.NewEvent(schema.NewEventOptions{
+		Action:  "agent.detected",
+		Harness: schema.HarnessInfo{Name: "test"},
+		Message: "test event",
+	})
+	if _, err := AppendEvent(event, Options{Path: path}); err != nil {
+		t.Fatalf("AppendEvent returned error: %v", err)
+	}
+
+	for _, target := range []string{path, path + ".lock"} {
+		info, err := os.Stat(target)
+		if err != nil {
+			t.Fatalf("stat %s: %v", target, err)
+		}
+		if got := info.Mode().Perm(); got != runtimeFileMode {
+			t.Fatalf("%s mode = %o, want %o", target, got, runtimeFileMode)
+		}
 	}
 }
 

--- a/cli/beacon/internal/endpoint/writer/writer_test.go
+++ b/cli/beacon/internal/endpoint/writer/writer_test.go
@@ -71,6 +71,26 @@ func TestAppendEventCreatesSharedRuntimeFilesDespiteUmask(t *testing.T) {
 	}
 }
 
+func TestEnsureRuntimeFileCreatesSharedRuntimeLogDespiteUmask(t *testing.T) {
+	oldUmask := syscall.Umask(0022)
+	t.Cleanup(func() {
+		syscall.Umask(oldUmask)
+	})
+
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	if err := EnsureRuntimeFile(path); err != nil {
+		t.Fatalf("EnsureRuntimeFile returned error: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != runtimeFileMode {
+		t.Fatalf("%s mode = %o, want %o", path, got, runtimeFileMode)
+	}
+}
+
 func TestAppendEventRedactsSecrets(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "runtime.jsonl")
 	event := schema.NewEvent(schema.NewEventOptions{

--- a/collector-builder/exporter/beaconjsonexporter/writer.go
+++ b/collector-builder/exporter/beaconjsonexporter/writer.go
@@ -123,12 +123,17 @@ func sanitizeTyped[T any](input *T, sanitize func(map[string]interface{}) map[st
 	return &out
 }
 
+// The collector usually runs as root, while agent hooks append to the same
+// runtime log as the console user, so shared runtime files must stay
+// writable by both regardless of which process creates them first.
+const runtimeFileMode = 0666
+
 // Keep this rotation contract mirrored with the endpoint CLI and hook writer.
 func appendJSONL(path string, line []byte, rotateBytes int64, rotateArchives int) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	lock, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0644)
+	lock, err := openRuntimeFile(path+".lock", os.O_CREATE|os.O_RDWR)
 	if err != nil {
 		return err
 	}
@@ -144,13 +149,32 @@ func appendJSONL(path string, line []byte, rotateBytes int64, rotateArchives int
 	if err := rotateIfNeeded(path, rotateBytes, rotateArchives, int64(len(line))); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := openRuntimeFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 	_, err = f.Write(line)
 	return err
+}
+
+func openRuntimeFile(path string, flag int) (*os.File, error) {
+	existed := true
+	if _, err := os.Stat(path); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		existed = false
+	}
+	f, err := os.OpenFile(path, flag, runtimeFileMode)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, runtimeFileMode); err != nil && !existed {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
 }
 
 func rotateIfNeeded(path string, maxSize int64, archives int, nextWriteBytes int64) error {

--- a/collector-builder/exporter/beaconjsonexporter/writer_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/writer_test.go
@@ -1,0 +1,30 @@
+package beaconjsonexporter
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestAppendJSONLCreatesSharedRuntimeFilesDespiteUmask(t *testing.T) {
+	oldUmask := syscall.Umask(0022)
+	t.Cleanup(func() {
+		syscall.Umask(oldUmask)
+	})
+
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	if err := appendJSONL(path, []byte(`{"message":"test"}`+"\n"), defaultRotateBytes, defaultRotateArchives); err != nil {
+		t.Fatalf("appendJSONL returned error: %v", err)
+	}
+
+	for _, target := range []string{path, path + ".lock"} {
+		info, err := os.Stat(target)
+		if err != nil {
+			t.Fatalf("stat %s: %v", target, err)
+		}
+		if got := info.Mode().Perm(); got != runtimeFileMode {
+			t.Fatalf("%s mode = %o, want %o", target, got, runtimeFileMode)
+		}
+	}
+}

--- a/packaging/macos/jamf/claude/common/repair-hooks.sh
+++ b/packaging/macos/jamf/claude/common/repair-hooks.sh
@@ -43,7 +43,11 @@ mkdir -p "$RUNTIME_DIR"
 touch "$RUNTIME_LOG" "$RUNTIME_LOCK" "$INVENTORY_LOG" "$INVENTORY_LOCK" "$INVENTORY_STATE" "$INVENTORY_STATE_LOCK"
 chown root:wheel "$RUNTIME_DIR" "$RUNTIME_LOG" "$RUNTIME_LOCK" "$INVENTORY_LOG" "$INVENTORY_LOCK" "$INVENTORY_STATE" "$INVENTORY_STATE_LOCK"
 chmod 755 "$RUNTIME_DIR"
-chmod 644 "$RUNTIME_LOG" "$RUNTIME_LOCK" "$INVENTORY_LOG" "$INVENTORY_LOCK" "$INVENTORY_STATE" "$INVENTORY_STATE_LOCK"
+# Runtime log and lock stay 666 so user-run hooks can append even when a
+# root-owned rotation or collector recreates them; Beacon's writers use the
+# same shared mode.
+chmod 666 "$RUNTIME_LOG" "$RUNTIME_LOCK"
+chmod 644 "$INVENTORY_LOG" "$INVENTORY_LOCK" "$INVENTORY_STATE" "$INVENTORY_STATE_LOCK"
 
 CONSOLE_USER="$(stat -f %Su /dev/console 2>/dev/null || true)"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> World-writable runtime logs and locks are intentional for cross-user sharing but widen local tampering surface; changes touch collector, hooks, doctor, and macOS packaging together.
> 
> **Overview**
> Aligns **shared** `runtime.jsonl` and `.lock` handling so the root-owned collector and console-user hooks can both append to the same path.
> 
> Writers in **beacon-hooks**, the **endpoint CLI writer**, and **beaconjson exporter** now create those files at mode **0666** via shared `openRuntimeFile` / `openEndpointRuntimeFile` helpers that **chmod after create** so a restrictive umask does not leave **0644**. **`writer.EnsureRuntimeFile`** pre-creates the log for doctor `--fix`, elastic setup, and similar flows without writing an event.
> 
> **Diagnostics** flip the permission policy: **0666** is OK; **high** failure when the log is **not writable** (`not_writable`). Doctor repair hints change from `chmod 644` to **`chmod 666`**. The **Jamf repair-hooks** script sets **666** only on the runtime log and lock (inventory files stay **644**).
> 
> Tests assert correct modes under **umask 0022** across the three write paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc40a8de52412f2ec906665ffd03dfb1e6394c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->