### PR TITLE
Add claude code in cloud s3 forwarding script

### DIFF
--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
@@ -516,9 +516,6 @@ func cloudUploadFromEnv() string {
 	case uploadGCS:
 		return uploadGCS
 	}
-	if strings.TrimSpace(os.Getenv("BEACON_CLOUD_S3_BUCKET")) != "" {
-		return uploadS3
-	}
 	return uploadGCS
 }
 

--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -19,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -29,12 +32,16 @@ const (
 	defaultStatePath   = "/tmp/beacon/shuttle-state.json"
 	defaultTokenURI    = "https://oauth2.googleapis.com/token"
 	defaultGCSEndpoint = "https://storage.googleapis.com"
+	defaultS3Region    = "us-east-1"
 	contentTypeJSONL   = "text/plain; charset=utf-8"
+	uploadGCS          = "gcs"
+	uploadS3           = "s3"
 )
 
 var httpClient = http.DefaultClient
 
 type Config struct {
+	Upload         string
 	LogPath        string
 	StatePath      string
 	Bucket         string
@@ -45,6 +52,11 @@ type Config struct {
 	UserID         string
 	Repository     string
 	GCSEndpoint    string
+	S3Region       string
+	S3AccessKeyID  string
+	S3SecretKey    string
+	S3SessionToken string
+	S3Endpoint     string
 }
 
 type serviceAccount struct {
@@ -67,17 +79,30 @@ type tokenResponse struct {
 
 func ConfigFromEnv() Config {
 	statePath := firstEnvDefault(defaultStatePath, "BEACON_CLOUD_SHUTTLE_STATE")
+	upload := cloudUploadFromEnv()
+	bucket := strings.TrimSpace(os.Getenv("BEACON_CLOUD_GCS_BUCKET"))
+	prefix := strings.Trim(strings.TrimSpace(os.Getenv("BEACON_CLOUD_GCS_PREFIX")), "/")
+	if upload == uploadS3 {
+		bucket = strings.TrimSpace(os.Getenv("BEACON_CLOUD_S3_BUCKET"))
+		prefix = strings.Trim(strings.TrimSpace(os.Getenv("BEACON_CLOUD_S3_PREFIX")), "/")
+	}
 	return Config{
+		Upload:         upload,
 		LogPath:        firstEnvDefault(defaultLogPath, "BEACON_CLOUD_LOG_PATH", "BEACON_ENDPOINT_LOG", "BEACON_LOG_PATH", "BEACON_RUNTIME_LOG"),
 		StatePath:      statePath,
-		Bucket:         strings.TrimSpace(os.Getenv("BEACON_CLOUD_GCS_BUCKET")),
-		Prefix:         strings.Trim(strings.TrimSpace(os.Getenv("BEACON_CLOUD_GCS_PREFIX")), "/"),
+		Bucket:         bucket,
+		Prefix:         prefix,
 		CredentialsB64: strings.TrimSpace(os.Getenv("BEACON_CLOUD_GCS_CREDENTIALS_B64")),
 		Provider:       firstEnvDefault("claude_code_web", "BEACON_RUN_PROVIDER"),
 		RunID:          resolveRunID(),
 		UserID:         firstEnvDefault("unknown", "BEACON_CLOUD_USER_ID_HASH", "BEACON_CLOUD_USER_ID"),
 		Repository:     firstEnv("BEACON_RUN_REPOSITORY"),
 		GCSEndpoint:    firstEnvDefault(defaultGCSEndpoint, "BEACON_CLOUD_GCS_ENDPOINT"),
+		S3Region:       firstEnvDefault(defaultS3Region, "BEACON_CLOUD_S3_REGION", "AWS_REGION", "AWS_DEFAULT_REGION"),
+		S3AccessKeyID:  firstEnv("AWS_ACCESS_KEY_ID"),
+		S3SecretKey:    firstEnv("AWS_SECRET_ACCESS_KEY"),
+		S3SessionToken: firstEnv("AWS_SESSION_TOKEN"),
+		S3Endpoint:     firstEnv("BEACON_CLOUD_S3_ENDPOINT"),
 	}
 }
 
@@ -105,20 +130,12 @@ func ResetFromEnv() error {
 }
 
 func Upload(ctx context.Context, cfg Config, force bool) error {
-	if strings.TrimSpace(cfg.Bucket) == "" || strings.TrimSpace(cfg.CredentialsB64) == "" {
+	cfg = normalizeConfig(cfg)
+	if !uploadConfigured(cfg) {
 		return nil
 	}
 	if strings.TrimSpace(cfg.RunID) == "" {
 		return nil
-	}
-	if cfg.LogPath == "" {
-		cfg.LogPath = defaultLogPath
-	}
-	if cfg.StatePath == "" {
-		cfg.StatePath = defaultStatePath
-	}
-	if cfg.GCSEndpoint == "" {
-		cfg.GCSEndpoint = defaultGCSEndpoint
 	}
 	info, err := os.Stat(cfg.LogPath)
 	if err != nil {
@@ -138,12 +155,8 @@ func Upload(ctx context.Context, cfg Config, force bool) error {
 		return err
 	}
 	defer cleanup()
-	token, err := accessToken(ctx, cfg.CredentialsB64)
-	if err != nil {
-		return err
-	}
 	objectName := ObjectName(cfg)
-	if err := uploadObject(ctx, cfg.GCSEndpoint, cfg.Bucket, objectName, snapshot, token); err != nil {
+	if err := uploadSnapshot(ctx, cfg, objectName, snapshot); err != nil {
 		return err
 	}
 	return writeState(cfg.StatePath, state{
@@ -311,7 +324,20 @@ func parseRSAPrivateKey(raw string) (*rsa.PrivateKey, error) {
 	return nil, errors.New("parse GCS private key")
 }
 
-func uploadObject(ctx context.Context, endpoint, bucket, objectName, filePath, token string) error {
+func uploadSnapshot(ctx context.Context, cfg Config, objectName, filePath string) error {
+	switch cfg.Upload {
+	case uploadS3:
+		return uploadS3Object(ctx, cfg, objectName, filePath)
+	default:
+		token, err := accessToken(ctx, cfg.CredentialsB64)
+		if err != nil {
+			return err
+		}
+		return uploadGCSObject(ctx, cfg.GCSEndpoint, cfg.Bucket, objectName, filePath, token)
+	}
+}
+
+func uploadGCSObject(ctx context.Context, endpoint, bucket, objectName, filePath, token string) error {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return err
@@ -339,6 +365,94 @@ func uploadObject(ctx context.Context, endpoint, bucket, objectName, filePath, t
 	return nil
 }
 
+func uploadS3Object(ctx context.Context, cfg Config, objectName, filePath string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	payloadHash, err := hashOpenFile(file)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	endpoint := strings.TrimRight(cfg.S3Endpoint, "/")
+	if endpoint == "" {
+		endpoint = "https://s3." + cfg.S3Region + ".amazonaws.com"
+	}
+	uploadURL := endpoint + "/" + escapePath(cfg.Bucket) + "/" + escapeObjectName(objectName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, file)
+	if err != nil {
+		return err
+	}
+	if info, err := file.Stat(); err == nil {
+		req.ContentLength = info.Size()
+	}
+	req.Header.Set("Content-Type", contentTypeJSONL)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	req.Header.Set("X-Amz-Date", time.Now().UTC().Format("20060102T150405Z"))
+	if cfg.S3SessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", cfg.S3SessionToken)
+	}
+	signS3Request(req, cfg, payloadHash)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("S3 upload failed: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
+func signS3Request(req *http.Request, cfg Config, payloadHash string) {
+	amzDate := req.Header.Get("X-Amz-Date")
+	dateStamp := amzDate[:8]
+	credentialScope := dateStamp + "/" + cfg.S3Region + "/s3/aws4_request"
+	headers := map[string]string{
+		"content-type":         req.Header.Get("Content-Type"),
+		"host":                 req.URL.Host,
+		"x-amz-content-sha256": payloadHash,
+		"x-amz-date":           amzDate,
+	}
+	if token := req.Header.Get("X-Amz-Security-Token"); token != "" {
+		headers["x-amz-security-token"] = token
+	}
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var canonicalHeaders strings.Builder
+	for _, key := range keys {
+		canonicalHeaders.WriteString(key)
+		canonicalHeaders.WriteString(":")
+		canonicalHeaders.WriteString(strings.TrimSpace(headers[key]))
+		canonicalHeaders.WriteString("\n")
+	}
+	signedHeaders := strings.Join(keys, ";")
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		req.URL.EscapedPath(),
+		req.URL.RawQuery,
+		canonicalHeaders.String(),
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+	signature := hex.EncodeToString(hmacSHA256(s3SigningKey(cfg.S3SecretKey, dateStamp, cfg.S3Region), stringToSign))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+cfg.S3AccessKeyID+"/"+credentialScope+", SignedHeaders="+signedHeaders+", Signature="+signature)
+}
+
 func readState(path string) (state, error) {
 	var st state
 	data, err := os.ReadFile(path)
@@ -361,6 +475,7 @@ func writeState(path string, st state) error {
 }
 
 func preserveExistingLog(cfg Config) error {
+	cfg = normalizeConfig(cfg)
 	info, err := os.Stat(cfg.LogPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -371,16 +486,14 @@ func preserveExistingLog(cfg Config) error {
 	if info.Size() == 0 {
 		return os.Remove(cfg.LogPath)
 	}
-	if st, err := readState(cfg.StatePath); err == nil && st.LastObject != "" && cfg.Bucket != "" && cfg.CredentialsB64 != "" {
+	if st, err := readState(cfg.StatePath); err == nil && st.LastObject != "" && uploadConfigured(cfg) {
 		snapshot, cleanup, err := snapshotLog(cfg.LogPath)
 		if err == nil {
 			defer cleanup()
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			if token, tokenErr := accessToken(ctx, cfg.CredentialsB64); tokenErr == nil {
-				if uploadErr := uploadObject(ctx, cfg.GCSEndpoint, cfg.Bucket, st.LastObject, snapshot, token); uploadErr == nil {
-					return os.Remove(cfg.LogPath)
-				}
+			if uploadErr := uploadSnapshot(ctx, cfg, st.LastObject, snapshot); uploadErr == nil {
+				return os.Remove(cfg.LogPath)
 			}
 		}
 	}
@@ -393,6 +506,83 @@ func preserveExistingLog(cfg Config) error {
 
 func resolveRunID() string {
 	return firstEnv("BEACON_RUN_ID", "CLAUDE_CODE_REMOTE_SESSION_ID")
+}
+
+func cloudUploadFromEnv() string {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv("BEACON_CLOUD_UPLOAD")))
+	switch value {
+	case uploadS3:
+		return uploadS3
+	case uploadGCS:
+		return uploadGCS
+	}
+	if strings.TrimSpace(os.Getenv("BEACON_CLOUD_S3_BUCKET")) != "" {
+		return uploadS3
+	}
+	return uploadGCS
+}
+
+func normalizeConfig(cfg Config) Config {
+	cfg.Upload = strings.ToLower(strings.TrimSpace(cfg.Upload))
+	if cfg.Upload == "" {
+		if cfg.S3AccessKeyID != "" || cfg.S3SecretKey != "" || cfg.S3Region != "" || strings.Contains(cfg.S3Endpoint, "s3") {
+			cfg.Upload = uploadS3
+		} else {
+			cfg.Upload = uploadGCS
+		}
+	}
+	if cfg.LogPath == "" {
+		cfg.LogPath = defaultLogPath
+	}
+	if cfg.StatePath == "" {
+		cfg.StatePath = defaultStatePath
+	}
+	if cfg.GCSEndpoint == "" {
+		cfg.GCSEndpoint = defaultGCSEndpoint
+	}
+	if cfg.S3Region == "" {
+		cfg.S3Region = defaultS3Region
+	}
+	cfg.Prefix = strings.Trim(cfg.Prefix, "/")
+	return cfg
+}
+
+func uploadConfigured(cfg Config) bool {
+	if strings.TrimSpace(cfg.Bucket) == "" {
+		return false
+	}
+	switch cfg.Upload {
+	case uploadS3:
+		return strings.TrimSpace(cfg.S3AccessKeyID) != "" && strings.TrimSpace(cfg.S3SecretKey) != ""
+	default:
+		return strings.TrimSpace(cfg.CredentialsB64) != ""
+	}
+}
+
+func hashOpenFile(file *os.File) (string, error) {
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func s3SigningKey(secret, dateStamp, region string) []byte {
+	dateKey := hmacSHA256([]byte("AWS4"+secret), dateStamp)
+	regionKey := hmacSHA256(dateKey, region)
+	serviceKey := hmacSHA256(regionKey, "s3")
+	return hmacSHA256(serviceKey, "aws4_request")
+}
+
+func hmacSHA256(key []byte, value string) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(value))
+	return mac.Sum(nil)
 }
 
 func cleanKeyParts(value string) []string {

--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"io"
@@ -138,6 +140,95 @@ func TestUploadSendsJSONLToGCS(t *testing.T) {
 		t.Fatalf("upload path = %q", uploadedPath)
 	}
 	if uploadedBody != "{\"event\":\"ok\"}\n" {
+		t.Fatalf("uploaded body = %q", uploadedBody)
+	}
+}
+
+func TestConfigFromEnvSelectsS3(t *testing.T) {
+	t.Setenv("BEACON_CLOUD_UPLOAD", "s3")
+	t.Setenv("BEACON_CLOUD_S3_BUCKET", "bucket")
+	t.Setenv("BEACON_CLOUD_S3_PREFIX", "prefix")
+	t.Setenv("BEACON_CLOUD_S3_REGION", "us-west-2")
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIATEST")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+	t.Setenv("AWS_SESSION_TOKEN", "token")
+	t.Setenv("BEACON_RUN_ID", "run")
+
+	cfg := ConfigFromEnv()
+	if cfg.Upload != uploadS3 {
+		t.Fatalf("Upload = %q, want %q", cfg.Upload, uploadS3)
+	}
+	if cfg.Bucket != "bucket" || cfg.Prefix != "prefix" || cfg.S3Region != "us-west-2" {
+		t.Fatalf("unexpected S3 config: %#v", cfg)
+	}
+	if cfg.S3AccessKeyID != "AKIATEST" || cfg.S3SecretKey != "secret" || cfg.S3SessionToken != "token" {
+		t.Fatalf("unexpected S3 credentials in config: %#v", cfg)
+	}
+}
+
+func TestUploadSendsJSONLToS3(t *testing.T) {
+	var uploadedPath, uploadedAuth, uploadedDate, uploadedHash, uploadedToken, uploadedType, uploadedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploadedPath = r.URL.EscapedPath()
+		uploadedAuth = r.Header.Get("Authorization")
+		uploadedDate = r.Header.Get("X-Amz-Date")
+		uploadedHash = r.Header.Get("X-Amz-Content-Sha256")
+		uploadedToken = r.Header.Get("X-Amz-Security-Token")
+		uploadedType = r.Header.Get("Content-Type")
+		data, _ := io.ReadAll(r.Body)
+		uploadedBody = string(data)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	body := "{\"event\":\"ok\"}\n"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	if err := os.WriteFile(logPath, []byte(body), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	cfg := Config{
+		Upload:         uploadS3,
+		LogPath:        logPath,
+		StatePath:      filepath.Join(t.TempDir(), "state.json"),
+		Bucket:         "bucket",
+		Prefix:         "prefix",
+		Provider:       "claude_code_web",
+		UserID:         "user",
+		RunID:          "run",
+		S3Region:       "us-west-2",
+		S3AccessKeyID:  "AKIATEST",
+		S3SecretKey:    "secret",
+		S3SessionToken: "session-token",
+		S3Endpoint:     server.URL,
+	}
+	if err := Upload(context.Background(), cfg, true); err != nil {
+		t.Fatalf("Upload returned error: %v", err)
+	}
+	if !strings.Contains(uploadedPath, "/bucket/prefix/provider=claude_code_web/user_id=user/run_id=run/runtime.jsonl") {
+		t.Fatalf("upload path = %q", uploadedPath)
+	}
+	if !strings.HasPrefix(uploadedAuth, "AWS4-HMAC-SHA256 Credential=AKIATEST/") {
+		t.Fatalf("Authorization = %q", uploadedAuth)
+	}
+	for _, want := range []string{"us-west-2/s3/aws4_request", "SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token"} {
+		if !strings.Contains(uploadedAuth, want) {
+			t.Fatalf("Authorization missing %q: %q", want, uploadedAuth)
+		}
+	}
+	if uploadedDate == "" {
+		t.Fatal("X-Amz-Date is empty")
+	}
+	sum := sha256.Sum256([]byte(body))
+	if uploadedHash != hex.EncodeToString(sum[:]) {
+		t.Fatalf("X-Amz-Content-Sha256 = %q", uploadedHash)
+	}
+	if uploadedToken != "session-token" {
+		t.Fatalf("X-Amz-Security-Token = %q", uploadedToken)
+	}
+	if uploadedType != contentTypeJSONL {
+		t.Fatalf("Content-Type = %q, want %q", uploadedType, contentTypeJSONL)
+	}
+	if uploadedBody != body {
 		t.Fatalf("uploaded body = %q", uploadedBody)
 	}
 }

--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
@@ -166,6 +166,22 @@ func TestConfigFromEnvSelectsS3(t *testing.T) {
 	}
 }
 
+func TestConfigFromEnvDefaultsToGCSWhenS3BucketIsAlsoSet(t *testing.T) {
+	t.Setenv("BEACON_CLOUD_UPLOAD", "")
+	t.Setenv("BEACON_CLOUD_GCS_BUCKET", "gcs-bucket")
+	t.Setenv("BEACON_CLOUD_GCS_PREFIX", "gcs-prefix")
+	t.Setenv("BEACON_CLOUD_GCS_CREDENTIALS_B64", "gcs-credentials")
+	t.Setenv("BEACON_CLOUD_S3_BUCKET", "s3-bucket")
+
+	cfg := ConfigFromEnv()
+	if cfg.Upload != uploadGCS {
+		t.Fatalf("Upload = %q, want %q", cfg.Upload, uploadGCS)
+	}
+	if cfg.Bucket != "gcs-bucket" || cfg.Prefix != "gcs-prefix" || cfg.CredentialsB64 != "gcs-credentials" {
+		t.Fatalf("unexpected GCS config: %#v", cfg)
+	}
+}
+
 func TestUploadSendsJSONLToS3(t *testing.T) {
 	var uploadedPath, uploadedAuth, uploadedDate, uploadedHash, uploadedToken, uploadedType, uploadedBody string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/beacon/cmd/cloud.go
+++ b/cli/beacon/cmd/cloud.go
@@ -21,8 +21,10 @@ var cloudOpts struct {
 	project        string
 	bucket         string
 	location       string
+	region         string
 	prefix         string
 	serviceAccount string
+	iamUser        string
 	printOnly      bool
 	apply          bool
 	printEnv       bool
@@ -112,6 +114,11 @@ var cloudGCSCmd = &cobra.Command{
 	Short: "Configure GCS forwarding for cloud agent telemetry",
 }
 
+var cloudS3Cmd = &cobra.Command{
+	Use:   "s3",
+	Short: "Configure S3 forwarding for cloud agent telemetry",
+}
+
 var cloudGCSSetupCmd = &cobra.Command{
 	Use:          "setup",
 	Short:        "Create or print self-serve GCS setup for cloud agent telemetry",
@@ -119,16 +126,25 @@ var cloudGCSSetupCmd = &cobra.Command{
 	RunE:         runCloudGCSSetup,
 }
 
+var cloudS3SetupCmd = &cobra.Command{
+	Use:          "setup",
+	Short:        "Create or print self-serve S3 setup for cloud agent telemetry",
+	SilenceUsage: true,
+	RunE:         runCloudS3Setup,
+}
+
 func init() {
 	rootCmd.AddCommand(cloudCmd)
 	cloudCmd.AddCommand(cloudClaudeWebCmd)
 	cloudCmd.AddCommand(cloudCursorCmd)
 	cloudCmd.AddCommand(cloudGCSCmd)
+	cloudCmd.AddCommand(cloudS3Cmd)
 	cloudClaudeWebCmd.AddCommand(cloudClaudeWebPrintHooksCmd)
 	cloudClaudeWebCmd.AddCommand(cloudClaudeWebPrintSetupCmd)
 	cloudCursorCmd.AddCommand(cloudCursorPrintHooksCmd)
 	cloudCursorCmd.AddCommand(cloudCursorPrintSetupCmd)
 	cloudGCSCmd.AddCommand(cloudGCSSetupCmd)
+	cloudS3Cmd.AddCommand(cloudS3SetupCmd)
 
 	cloudClaudeWebPrintHooksCmd.Flags().StringVar(&cloudOpts.binaryPath, "binary-path", "", "Path to beacon-hooks inside the cloud sandbox")
 	cloudClaudeWebPrintHooksCmd.Flags().StringVar(&cloudOpts.logPath, "log-path", "/tmp/beacon/runtime.jsonl", "Cloud sandbox runtime JSONL path")
@@ -146,6 +162,14 @@ func init() {
 	cloudGCSSetupCmd.Flags().BoolVar(&cloudOpts.printOnly, "print", false, "Print the gcloud commands without running them")
 	cloudGCSSetupCmd.Flags().BoolVar(&cloudOpts.apply, "apply", false, "Run the gcloud setup commands")
 	cloudGCSSetupCmd.Flags().BoolVar(&cloudOpts.printEnv, "print-env", false, "Print Claude web environment variables after setup")
+
+	cloudS3SetupCmd.Flags().StringVar(&cloudOpts.bucket, "bucket", "", "S3 bucket for cloud agent telemetry")
+	cloudS3SetupCmd.Flags().StringVar(&cloudOpts.region, "region", "us-east-1", "AWS region for the S3 bucket")
+	cloudS3SetupCmd.Flags().StringVar(&cloudOpts.prefix, "prefix", "agent-traces", "S3 object prefix for cloud telemetry")
+	cloudS3SetupCmd.Flags().StringVar(&cloudOpts.iamUser, "iam-user", "beacon-cloud-trace-uploader", "IAM user name for cloud telemetry uploads")
+	cloudS3SetupCmd.Flags().BoolVar(&cloudOpts.printOnly, "print", false, "Print the AWS CLI commands without running them")
+	cloudS3SetupCmd.Flags().BoolVar(&cloudOpts.apply, "apply", false, "Run the AWS setup commands")
+	cloudS3SetupCmd.Flags().BoolVar(&cloudOpts.printEnv, "print-env", false, "Print Claude web environment variables after setup")
 }
 
 func defaultCloudLogPath(path string) string {
@@ -390,7 +414,11 @@ func isNotFoundOutput(text string) bool {
 	return strings.Contains(lower, "not found") ||
 		strings.Contains(lower, "does not exist") ||
 		strings.Contains(lower, "matched no") ||
-		strings.Contains(lower, "no urls matched")
+		strings.Contains(lower, "no urls matched") ||
+		strings.Contains(lower, "nosuchbucket") ||
+		strings.Contains(lower, "nosuchentity") ||
+		strings.Contains(lower, "status code: 404") ||
+		strings.Contains(lower, "404")
 }
 
 func isGCSBucketIAMBinding(args []string) bool {

--- a/cli/beacon/cmd/cloud_s3.go
+++ b/cli/beacon/cmd/cloud_s3.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const s3InlinePolicyName = "BeaconCloudTraceUpload"
+
+type awsAccessKey struct {
+	AccessKey struct {
+		AccessKeyID     string `json:"AccessKeyId"`
+		SecretAccessKey string `json:"SecretAccessKey"`
+	} `json:"AccessKey"`
+}
+
+func runCloudS3Setup(cmd *cobra.Command, args []string) error {
+	if strings.TrimSpace(cloudOpts.bucket) == "" {
+		return fmt.Errorf("--bucket is required")
+	}
+	if strings.TrimSpace(cloudOpts.region) == "" {
+		return fmt.Errorf("--region is required")
+	}
+	if strings.TrimSpace(cloudOpts.iamUser) == "" {
+		return fmt.Errorf("--iam-user is required")
+	}
+	if !cloudOpts.apply && !cloudOpts.printOnly {
+		return fmt.Errorf("choose --print to review commands or --apply to run them")
+	}
+	commands, err := s3SetupCommands(cloudOpts.bucket, cloudOpts.region, cloudOpts.prefix, cloudOpts.iamUser)
+	if err != nil {
+		return err
+	}
+	if cloudOpts.printOnly {
+		for _, command := range commands {
+			fmt.Println(shellCommand(command...))
+		}
+	}
+	if !cloudOpts.apply {
+		return nil
+	}
+	if err := ensureS3Bucket(cloudOpts.bucket, cloudOpts.region); err != nil {
+		return err
+	}
+	if err := runAWS("aws", "s3api", "put-public-access-block", "--bucket", cloudOpts.bucket, "--public-access-block-configuration", "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"); err != nil {
+		return err
+	}
+	if err := ensureIAMUser(cloudOpts.iamUser); err != nil {
+		return err
+	}
+	policy, err := s3UploadPolicy(cloudOpts.bucket, cloudOpts.prefix)
+	if err != nil {
+		return err
+	}
+	if err := runAWS("aws", "iam", "put-user-policy", "--user-name", cloudOpts.iamUser, "--policy-name", s3InlinePolicyName, "--policy-document", policy); err != nil {
+		return err
+	}
+	if cloudOpts.printEnv {
+		key, err := createIAMAccessKey(cloudOpts.iamUser)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("BEACON_CLOUD_UPLOAD=s3\n")
+		fmt.Printf("BEACON_CLOUD_S3_BUCKET=%s\n", cloudOpts.bucket)
+		fmt.Printf("BEACON_CLOUD_S3_PREFIX=%s\n", strings.Trim(cloudOpts.prefix, "/"))
+		fmt.Printf("BEACON_CLOUD_S3_REGION=%s\n", cloudOpts.region)
+		fmt.Printf("AWS_ACCESS_KEY_ID=%s\n", key.AccessKey.AccessKeyID)
+		fmt.Printf("AWS_SECRET_ACCESS_KEY=%s\n", key.AccessKey.SecretAccessKey)
+	}
+	return nil
+}
+
+func s3SetupCommands(bucket, region, prefix, iamUser string) ([][]string, error) {
+	policy, err := s3UploadPolicy(bucket, prefix)
+	if err != nil {
+		return nil, err
+	}
+	commands := [][]string{
+		{"aws", "s3api", "head-bucket", "--bucket", bucket},
+		s3CreateBucketCommand(bucket, region),
+		{"aws", "s3api", "put-public-access-block", "--bucket", bucket, "--public-access-block-configuration", "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"},
+		{"aws", "iam", "get-user", "--user-name", iamUser},
+		{"aws", "iam", "create-user", "--user-name", iamUser},
+		{"aws", "iam", "put-user-policy", "--user-name", iamUser, "--policy-name", s3InlinePolicyName, "--policy-document", policy},
+		{"aws", "iam", "create-access-key", "--user-name", iamUser, "--output", "json"},
+	}
+	return commands, nil
+}
+
+func s3CreateBucketCommand(bucket, region string) []string {
+	args := []string{"aws", "s3api", "create-bucket", "--bucket", bucket, "--region", region}
+	if region != "us-east-1" {
+		args = append(args, "--create-bucket-configuration", "LocationConstraint="+region)
+	}
+	return args
+}
+
+func s3UploadPolicy(bucket, prefix string) (string, error) {
+	prefix = strings.Trim(prefix, "/")
+	resource := "arn:aws:s3:::" + bucket + "/*"
+	if prefix != "" {
+		resource = "arn:aws:s3:::" + bucket + "/" + prefix + "/*"
+	}
+	policy := map[string]interface{}{
+		"Version": "2012-10-17",
+		"Statement": []map[string]interface{}{
+			{
+				"Effect":   "Allow",
+				"Action":   []string{"s3:PutObject"},
+				"Resource": resource,
+			},
+		},
+	}
+	data, err := json.Marshal(policy)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func ensureS3Bucket(bucket, region string) error {
+	describe := []string{"aws", "s3api", "head-bucket", "--bucket", bucket}
+	output, err := runAWSCommand(describe...)
+	if err == nil {
+		return nil
+	}
+	if !isNotFoundOutput(string(output)) {
+		return fmt.Errorf("%s failed: %w\n%s", shellCommand(describe...), err, strings.TrimSpace(string(output)))
+	}
+	return runAWS(s3CreateBucketCommand(bucket, region)...)
+}
+
+func ensureIAMUser(user string) error {
+	describe := []string{"aws", "iam", "get-user", "--user-name", user}
+	output, err := runAWSCommand(describe...)
+	if err == nil {
+		return nil
+	}
+	if !isNotFoundOutput(string(output)) {
+		return fmt.Errorf("%s failed: %w\n%s", shellCommand(describe...), err, strings.TrimSpace(string(output)))
+	}
+	return runAWS("aws", "iam", "create-user", "--user-name", user)
+}
+
+func createIAMAccessKey(user string) (awsAccessKey, error) {
+	var key awsAccessKey
+	args := []string{"aws", "iam", "create-access-key", "--user-name", user, "--output", "json"}
+	output, err := runAWSCommand(args...)
+	if err != nil {
+		return key, fmt.Errorf("%s failed: %w\n%s", shellCommand(args...), err, strings.TrimSpace(string(output)))
+	}
+	if err := json.Unmarshal(output, &key); err != nil {
+		return key, fmt.Errorf("parse AWS access key response: %w", err)
+	}
+	if key.AccessKey.AccessKeyID == "" || key.AccessKey.SecretAccessKey == "" {
+		return key, fmt.Errorf("AWS access key response missing credentials")
+	}
+	return key, nil
+}
+
+func runAWS(args ...string) error {
+	output, err := runAWSCommand(args...)
+	if err != nil {
+		text := strings.TrimSpace(string(output))
+		if isAlreadyExistsOutput(text) {
+			return nil
+		}
+		return fmt.Errorf("%s failed: %w\n%s", shellCommand(args...), err, text)
+	}
+	return nil
+}
+
+func runAWSCommand(args ...string) ([]byte, error) {
+	return exec.Command(args[0], args[1:]...).CombinedOutput()
+}

--- a/cli/beacon/cmd/cloud_s3.go
+++ b/cli/beacon/cmd/cloud_s3.go
@@ -46,7 +46,7 @@ func runCloudS3Setup(cmd *cobra.Command, args []string) error {
 	if err := ensureS3Bucket(cloudOpts.bucket, cloudOpts.region); err != nil {
 		return err
 	}
-	if err := runAWS("aws", "s3api", "put-public-access-block", "--bucket", cloudOpts.bucket, "--public-access-block-configuration", "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"); err != nil {
+	if err := runAWS(s3PutPublicAccessBlockCommand(cloudOpts.bucket, cloudOpts.region)...); err != nil {
 		return err
 	}
 	if err := ensureIAMUser(cloudOpts.iamUser); err != nil {
@@ -82,7 +82,7 @@ func s3SetupCommands(bucket, region, prefix, iamUser string) ([][]string, error)
 	commands := [][]string{
 		{"aws", "s3api", "head-bucket", "--bucket", bucket},
 		s3CreateBucketCommand(bucket, region),
-		{"aws", "s3api", "put-public-access-block", "--bucket", bucket, "--public-access-block-configuration", "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"},
+		s3PutPublicAccessBlockCommand(bucket, region),
 		{"aws", "iam", "get-user", "--user-name", iamUser},
 		{"aws", "iam", "create-user", "--user-name", iamUser},
 		{"aws", "iam", "put-user-policy", "--user-name", iamUser, "--policy-name", s3InlinePolicyName, "--policy-document", policy},
@@ -97,6 +97,10 @@ func s3CreateBucketCommand(bucket, region string) []string {
 		args = append(args, "--create-bucket-configuration", "LocationConstraint="+region)
 	}
 	return args
+}
+
+func s3PutPublicAccessBlockCommand(bucket, region string) []string {
+	return []string{"aws", "s3api", "put-public-access-block", "--bucket", bucket, "--region", region, "--public-access-block-configuration", "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"}
 }
 
 func s3UploadPolicy(bucket, prefix string) (string, error) {

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -15,6 +16,7 @@ func TestCloudCommandsRegistered(t *testing.T) {
 		{"cloud", "cursor", "print-setup"},
 		{"cloud", "devin", "pull"},
 		{"cloud", "gcs", "setup"},
+		{"cloud", "s3", "setup"},
 	} {
 		cmd, _, err := rootCmd.Find(path)
 		if err != nil {
@@ -171,5 +173,63 @@ func TestGCSSetupClassifiesNotFoundOutput(t *testing.T) {
 	}
 	if isNotFoundOutput("ERROR: permission denied") {
 		t.Fatal("permission denied should not be treated as not found")
+	}
+}
+
+func TestS3SetupCommandsUseLeastPrivilegePolicy(t *testing.T) {
+	commands, err := s3SetupCommands("bucket", "us-west-2", "agent-traces/customer=my-team", "beacon-uploader")
+	if err != nil {
+		t.Fatalf("s3SetupCommands returned error: %v", err)
+	}
+	joined := make([]string, 0, len(commands))
+	for _, command := range commands {
+		joined = append(joined, shellCommand(command...))
+	}
+	got := strings.Join(joined, "\n")
+	for _, want := range []string{
+		"aws s3api head-bucket --bucket bucket",
+		"aws s3api create-bucket --bucket bucket --region us-west-2 --create-bucket-configuration LocationConstraint=us-west-2",
+		"aws s3api put-public-access-block --bucket bucket",
+		"aws iam create-user --user-name beacon-uploader",
+		"aws iam put-user-policy --user-name beacon-uploader --policy-name BeaconCloudTraceUpload",
+		"aws iam create-access-key --user-name beacon-uploader --output json",
+		`arn:aws:s3:::bucket/agent-traces/customer=my-team/*`,
+		`"s3:PutObject"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("setup commands missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestS3CreateBucketCommandOmitsLocationConstraintForUSEast1(t *testing.T) {
+	got := shellCommand(s3CreateBucketCommand("bucket", "us-east-1")...)
+	if strings.Contains(got, "LocationConstraint") {
+		t.Fatalf("us-east-1 create-bucket should omit LocationConstraint: %s", got)
+	}
+}
+
+func TestS3UploadPolicyScopesToPrefix(t *testing.T) {
+	policyJSON, err := s3UploadPolicy("bucket", "/prefix/")
+	if err != nil {
+		t.Fatalf("s3UploadPolicy returned error: %v", err)
+	}
+	var policy struct {
+		Statement []struct {
+			Action   []string `json:"Action"`
+			Resource string   `json:"Resource"`
+		} `json:"Statement"`
+	}
+	if err := json.Unmarshal([]byte(policyJSON), &policy); err != nil {
+		t.Fatalf("policy is not JSON: %v", err)
+	}
+	if len(policy.Statement) != 1 {
+		t.Fatalf("Statement length = %d, want 1", len(policy.Statement))
+	}
+	if got := strings.Join(policy.Statement[0].Action, ","); got != "s3:PutObject" {
+		t.Fatalf("Action = %q, want s3:PutObject", got)
+	}
+	if policy.Statement[0].Resource != "arn:aws:s3:::bucket/prefix/*" {
+		t.Fatalf("Resource = %q", policy.Statement[0].Resource)
 	}
 }

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -189,7 +189,7 @@ func TestS3SetupCommandsUseLeastPrivilegePolicy(t *testing.T) {
 	for _, want := range []string{
 		"aws s3api head-bucket --bucket bucket",
 		"aws s3api create-bucket --bucket bucket --region us-west-2 --create-bucket-configuration LocationConstraint=us-west-2",
-		"aws s3api put-public-access-block --bucket bucket",
+		"aws s3api put-public-access-block --bucket bucket --region us-west-2",
 		"aws iam create-user --user-name beacon-uploader",
 		"aws iam put-user-policy --user-name beacon-uploader --policy-name BeaconCloudTraceUpload",
 		"aws iam create-access-key --user-name beacon-uploader --output json",

--- a/docs/cli/cloud-s3-setup.mdx
+++ b/docs/cli/cloud-s3-setup.mdx
@@ -1,0 +1,73 @@
+---
+title: "beacon cloud s3 setup"
+description: "Create or print S3 setup commands for cloud-agent telemetry"
+---
+
+## Command Overview
+
+`beacon cloud s3 setup` creates or prints self-serve Amazon S3 setup commands
+for cloud-agent telemetry.
+
+```bash title="Command syntax"
+beacon cloud s3 setup
+```
+
+The helper creates or validates a bucket, blocks public access, creates a
+dedicated IAM user, grants prefix-scoped `s3:PutObject`, creates one access key,
+and prints the `BEACON_CLOUD_S3_*` plus AWS credential environment variables for
+cloud agents.
+
+<Warning>
+  This self-serve flow passes scoped AWS access keys into the provider-managed
+  cloud agent environment. Use it for proof-of-concept testing and prototyping.
+  For production enterprise deployments, use [Asymptote Managed](/deployment/managed)
+  or contact Asymptote about secure forwarding in customer-managed infrastructure.
+</Warning>
+
+## Examples
+
+Create S3 resources and print cloud-agent environment variables:
+
+```bash title="Create S3 resources and print environment variables"
+beacon cloud s3 setup \
+  --bucket "$BEACON_CLOUD_S3_BUCKET" \
+  --region us-east-1 \
+  --prefix "$BEACON_CLOUD_S3_PREFIX" \
+  --iam-user beacon-cloud-trace-uploader \
+  --apply \
+  --print-env
+```
+
+Print the setup commands without applying them:
+
+```bash title="Print S3 setup commands"
+beacon cloud s3 setup \
+  --bucket "$BEACON_CLOUD_S3_BUCKET" \
+  --region us-east-1 \
+  --prefix "$BEACON_CLOUD_S3_PREFIX" \
+  --iam-user beacon-cloud-trace-uploader \
+  --print
+```
+
+The printed policy grants only:
+
+```text
+s3:PutObject on arn:aws:s3:::<bucket>/<prefix>/*
+```
+
+Delete or rotate the generated IAM access key after the cloud-agent test is
+complete.
+
+## Related
+
+<Columns cols={2}>
+  <Card title="beacon cloud" icon="cloud" href="/cli/cloud">
+    Review cloud command group behavior.
+  </Card>
+  <Card title="Claude Code Cloud Agents" icon="cloud" href="/runtimes/claude-code-cloud-agents">
+    Configure Claude Code cloud agent telemetry and S3 upload end to end.
+  </Card>
+  <Card title="S3 forwarding" icon="database" href="/log-forwarding/s3">
+    Review local endpoint S3 forwarding for persistent endpoint deployments.
+  </Card>
+</Columns>

--- a/docs/cli/cloud.mdx
+++ b/docs/cli/cloud.mdx
@@ -8,7 +8,7 @@ description: "Configure Beacon telemetry for provider-managed cloud agents"
 `beacon cloud` prints setup helpers for provider-managed cloud agent
 environments. Supported flows capture Claude Code or Cursor cloud agent
 telemetry and upload the cloud session's `runtime.jsonl` to customer-managed
-Google Cloud Storage.
+Google Cloud Storage or Amazon S3.
 
 For complete walkthroughs, see [Claude Code Cloud Agents](/runtimes/claude-code-cloud-agents)
 and [Cursor Cloud Agents](/runtimes/cursor-cloud-agents).
@@ -20,6 +20,7 @@ and [Cursor Cloud Agents](/runtimes/cursor-cloud-agents).
 <span id="beacon-cloud-cursor-print-setup" />
 <span id="beacon-cloud-cursor-print-hooks" />
 <span id="beacon-cloud-gcs-setup" />
+<span id="beacon-cloud-s3-setup" />
 
 <Columns cols={2}>
   <Card title="beacon cloud claude-web print-setup" icon="cloud" href="/cli/cloud-claude-web-print-setup">
@@ -37,13 +38,19 @@ and [Cursor Cloud Agents](/runtimes/cursor-cloud-agents).
   <Card title="beacon cloud gcs setup" icon="database" href="/cli/cloud-gcs-setup">
     Create or print self-serve GCS setup commands for cloud-agent telemetry.
   </Card>
+  <Card title="beacon cloud s3 setup" icon="database" href="/cli/cloud-s3-setup">
+    Create or print self-serve S3 setup commands for cloud-agent telemetry.
+  </Card>
 </Columns>
 
-## GCS Setup Note
+## Object Storage Setup Note
 
-The helper creates or validates a bucket, creates a dedicated uploader service
-account, grants object upload access, creates a service-account key, and prints
-the `BEACON_CLOUD_GCS_*` environment variables for cloud agents.
+The GCS helper creates or validates a bucket, creates a dedicated uploader
+service account, grants object upload access, creates a service-account key, and
+prints the `BEACON_CLOUD_GCS_*` environment variables for cloud agents. The S3
+helper creates or validates a bucket, blocks public access, creates a dedicated
+IAM user, grants prefix-scoped `s3:PutObject`, creates one access key, and
+prints the `BEACON_CLOUD_S3_*` and AWS credential variables.
 
 <Warning>
   This self-serve flow passes a scoped Google service-account key into the
@@ -59,8 +66,11 @@ the `BEACON_CLOUD_GCS_*` environment variables for cloud agents.
   <Card title="beacon cloud gcs setup" icon="database" href="/cli/cloud-gcs-setup">
     Create or print self-serve GCS setup commands for cloud-agent telemetry.
   </Card>
+  <Card title="beacon cloud s3 setup" icon="database" href="/cli/cloud-s3-setup">
+    Create or print self-serve S3 setup commands for cloud-agent telemetry.
+  </Card>
   <Card title="Claude Code Cloud Agents" icon="cloud" href="/runtimes/claude-code-cloud-agents">
-    Configure Claude Code cloud agent telemetry and GCS upload end to end.
+    Configure Claude Code cloud agent telemetry and object-storage upload end to end.
   </Card>
   <Card title="Cursor Cloud Agents" icon="cloud" href="/runtimes/cursor-cloud-agents">
     Configure Cursor cloud agent telemetry and GCS upload end to end.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -306,7 +306,8 @@
                   "cli/cloud-claude-web-print-hooks",
                   "cli/cloud-cursor-print-setup",
                   "cli/cloud-cursor-print-hooks",
-                  "cli/cloud-gcs-setup"
+                  "cli/cloud-gcs-setup",
+                  "cli/cloud-s3-setup"
                 ]
               },
               {
@@ -905,6 +906,10 @@
     {
       "source": "/cli/cloud#beacon-cloud-gcs-setup",
       "destination": "/cli/cloud-gcs-setup"
+    },
+    {
+      "source": "/cli/cloud#beacon-cloud-s3-setup",
+      "destination": "/cli/cloud-s3-setup"
     },
     {
       "source": "/cli/endpoint-dashboard",

--- a/docs/runtimes/claude-code-cloud-agents.mdx
+++ b/docs/runtimes/claude-code-cloud-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Cloud Agents"
-description: "Capture Claude Code cloud agent telemetry and forward cloud-agent runtime logs to customer-managed Google Cloud Storage"
+description: "Capture Claude Code cloud agent telemetry and forward cloud-agent runtime logs to customer-managed object storage"
 ---
 
 <Frame>
@@ -15,12 +15,13 @@ description: "Capture Claude Code cloud agent telemetry and forward cloud-agent 
 ## Integration Overview
 
 Use this integration to capture Claude Code cloud-agent activity and upload each
-session log to your own Google Cloud Storage bucket. It is meant for testing
-cloud-agent telemetry without running a hosted Asymptote backend.
+session log to your own Google Cloud Storage or Amazon S3 bucket. It is meant
+for testing cloud-agent telemetry without running a hosted Asymptote backend.
 
 This flow depends on the Beacon CLI. You run `beacon cloud` commands from your
-workstation to create the GCS upload path, print Claude environment variables,
-and generate the setup script that runs inside the Claude cloud sandbox.
+workstation to create the object-storage upload path, print Claude environment
+variables, and generate the setup script that runs inside the Claude cloud
+sandbox.
 
 <Info>
   If you're interested in leveraging this telemetry ingest across your
@@ -34,18 +35,18 @@ Claude Code Cloud Agents run in Anthropic's cloud environment, so Beacon cannot
 use the long-running endpoint agent that local installs use. Instead, the setup
 script installs Beacon hooks inside the sandbox. During a cloud-agent session,
 those hooks write `/tmp/beacon/runtime.jsonl`; at the end of the session, Beacon
-uploads that file to GCS.
+uploads that file to customer-managed object storage.
 
 ```mermaid
 flowchart LR
   ClaudeWeb["Claude Code Cloud Agents"] --> Hooks["Beacon hooks in sandbox"]
   Hooks --> RuntimeLog["/tmp/beacon/runtime.jsonl"]
-  RuntimeLog --> GCS["Customer-managed GCS bucket"]
+  RuntimeLog --> Storage["Customer-managed GCS or S3 bucket"]
 ```
 
 The setup has three parts:
 
-1. Create a dedicated GCS bucket and uploader service account with Beacon.
+1. Create a dedicated GCS or S3 upload path with Beacon.
 2. Add Beacon cloud telemetry environment variables to the Claude Code cloud environment.
 3. Paste a Beacon-generated setup script into the Claude cloud environment.
 
@@ -55,17 +56,23 @@ Each Claude Code cloud agent session writes one readable JSONL object:
 gs://<bucket>/<prefix>/provider=claude_code_web/user_id=<user_id>/run_id=<claude_session_id>/runtime.jsonl
 ```
 
+or:
+
+```text
+s3://<bucket>/<prefix>/provider=claude_code_web/user_id=<user_id>/run_id=<claude_session_id>/runtime.jsonl
+```
+
 ## Prerequisites
 
 - Beacon CLI `v0.0.51` or later.
-- `gcloud` installed and authenticated to the Google Cloud project you will use
-  for telemetry storage.
-- A Google Cloud project where you can create buckets, service accounts, IAM
-  bindings, and service account keys.
+- For GCS: `gcloud` installed and authenticated to the Google Cloud project you
+  will use for telemetry storage.
+- For S3: AWS CLI installed and authenticated to an AWS account where you can
+  create buckets, IAM users, inline IAM policies, and access keys.
 - Claude Code cloud agent access for the repository you want to test.
 - A Claude cloud environment with outbound access to:
-  - `oauth2.googleapis.com`
-  - `storage.googleapis.com`
+  - For GCS: `oauth2.googleapis.com` and `storage.googleapis.com`
+  - For S3: `s3.<region>.amazonaws.com`
   - `github.com`
   - `*.githubusercontent.com`
 
@@ -78,14 +85,24 @@ brew upgrade beacon
 beacon version
 ```
 
-Authenticate `gcloud` and select your project:
+For GCS, authenticate `gcloud` and select your project:
 
 ```bash
 gcloud auth login
 gcloud config set project <your-gcp-project>
 ```
 
-## 1. Create the GCS Upload Path
+For S3, authenticate the AWS CLI:
+
+```bash
+aws sts get-caller-identity
+```
+
+## 1. Create the Upload Path
+
+Choose GCS or S3 for the cloud-agent session logs.
+
+### GCS
 
 From your workstation, choose a bucket and prefix:
 
@@ -134,6 +151,45 @@ share screenshots or logs.
 The helper creates a dedicated uploader service account and grants it object
 upload access to the selected bucket.
 
+### S3
+
+From your workstation, choose a bucket, region, and prefix:
+
+```bash
+export AWS_REGION="us-east-1"
+export BEACON_TEST_BUCKET="your-beacon-cloud-agent-traces"
+export BEACON_CLOUD_S3_PREFIX="agent-traces/customer=my-team"
+```
+
+Review the AWS changes Beacon will make:
+
+```bash
+beacon cloud s3 setup \
+  --bucket "$BEACON_TEST_BUCKET" \
+  --region "$AWS_REGION" \
+  --prefix "$BEACON_CLOUD_S3_PREFIX" \
+  --iam-user beacon-cloud-trace-uploader \
+  --print
+```
+
+Apply the setup and print the Claude environment variables:
+
+```bash
+beacon cloud s3 setup \
+  --bucket "$BEACON_TEST_BUCKET" \
+  --region "$AWS_REGION" \
+  --prefix "$BEACON_CLOUD_S3_PREFIX" \
+  --iam-user beacon-cloud-trace-uploader \
+  --apply \
+  --print-env
+```
+
+Copy the printed values. Redact `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY` anywhere you share screenshots or logs.
+
+The helper creates a dedicated IAM user and grants it `s3:PutObject` only under
+the selected bucket prefix.
+
 ## 2. Configure Claude Code Cloud Agents
 
 Open the Claude Code web application and select the cloud environment for your
@@ -146,22 +202,40 @@ repository.
 Set network access to **Custom** and allow:
 
 ```text
-oauth2.googleapis.com
-storage.googleapis.com
+s3.<region>.amazonaws.com
 github.com
 *.githubusercontent.com
 ```
 
-Add these environment variables:
+For GCS, allow `oauth2.googleapis.com` and `storage.googleapis.com` instead of
+the S3 regional hostname.
+
+Add these common environment variables:
 
 ```bash
 BEACON_ORIGIN=cloud
 BEACON_RUN_PROVIDER=claude_code_web
 BEACON_RUN_EPHEMERAL=true
 BEACON_CLOUD_USER_ID_HASH=<stable-user-or-test-id>
+```
+
+For GCS, add:
+
+```bash
 BEACON_CLOUD_GCS_BUCKET=<bucket-from-setup>
 BEACON_CLOUD_GCS_PREFIX=<prefix-from-setup>
 BEACON_CLOUD_GCS_CREDENTIALS_B64=<base64-service-account-json>
+```
+
+For S3, add:
+
+```bash
+BEACON_CLOUD_UPLOAD=s3
+BEACON_CLOUD_S3_BUCKET=<bucket-from-setup>
+BEACON_CLOUD_S3_PREFIX=<prefix-from-setup>
+BEACON_CLOUD_S3_REGION=<region-from-setup>
+AWS_ACCESS_KEY_ID=<access-key-id-from-setup>
+AWS_SECRET_ACCESS_KEY=<secret-access-key-from-setup>
 ```
 
 <Frame caption="Configure network access, Beacon metadata, GCS bucket settings, and the setup script in the Claude cloud environment.">
@@ -204,12 +278,19 @@ Read the README, run pwd && ls, create a tiny temporary markdown note under /tmp
   <img src="/images/claude-code-on-the-web/session-init-and-task-output.png" alt="Claude Code cloud agent session showing setup completed, a README task, shell command activity, and a temporary note creation." />
 </Frame>
 
-## 5. Verify GCS Upload
+## 5. Verify Upload
 
-List the uploaded session objects:
+For GCS, list the uploaded session objects:
+
 
 ```bash
 gcloud storage ls --recursive "gs://${BEACON_TEST_BUCKET}/${BEACON_CLOUD_GCS_PREFIX}/"
+```
+
+For S3, list the uploaded session objects:
+
+```bash
+aws s3 ls --recursive "s3://${BEACON_TEST_BUCKET}/${BEACON_CLOUD_S3_PREFIX}/"
 ```
 
 You should see a path like:
@@ -228,6 +309,12 @@ Inspect the log:
 gcloud storage cat "gs://${BEACON_TEST_BUCKET}/${BEACON_CLOUD_GCS_PREFIX}/provider=claude_code_web/user_id=<user_id>/run_id=<run_id>/runtime.jsonl" | head
 ```
 
+For S3:
+
+```bash
+aws s3 cp "s3://${BEACON_TEST_BUCKET}/${BEACON_CLOUD_S3_PREFIX}/provider=claude_code_web/user_id=<user_id>/run_id=<run_id>/runtime.jsonl" - | head
+```
+
 Expected fields include:
 
 ```text
@@ -243,13 +330,15 @@ run.run_id=cse_...
 ## Security Note
 
 The self-serve GCS flow above creates a dedicated service account scoped to
-object uploads for one bucket, then stores its credentials in the Claude Code
-environment. This is useful for proof-of-concept testing, but treat that
-environment variable as a sensitive credential.
+object uploads for one bucket. The S3 flow creates a dedicated IAM user scoped
+to `s3:PutObject` under one prefix. Both flows store credentials in the Claude
+Code environment. This is useful for proof-of-concept testing, but treat those
+environment variables as sensitive credentials.
 
 Claude notes that cloud environment variables are visible to users of that
 environment and recommends avoiding secrets there when possible. Avoid broad
-credentials and review access before using this flow with sensitive telemetry.
+credentials, rotate or delete the generated key after testing, and review access
+before using this flow with sensitive telemetry.
 
 ## Troubleshooting
 
@@ -269,9 +358,9 @@ ls -l /tmp/beacon/runtime.jsonl
 head /tmp/beacon/runtime.jsonl
 ```
 
-If `runtime.jsonl` exists but GCS is empty, check network access and GCS
-credentials. The cloud sandbox must reach both `oauth2.googleapis.com` and
-`storage.googleapis.com`.
+If `runtime.jsonl` exists but object storage is empty, check network access and
+credentials. The cloud sandbox must reach either the GCS OAuth/storage endpoints
+or the regional S3 endpoint you configured.
 
 ### Claude tries to commit hook settings
 
@@ -285,8 +374,8 @@ sandbox-specific configuration and should stay out of commits.
   <Card title="Claude Code runtime support" icon="terminal" href="/runtimes/claude-code">
     Review local Claude Code telemetry through OTLP and hooks.
   </Card>
-  <Card title="Google Cloud Storage forwarding" icon="database" href="/log-forwarding/gcs">
-    Review local endpoint GCS forwarding for persistent endpoint deployments.
+  <Card title="Object storage forwarding" icon="database" href="/log-forwarding/s3">
+    Review local endpoint S3 forwarding for persistent endpoint deployments.
   </Card>
   <Card title="Asymptote Managed" icon="cloud" href="/deployment/managed">
     Use managed secure ingest for production enterprise cloud-agent telemetry.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches credential handling and custom AWS request signing in the upload path; setup can create IAM users and print long-lived keys into cloud agent environments (POC-oriented, similar to GCS keys).
> 
> **Overview**
> Adds **Amazon S3** as an alternative to GCS for uploading cloud-agent `runtime.jsonl` from the sandbox.
> 
> **Runtime (`cloudshuttle`)** — Uploads are selected via `BEACON_CLOUD_UPLOAD` (`gcs` default, `s3` explicit). S3 uses env-driven bucket/prefix/region/credentials (including session tokens), AWS SigV4-signed `PUT`s, and the same object key layout as GCS. GCS-only credential checks are replaced with `normalizeConfig` / `uploadConfigured` so preserve-on-reset and forced upload work for either backend.
> 
> **CLI** — New `beacon cloud s3 setup` (`--print` / `--apply` / `--print-env`) provisions bucket (with public access block), a dedicated IAM user, prefix-scoped `s3:PutObject`, and prints `BEACON_CLOUD_S3_*` plus AWS keys. Shared `isNotFoundOutput` now recognizes common AWS 404 patterns.
> 
> **Docs** — Claude Code cloud agents guide and CLI docs cover end-to-end S3 setup alongside GCS; new `cli/cloud-s3-setup` page and nav entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf0ba5569c77c37d8e4dfe2688e435f9e32e0167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->