### PR TITLE
Strengthen path traversal protection in archive extraction

### DIFF
--- a/cli/beacon/internal/endpoint/selfupdate/fsutil.go
+++ b/cli/beacon/internal/endpoint/selfupdate/fsutil.go
@@ -33,11 +33,18 @@ func acquireLock(path string) (func(), error) {
 }
 
 // safeJoin resolves an archive entry name against dest and rejects anything that
-// would escape dest (path traversal / "zip slip"). It rejects absolute paths and
-// any entry whose cleaned, joined path is not contained within dest.
+// would escape dest (path traversal / "zip slip"). It rejects absolute paths,
+// any ".." path segment (including backslash-separated ones), and any entry
+// whose cleaned, joined path is not contained within dest.
 func safeJoin(dest, name string) (string, error) {
 	if filepath.IsAbs(name) || strings.HasPrefix(name, "/") || strings.HasPrefix(name, "\\") {
 		return "", fmt.Errorf("absolute path in archive entry: %q", name)
+	}
+	normalized := strings.ReplaceAll(name, "\\", "/")
+	for _, seg := range strings.Split(normalized, "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("path traversal in archive entry: %q", name)
+		}
 	}
 	cleanDest := filepath.Clean(dest)
 	target := filepath.Clean(filepath.Join(cleanDest, name))

--- a/cli/beacon/internal/endpoint/selfupdate/fsutil_test.go
+++ b/cli/beacon/internal/endpoint/selfupdate/fsutil_test.go
@@ -12,9 +12,14 @@ import (
 func TestSafeJoinRejectsTraversal(t *testing.T) {
 	dest := "/tmp/dest"
 	bad := []string{
+		"..",
 		"../escape",
 		"../../etc/passwd",
 		"a/../../escape",
+		"a/../b",
+		"a/..",
+		"a\\..\\..\\escape",
+		"..\\escape",
 		"/etc/passwd",
 		"\\windows\\system32",
 	}


### PR DESCRIPTION
## Summary

Enhance the `safeJoin` function in the self-update archive extraction logic to explicitly reject `".."` path segments, preventing potential path traversal attacks even when path normalization might be bypassed.

## Changes

- **Explicit `".."` segment rejection**: Added validation to detect and reject any `".."` path segment in archive entries, including those using backslash separators on Windows
- **Normalized path checking**: Convert backslash separators to forward slashes before splitting and validating path segments
- **Expanded test coverage**: Added test cases covering:
  - Bare `".."` entries
  - Mixed path traversal patterns (`a/../b`, `a/..`)
  - Backslash-separated traversal attempts (`a\\..\\..\escape`, `..\escape`)

## Implementation Details

The fix normalizes the archive entry name by converting all backslashes to forward slashes, then validates each path segment individually. Any segment matching `".."` is rejected with a clear error message. This defense-in-depth approach complements the existing `filepath.Clean` validation and ensures traversal attempts cannot slip through regardless of path separator style or normalization edge cases.

https://claude.ai/code/session_01GJyEVeydpmtcNCqKHfhiEu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive hardening in archive path validation with no change to successful extraction paths; lowers zip-slip risk rather than introducing new behavior.
> 
> **Overview**
> Hardens **`safeJoin`** in beacon self-update archive extraction by rejecting any path segment equal to **`..`** before the existing `filepath.Clean` containment check.
> 
> Archive entry names are normalized (`\` → `/`), split on `/`, and rejected with a dedicated traversal error if any segment is **`..`**, including Windows-style backslash patterns. **`TestSafeJoinRejectsTraversal`** gains cases for bare **`..`**, mixed **`a/../b`** / **`a/..`**, and backslash traversal strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbae2c7ebf5f4200c4d081b1b2de37b3a773b850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->