### PR TITLE
Fix date signing for s3 path

### DIFF
--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle.go
@@ -503,7 +503,7 @@ func signS3Request(req *http.Request, cfg Config, payloadHash string) {
 	signedHeaders := strings.Join(keys, ";")
 	canonicalRequest := strings.Join([]string{
 		req.Method,
-		req.URL.EscapedPath(),
+		awsCanonicalURI(req.URL.Path),
 		req.URL.RawQuery,
 		canonicalHeaders.String(),
 		signedHeaders,
@@ -678,6 +678,30 @@ func escapeObjectName(objectName string) string {
 
 func escapePath(value string) string {
 	return (&url.URL{Path: value}).EscapedPath()
+}
+
+func awsCanonicalURI(pathValue string) string {
+	if pathValue == "" {
+		return "/"
+	}
+	var out strings.Builder
+	for i := 0; i < len(pathValue); i++ {
+		b := pathValue[i]
+		switch {
+		case b == '/':
+			out.WriteByte('/')
+		case (b >= 'A' && b <= 'Z') ||
+			(b >= 'a' && b <= 'z') ||
+			(b >= '0' && b <= '9') ||
+			b == '-' || b == '_' || b == '.' || b == '~':
+			out.WriteByte(b)
+		default:
+			out.WriteByte('%')
+			out.WriteByte("0123456789ABCDEF"[b>>4])
+			out.WriteByte("0123456789ABCDEF"[b&0x0f])
+		}
+	}
+	return out.String()
 }
 
 func defaultString(value, fallback string) string {

--- a/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
+++ b/cli/beacon-hooks/internal/cloudshuttle/shuttle_test.go
@@ -270,6 +270,14 @@ func TestUploadSendsJSONLToS3(t *testing.T) {
 	}
 }
 
+func TestAWSCanonicalURIEncodesHivePartitionEquals(t *testing.T) {
+	got := awsCanonicalURI("/bucket/prefix/runtime/date=2026-07-12/1783891419-claude_code_web-cse_123.jsonl.gz")
+	want := "/bucket/prefix/runtime/date%3D2026-07-12/1783891419-claude_code_web-cse_123.jsonl.gz"
+	if got != want {
+		t.Fatalf("awsCanonicalURI = %q, want %q", got, want)
+	}
+}
+
 func TestUploadReusesLastObjectForSameRun(t *testing.T) {
 	current := time.Date(2026, 7, 12, 20, 17, 3, 0, time.UTC)
 	restore := stubNowFunc(t, func() time.Time { return current })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches S3 request signing for cloud uploads; wrong encoding would break uploads, but the change is narrow and covered by a focused test.
> 
> **Overview**
> Fixes **AWS SigV4** signing for S3 uploads when object keys include hive-style segments such as `date=2026-07-12`.
> 
> `signS3Request` now builds the canonical request URI with a new **`awsCanonicalURI`** helper instead of **`req.URL.EscapedPath()`**, so characters like `=` are percent-encoded the way S3 expects (e.g. `date%3D2026-07-12`). That aligns the signature with the real object path and should stop auth failures on partitioned runtime keys.
> 
> A unit test covers encoding of `=` in those paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af017dad9bb825852e06d2ca0f17379b88b70c0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->