### PR TITLE
Document dual object storage installation

### DIFF
--- a/docs/guides/macos-object-storage-system.mdx
+++ b/docs/guides/macos-object-storage-system.mdx
@@ -161,7 +161,28 @@ sudo env \
 
 The services have separate labels, configs, credentials, and checkpoint
 directories. Install both helpers to forward the same local events to S3 and
-GCS:
+GCS. After exporting the provider variables from the two sections above, run:
+
+```bash
+sudo env \
+  BEACON_S3_BUCKET="$BEACON_S3_BUCKET" \
+  BEACON_S3_PREFIX="$BEACON_S3_PREFIX" \
+  BEACON_S3_STORAGE_CLASS="$BEACON_S3_STORAGE_CLASS" \
+  AWS_REGION="$AWS_REGION" \
+  AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+  AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+  AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}" \
+  /opt/beacon/jamf/claude/s3/install-forwarder.sh
+
+sudo env \
+  BEACON_GCS_BUCKET="$BEACON_GCS_BUCKET" \
+  BEACON_GCS_PREFIX="$BEACON_GCS_PREFIX" \
+  BEACON_GCS_STORAGE_CLASS="$BEACON_GCS_STORAGE_CLASS" \
+  GOOGLE_APPLICATION_CREDENTIALS="$GOOGLE_APPLICATION_CREDENTIALS" \
+  /opt/beacon/jamf/claude/gcs/install-forwarder.sh
+```
+
+This creates two independent services:
 
 ```text
 com.beacon.endpoint.s3-forwarder


### PR DESCRIPTION
## Summary
- add the missing S3 and GCS helper invocations to the "Forward To Both" section
- retain the resulting launchd labels so users can verify both services

## Test plan
- [x] `git diff --check origin/main...HEAD`
- [x] verify the guide uses the provider variables defined in the preceding sections


Made with [Cursor](https://cursor.com)