### PR TITLE
Add Falcon HEC forward GitHub Actions reference workflow

### DIFF
--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -377,7 +377,8 @@ See [`examples/github-actions/claude-code-telemetry.yml`](../../examples/github-
 [`examples/github-actions/codex-action-session.yml`](../../examples/github-actions/codex-action-session.yml),
 [`examples/github-actions/s3-upload-telemetry.yml`](../../examples/github-actions/s3-upload-telemetry.yml),
 [`examples/github-actions/gcs-upload-telemetry.yml`](../../examples/github-actions/gcs-upload-telemetry.yml),
-and [`examples/github-actions/splunk-forward-telemetry.yml`](../../examples/github-actions/splunk-forward-telemetry.yml)
+[`examples/github-actions/splunk-forward-telemetry.yml`](../../examples/github-actions/splunk-forward-telemetry.yml),
+and [`examples/github-actions/falcon-forward-telemetry.yml`](../../examples/github-actions/falcon-forward-telemetry.yml)
 for complete reference workflows.
 
 ## Wazuh

--- a/docs/log-forwarding/ci-telemetry-exports.mdx
+++ b/docs/log-forwarding/ci-telemetry-exports.mdx
@@ -96,9 +96,10 @@ jobs:
           upload-artifact: "true"
 ```
 
-See the sample workflow:
+See the sample workflows:
 
 - [Splunk forward telemetry workflow](https://github.com/Asymptote-Labs/agent-beacon/blob/main/examples/github-actions/splunk-forward-telemetry.yml)
+- [Falcon forward telemetry workflow](https://github.com/Asymptote-Labs/agent-beacon/blob/main/examples/github-actions/falcon-forward-telemetry.yml)
 
 For Falcon LogScale HEC, set `BEACON_CI_FALCON_HEC_TOKEN` and use `forward: falcon`.
 

--- a/examples/github-actions/claude-code-telemetry.yml
+++ b/examples/github-actions/claude-code-telemetry.yml
@@ -43,9 +43,12 @@ jobs:
           command: claude --print "Summarize the changes in this pull request"
           # Optional: forward to a customer-managed SIEM before teardown.
           # Requires a Beacon release that includes ci exec --forward.
-          # See examples/github-actions/splunk-forward-telemetry.yml.
+          # See examples/github-actions/splunk-forward-telemetry.yml or
+          # examples/github-actions/falcon-forward-telemetry.yml.
           # forward: splunk
           # forward-endpoint: https://splunk.example:8088/services/collector
+          # forward: falcon
+          # forward-endpoint: https://cloud.us-1.humio.com/api/v1/ingest/hec
           # Optional: upload the completed runtime JSONL to object storage.
           # Supported values: s3, gcs, or s3,gcs.
           # upload: s3

--- a/examples/github-actions/falcon-forward-telemetry.yml
+++ b/examples/github-actions/falcon-forward-telemetry.yml
@@ -1,0 +1,38 @@
+# Reference workflow for testing Agent Beacon CI telemetry with direct Falcon
+# LogScale HEC forwarding. Copy this file to .github/workflows/ in a test
+# repository and update the Falcon endpoint, secret names, and action ref.
+#
+# This file lives under examples/ (not .github/workflows/) so it is a reference
+# only and does not run in this repository.
+# Replace <tag> with the Beacon release tag you want to run (v0.0.39 or newer).
+
+name: Test Agent Beacon Falcon forward
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  beacon-falcon-forward:
+    runs-on: ubuntu-latest
+    # Keep the Falcon token at the job level so Beacon can forward events
+    # without exposing the secret to the Claude child process.
+    env:
+      BEACON_CI_FALCON_HEC_TOKEN: ${{ secrets.FALCON_HEC_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run Agent Beacon with Falcon forwarding
+        uses: asymptote-labs/agent-beacon@<tag>
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          command: claude --print "Say hello from Agent Beacon CI telemetry"
+          forward: falcon
+          forward-endpoint: https://cloud.us-1.humio.com/api/v1/ingest/hec
+          upload-artifact: "true"


### PR DESCRIPTION
## Summary
- Add `examples/github-actions/falcon-forward-telemetry.yml`, mirroring the existing Splunk CI forward example with job-level `BEACON_CI_FALCON_HEC_TOKEN`, `forward: falcon`, and a Falcon LogScale HEC endpoint.
- Link the new example from CI telemetry export docs and `cli/beacon/README.md`, and point `claude-code-telemetry.yml` at both Splunk and Falcon dedicated workflows.

## Background
Splunk already has a full copy-paste CI forward workflow. Falcon CI forwarding is supported by `action.yml` and documented inline (`BEACON_CI_FALCON_HEC_TOKEN` / `forward: falcon`), but had no matching reference file. No open issues or PRs target this gap.

## Test plan
- [x] Verified `examples/github-actions/falcon-forward-telemetry.yml` parses as valid YAML
- [x] Compared structure against `splunk-forward-telemetry.yml` and confirmed inputs match `action.yml` (`forward: falcon`, `BEACON_CI_FALCON_HEC_TOKEN`, `forward-endpoint`)
- [x] Ran `go test ./internal/ci/... -run 'Forward|Falcon'` in `cli/beacon`
- [x] Maintainer can copy the workflow into a test repo, set `FALCON_HEC_TOKEN`, and run `workflow_dispatch`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example YAML only; no runtime, auth, or forwarding implementation changes.
> 
> **Overview**
> Adds a **copy-paste reference workflow** for CI telemetry with **CrowdStrike Falcon LogScale HEC** forwarding, parallel to the existing Splunk example.
> 
> The new `examples/github-actions/falcon-forward-telemetry.yml` shows job-level `BEACON_CI_FALCON_HEC_TOKEN`, `forward: falcon`, a sample LogScale ingest URL, and the Agent Beacon composite action with artifact upload.
> 
> **Docs and cross-links** are updated so Falcon is discoverable alongside Splunk: `cli/beacon/README.md` and `docs/log-forwarding/ci-telemetry-exports.mdx` link the new example; `claude-code-telemetry.yml` comments now point at both Splunk and Falcon dedicated workflows and include optional `forward: falcon` / endpoint snippets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f970938ff2fbdf101b0361889e675c605adf0be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->