### PR TITLE
Capture Cursor Cloud prompts in object storage

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,5 +1,4 @@
 {
-  "image": "ubuntu-22.04",
   "install": "./.cursor/install.sh",
   "start": "./.cursor/start.sh"
 }

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -3,47 +3,53 @@
   "hooks": {
     "afterFileEdit": [
       {
-        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor post-tool"
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/tmp/beacon/bin/beacon-hooks' --platform cursor post-tool"
       }
     ],
     "afterShellExecution": [
       {
-        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor post-tool"
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/tmp/beacon/bin/beacon-hooks' --platform cursor post-tool"
       }
     ],
     "beforeReadFile": [
       {
-        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor pre-tool"
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/tmp/beacon/bin/beacon-hooks' --platform cursor pre-tool"
       }
     ],
     "beforeShellExecution": [
       {
-        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor pre-tool"
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/tmp/beacon/bin/beacon-hooks' --platform cursor pre-tool"
+      }
+    ],
+    "beforeSubmitPrompt": [
+      {
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/tmp/beacon/bin/beacon-hooks' --platform cursor prompt-submit",
+        "timeout": 30
       }
     ],
     "postToolUse": [
       {
-        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor post-tool"
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/tmp/beacon/bin/beacon-hooks' --platform cursor post-tool"
       }
     ],
     "postToolUseFailure": [
       {
-        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor post-tool"
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/tmp/beacon/bin/beacon-hooks' --platform cursor post-tool"
       }
     ],
     "preCompact": [
       {
-        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor cursor-event"
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/tmp/beacon/bin/beacon-hooks' --platform cursor cursor-event"
       }
     ],
     "subagentStart": [
       {
-        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor subagent-start"
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/tmp/beacon/bin/beacon-hooks' --platform cursor subagent-start"
       }
     ],
     "subagentStop": [
       {
-        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG=/tmp/beacon/runtime.jsonl /tmp/beacon/bin/beacon-hooks --platform cursor subagent-stop"
+        "command": "BEACON_ENDPOINT_MODE=1 BEACON_ORIGIN=cloud BEACON_RUN_PROVIDER=cursor_cloud BEACON_RUN_EPHEMERAL=true BEACON_ENDPOINT_LOG='/tmp/beacon/runtime.jsonl' '/tmp/beacon/bin/beacon-hooks' --platform cursor subagent-stop"
       }
     ]
   }

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -27,17 +27,24 @@ install_from_release() {
   tar -xzf "$BEACON_HOME/${archive}" -C "$BEACON_BIN_DIR"
 }
 
+go_is_compatible() {
+  local go_binary="$1"
+  local current_version
+  current_version="$("$go_binary" version 2>/dev/null | awk '{print $3}')"
+  [[ "$current_version" =~ ^go1\.([0-9]+) ]] && [ "${BASH_REMATCH[1]}" -ge 24 ]
+}
+
 install_go() {
   local bundled_go="$BEACON_HOME/go-toolchain/go/bin/go"
-  if [ -x "$bundled_go" ]; then
+  if [ -x "$bundled_go" ] && go_is_compatible "$bundled_go"; then
     export PATH="$(dirname "$bundled_go"):$PATH"
     return
   fi
 
   if command -v go >/dev/null 2>&1; then
-    local current_version
-    current_version="$(go version 2>/dev/null | awk '{print $3}')"
-    if [[ "$current_version" =~ ^go1\.([0-9]+) ]] && [ "${BASH_REMATCH[1]}" -ge 24 ]; then
+    local system_go
+    system_go="$(command -v go)"
+    if go_is_compatible "$system_go"; then
       return
     fi
   fi

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -28,8 +28,18 @@ install_from_release() {
 }
 
 install_go() {
-  if command -v go >/dev/null 2>&1; then
+  local bundled_go="$BEACON_HOME/go-toolchain/go/bin/go"
+  if [ -x "$bundled_go" ]; then
+    export PATH="$(dirname "$bundled_go"):$PATH"
     return
+  fi
+
+  if command -v go >/dev/null 2>&1; then
+    local current_version
+    current_version="$(go version 2>/dev/null | awk '{print $3}')"
+    if [[ "$current_version" =~ ^go1\.([0-9]+) ]] && [ "${BASH_REMATCH[1]}" -ge 24 ]; then
+      return
+    fi
   fi
 
   local go_version="${BEACON_GO_VERSION:-1.24.4}"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -50,8 +50,10 @@ install_go() {
 
 build_from_source() {
   install_go
-  (cd "$REPO_ROOT/cli/beacon" && go build -o "$BEACON_BIN_DIR/beacon" .)
+  export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
   (cd "$REPO_ROOT/cli/beacon-hooks" && go build -o "$BEACON_BIN_DIR/beacon-hooks" .)
+  cp "$BEACON_BIN_DIR/beacon-hooks" "$REPO_ROOT/cli/beacon/internal/embedded/hooks.bin"
+  (cd "$REPO_ROOT/cli/beacon" && go build -o "$BEACON_BIN_DIR/beacon" .)
 }
 
 if [ -n "${BEACON_VERSION:-}" ]; then

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -6,7 +6,9 @@ BEACON_LOG_PATH="${BEACON_CLOUD_LOG_PATH:-$BEACON_HOME/runtime.jsonl}"
 
 mkdir -p "$(dirname "$BEACON_LOG_PATH")"
 
-case "${BEACON_CLOUD_UPLOAD:-gcs}" in
+BEACON_CLOUD_UPLOAD_NORMALIZED="$(printf '%s' "${BEACON_CLOUD_UPLOAD:-gcs}" | tr '[:upper:]' '[:lower:]')"
+
+case "$BEACON_CLOUD_UPLOAD_NORMALIZED" in
   s3)
     if [ -n "${BEACON_CLOUD_S3_BUCKET:-}" ] &&
       [ -n "${AWS_ACCESS_KEY_ID:-}" ] &&
@@ -16,15 +18,15 @@ case "${BEACON_CLOUD_UPLOAD:-gcs}" in
       echo "Beacon Cloud S3 forwarding is not active; set the S3 bucket, region, and AWS credentials to enable uploads."
     fi
     ;;
-  gcs)
+  *)
+    if [ "$BEACON_CLOUD_UPLOAD_NORMALIZED" != "gcs" ]; then
+      echo "Beacon Cloud upload destination '$BEACON_CLOUD_UPLOAD' is unknown; using the GCS fallback."
+    fi
     if [ -n "${BEACON_CLOUD_GCS_BUCKET:-}" ] && [ -n "${BEACON_CLOUD_GCS_CREDENTIALS_B64:-}" ]; then
       echo "Beacon Cloud GCS forwarding is configured for bucket: $BEACON_CLOUD_GCS_BUCKET"
     else
       echo "Beacon Cloud GCS forwarding is not active; set the GCS bucket and credentials to enable uploads."
     fi
-    ;;
-  *)
-    echo "Beacon Cloud forwarding has unsupported BEACON_CLOUD_UPLOAD=${BEACON_CLOUD_UPLOAD}."
     ;;
 esac
 

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -7,13 +7,15 @@ BEACON_LOG_PATH="${BEACON_CLOUD_LOG_PATH:-$BEACON_HOME/runtime.jsonl}"
 mkdir -p "$(dirname "$BEACON_LOG_PATH")"
 
 BEACON_CLOUD_UPLOAD_NORMALIZED="$(printf '%s' "${BEACON_CLOUD_UPLOAD:-gcs}" | tr '[:upper:]' '[:lower:]')"
+BEACON_CLOUD_S3_REGION_EFFECTIVE="${BEACON_CLOUD_S3_REGION:-${AWS_REGION:-${AWS_DEFAULT_REGION:-}}}"
 
 case "$BEACON_CLOUD_UPLOAD_NORMALIZED" in
   s3)
     if [ -n "${BEACON_CLOUD_S3_BUCKET:-}" ] &&
+      [ -n "$BEACON_CLOUD_S3_REGION_EFFECTIVE" ] &&
       [ -n "${AWS_ACCESS_KEY_ID:-}" ] &&
       [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
-      echo "Beacon Cloud S3 forwarding is configured for bucket: $BEACON_CLOUD_S3_BUCKET"
+      echo "Beacon Cloud S3 forwarding is configured for bucket: $BEACON_CLOUD_S3_BUCKET in region: $BEACON_CLOUD_S3_REGION_EFFECTIVE"
     else
       echo "Beacon Cloud S3 forwarding is not active; set the S3 bucket, region, and AWS credentials to enable uploads."
     fi

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -6,10 +6,26 @@ BEACON_LOG_PATH="${BEACON_CLOUD_LOG_PATH:-$BEACON_HOME/runtime.jsonl}"
 
 mkdir -p "$(dirname "$BEACON_LOG_PATH")"
 
-if [ -n "${BEACON_CLOUD_GCS_BUCKET:-}" ] && [ -n "${BEACON_CLOUD_GCS_CREDENTIALS_B64:-}" ]; then
-  echo "Beacon Cloud GCS forwarding is configured for bucket: $BEACON_CLOUD_GCS_BUCKET"
-else
-  echo "Beacon Cloud GCS forwarding is not active; set BEACON_CLOUD_GCS_BUCKET and BEACON_CLOUD_GCS_CREDENTIALS_B64 to enable uploads."
-fi
+case "${BEACON_CLOUD_UPLOAD:-gcs}" in
+  s3)
+    if [ -n "${BEACON_CLOUD_S3_BUCKET:-}" ] &&
+      [ -n "${AWS_ACCESS_KEY_ID:-}" ] &&
+      [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+      echo "Beacon Cloud S3 forwarding is configured for bucket: $BEACON_CLOUD_S3_BUCKET"
+    else
+      echo "Beacon Cloud S3 forwarding is not active; set the S3 bucket, region, and AWS credentials to enable uploads."
+    fi
+    ;;
+  gcs)
+    if [ -n "${BEACON_CLOUD_GCS_BUCKET:-}" ] && [ -n "${BEACON_CLOUD_GCS_CREDENTIALS_B64:-}" ]; then
+      echo "Beacon Cloud GCS forwarding is configured for bucket: $BEACON_CLOUD_GCS_BUCKET"
+    else
+      echo "Beacon Cloud GCS forwarding is not active; set the GCS bucket and credentials to enable uploads."
+    fi
+    ;;
+  *)
+    echo "Beacon Cloud forwarding has unsupported BEACON_CLOUD_UPLOAD=${BEACON_CLOUD_UPLOAD}."
+    ;;
+esac
 
 echo "Beacon runtime log path: $BEACON_LOG_PATH"

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ CI, and cloud surfaces.
 | --- | --- | --- |
 | [Anthropic](https://docs.asymptotelabs.ai/sdk/integrations-anthropic) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported Anthropic model call spans, errors, and OpenTelemetry attributes |
 | [Claude Agent SDK](https://docs.asymptotelabs.ai/sdk/integrations-claude-agent-sdk) | Query wrapper through `Observe.wrapClaudeAgentQuery()` | Query root spans with Beacon-compatible prompt attributes |
-| [Claude Code Cloud Agents](https://docs.asymptotelabs.ai/claude-code-cloud-agents) | Cloud sandbox hooks with GCS upload | Session, prompt, tool, command, file, and lifecycle telemetry where Claude Code cloud hook payloads expose it |
-| [Cursor Cloud Agents](https://docs.asymptotelabs.ai/cursor-cloud-agents) | Cloud sandbox hooks with GCS upload | Tool, shell command, file, subagent, and compaction telemetry where Cursor cloud hook payloads expose it |
+| [Claude Code Cloud Agents](https://docs.asymptotelabs.ai/claude-code-cloud-agents) | Cloud sandbox hooks with direct GCS or S3 upload | Session, prompt, tool, command, file, and lifecycle telemetry where Claude Code cloud hook payloads expose it |
+| [Cursor Cloud Agents](https://docs.asymptotelabs.ai/cursor-cloud-agents) | Cloud sandbox hooks with direct GCS or S3 upload | Follow-up prompts, tool, shell command, file, subagent, and compaction telemetry after project hooks become active |
 | [Devin Cloud Agents](https://docs.asymptotelabs.ai/devin-cloud-agents) | Org-wide API poll via `beacon cloud devin pull`, with GCS upload | Session, prompt, agent message, status, pull request, and ACU usage telemetry the Devin sessions API exposes (message-level; the autonomous agent runs no in-sandbox hooks) |
 | [OpenAI](https://docs.asymptotelabs.ai/sdk/integrations-openai) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported OpenAI model call spans, errors, and OpenTelemetry attributes |
 | [Vercel AI SDK](https://docs.asymptotelabs.ai/sdk/integrations-vercel-ai-sdk) | Tracer handoff through `experimental_telemetry` | AI SDK model call and tool spans where telemetry is enabled |
@@ -147,8 +147,8 @@ management (SIEM), log aggregation, and object storage destinations.
 
 | Destination | Support path |
 | --- | --- |
-| [AWS S3](https://docs.asymptotelabs.ai/cli/siem-forwarding-s3) | Vector content pack over local runtime and inventory JSONL using customer-managed AWS credentials |
-| [Google Cloud Storage](https://docs.asymptotelabs.ai/cli/siem-forwarding-gcs) | Vector content pack and packaged macOS helpers over runtime and inventory JSONL using customer-managed Google credentials |
+| [AWS S3](https://docs.asymptotelabs.ai/cli/siem-forwarding-s3) | Vector over endpoint JSONL, CI upload, or direct compressed snapshots from supported cloud agents |
+| [Google Cloud Storage](https://docs.asymptotelabs.ai/cli/siem-forwarding-gcs) | Vector and packaged macOS helpers over endpoint JSONL, CI upload, or direct compressed snapshots from supported cloud agents |
 
 #### Local
 

--- a/cli/beacon-hooks/cmd/prompt_submit.go
+++ b/cli/beacon-hooks/cmd/prompt_submit.go
@@ -54,5 +54,6 @@ func runPromptSubmit(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	maybeUploadCursorCloudTelemetry(logger)
 	outputJSON(hookNoopResponse())
 }

--- a/cli/beacon-hooks/cmd/prompt_submit_cloud_test.go
+++ b/cli/beacon-hooks/cmd/prompt_submit_cloud_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunPromptSubmitUploadsCursorCloudTelemetryToS3(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+
+	uploaded := make(chan []byte, 1)
+	var uploadPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if r.Header.Get("Content-Encoding") != "gzip" {
+			t.Errorf("Content-Encoding = %q, want gzip", r.Header.Get("Content-Encoding"))
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "AWS4-HMAC-SHA256 ") {
+			t.Errorf("Authorization = %q, want SigV4", r.Header.Get("Authorization"))
+		}
+		uploadPath = r.URL.Path
+		reader, err := gzip.NewReader(r.Body)
+		if err != nil {
+			t.Errorf("open gzip body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer reader.Close()
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			t.Errorf("read gzip body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		uploaded <- body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CLOUD_SHUTTLE_STATE", filepath.Join(tempDir, "shuttle-state.json"))
+	t.Setenv("BEACON_ORIGIN", "cloud")
+	t.Setenv("BEACON_RUN_PROVIDER", "cursor_cloud")
+	t.Setenv("BEACON_RUN_ID", "")
+	t.Setenv("BEACON_CLOUD_UPLOAD", "s3")
+	t.Setenv("BEACON_CLOUD_S3_BUCKET", "telemetry-bucket")
+	t.Setenv("BEACON_CLOUD_S3_PREFIX", "agent-traces")
+	t.Setenv("BEACON_CLOUD_S3_REGION", "us-east-1")
+	t.Setenv("BEACON_CLOUD_S3_ENDPOINT", server.URL)
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIATEST")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+
+	out := runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"conversation_id": "conv-prompt",
+		"hook_event_name": "beforeSubmitPrompt",
+		"prompt":          "Summarize this repository",
+		"cwd":             "/workspace",
+	})
+	if out["continue"] != true {
+		t.Fatalf("prompt response = %#v, want continue=true", out)
+	}
+
+	body := <-uploaded
+	var event map[string]interface{}
+	if err := json.Unmarshal(body, &event); err != nil {
+		t.Fatalf("unmarshal uploaded event: %v\n%s", err, body)
+	}
+	if action := event["event"].(map[string]interface{})["action"]; action != "prompt.submitted" {
+		t.Fatalf("event.action = %q, want prompt.submitted", action)
+	}
+	if prompt := event["prompt"].(map[string]interface{})["text"]; prompt != "Summarize this repository" {
+		t.Fatalf("prompt.text = %q", prompt)
+	}
+	run := event["run"].(map[string]interface{})
+	if run["provider"] != "cursor_cloud" || run["run_id"] != "conv-prompt" {
+		t.Fatalf("run = %#v", run)
+	}
+	if !strings.Contains(uploadPath, "/telemetry-bucket/agent-traces/runtime/") ||
+		!strings.HasSuffix(uploadPath, "-cursor_cloud-conv-prompt.jsonl.gz") {
+		t.Fatalf("upload path = %q", uploadPath)
+	}
+}

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -71,15 +71,16 @@ For Cursor Cloud Agents, keep the repository-owned setup in `.cursor/`:
 
 ```text
 .cursor/environment.json
+.cursor/hooks.json
 .cursor/install.sh
 .cursor/start.sh
 ```
 
 The install script builds the current branch by default, or downloads a release
-when `BEACON_VERSION` is set, then merges Beacon commands into
-`.cursor/hooks.json` during environment setup. It defaults to safe hook coverage
-while testing forwarding and skips shell/edit-specific hooks; set
-`BEACON_CURSOR_CLOUD_FULL_HOOKS=1` to enable the full Cursor Cloud hook set.
+when `BEACON_VERSION` is set. Generate `.cursor/hooks.json` with
+`beacon cloud cursor print-hooks`, then commit it before starting a cloud agent;
+the environment update script must not create hooks after Cursor has already
+loaded the project configuration.
 
 For Claude Code on the web, generate the setup script for a Beacon release and
 paste it into the provider's cloud setup field:
@@ -91,7 +92,7 @@ paste it into the provider's cloud setup field:
 The setup script installs `beacon-hooks` into the cloud sandbox and uploads a
 gzip-compressed `/tmp/beacon/runtime.jsonl` snapshot to object storage. Claude web writes
 `.claude/settings.local.json` inside the sandbox clone. Cursor cloud uses
-`.cursor/environment.json` to install Beacon and generate project-level
+`.cursor/environment.json` to install Beacon and committed project-level
 `.cursor/hooks.json` because Cursor cloud only runs repository project hooks.
 
 ```text
@@ -99,12 +100,13 @@ gzip-compressed `/tmp/beacon/runtime.jsonl` snapshot to object storage. Claude w
 <prefix>/runtime/date=YYYY-MM-DD/<timestamp>-cursor_cloud-<generated-or-explicit-run-id>.jsonl.gz
 ```
 
-Cloud network access must allow `oauth2.googleapis.com` and
-`storage.googleapis.com`. Cursor cloud currently supports command hooks for tool
-activity, shell execution, file reads and edits, subagents, and compaction
-events; it does not currently run session start, session end, prompt submit, or
-stop hooks in cloud agents. If you are testing unreleased Beacon changes, clone
-and build the feature branch in the setup script instead of using
+Cloud network access must allow the selected destination: both
+`oauth2.googleapis.com` and `storage.googleapis.com` for GCS, or
+`s3.<region>.amazonaws.com` for S3. Cursor cloud project hooks capture follow-up
+prompts, tool activity, shell execution, file reads and edits, subagents, and
+compaction after the writable environment becomes available. Early bootstrap
+turns can precede project-hook activation. If you are testing unreleased Beacon
+changes, build the feature branch in the setup script instead of using
 `print-setup --version`.
 
 Add optional Falcon LogScale HEC forwarding during install or repair:

--- a/cli/beacon/cmd/cloud_test.go
+++ b/cli/beacon/cmd/cloud_test.go
@@ -42,6 +42,8 @@ func TestRenderCursorCloudHooks(t *testing.T) {
 		`"postToolUseFailure"`,
 		`"beforeShellExecution"`,
 		`"afterShellExecution"`,
+		`"beforeSubmitPrompt"`,
+		`prompt-submit`,
 		`"beforeReadFile"`,
 		`"afterFileEdit"`,
 		`"subagentStart"`,
@@ -55,7 +57,7 @@ func TestRenderCursorCloudHooks(t *testing.T) {
 			t.Fatalf("rendered hooks missing %q:\n%s", want, got)
 		}
 	}
-	for _, unsupported := range []string{`"preToolUse"`, `"sessionStart"`, `"sessionEnd"`, `"beforeSubmitPrompt"`, `"stop"`} {
+	for _, unsupported := range []string{`"preToolUse"`, `"sessionStart"`, `"sessionEnd"`, `"stop"`} {
 		if strings.Contains(got, unsupported) {
 			t.Fatalf("rendered cursor cloud hooks should not contain %q:\n%s", unsupported, got)
 		}
@@ -72,6 +74,7 @@ func TestRenderCursorCloudSafeHooks(t *testing.T) {
 		t.Fatalf("render cursor cloud hooks: %v", err)
 	}
 	for _, want := range []string{
+		`"beforeSubmitPrompt"`,
 		`"beforeReadFile"`,
 		`"postToolUse"`,
 		`"subagentStart"`,

--- a/cli/beacon/internal/endpoint/hooks/cursor.go
+++ b/cli/beacon/internal/endpoint/hooks/cursor.go
@@ -130,6 +130,7 @@ func CursorCloudHookRefs(opts CursorCloudOptions) map[string][]HookRef {
 	}
 	prefix := cursorCloudCommandPrefix(opts.BinaryPath, opts.LogPath)
 	refs := map[string][]HookRef{
+		"beforeSubmitPrompt": {{Command: prefix + " prompt-submit", Timeout: 30}},
 		"postToolUse":        {{Command: prefix + " post-tool"}},
 		"postToolUseFailure": {{Command: prefix + " post-tool"}},
 		"beforeReadFile": {

--- a/docs/architecture/architecture.mdx
+++ b/docs/architecture/architecture.mdx
@@ -27,7 +27,12 @@ The endpoint architecture is local-first: local endpoint telemetry can be inspec
 4. Beacon writes the event to the active `runtime.jsonl` file.
 5. Operators inspect local activity in the dashboard or forward the JSONL stream to their security stack.
 
-For CI and cloud-agent setup paths, see the [runtime surface overview](/runtimes), [`beacon ci`](/cli/ci), [`beacon cloud`](/cli/cloud), and [Asymptote Observe SDK](/sdk).
+For CI and cloud-agent setup paths, see the [runtime surface overview](/runtimes),
+[`beacon ci`](/cli/ci), [`beacon cloud`](/cli/cloud), and
+[Asymptote Observe SDK](/sdk). Provider-managed cloud agents run
+`beacon-hooks` inside the sandbox, write `/tmp/beacon/runtime.jsonl`, and can
+upload compressed per-run snapshots directly to customer-managed GCS or S3
+without the persistent endpoint collector or Vector.
 
 ## Architecture Details
 

--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -11,6 +11,20 @@ Stay up to date with the latest changes to the Agent Beacon CLI.
 
 ## July 2026
 
+### Unreleased
+
+- **Cursor Cloud prompt telemetry** · Committed `beforeSubmitPrompt` project
+  hooks now retain observed follow-up prompts and immediately refresh the
+  per-run object-storage snapshot, including prompt-only turns after hooks
+  become active.
+- **Cursor Cloud S3 walkthrough** · Expanded the self-serve Cursor Cloud flow
+  with direct, SigV4-signed uploads to customer-managed S3, static Runtime
+  Secret credentials, regional egress requirements, and end-to-end prompt
+  verification.
+- **Repository environment reliability** · Updated the committed Cursor
+  environment to use the current schema, build and embed `beacon-hooks` before
+  the CLI, select a compatible Go toolchain, and report GCS or S3 startup state.
+
 ### v1.0.3 · July 14, 2026
 
 - **Detailed Claude Code tool telemetry** · Endpoint-managed and CI Claude Code sessions now enable `OTEL_LOG_TOOL_DETAILS=1`, preserving Bash commands, file paths, URLs, search patterns, and MCP server/tool arguments in exported OpenTelemetry events.

--- a/docs/cli/cloud-cursor-print-hooks.mdx
+++ b/docs/cli/cloud-cursor-print-hooks.mdx
@@ -17,16 +17,17 @@ The rendered hooks set `BEACON_ORIGIN=cloud`, `BEACON_RUN_PROVIDER=cursor_cloud`
 
 Cursor Cloud only runs command-based project hooks after the cloud VM starts.
 The generated hook set uses supported Cursor Cloud hooks such as
-`beforeReadFile`, `beforeShellExecution`, `afterShellExecution`,
+`beforeSubmitPrompt`, `beforeReadFile`, `beforeShellExecution`, `afterShellExecution`,
 `afterFileEdit`, `postToolUse`, `postToolUseFailure`, `subagentStart`,
-`subagentStop`, and `preCompact`. It does not include broad `preToolUse`,
-`beforeSubmitPrompt`, `sessionStart`, `sessionEnd`, or `stop` because Cursor
-does not run those hooks in cloud agents. See
+`subagentStop`, and `preCompact`. It currently omits broad `preToolUse`,
+`sessionStart`, `sessionEnd`, and `stop`. See
 [Cursor's Cloud Agent hook support matrix](https://cursor.com/docs/hooks#cloud-agent-support)
 for the current platform support list.
 
 Beacon uses Cursor's `conversation_id` hook payload as the default
 `run.run_id` for Cursor Cloud telemetry unless `BEACON_RUN_ID` is already set.
+Prompt events are written and uploaded as soon as `beforeSubmitPrompt` runs,
+including prompt-only follow-up turns.
 
 ## Examples
 

--- a/docs/cli/cloud-cursor-print-setup.mdx
+++ b/docs/cli/cloud-cursor-print-setup.mdx
@@ -33,8 +33,14 @@ for the current platform support list.
 Print setup for a specific Beacon release:
 
 ```bash title="Print setup for a specific Beacon release"
-beacon cloud cursor print-setup --version v0.0.95
+beacon cloud cursor print-setup --version vX.Y.Z
 ```
+
+Replace `vX.Y.Z` with the desired release tag. Cursor Cloud prompt capture
+requires a release containing the committed `beforeSubmitPrompt` hook and
+immediate upload behavior. Until that release exists, build the branch
+containing the change in the cloud environment instead of downloading an older
+release.
 
 ## Related
 
@@ -46,6 +52,6 @@ beacon cloud cursor print-setup --version v0.0.95
     Print project-level Cursor hook settings for a cloud sandbox.
   </Card>
   <Card title="Cursor Cloud Agents" icon="cloud" href="/runtimes/cursor-cloud-agents">
-    Configure Cursor cloud agent telemetry and GCS upload end to end.
+    Configure Cursor cloud agent telemetry and GCS or S3 upload end to end.
   </Card>
 </Columns>

--- a/docs/cli/cloud-cursor-print-setup.mdx
+++ b/docs/cli/cloud-cursor-print-setup.mdx
@@ -20,9 +20,11 @@ project hooks with [`beacon cloud cursor print-hooks`](/cli/cloud-cursor-print-h
 commit `.cursor/hooks.json` to the repository, then start Cursor Cloud Agents
 from a commit that contains that file.
 
-Cursor cloud agents do not run prompt or session lifecycle hooks such as
-`beforeSubmitPrompt`, `sessionStart`, `sessionEnd`, and `stop`. Beacon refreshes
-the uploaded `runtime.jsonl` object as supported hook events run. See
+Cursor Cloud Agents run the committed `beforeSubmitPrompt` project hook after
+the cloud environment is available, so Beacon can capture and immediately
+upload prompt events. `sessionStart` and `sessionEnd` remain unavailable in
+Cursor Cloud. Beacon refreshes the uploaded `runtime.jsonl` object as supported
+hook events run. See
 [Cursor's Cloud Agent hook support matrix](https://cursor.com/docs/hooks#cloud-agent-support)
 for the current platform support list.
 

--- a/docs/cli/cloud-s3-setup.mdx
+++ b/docs/cli/cloud-s3-setup.mdx
@@ -14,8 +14,9 @@ beacon cloud s3 setup
 
 The helper creates or validates a bucket, blocks public access, creates a
 dedicated IAM user, grants prefix-scoped `s3:PutObject`, creates one access key,
-and prints the `BEACON_CLOUD_S3_*` plus AWS credential environment variables for
-cloud agents.
+and prints `BEACON_CLOUD_UPLOAD=s3`, `BEACON_CLOUD_S3_BUCKET`,
+`BEACON_CLOUD_S3_PREFIX`, `BEACON_CLOUD_S3_REGION`, `AWS_ACCESS_KEY_ID`, and
+`AWS_SECRET_ACCESS_KEY` for cloud agents.
 
 <Warning>
   This self-serve flow passes scoped AWS access keys into the provider-managed
@@ -66,6 +67,9 @@ complete.
   </Card>
   <Card title="Claude Code Cloud Agents" icon="cloud" href="/runtimes/claude-code-cloud-agents">
     Configure Claude Code cloud agent telemetry and S3 upload end to end.
+  </Card>
+  <Card title="Cursor Cloud Agents" icon="cloud" href="/runtimes/cursor-cloud-agents">
+    Configure Cursor cloud agent telemetry and S3 upload end to end.
   </Card>
   <Card title="Log forwarding" icon="database" href="/log-forwarding">
     Review local endpoint S3 forwarding for persistent endpoint deployments.

--- a/docs/cli/cloud.mdx
+++ b/docs/cli/cloud.mdx
@@ -53,9 +53,9 @@ IAM user, grants prefix-scoped `s3:PutObject`, creates one access key, and
 prints the `BEACON_CLOUD_S3_*` and AWS credential variables.
 
 <Warning>
-  This self-serve flow passes a scoped Google service-account key into the
-  provider-managed cloud agent environment. Use it for proof-of-concept testing
-  and prototyping. For production enterprise deployments, use
+  These self-serve flows pass a scoped Google service-account key or AWS access
+  key into the provider-managed cloud agent environment. Use them for
+  proof-of-concept testing and prototyping. For production enterprise deployments, use
   [Asymptote Managed](/deployment/managed) or contact Asymptote about secure
   forwarding in customer-managed infrastructure.
 </Warning>
@@ -73,9 +73,9 @@ prints the `BEACON_CLOUD_S3_*` and AWS credential variables.
     Configure Claude Code cloud agent telemetry and object-storage upload end to end.
   </Card>
   <Card title="Cursor Cloud Agents" icon="cloud" href="/runtimes/cursor-cloud-agents">
-    Configure Cursor cloud agent telemetry and GCS upload end to end.
+    Configure Cursor cloud agent telemetry and GCS or S3 upload end to end.
   </Card>
   <Card title="Log forwarding" icon="database" href="/log-forwarding">
-    Review local endpoint GCS forwarding for persistent endpoint deployments.
+    Compare direct cloud-agent uploads with local endpoint object-storage forwarding.
   </Card>
 </Columns>

--- a/docs/concepts/core-concepts.mdx
+++ b/docs/concepts/core-concepts.mdx
@@ -41,7 +41,12 @@ An **agent harness** is the runtime or integration that produced an event. It ca
 
 ## Cloud-Agent Telemetry
 
-**Cloud-agent telemetry** is activity captured from provider-managed cloud agent sandboxes. Beacon cloud helpers print hook and storage setup so cloud sessions can produce Beacon-compatible `runtime.jsonl` artifacts, currently with self-serve Google Cloud Storage upload paths for supported cloud agents.
+**Cloud-agent telemetry** is activity captured from provider-managed cloud agent
+sandboxes. Beacon cloud helpers print hook and storage setup so cloud sessions
+can produce Beacon-compatible `runtime.jsonl` artifacts and upload compressed
+per-run snapshots directly to customer-managed Google Cloud Storage or Amazon
+S3. Cursor Cloud project hooks capture supported events after the writable
+environment becomes available, so early bootstrap turns may precede telemetry.
 
 ## Observe SDK
 

--- a/docs/log-forwarding/index.mdx
+++ b/docs/log-forwarding/index.mdx
@@ -13,9 +13,10 @@ For [ephemeral CI jobs](/concepts/core-concepts#ci-telemetry), see [CI Telemetry
 
 For [provider-managed cloud agents](/concepts/core-concepts#cloud-agent-telemetry), see
 [Claude Code Cloud Agents](/runtimes/claude-code-cloud-agents) or
-[Cursor Cloud Agents](/runtimes/cursor-cloud-agents). Cloud agents currently support
-Google Cloud Storage as the self-serve artifact destination; AWS S3 and SIEM
-destinations are planned.
+[Cursor Cloud Agents](/runtimes/cursor-cloud-agents). Supported cloud-agent
+hooks can upload compressed per-run JSONL snapshots directly to
+customer-managed Google Cloud Storage or Amazon S3. This direct sandbox upload
+does not use the persistent endpoint's Vector forwarder.
 
 ## Runtime log paths
 

--- a/docs/runtimes/cursor-cloud-agents.mdx
+++ b/docs/runtimes/cursor-cloud-agents.mdx
@@ -6,13 +6,13 @@ description: "Capture Cursor cloud agent telemetry and forward cloud-agent runti
 ## Integration Overview
 
 Use this integration to capture Cursor cloud-agent activity and upload each
-session log to your own Google Cloud Storage or Amazon S3 bucket. It is meant for testing
-cloud-agent telemetry without running a hosted Asymptote backend.
+session log to your own Google Cloud Storage or Amazon S3 bucket. It is meant
+for testing cloud-agent telemetry without running a hosted Asymptote backend.
 
 This flow depends on the Beacon CLI. You run `beacon cloud` commands from your
-workstation to create the GCS upload path, generate project hooks to commit to
-your repository, and generate the setup script that installs Beacon binaries in
-the Cursor cloud sandbox.
+workstation to create the object-storage upload path, generate project hooks to
+commit to your repository, and generate the setup script that installs Beacon
+binaries in the Cursor cloud sandbox.
 
 <Info>
   If you're interested in leveraging this telemetry ingest across your
@@ -27,7 +27,7 @@ long-running endpoint agent that local installs use. Instead, commit
 project-level Cursor hooks to `.cursor/hooks.json` and use the setup script to
 install Beacon binaries in the sandbox. During a cloud-agent session, those
 hooks write `/tmp/beacon/runtime.jsonl`; Beacon refreshes the corresponding GCS
-object as supported Cursor hook events run.
+or S3 object as supported Cursor hook events run.
 
 ```mermaid
 flowchart LR
@@ -62,11 +62,13 @@ that value instead.
 
 ## Prerequisites
 
-- Beacon CLI `v0.0.56` or later.
+- Beacon CLI `v1.0.3` or later for direct S3 upload. Cursor Cloud prompt capture
+  requires the branch containing this change until a release includes it.
 - For GCS: `gcloud` installed and authenticated to a project where you can
   create buckets, service accounts, IAM bindings, and service account keys.
 - For S3: AWS CLI installed and authenticated to an account where you can
   create buckets, IAM users, inline policies, and access keys.
+- `jq` on the verification workstation.
 - Cursor Cloud Agent access for the repository you want to test.
 - A Cursor cloud environment with outbound access to:
   - `oauth2.googleapis.com`
@@ -180,6 +182,9 @@ beacon cloud s3 setup \
 The helper creates a dedicated IAM user and grants it `s3:PutObject` only under
 the selected bucket prefix.
 
+Copy the printed values. Treat `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY` as sensitive and redact them from screenshots and logs.
+
 ## 2. Configure Cursor Cloud Agents
 
 Open your Cursor Cloud Agent environment for the repository.
@@ -213,7 +218,7 @@ AWS_SECRET_ACCESS_KEY=<secret-access-key-from-setup>
 ```
 
 <Frame caption="Configure network access and Beacon runtime secrets for Cursor Cloud Agents.">
-  <img src="/images/cursor-cloud-agents/cursor-cloud-agent-config.png" alt="Cursor Cloud Agents settings showing network allowlist entries and Beacon runtime secrets for GCS upload." />
+  <img src="/images/cursor-cloud-agents/cursor-cloud-agent-config.png" alt="Cursor Cloud Agents settings showing network allowlist entries and Beacon runtime secrets for object-storage upload." />
 </Frame>
 
 If your Cursor cloud environment restricts outbound network access, allow:
@@ -254,8 +259,12 @@ git push
 Generate the setup script for your Beacon release:
 
 ```bash
-beacon cloud cursor print-setup --version v0.0.95
+beacon cloud cursor print-setup --version vX.Y.Z
 ```
+
+Replace `vX.Y.Z` with a release tag that contains Cursor Cloud prompt capture.
+Until that release exists, use the source-build path below; `v1.0.3` supports
+direct S3 upload but predates the prompt hook.
 
 Paste the generated script into the Cursor cloud environment setup step. The
 script:
@@ -276,21 +285,34 @@ script:
 
 ## 5. Run a Cloud Agent Task
 
-Start a Cursor cloud agent task that uses tools. For example:
+Start a Cursor cloud agent task that uses tools so the environment becomes
+writable and project hooks become active. For example:
 
 ```text
-Read the README, run pwd && ls, create a tiny temporary markdown note under /tmp or in the repo, then summarize what you did.
+Read the README, run pwd && ls, create a tiny temporary markdown note under
+/tmp or in the repo, then summarize what you did.
 ```
 
-Beacon captures Cursor cloud hook activity such as tool use, shell execution,
-file reads and edits, subagent lifecycle events, and compaction events where
-Cursor exposes hook payloads.
+Beacon captures observed prompt submissions, tool use, shell execution, file
+reads and edits, subagent lifecycle events, and compaction events where Cursor
+exposes hook payloads.
+
+Then submit a prompt-only follow-up with a unique marker:
+
+```text
+BEACON_PROMPT_SMOKE_<unique-id>
+
+Do not inspect files or run tools. Reply exactly: PROMPT CAPTURE TEST COMPLETE
+```
 
 <Note>
   Beacon captures prompt text through Cursor Cloud's `beforeSubmitPrompt`
   project hook and uploads that event immediately. Commit `.cursor/hooks.json`
   before starting the run so the prompt hook is available when the cloud
-  environment starts. `sessionStart` and `sessionEnd` remain unavailable. See
+  environment starts. Cursor can perform early read-only or bootstrap work
+  before project hooks become active, so the initial launch prompt may be
+  absent; follow-up prompts are captured once hooks are running.
+  `sessionStart` and `sessionEnd` remain unavailable. See
   [Cursor's Cloud Agent hook support matrix](https://cursor.com/docs/hooks#cloud-agent-support)
   for the current platform support list.
 </Note>
@@ -331,6 +353,25 @@ For S3:
 aws s3 cp "s3://${BEACON_TEST_BUCKET}/${BEACON_CLOUD_S3_PREFIX}/runtime/date=<date>/<object>.jsonl.gz" - | gzip -dc | head
 ```
 
+For GCS, verify prompt capture with the unique marker from the follow-up:
+
+```bash
+gcloud storage cat "gs://${BEACON_TEST_BUCKET}/${BEACON_CLOUD_GCS_PREFIX}/runtime/date=<date>/<object>.jsonl.gz" \
+  | gzip -dc \
+  | jq -c 'select(.event.action == "prompt.submitted") | {prompt: .prompt.text, run: .run}'
+```
+
+For S3:
+
+```bash
+aws s3 cp "s3://${BEACON_TEST_BUCKET}/${BEACON_CLOUD_S3_PREFIX}/runtime/date=<date>/<object>.jsonl.gz" - \
+  | gzip -dc \
+  | jq -c 'select(.event.action == "prompt.submitted") | {prompt: .prompt.text, run: .run}'
+```
+
+The last prompt can be the final record in the object. That proves Beacon
+uploaded the prompt immediately rather than waiting for a later tool event.
+
 Expected fields include:
 
 ```text
@@ -349,8 +390,9 @@ scoped to object uploads, then store its credentials in the Cursor cloud
 environment. This is useful for proof-of-concept testing, but treat those
 environment variables as sensitive credentials.
 
-Avoid broad credentials and review access before using this flow with sensitive
-telemetry.
+Store credential values as Cursor Runtime Secrets, avoid broad credentials,
+rotate test keys after use, and review access before using this flow with
+sensitive telemetry.
 
 ## Troubleshooting
 
@@ -400,7 +442,7 @@ git diff -- .cursor/hooks.json
     Review local Cursor telemetry through Beacon-managed hooks.
   </Card>
   <Card title="Log forwarding" icon="database" href="/log-forwarding">
-    Review local endpoint GCS forwarding for persistent endpoint deployments.
+    Compare direct cloud-agent uploads with local endpoint object-storage forwarding.
   </Card>
   <Card title="Asymptote Managed" icon="cloud" href="/deployment/managed">
     Use managed secure ingest for production enterprise cloud-agent telemetry.

--- a/docs/runtimes/cursor-cloud-agents.mdx
+++ b/docs/runtimes/cursor-cloud-agents.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Cursor Cloud Agents"
-description: "Capture Cursor cloud agent telemetry and forward cloud-agent runtime logs to customer-managed Google Cloud Storage"
+description: "Capture Cursor cloud agent telemetry and forward cloud-agent runtime logs to customer-managed Google Cloud Storage or Amazon S3"
 ---
 
 ## Integration Overview
 
 Use this integration to capture Cursor cloud-agent activity and upload each
-session log to your own Google Cloud Storage bucket. It is meant for testing
+session log to your own Google Cloud Storage or Amazon S3 bucket. It is meant for testing
 cloud-agent telemetry without running a hosted Asymptote backend.
 
 This flow depends on the Beacon CLI. You run `beacon cloud` commands from your
@@ -33,12 +33,12 @@ object as supported Cursor hook events run.
 flowchart LR
   CursorCloud["Cursor Cloud Agents"] --> Hooks["Beacon hooks in sandbox"]
   Hooks --> RuntimeLog["/tmp/beacon/runtime.jsonl"]
-  RuntimeLog --> GCS["Customer-managed GCS bucket"]
+  RuntimeLog --> Storage["Customer-managed GCS or S3 bucket"]
 ```
 
 The setup has four parts:
 
-1. Create a dedicated GCS bucket and uploader service account with Beacon.
+1. Create a dedicated GCS or S3 upload path with Beacon.
 2. Add Beacon cloud telemetry environment variables to the Cursor cloud environment.
 3. Commit Beacon's project-level Cursor hooks to `.cursor/hooks.json`.
 4. Run a Beacon-generated setup script inside the Cursor cloud environment to
@@ -50,6 +50,12 @@ Each Cursor cloud agent conversation writes one readable JSONL object:
 gs://<bucket>/<prefix>/runtime/date=YYYY-MM-DD/<timestamp>-cursor_cloud-<cursor_conversation_id>.jsonl.gz
 ```
 
+or:
+
+```text
+s3://<bucket>/<prefix>/runtime/date=YYYY-MM-DD/<timestamp>-cursor_cloud-<cursor_conversation_id>.jsonl.gz
+```
+
 Beacon uses Cursor's `conversation_id` hook field as the default `run_id` for
 Cursor Cloud telemetry. If you set `BEACON_RUN_ID` yourself, Beacon preserves
 that value instead.
@@ -57,14 +63,15 @@ that value instead.
 ## Prerequisites
 
 - Beacon CLI `v0.0.56` or later.
-- `gcloud` installed and authenticated to the Google Cloud project you will use
-  for telemetry storage.
-- A Google Cloud project where you can create buckets, service accounts, IAM
-  bindings, and service account keys.
+- For GCS: `gcloud` installed and authenticated to a project where you can
+  create buckets, service accounts, IAM bindings, and service account keys.
+- For S3: AWS CLI installed and authenticated to an account where you can
+  create buckets, IAM users, inline policies, and access keys.
 - Cursor Cloud Agent access for the repository you want to test.
 - A Cursor cloud environment with outbound access to:
   - `oauth2.googleapis.com`
   - `storage.googleapis.com`
+  - `s3.<region>.amazonaws.com`
   - `github.com`
   - `*.githubusercontent.com`
 
@@ -84,7 +91,11 @@ gcloud auth login
 gcloud config set project <your-gcp-project>
 ```
 
-## 1. Create the GCS Upload Path
+## 1. Create the Object Storage Upload Path
+
+Choose GCS or S3 for the cloud-agent session logs.
+
+### GCS
 
 From your workstation, choose a bucket and prefix:
 
@@ -133,6 +144,42 @@ share screenshots or logs.
 The helper creates a dedicated uploader service account and grants it object
 upload access to the selected bucket.
 
+### S3
+
+From your workstation, choose a bucket, region, and prefix:
+
+```bash
+export AWS_REGION="us-east-1"
+export BEACON_TEST_BUCKET="your-beacon-cloud-agent-traces"
+export BEACON_CLOUD_S3_PREFIX="agent-traces/customer=my-team"
+```
+
+Review the AWS changes Beacon will make:
+
+```bash
+beacon cloud s3 setup \
+  --bucket "$BEACON_TEST_BUCKET" \
+  --region "$AWS_REGION" \
+  --prefix "$BEACON_CLOUD_S3_PREFIX" \
+  --iam-user beacon-cloud-trace-uploader \
+  --print
+```
+
+Apply the setup and print the cloud telemetry environment variables:
+
+```bash
+beacon cloud s3 setup \
+  --bucket "$BEACON_TEST_BUCKET" \
+  --region "$AWS_REGION" \
+  --prefix "$BEACON_CLOUD_S3_PREFIX" \
+  --iam-user beacon-cloud-trace-uploader \
+  --apply \
+  --print-env
+```
+
+The helper creates a dedicated IAM user and grants it `s3:PutObject` only under
+the selected bucket prefix.
+
 ## 2. Configure Cursor Cloud Agents
 
 Open your Cursor Cloud Agent environment for the repository.
@@ -144,9 +191,25 @@ BEACON_ORIGIN=cloud
 BEACON_RUN_PROVIDER=cursor_cloud
 BEACON_RUN_EPHEMERAL=true
 BEACON_CLOUD_USER_ID_HASH=<stable-user-or-test-id>
+```
+
+For GCS, add:
+
+```bash
 BEACON_CLOUD_GCS_BUCKET=<bucket-from-setup>
 BEACON_CLOUD_GCS_PREFIX=<prefix-from-setup>
 BEACON_CLOUD_GCS_CREDENTIALS_B64=<base64-service-account-json>
+```
+
+For S3, add:
+
+```bash
+BEACON_CLOUD_UPLOAD=s3
+BEACON_CLOUD_S3_BUCKET=<bucket-from-setup>
+BEACON_CLOUD_S3_PREFIX=<prefix-from-setup>
+BEACON_CLOUD_S3_REGION=<region-from-setup>
+AWS_ACCESS_KEY_ID=<access-key-id-from-setup>
+AWS_SECRET_ACCESS_KEY=<secret-access-key-from-setup>
 ```
 
 <Frame caption="Configure network access and Beacon runtime secrets for Cursor Cloud Agents.">
@@ -158,6 +221,7 @@ If your Cursor cloud environment restricts outbound network access, allow:
 ```text
 oauth2.googleapis.com
 storage.googleapis.com
+s3.<region>.amazonaws.com
 github.com
 *.githubusercontent.com
 ```
@@ -223,20 +287,26 @@ file reads and edits, subagent lifecycle events, and compaction events where
 Cursor exposes hook payloads.
 
 <Note>
-  Cursor Cloud Agents do not run `beforeSubmitPrompt`, `sessionStart`,
-  `sessionEnd`, or `stop` hooks. Prompt text and final session lifecycle hooks
-  are therefore not available through this self-serve hook path; Beacon records
-  the supported in-sandbox events Cursor exposes after the cloud VM starts. See
+  Beacon captures prompt text through Cursor Cloud's `beforeSubmitPrompt`
+  project hook and uploads that event immediately. Commit `.cursor/hooks.json`
+  before starting the run so the prompt hook is available when the cloud
+  environment starts. `sessionStart` and `sessionEnd` remain unavailable. See
   [Cursor's Cloud Agent hook support matrix](https://cursor.com/docs/hooks#cloud-agent-support)
   for the current platform support list.
 </Note>
 
-## 6. Verify GCS Upload
+## 6. Verify Object Storage Upload
 
-List the uploaded session objects:
+For GCS, list the uploaded session objects:
 
 ```bash
 gcloud storage ls --recursive "gs://${BEACON_TEST_BUCKET}/${BEACON_CLOUD_GCS_PREFIX}/"
+```
+
+For S3:
+
+```bash
+aws s3 ls --recursive "s3://${BEACON_TEST_BUCKET}/${BEACON_CLOUD_S3_PREFIX}/"
 ```
 
 You should see a path like:
@@ -255,6 +325,12 @@ Inspect the log:
 gcloud storage cat "gs://${BEACON_TEST_BUCKET}/${BEACON_CLOUD_GCS_PREFIX}/runtime/date=<date>/<object>.jsonl.gz" | gzip -dc | head
 ```
 
+For S3:
+
+```bash
+aws s3 cp "s3://${BEACON_TEST_BUCKET}/${BEACON_CLOUD_S3_PREFIX}/runtime/date=<date>/<object>.jsonl.gz" - | gzip -dc | head
+```
+
 Expected fields include:
 
 ```text
@@ -268,10 +344,10 @@ run.provider=cursor_cloud
 
 ## Security Note
 
-The self-serve GCS flow above creates a dedicated service account scoped to
-object uploads for one bucket, then stores its credentials in the Cursor cloud
-environment. This is useful for proof-of-concept testing, but treat that
-environment variable as a sensitive credential.
+The self-serve flows create a dedicated GCS service account or AWS IAM user
+scoped to object uploads, then store its credentials in the Cursor cloud
+environment. This is useful for proof-of-concept testing, but treat those
+environment variables as sensitive credentials.
 
 Avoid broad credentials and review access before using this flow with sensitive
 telemetry.
@@ -296,15 +372,14 @@ ls -l /tmp/beacon/runtime.jsonl
 head /tmp/beacon/runtime.jsonl
 ```
 
-If `runtime.jsonl` exists but GCS is empty, check network access and GCS
-credentials. The cloud sandbox must reach both `oauth2.googleapis.com` and
-`storage.googleapis.com`.
+If `runtime.jsonl` exists but object storage is empty, check network access and
+credentials. The cloud sandbox must reach the GCS OAuth/storage endpoints or
+the regional S3 endpoint selected by `BEACON_CLOUD_UPLOAD=s3`.
 
 If `runtime.jsonl` does not exist, confirm the task used a Cursor Cloud
-supported hook surface such as a file read, shell command, file edit, tool use,
-subagent event, or compaction event. Prompt-only tasks do not emit
-`beforeSubmitPrompt` in Cursor Cloud because the prompt is submitted before the
-cloud VM exists. Cursor documents the supported and unsupported cloud hooks in
+supported hook surface such as prompt submission, a file read, shell command,
+file edit, tool use, subagent event, or compaction event. Cursor documents the
+supported and unsupported cloud hooks in
 its [Cloud Agent hook support matrix](https://cursor.com/docs/hooks#cloud-agent-support).
 
 ### Cursor tries to commit hook settings

--- a/docs/runtimes/cursor.mdx
+++ b/docs/runtimes/cursor.mdx
@@ -47,7 +47,7 @@ beacon endpoint hooks install --harness cursor --level project
 
 | Area | Support |
 |------|---------|
-| Prompt telemetry | Supported for local Cursor through `beforeSubmitPrompt` hooks; not available in Cursor Cloud Agents because Cursor submits the prompt before the cloud VM exists. See [Cursor's Cloud Agent hook support matrix](https://cursor.com/docs/hooks#cloud-agent-support). |
+| Prompt telemetry | Supported for local and cloud Cursor through `beforeSubmitPrompt` hooks. Cursor Cloud requires the project hook to be committed before the run starts; Beacon uploads the prompt event immediately. See [Cursor's Cloud Agent hook support matrix](https://cursor.com/docs/hooks#cloud-agent-support). |
 | Command, tool, and file telemetry | Supported for tool, shell command, MCP-like, approval, and file edit payloads where Cursor exposes them; Cursor Cloud support is limited to Cursor's [cloud-supported command hooks](https://cursor.com/docs/hooks#cloud-agent-support). |
 | Agent reasoning telemetry | Supported for local Cursor through `afterAgentThought` hooks. Each completed thinking block is recorded as an `agent.reasoning` event carrying the reasoning text in the OpenTelemetry GenAI output-messages shape (`gen_ai.output.messages` with a `reasoning` part), plus a `content` marker with the original text's hash and byte count. Reasoning is only available for models/modes where Cursor exposes visible thinking text. |
 | Repository and branch context | Events include the workspace path as `repository`, and `branch` is resolved from the workspace's local git checkout (`.git/HEAD`) when Cursor does not supply one; disable local git resolution with `BEACON_DISABLE_GIT_METADATA=1`. |

--- a/docs/runtimes/cursor.mdx
+++ b/docs/runtimes/cursor.mdx
@@ -47,7 +47,7 @@ beacon endpoint hooks install --harness cursor --level project
 
 | Area | Support |
 |------|---------|
-| Prompt telemetry | Supported for local and cloud Cursor through `beforeSubmitPrompt` hooks. Cursor Cloud requires the project hook to be committed before the run starts; Beacon uploads the prompt event immediately. See [Cursor's Cloud Agent hook support matrix](https://cursor.com/docs/hooks#cloud-agent-support). |
+| Prompt telemetry | Supported for local and cloud Cursor through `beforeSubmitPrompt` hooks. Cursor Cloud requires the project hook to be committed before the run starts and uploads observed prompts immediately; the initial launch prompt can precede hook activation during bootstrap. See [Cursor's Cloud Agent hook support matrix](https://cursor.com/docs/hooks#cloud-agent-support). |
 | Command, tool, and file telemetry | Supported for tool, shell command, MCP-like, approval, and file edit payloads where Cursor exposes them; Cursor Cloud support is limited to Cursor's [cloud-supported command hooks](https://cursor.com/docs/hooks#cloud-agent-support). |
 | Agent reasoning telemetry | Supported for local Cursor through `afterAgentThought` hooks. Each completed thinking block is recorded as an `agent.reasoning` event carrying the reasoning text in the OpenTelemetry GenAI output-messages shape (`gen_ai.output.messages` with a `reasoning` part), plus a `content` marker with the original text's hash and byte count. Reasoning is only available for models/modes where Cursor exposes visible thinking text. |
 | Repository and branch context | Events include the workspace path as `repository`, and `branch` is resolved from the workspace's local git checkout (`.git/HEAD`) when Cursor does not supply one; disable local git resolution with `BEACON_DISABLE_GIT_METADATA=1`. |
@@ -70,6 +70,6 @@ Hook events include metadata such as file path, operation, language, diff hash, 
     Install, inspect, and uninstall runtime hook integrations.
   </Card>
   <Card title="Cursor Cloud Agents" icon="cloud" href="/runtimes/cursor-cloud-agents">
-    Capture Cursor cloud agent telemetry with sandbox-local hooks and GCS upload.
+    Capture Cursor cloud agent telemetry with sandbox-local hooks and direct GCS or S3 upload.
   </Card>
 </Columns>

--- a/docs/runtimes/index.mdx
+++ b/docs/runtimes/index.mdx
@@ -50,8 +50,8 @@ These integrations are grouped by where the agent runs and how telemetry is coll
 
 | Cloud surface | Collection path | Telemetry coverage |
 |---------------|-----------------|--------------------|
-| [Claude Code Cloud Agents](/runtimes/claude-code-cloud-agents) | Cloud sandbox hooks with GCS upload | Session, prompt, tool, command, file, and lifecycle telemetry where Claude Code cloud hook payloads expose it |
-| [Cursor Cloud Agents](/runtimes/cursor-cloud-agents) | Cloud sandbox hooks with GCS upload | Tool, shell command, file, subagent, and compaction telemetry where Cursor cloud hook payloads expose it |
+| [Claude Code Cloud Agents](/runtimes/claude-code-cloud-agents) | Cloud sandbox hooks with direct GCS or S3 upload | Session, prompt, tool, command, file, and lifecycle telemetry where Claude Code cloud hook payloads expose it |
+| [Cursor Cloud Agents](/runtimes/cursor-cloud-agents) | Cloud sandbox hooks with direct GCS or S3 upload | Follow-up prompts, tool, shell command, file, subagent, and compaction telemetry after project hooks become active |
 | [Anthropic](/sdk/integrations-anthropic) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported Anthropic model call spans, errors, and OpenTelemetry attributes |
 | [Claude Agent SDK](/sdk/integrations-claude-agent-sdk) | Query wrapper through `Observe.wrapClaudeAgentQuery()` | Query root spans with Beacon-compatible prompt attributes |
 | [OpenAI](/sdk/integrations-openai) | OpenLLMetry instrumentation through `@asymptote/sdk` | Supported OpenAI model call spans, errors, and OpenTelemetry attributes |

--- a/docs/security/data-flow-threat-model.mdx
+++ b/docs/security/data-flow-threat-model.mdx
@@ -37,12 +37,18 @@ flowchart LR
 | Network exposure of collectors | Default OTLP receivers bind to `127.0.0.1` rather than an externally reachable interface |
 | Over-collection of prompt or diff content | Scope supported runtimes and hook deployment deliberately before rollout, and review destination access for retained local telemetry |
 | Secret leakage in retained content | Beacon applies redaction, sanitization, truncation, and event-size limits before writing supported content fields |
-| SIEM credential exposure in endpoint config | File-based destinations tail local JSONL; Beacon does not store Elastic, Datadog, Sumo Logic, Rapid7, Microsoft Sentinel, AWS, or Google Cloud credentials. Splunk HEC and Falcon LogScale HEC tokens are stored in local collector configuration only when those optional destinations are enabled |
+| Destination credential exposure | Persistent endpoint file-based destinations tail local JSONL, so Beacon endpoint configuration does not store Elastic, Datadog, Sumo Logic, Rapid7, Microsoft Sentinel, AWS, or Google Cloud credentials. Optional Splunk and Falcon tokens live in collector configuration. Self-serve cloud-agent uploads are a separate proof-of-concept path: scoped GCS or AWS credentials are injected into the provider-managed sandbox as runtime secrets and must be rotated and access-reviewed. |
 | Removal uncertainty | Endpoint uninstall removes managed service and configuration state, with explicit `--keep-logs` and `--keep-config` exceptions |
 
 ## Current Boundaries
 
 Beacon focuses on supported agent harness telemetry and local endpoint configuration context. It does not provide kernel or process monitoring, shell history collection, cloud audit ingestion, browser or SaaS telemetry, credential-use attribution, Datadog API export from Beacon, Sumo Logic API export from Beacon, Rapid7 API export from Beacon, or automatic mutation of Factory Droid shell profiles.
+
+Provider-managed cloud agents use a separate ephemeral boundary from the local
+endpoint. Their hook adapter writes sandbox-local JSONL and can send compressed
+snapshots directly to customer-managed object storage. Upload failures are
+fail-open so telemetry delivery cannot block the agent task; verify the remote
+object rather than treating a successful agent run as proof of delivery.
 
 ## Related
 

--- a/docs/security/retention-redaction.mdx
+++ b/docs/security/retention-redaction.mdx
@@ -67,7 +67,15 @@ Command events can include normalized tool and command context, with truncation 
 
 ## Forwarding Implications
 
-Content handling is applied before events are written to `runtime.jsonl`. File-based destinations such as Wazuh, Elastic/Filebeat, Datadog Agent custom log collection, Sumo Logic forwarding, Rapid7 forwarding, Microsoft Sentinel forwarding, AWS S3 Vector forwarding, Google Cloud Storage Vector forwarding, and customer-managed shippers read the resulting local JSONL. Splunk HEC and Falcon LogScale HEC forwarding receive the same normalized collector output according to the configured endpoint pipeline.
+Content handling is applied before events are written to `runtime.jsonl`.
+File-based destinations such as Wazuh, Elastic/Filebeat, Datadog Agent custom
+log collection, Sumo Logic forwarding, Rapid7 forwarding, Microsoft Sentinel
+forwarding, AWS S3 Vector forwarding, Google Cloud Storage Vector forwarding,
+and customer-managed shippers read the resulting local JSONL. Supported cloud
+agents upload a compressed snapshot of their sandbox-local JSONL directly to
+customer-managed GCS or S3. Splunk HEC and Falcon LogScale HEC forwarding
+receive the same normalized collector output according to the configured
+endpoint pipeline.
 
 Review runtime scope, artifact access, destination permissions, and downstream retention before rollout so retained content matches your approved telemetry policy.
 


### PR DESCRIPTION
## Summary
- capture `beforeSubmitPrompt` events in Cursor Cloud and upload prompt-only telemetry immediately
- fix the repository-managed Cursor environment source build and add S3-aware startup diagnostics
- document and test Cursor Cloud uploads to customer-managed GCS or S3

## Test plan
- [x] `cd cli/beacon && go test ./...`
- [x] `cd cli/beacon-hooks && go test ./...`
- [x] verify committed `.cursor/hooks.json` matches `beacon cloud cursor print-hooks`
- [x] validate Cursor JSON and shell scripts
- [ ] run a fresh Cursor Cloud prompt-only session and confirm the event in S3

Made with [Cursor](https://cursor.com)