### PR TITLE
fix(beaconjson): recognize browser chat harnesses (claude_web/chatgpt_web)

### DIFF
--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -1391,6 +1391,13 @@ func NormalizeHarnessName(name string) string {
 		return "claude_cowork"
 	case strings.Contains(lower, "claude_agent_sdk") || strings.Contains(lower, "claude-agent-sdk") || strings.Contains(lower, "claude agent sdk"):
 		return "claude_agent_sdk"
+	// Browser-based chat collectors (agent-beacon-browser-extension). These must
+	// precede the generic "claude" rule below, which would otherwise coerce
+	// claude_web → claude_code.
+	case strings.Contains(lower, "claude_web") || strings.Contains(lower, "claude-web") || lower == "claude.ai":
+		return "claude_web"
+	case strings.Contains(lower, "chatgpt") || lower == "chatgpt.com" || strings.Contains(lower, "openai_web"):
+		return "chatgpt_web"
 	case strings.Contains(lower, "claude_code") || strings.Contains(lower, "claude-code") || strings.Contains(lower, "claude code") || strings.HasPrefix(lower, "claude_code."):
 		return "claude_code"
 	case lower == "claude" || strings.Contains(lower, "claude"):

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
@@ -732,3 +732,37 @@ func newObserveSDKTraceSpan(name string) (ptrace.Span, ptrace.Traces) {
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(1700000000, 0).UTC()))
 	return span, traces
 }
+
+// Browser-based collectors (agent-beacon-browser-extension) must keep their own
+// harness identity and not be coerced into claude_code by the generic "claude"
+// rule.
+func TestNormalizeHarnessNameBrowserSources(t *testing.T) {
+	cases := map[string]string{
+		"claude_web":  "claude_web",
+		"claude-web":  "claude_web",
+		"claude.ai":   "claude_web",
+		"chatgpt_web": "chatgpt_web",
+		"chatgpt.com": "chatgpt_web",
+		// Regression: existing harnesses must be unchanged.
+		"claude_code": "claude_code",
+		"claude":      "claude_code",
+		"codex":       "codex_cli",
+		"gemini":      "gemini_cli",
+	}
+	for in, want := range cases {
+		if got := NormalizeHarnessName(in); got != want {
+			t.Errorf("NormalizeHarnessName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHarnessNameHonorsBrowserExtensionAttr(t *testing.T) {
+	attrs := map[string]interface{}{
+		"beacon.harness.name": "claude_web",
+		"beacon.origin":       "browser-extension",
+		"service.name":        "agent-beacon-browser-collector",
+	}
+	if got := HarnessName(attrs); got != "claude_web" {
+		t.Errorf("HarnessName = %q, want claude_web", got)
+	}
+}


### PR DESCRIPTION
## What

Teach the `beaconjson` exporter's `NormalizeHarnessName` to recognize **browser-based chat
collectors** (`claude_web`, `chatgpt_web`) instead of coercing them to `claude_code`.

## Why

The generic `strings.Contains(lower, "claude")` rule matched any harness containing "claude" —
including `claude_web` emitted by the new [agent-beacon-browser-extension](https://github.com/Asymptote-Labs/agent-beacon-browser-extension)
— and returned `claude_code`. That conflated browser chat telemetry with Claude Code CLI/cloud
sessions at the top-level `harness.name`. (They stayed distinguishable via `beacon.origin=browser-extension`
and `service.name`, but the label was wrong.)

Confirmed live: browser records landed in `runtime.jsonl` as `harness.name=claude_code` while
`raw.attributes.beacon.harness.name` was `claude_web`.

## Change

Add explicit `claude_web` / `chatgpt_web` cases **before** the generic `claude` catch-all in
`NormalizeHarnessName`. (`chatgpt_web` already passed through unchanged; the real fix is `claude_web`.)

Adds `TestNormalizeHarnessNameBrowserSources` + `TestHarnessNameHonorsBrowserExtensionAttr` covering
the new cases and regressions (`claude_code` / `claude` / `codex` / `gemini` unchanged). `go test ./...`
green for the exporter package.

## Deploy note

This changes the collector binary — it only takes effect after `beacon-otelcol` is rebuilt and the
launchd daemon restarted. Merging alone won't relabel live telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized labeling logic in the beaconjson exporter with tests; no auth or data-path changes, though incorrect harness names could persist until the collector is redeployed.
> 
> **Overview**
> Fixes **mislabeled `harness.name`** for browser-extension chat telemetry: `claude_web` (and aliases like `claude.ai`) was normalized to **`claude_code`** because the generic `claude` rule ran first.
> 
> **`NormalizeHarnessName`** now maps **`claude_web`** / **`chatgpt_web`** (and common aliases) **before** the catch-all `claude` → `claude_code` rule, so exported JSONL top-level harness identity matches `beacon.harness.name` from the browser collector.
> 
> Adds unit tests for the new aliases plus regressions for `claude_code`, `claude`, `codex`, and `gemini`, and asserts **`HarnessName`** keeps `claude_web` when `beacon.harness.name` is set.
> 
> **Deploy:** requires rebuilding/restarting **`beacon-otelcol`**; merge alone does not relabel live data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0c05978d7c4e56e36e968edd2e4c483a5ce5da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->