### PR TITLE
feat(windows): the filesystem contract, and three bugs the gate found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,12 +203,14 @@ jobs:
           Copy-Item beacon-hooks.exe ..\beacon\internal\embedded\hooks.bin -Force
       # Scoped to the packages this port actually gives Windows implementations, not `./...`.
       #
-      # The rest of the cli/beacon suite has never run on Windows and assumes a POSIX host in ways
-      # unrelated to any of this: 47 tests redirect the home directory with t.Setenv("HOME"), which
-      # does nothing there because os.UserHomeDir reads USERPROFILE; 15 assert Unix file modes that
-      # Windows does not implement; others exec fixtures with no .exe extension. Running them here
-      # would produce a permanently red gate that says nothing about the code under test, and a red
-      # gate nobody can fix is one nobody reads.
+      # The scope grows as packages are made portable. config, collector, harness and hooks joined
+      # when the Windows filesystem work needed them gated -- which immediately paid for itself by
+      # surfacing a production bug: validateExecutable tested the POSIX executable bit, which is
+      # never set on Windows, so DiscoverBinary rejected every collector binary there.
+      #
+      # The remaining cli/beacon packages still assume a POSIX host and are not scoped in. Running
+      # them here would produce a permanently red gate that says nothing about the code under test,
+      # and a red gate nobody can fix is one nobody reads.
       #
       # Tracked as follow-up work rather than dropped -- see #318. The scope
       # widens as those packages are made portable; it must not widen by adding `./...` back while
@@ -221,7 +223,11 @@ jobs:
             ./internal/endpoint/inventory/... `
             ./internal/ingest/endpoint/... `
             ./internal/endpoint/service/... `
-            ./internal/endpoint/selfupdate/...
+            ./internal/endpoint/selfupdate/... `
+            ./internal/endpoint/config/... `
+            ./internal/endpoint/collector/... `
+            ./internal/endpoint/harness/... `
+            ./internal/endpoint/hooks/...
       - name: Test the ported packages with the race detector
         working-directory: cli/beacon
         run: |

--- a/.github/workflows/windows-sandbox.yml
+++ b/.github/workflows/windows-sandbox.yml
@@ -149,7 +149,25 @@ jobs:
           $installer = Join-Path $env:TEMP 'install-claude.ps1'
           Invoke-WebRequest -Uri 'https://claude.ai/install.ps1' -OutFile $installer
           & $installer $version
-          "$env:LOCALAPPDATA\Programs\claude" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          if ($LASTEXITCODE -ne 0) { throw "the Claude Code installer exited $LASTEXITCODE" }
+
+          # install.ps1 puts the agent in %USERPROFILE%\.local\bin -- the same ~/.local/bin
+          # convention the Linux image uses, not a Windows-specific Programs directory.
+          $claudeBin = Join-Path $env:USERPROFILE '.local\bin'
+          $claudeBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+          # Verified here rather than left for a later step to discover. Assuming the install
+          # location cost a probe run: the install succeeded, `claude` was simply not on PATH, and
+          # the failure two steps later read as the agent being missing rather than as a wrong PATH
+          # entry. Failing at the point the assumption is made is the difference.
+          $claudeExe = Join-Path $claudeBin 'claude.exe'
+          if (-not (Test-Path -LiteralPath $claudeExe)) {
+            Write-Output "installer output above reports where it landed; searching the profile:"
+            Get-ChildItem -Path $env:USERPROFILE -Filter claude.exe -Recurse -ErrorAction SilentlyContinue |
+              Select-Object -First 5 -ExpandProperty FullName
+            throw "claude.exe is not at $claudeExe; the install location has moved"
+          }
+          Write-Output "claude installed at $claudeExe"
 
       - name: Report the environment the probe ran in
         run: |

--- a/beacon-sandbox/dispatch/dispatch.go
+++ b/beacon-sandbox/dispatch/dispatch.go
@@ -182,6 +182,15 @@ func runGH(args ...string) (string, error) {
 	return string(out), err
 }
 
+// firstLine keeps a retry message to one line. A gh failure can be several lines of connection
+// advice, and repeating all of it on every poll would bury the progress it is interleaved with.
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}
+
 // runIDPattern guards against a malformed id reaching a URL or a path. gh returns numeric ids;
 // anything else means the output shape changed and should be reported, not interpolated.
 var runIDPattern = regexp.MustCompile(`^[0-9]+$`)
@@ -243,15 +252,28 @@ func latestRunID(opts Options) (int64, error) {
 // while we poll, we follow the earlier one -- ours.
 func awaitNewRun(opts Options, before int64, logf func(string, ...any)) (string, error) {
 	deadline := time.Now().Add(5 * time.Minute)
+	var lastErr error
 	for time.Now().Before(deadline) {
 		runs, err := listRuns(opts, 10)
 		if err != nil {
-			return "", err
+			// Transient rather than fatal. A single failed API call used to abandon a run that was
+			// proceeding perfectly well, and the dispatch reported failure while the workflow it had
+			// just started went on to finish unobserved. Retried until the deadline, with the last
+			// error kept so a persistent outage still reports the real cause rather than a timeout.
+			lastErr = err
+			logf("could not list runs (%v); retrying", firstLine(err.Error()))
+			time.Sleep(5 * time.Second)
+			continue
 		}
+		lastErr = nil
 		if found := pickNewRun(runs, before); found > 0 {
 			return fmt.Sprint(found), nil
 		}
 		time.Sleep(5 * time.Second)
+	}
+	if lastErr != nil {
+		return "", fmt.Errorf("could not reach the GitHub API while waiting for a new %s run: %w",
+			Workflow, lastErr)
 	}
 	return "", fmt.Errorf("no new %s run appeared within 5 minutes of dispatching; check "+
 		"`gh run list --workflow %s`", Workflow, Workflow)
@@ -293,11 +315,19 @@ func maxRunID(runs []ghRun) int64 {
 func awaitCompletion(opts Options, runID string, logf func(string, ...any)) (string, error) {
 	deadline := time.Now().Add(opts.Timeout)
 	lastStatus := ""
+	var lastErr error
 	for time.Now().Before(deadline) {
 		runs, err := listRuns(opts, 20)
 		if err != nil {
-			return "", err
+			// Same reasoning as awaitNewRun: a blip on the way to api.github.com must not discard a
+			// run that is doing fine. This loop can be waiting 20+ minutes, so the odds of hitting
+			// one are correspondingly higher.
+			lastErr = err
+			logf("could not list runs (%v); retrying", firstLine(err.Error()))
+			time.Sleep(opts.PollInterval)
+			continue
 		}
+		lastErr = nil
 		for _, r := range runs {
 			if fmt.Sprint(r.DatabaseID) != runID {
 				continue
@@ -311,6 +341,10 @@ func awaitCompletion(opts Options, runID string, logf func(string, ...any)) (str
 			}
 		}
 		time.Sleep(opts.PollInterval)
+	}
+	if lastErr != nil {
+		return "", fmt.Errorf("could not reach the GitHub API while waiting for run %s (still "+
+			"running at %s): %w", runID, runURL(opts.Repo, runID), lastErr)
 	}
 	return "", fmt.Errorf("run %s did not complete within %s; it may still be going at %s",
 		runID, opts.Timeout, runURL(opts.Repo, runID))

--- a/beacon-sandbox/image/image.go
+++ b/beacon-sandbox/image/image.go
@@ -77,8 +77,12 @@ func WindowsLayout() Layout {
 		AgentHome: home,
 		WorkDir:   `C:\beacon-sandbox\work`,
 		BeaconDir: beaconDir,
-		// The agent installs to %LOCALAPPDATA%\Programs, which is where install.ps1 puts it.
-		PathPrepend: []string{beaconDir, filepath.Join(home, "AppData", "Local", "Programs", "claude")},
+		// install.ps1 puts the agent in %USERPROFILE%\.local\bin -- the same ~/.local/bin
+		// convention the Linux image uses, not a Windows-specific Programs directory. Assuming
+		// otherwise cost a probe run: the install succeeded, `claude` was not on PATH, and the
+		// failure read as the agent being missing rather than as a wrong PATH entry. The
+		// installer prints its location, and this matches what it printed.
+		PathPrepend: []string{beaconDir, filepath.Join(home, ".local", "bin")},
 	}
 }
 

--- a/beacon-sandbox/runner/runner.go
+++ b/beacon-sandbox/runner/runner.go
@@ -300,6 +300,14 @@ func Run(ctx context.Context, p sandbox.Provider, sc scenario.Scenario, opts Opt
 		art.Meta["ci_exec_rc"] = fmt.Sprintf("%d", res.ExitCode)
 		if res.ExitCode != 0 {
 			logf("beacon ci exec exited %d -- the collected log may be incomplete", res.ExitCode)
+			// Written whole, not folded into meta. meta values pass through oneLine, which caps
+			// them at 400 characters -- enough to show the middle of a stderr tail and cut off the
+			// error at its end, which is the only part worth having. A failing collector is exactly
+			// when the full text is needed, so it goes to the run directory intact.
+			if err := os.WriteFile(filepath.Join(runDir, "ci-exec-output.txt"),
+				[]byte(res.Stdout+"\n--- stderr ---\n"+res.Stderr), 0o600); err == nil {
+				logf("wrote the full ci exec output to ci-exec-output.txt")
+			}
 		}
 	}
 

--- a/beacon-sandbox/runner/shell.go
+++ b/beacon-sandbox/runner/shell.go
@@ -96,9 +96,14 @@ func (s posixShell) WithEnv(name, value, script string) string {
 // outright was indistinguishable from one that worked.
 func (s posixShell) CIExecSession(logPath, _ string, claudeArgs []string) string {
 	inner := "claude " + strings.Join(claudeArgs, " ") + " > claude-out.json 2> claude-err.txt"
+	// stderr is surfaced on failure, not just stdout. `beacon ci exec` reports why it could not
+	// start or supervise the collector on stderr, and tailing only ci-out.txt meant a non-zero exit
+	// arrived with no explanation at all -- the reason was sitting in a file nothing ever read.
 	return fmt.Sprintf("beacon ci exec --harness claude --log-path %s -- sh -c %s "+
 		"> ci-out.txt 2> ci-err.txt; rc=$?; echo CI_EXEC_RC=$rc; "+
-		"tail -c 400 ci-out.txt; exit $rc",
+		"tail -c 400 ci-out.txt; "+
+		"if [ \"$rc\" -ne 0 ]; then echo '--- ci exec stderr ---'; tail -c 800 ci-err.txt; fi; "+
+		"exit $rc",
 		s.Quote(logPath), s.Quote(inner))
 }
 
@@ -259,8 +264,12 @@ $rc = $LASTEXITCODE
 if ($null -eq $rc) { $rc = 0 }
 "CI_EXEC_RC=$rc"
 %s
+if ($rc -ne 0) {
+  '--- ci exec stderr ---'
+%s
+}
 exit $rc`,
-		inner, s.Quote(logPath), s.TailBytes("ci-out.txt", 400))
+		inner, s.Quote(logPath), s.TailBytes("ci-out.txt", 400), s.TailBytes("ci-err.txt", 800))
 }
 
 // PlainSession runs the agent directly, for install scenarios where a persistent collector is

--- a/cli/beacon/internal/embedded/embed.go
+++ b/cli/beacon/internal/embedded/embed.go
@@ -11,6 +11,17 @@ import (
 //go:embed hooks.bin
 var HooksBinary []byte
 
+// BinaryStem is the hook binary's name without any platform extension.
+//
+// Detection matches on this rather than on GetBinaryName. A command containing
+// "beacon-hooks.exe" also contains "beacon-hooks", so the stem recognizes both spellings, while
+// the platform-specific name recognizes only one -- which meant a Windows Beacon could not see a
+// hook command written without the extension, and would neither repair nor remove it. Settings
+// files are synced between machines and written by older builds, so both spellings genuinely occur.
+//
+// Writing still uses GetBinaryName: what we install must be the name this platform can execute.
+const BinaryStem = "beacon-hooks"
+
 // GetBinaryName returns the appropriate binary name for the current platform
 func GetBinaryName() string {
 	if runtime.GOOS == "windows" {

--- a/cli/beacon/internal/endpoint/cloudwatch/cloudwatch.go
+++ b/cli/beacon/internal/endpoint/cloudwatch/cloudwatch.go
@@ -2,6 +2,7 @@ package cloudwatch
 
 import (
 	"embed"
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -11,9 +12,12 @@ import (
 var packFS embed.FS
 
 const (
-	DefaultLogPath   = "/var/log/beacon-agent/runtime.jsonl"
 	DefaultOutputDir = "beacon-cloudwatch-pack"
 )
+
+// DefaultLogPath is a var rather than a const because the system log location is now
+// resolved per platform by one function instead of repeated as a literal in every pack.
+var DefaultLogPath = endpointconfig.SystemLogPath()
 
 const configAsset = "pack/vector.toml.tmpl"
 

--- a/cli/beacon/internal/endpoint/collector/collector.go
+++ b/cli/beacon/internal/endpoint/collector/collector.go
@@ -82,7 +82,7 @@ func validateExecutable(path string) error {
 	if info.IsDir() {
 		return fmt.Errorf("is a directory")
 	}
-	if info.Mode().Perm()&0111 == 0 {
+	if !isExecutableMode(info) {
 		return fmt.Errorf("is not executable")
 	}
 	return nil

--- a/cli/beacon/internal/endpoint/collector/collector_test.go
+++ b/cli/beacon/internal/endpoint/collector/collector_test.go
@@ -2,11 +2,13 @@ package collector
 
 import (
 	"errors"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -180,6 +182,7 @@ func TestWriteConfigCreatesConfigAndSpoolDirectory(t *testing.T) {
 }
 
 func TestWriteConfigUsesPrivatePermissionsWithSplunkToken(t *testing.T) {
+	testenv.RequirePOSIXFileModes(t)
 	cfg := testConfig(t)
 	cfg.Destinations = &endpointconfig.Destinations{SplunkHEC: &endpointconfig.SplunkHEC{
 		Endpoint: "https://splunk.example:8088/services/collector",
@@ -199,6 +202,7 @@ func TestWriteConfigUsesPrivatePermissionsWithSplunkToken(t *testing.T) {
 }
 
 func TestWriteConfigUsesPrivatePermissionsWithFalconToken(t *testing.T) {
+	testenv.RequirePOSIXFileModes(t)
 	cfg := testConfig(t)
 	cfg.Destinations = &endpointconfig.Destinations{FalconHEC: &endpointconfig.FalconHEC{
 		Endpoint: "https://cloud.us.humio.com/api/v1/ingest/hec",
@@ -259,8 +263,22 @@ func TestWaitForPortsAvailableReportsPersistentConflict(t *testing.T) {
 	}
 }
 
+// stubCollectorName returns the fixture file name a collector binary must have to be discoverable
+// on this platform.
+//
+// exec.LookPath resolves a bare name through PATHEXT on Windows, so a fixture written without an
+// extension is invisible to it however its bits are set -- DiscoverBinary would report no collector
+// installed while the file sat right there on PATH. The production BinaryName stays extensionless
+// because LookPath is what applies the extension.
+func stubCollectorName() string {
+	if runtime.GOOS == "windows" {
+		return BinaryName + ".exe"
+	}
+	return BinaryName
+}
+
 func TestDiscoverBinaryPrefersConfiguredExistingPath(t *testing.T) {
-	bin := filepath.Join(t.TempDir(), BinaryName)
+	bin := filepath.Join(t.TempDir(), stubCollectorName())
 	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0755); err != nil {
 		t.Fatalf("write fake collector: %v", err)
 	}
@@ -281,7 +299,7 @@ func TestResolveBinaryRejectsMissingConfiguredPath(t *testing.T) {
 
 func TestDiscoverBinaryFindsBeaconOtelcolOnPath(t *testing.T) {
 	dir := t.TempDir()
-	bin := filepath.Join(dir, BinaryName)
+	bin := filepath.Join(dir, stubCollectorName())
 	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0755); err != nil {
 		t.Fatalf("write fake collector: %v", err)
 	}
@@ -348,7 +366,7 @@ func TestCheckStatusDoesNotTreatOpenOTLPPortsAsHealthy(t *testing.T) {
 	if healthReady() {
 		t.Skip("collector health check endpoint is already active")
 	}
-	bin := filepath.Join(t.TempDir(), BinaryName)
+	bin := filepath.Join(t.TempDir(), stubCollectorName())
 	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0755); err != nil {
 		t.Fatalf("write fake collector: %v", err)
 	}

--- a/cli/beacon/internal/endpoint/collector/collector_test.go
+++ b/cli/beacon/internal/endpoint/collector/collector_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"errors"
+	"fmt"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"net"
 	"net/http"
@@ -40,7 +41,11 @@ func TestConfigYAMLIncludesReleaseContractFields(t *testing.T) {
 		"endpoint: 127.0.0.1:14317",
 		"endpoint: 127.0.0.1:14318",
 		"beaconjson:",
-		"path: " + `"` + cfg.LogPath + `"`,
+		// %q, matching how the config is generated. Hand-quoting the path only agreed with the
+		// generator by accident: a POSIX path contains nothing that needs escaping, while a
+		// Windows one is full of backslashes that a double-quoted YAML scalar must escape. The
+		// assertion now checks the contract -- a correctly quoted path -- rather than a coincidence.
+		fmt.Sprintf("path: %q", cfg.LogPath),
 		"max_event_bytes: 65536",
 		"rotate_bytes: 10485760",
 		"rotate_archives: 5",

--- a/cli/beacon/internal/endpoint/collector/executable_unix.go
+++ b/cli/beacon/internal/endpoint/collector/executable_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package collector
+
+import "os"
+
+// isExecutableMode reports whether the file's permission bits allow execution.
+func isExecutableMode(info os.FileInfo) bool {
+	return info.Mode().Perm()&0111 != 0
+}

--- a/cli/beacon/internal/endpoint/collector/executable_windows.go
+++ b/cli/beacon/internal/endpoint/collector/executable_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package collector
+
+import "os"
+
+// isExecutableMode reports whether the file can be executed.
+//
+// Windows has no executable permission bits. Go reports 0666 for an ordinary file and 0444 for a
+// read-only one, so the POSIX test `Perm()&0111 != 0` is false for *every* file there -- including
+// a genuine .exe. Applied unchanged, it made DiscoverBinary reject every collector binary on
+// Windows and report that none was installed.
+//
+// Executability there is decided by extension, and the caller is looking for one specific named
+// binary rather than scanning for anything runnable, so being a regular file is the meaningful
+// check: exec.LookPath already applies PATHEXT when resolving BinaryName from PATH, and the
+// explicit candidate paths name the file directly.
+func isExecutableMode(info os.FileInfo) bool {
+	return info.Mode().IsRegular()
+}

--- a/cli/beacon/internal/endpoint/config/config.go
+++ b/cli/beacon/internal/endpoint/config/config.go
@@ -39,6 +39,34 @@ func SystemConfigPath() string {
 	return filepath.Join(SystemBaseDir(), "config.json")
 }
 
+// SystemLogDir is the single source of truth for where a system-mode endpoint writes its logs.
+//
+// The runtime log path was previously a literal repeated in fourteen places -- every destination
+// pack, the writer, the hook adapter's default, the inventory heartbeat and the self-updater --
+// which is exactly the shape SystemBaseDir was introduced to remove for the config directory. One
+// function is what makes a second platform possible at all: fourteen literals cannot disagree with
+// each other on Linux, but they cannot be given a Windows value either.
+//
+// The Linux and macOS value is unchanged, and deliberately so. /var/log/beacon-agent is where
+// installed endpoints already write, where the packaging scripts create directories, and what the
+// forwarder packs tail; moving it would be a migration, not a refactor.
+func SystemLogDir() string {
+	switch runtime.GOOS {
+	case "windows":
+		// Alongside the config rather than under a separate root. Windows has no /var/log
+		// equivalent, and %ProgramData% is the documented home for machine-wide application state
+		// that outlives any one user.
+		return filepath.Join(SystemBaseDir(), "logs")
+	default:
+		return "/var/log/beacon-agent"
+	}
+}
+
+// SystemLogPath is the system-mode runtime log.
+func SystemLogPath() string {
+	return filepath.Join(SystemLogDir(), "runtime.jsonl")
+}
+
 const (
 	DefaultSplunkSource     = "beacon-endpoint-agent"
 	DefaultSplunkSourcetype = "beacon:endpoint"

--- a/cli/beacon/internal/endpoint/config/config.go
+++ b/cli/beacon/internal/endpoint/config/config.go
@@ -14,6 +14,11 @@ const (
 	// LinuxSystemBaseDir follows the FHS: configuration under /etc, which is where a
 	// package-managed install and an admin both expect to find it.
 	LinuxSystemBaseDir = "/etc/beacon/endpoint"
+	// WindowsSystemBaseFallback is used when %ProgramData% is unset. Windows always defines it in
+	// practice, but a service running under an unusual profile can arrive without it, and writing
+	// to a relative path in that case would scatter machine state into whatever directory the
+	// process happened to start in.
+	WindowsSystemBaseFallback = `C:\ProgramData`
 
 	UserConfigPath  = ".beacon/endpoint/config.json"
 	DefaultGRPCPort = 4317
@@ -29,6 +34,21 @@ func SystemBaseDir() string {
 	switch runtime.GOOS {
 	case "linux":
 		return LinuxSystemBaseDir
+	case "windows":
+		// %ProgramData% is the documented home for machine-wide application state that outlives
+		// any one user, and is the closest equivalent to both /Library/Application Support and
+		// /etc. Read from the environment rather than hardcoded because a redirected or localized
+		// install puts it elsewhere, and writing to the wrong root would be silent.
+		//
+		// Windows is a named case rather than sharing the default: before it was, an endpoint
+		// there resolved its state directory to the *macOS* path, so the log directory derived
+		// from it came out as "\Library\Application Support\...". Nothing would have failed
+		// loudly; it would simply have written machine state to a directory no Windows tool,
+		// installer or admin looks in.
+		if programData := os.Getenv("ProgramData"); programData != "" {
+			return filepath.Join(programData, "Beacon", "Endpoint")
+		}
+		return filepath.Join(WindowsSystemBaseFallback, "Beacon", "Endpoint")
 	default:
 		return DarwinSystemBaseDir
 	}

--- a/cli/beacon/internal/endpoint/config/config_test.go
+++ b/cli/beacon/internal/endpoint/config/config_test.go
@@ -104,6 +104,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 }
 
 func TestSaveLoadSplunkHECRoundTripAndPrivatePermissions(t *testing.T) {
+	testenv.RequirePOSIXFileModes(t)
 	home := t.TempDir()
 	testenv.SetHome(t, home)
 	cfg := Default(true, filepath.Join(home, "logs", "runtime.jsonl"))
@@ -153,6 +154,7 @@ func TestSaveRejectsIncompleteSplunkHEC(t *testing.T) {
 }
 
 func TestSaveLoadFalconHECRoundTripAndPrivatePermissions(t *testing.T) {
+	testenv.RequirePOSIXFileModes(t)
 	home := t.TempDir()
 	testenv.SetHome(t, home)
 	cfg := Default(true, filepath.Join(home, "logs", "runtime.jsonl"))

--- a/cli/beacon/internal/endpoint/config/config_test.go
+++ b/cli/beacon/internal/endpoint/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,7 +10,7 @@ import (
 
 func TestDefaultUserConfigUsesHomeScopedPaths(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	cfg := Default(true, filepath.Join(home, "runtime.jsonl"))
 
@@ -51,7 +52,7 @@ func TestInventoryContentCaptureOptIn(t *testing.T) {
 
 func TestSaveLoadRoundTrip(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	logPath := filepath.Join(home, "logs", "runtime.jsonl")
 
 	cfg := Default(true, logPath)
@@ -104,7 +105,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 
 func TestSaveLoadSplunkHECRoundTripAndPrivatePermissions(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	cfg := Default(true, filepath.Join(home, "logs", "runtime.jsonl"))
 	cfg.Destinations = &Destinations{SplunkHEC: &SplunkHEC{
 		Endpoint: "https://splunk.example:8088/services/collector",
@@ -142,7 +143,7 @@ func TestSaveLoadSplunkHECRoundTripAndPrivatePermissions(t *testing.T) {
 
 func TestSaveRejectsIncompleteSplunkHEC(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	cfg := Default(true, filepath.Join(home, "runtime.jsonl"))
 	cfg.Destinations = &Destinations{SplunkHEC: &SplunkHEC{Endpoint: "https://splunk.example:8088/services/collector"}}
 
@@ -153,7 +154,7 @@ func TestSaveRejectsIncompleteSplunkHEC(t *testing.T) {
 
 func TestSaveLoadFalconHECRoundTripAndPrivatePermissions(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	cfg := Default(true, filepath.Join(home, "logs", "runtime.jsonl"))
 	cfg.Destinations = &Destinations{FalconHEC: &FalconHEC{
 		Endpoint: "https://cloud.us.humio.com/api/v1/ingest/hec",
@@ -191,7 +192,7 @@ func TestSaveLoadFalconHECRoundTripAndPrivatePermissions(t *testing.T) {
 
 func TestSaveRejectsIncompleteFalconHEC(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	cfg := Default(true, filepath.Join(home, "runtime.jsonl"))
 	cfg.Destinations = &Destinations{FalconHEC: &FalconHEC{Endpoint: "https://cloud.us.humio.com/api/v1/ingest/hec"}}
 
@@ -202,7 +203,7 @@ func TestSaveRejectsIncompleteFalconHEC(t *testing.T) {
 
 func TestLoadIgnoresLegacyContentRetention(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, UserConfigPath)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
@@ -232,7 +233,7 @@ func TestLoadIgnoresLegacyContentRetention(t *testing.T) {
 
 func TestLoadRejectsCorruptJSON(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, UserConfigPath)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)

--- a/cli/beacon/internal/endpoint/config/systemlog_test.go
+++ b/cli/beacon/internal/endpoint/config/systemlog_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The POSIX value must not move. /var/log/beacon-agent is where installed endpoints already write,
+// where the packaging scripts create directories, and what the forwarder packs tail -- changing it
+// would be a migration rather than a refactor, and this consolidation is meant to be neither.
+func TestSystemLogPathIsUnchangedOnPOSIX(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the POSIX location does not apply")
+	}
+	if got, want := SystemLogDir(), "/var/log/beacon-agent"; got != want {
+		t.Errorf("SystemLogDir() = %q, want %q", got, want)
+	}
+	if got, want := SystemLogPath(), "/var/log/beacon-agent/runtime.jsonl"; got != want {
+		t.Errorf("SystemLogPath() = %q, want %q", got, want)
+	}
+}
+
+// On Windows the log lives under the same machine-wide root as the config, because there is no
+// /var/log equivalent and %ProgramData% is where state that outlives any one user belongs.
+func TestSystemLogPathIsUnderTheSystemBaseDirOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("the Windows location does not apply")
+	}
+	if !strings.HasPrefix(SystemLogDir(), SystemBaseDir()) {
+		t.Errorf("SystemLogDir() = %q, want it under SystemBaseDir() %q", SystemLogDir(), SystemBaseDir())
+	}
+	if got, want := SystemLogPath(), filepath.Join(SystemLogDir(), "runtime.jsonl"); got != want {
+		t.Errorf("SystemLogPath() = %q, want %q", got, want)
+	}
+}
+
+// The log path must derive from the same root as the config, or a Windows install would scatter
+// its state across two locations and only one of them would be documented.
+func TestSystemLogPathDerivesFromOneRoot(t *testing.T) {
+	if got := SystemLogPath(); !strings.HasSuffix(filepath.ToSlash(got), "/runtime.jsonl") {
+		t.Errorf("SystemLogPath() = %q, want it to name runtime.jsonl", got)
+	}
+	if SystemLogDir() == "" || SystemBaseDir() == "" {
+		t.Fatal("neither root may be empty; an empty prefix silently writes to the process's cwd")
+	}
+}

--- a/cli/beacon/internal/endpoint/datadog/datadog.go
+++ b/cli/beacon/internal/endpoint/datadog/datadog.go
@@ -1,6 +1,7 @@
 package datadog
 
 import (
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"io/fs"
 
 	"embed"
@@ -12,9 +13,12 @@ import (
 var packFS embed.FS
 
 const (
-	DefaultLogPath   = "/var/log/beacon-agent/runtime.jsonl"
 	DefaultOutputDir = "beacon-datadog-pack"
 )
+
+// DefaultLogPath is a var rather than a const because the system log location is now
+// resolved per platform by one function instead of repeated as a literal in every pack.
+var DefaultLogPath = endpointconfig.SystemLogPath()
 
 const configAsset = "pack/conf.yaml.tmpl"
 

--- a/cli/beacon/internal/endpoint/elastic/elastic.go
+++ b/cli/beacon/internal/endpoint/elastic/elastic.go
@@ -3,6 +3,7 @@ package elastic
 import (
 	"embed"
 	"fmt"
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -15,9 +16,12 @@ import (
 var packFS embed.FS
 
 const (
-	DefaultLogPath   = "/var/log/beacon-agent/runtime.jsonl"
 	DefaultOutputDir = "beacon-elastic-pack"
 )
+
+// DefaultLogPath is a var rather than a const because the system log location is now
+// resolved per platform by one function instead of repeated as a literal in every pack.
+var DefaultLogPath = endpointconfig.SystemLogPath()
 
 type File struct {
 	Name    string

--- a/cli/beacon/internal/endpoint/falcon/falcon.go
+++ b/cli/beacon/internal/endpoint/falcon/falcon.go
@@ -2,6 +2,7 @@ package falcon
 
 import (
 	"embed"
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -11,9 +12,12 @@ import (
 var packFS embed.FS
 
 const (
-	DefaultLogPath   = "/var/log/beacon-agent/runtime.jsonl"
 	DefaultOutputDir = "beacon-falcon-pack"
 )
+
+// DefaultLogPath is a var rather than a const because the system log location is now
+// resolved per platform by one function instead of repeated as a literal in every pack.
+var DefaultLogPath = endpointconfig.SystemLogPath()
 
 const (
 	configAsset    = "pack/vector.toml.tmpl"

--- a/cli/beacon/internal/endpoint/gcs/gcs.go
+++ b/cli/beacon/internal/endpoint/gcs/gcs.go
@@ -2,6 +2,7 @@ package gcs
 
 import (
 	"embed"
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -11,9 +12,12 @@ import (
 var packFS embed.FS
 
 const (
-	DefaultLogPath   = "/var/log/beacon-agent/runtime.jsonl"
 	DefaultOutputDir = "beacon-gcs-pack"
 )
+
+// DefaultLogPath is a var rather than a const because the system log location is now
+// resolved per platform by one function instead of repeated as a literal in every pack.
+var DefaultLogPath = endpointconfig.SystemLogPath()
 
 const smokeTestAsset = "pack/gcs-upload-smoke-test.sh.tmpl"
 

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -246,6 +246,7 @@ func TestDiscoverCodexDoesNotDetectConfigDirectoryOnly(t *testing.T) {
 }
 
 func TestDiscoverCodexDetectsExecutableOnPath(t *testing.T) {
+	testenv.RequirePOSIXExecutableFixtures(t)
 	home := t.TempDir()
 	testenv.SetHome(t, home)
 	binDir := t.TempDir()
@@ -434,6 +435,7 @@ func TestDiscoverGeminiDoesNotDetectConfigDirectoryOnly(t *testing.T) {
 }
 
 func TestDiscoverGeminiDetectsExecutableOnPath(t *testing.T) {
+	testenv.RequirePOSIXExecutableFixtures(t)
 	home := t.TempDir()
 	testenv.SetHome(t, home)
 	binDir := t.TempDir()
@@ -488,6 +490,7 @@ func TestGeminiStatusVariants(t *testing.T) {
 }
 
 func TestDiscoverFactoryDetectsExecutableOnPath(t *testing.T) {
+	testenv.RequirePOSIXExecutableFixtures(t)
 	home := t.TempDir()
 	testenv.SetHome(t, home)
 	t.Setenv("SHELL", "/bin/bash")
@@ -514,6 +517,7 @@ func TestDiscoverFactoryDetectsExecutableOnPath(t *testing.T) {
 }
 
 func TestDiscoverCopilotCLIDetectsExecutableOnPath(t *testing.T) {
+	testenv.RequirePOSIXExecutableFixtures(t)
 	home := t.TempDir()
 	testenv.SetHome(t, home)
 	t.Setenv("SHELL", "/bin/bash")
@@ -558,6 +562,7 @@ func TestDiscoverCopilotCLIDetectsConfigFile(t *testing.T) {
 }
 
 func TestDiscoverDevinDetectsExecutableOnPath(t *testing.T) {
+	testenv.RequirePOSIXExecutableFixtures(t)
 	home := t.TempDir()
 	testenv.SetHome(t, home)
 	binDir := t.TempDir()

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -2,6 +2,7 @@ package harness
 
 import (
 	"encoding/json"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,7 +36,7 @@ func TestMergeCodexOTELReplacesExistingBlock(t *testing.T) {
 
 func TestConfigureClaudeWritesTelemetryEnvAndBackup(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, ".claude", "settings.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatalf("mkdir claude config dir: %v", err)
@@ -87,7 +88,7 @@ func TestConfigureClaudeWritesTelemetryEnvAndBackup(t *testing.T) {
 
 func TestConfigureClaudeEnablesPromptLogging(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, ".claude", "settings.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatalf("mkdir claude config dir: %v", err)
@@ -149,7 +150,7 @@ func TestClaudeStatusVariants(t *testing.T) {
 
 func TestConfigureCodexWritesTelemetryBlockAndBackup(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, ".codex", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatalf("mkdir codex config dir: %v", err)
@@ -205,7 +206,7 @@ func TestConfigureCodexWritesTelemetryBlockAndBackup(t *testing.T) {
 
 func TestConfigureCodexEnablesPromptLogging(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	path, err := ConfigureCodex(ConfigureOptions{
 		Endpoint: "http://127.0.0.1:4317",
@@ -225,7 +226,7 @@ func TestConfigureCodexEnablesPromptLogging(t *testing.T) {
 
 func TestDiscoverCodexDoesNotDetectConfigDirectoryOnly(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	binDir := t.TempDir()
 	t.Setenv("PATH", binDir)
 	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0755); err != nil {
@@ -246,7 +247,7 @@ func TestDiscoverCodexDoesNotDetectConfigDirectoryOnly(t *testing.T) {
 
 func TestDiscoverCodexDetectsExecutableOnPath(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	binDir := t.TempDir()
 	t.Setenv("PATH", binDir)
 	codexPath := filepath.Join(binDir, "codex")
@@ -328,7 +329,7 @@ func TestCodexStatusVariants(t *testing.T) {
 
 func TestConfigureGeminiWritesTelemetryAndBackup(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, ".gemini", "settings.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatalf("mkdir gemini config dir: %v", err)
@@ -385,7 +386,7 @@ func TestConfigureGeminiWritesTelemetryAndBackup(t *testing.T) {
 
 func TestConfigureGeminiEnablesPromptLoggingAndTraces(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	path, err := ConfigureGemini(ConfigureOptions{
 		Endpoint: "http://127.0.0.1:4317",
@@ -413,7 +414,7 @@ func TestConfigureGeminiEnablesPromptLoggingAndTraces(t *testing.T) {
 
 func TestDiscoverGeminiDoesNotDetectConfigDirectoryOnly(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	binDir := t.TempDir()
 	t.Setenv("PATH", binDir)
 	if err := os.MkdirAll(filepath.Join(home, ".gemini"), 0755); err != nil {
@@ -434,7 +435,7 @@ func TestDiscoverGeminiDoesNotDetectConfigDirectoryOnly(t *testing.T) {
 
 func TestDiscoverGeminiDetectsExecutableOnPath(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	binDir := t.TempDir()
 	t.Setenv("PATH", binDir)
 	geminiPath := filepath.Join(binDir, "gemini")
@@ -488,7 +489,7 @@ func TestGeminiStatusVariants(t *testing.T) {
 
 func TestDiscoverFactoryDetectsExecutableOnPath(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	t.Setenv("SHELL", "/bin/bash")
 	binDir := t.TempDir()
 	t.Setenv("PATH", binDir)
@@ -514,7 +515,7 @@ func TestDiscoverFactoryDetectsExecutableOnPath(t *testing.T) {
 
 func TestDiscoverCopilotCLIDetectsExecutableOnPath(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	t.Setenv("SHELL", "/bin/bash")
 	binDir := t.TempDir()
 	t.Setenv("PATH", binDir)
@@ -540,7 +541,7 @@ func TestDiscoverCopilotCLIDetectsExecutableOnPath(t *testing.T) {
 
 func TestDiscoverCopilotCLIDetectsConfigFile(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	t.Setenv("PATH", t.TempDir())
 	configPath := filepath.Join(home, ".copilot", "config.json")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
@@ -558,7 +559,7 @@ func TestDiscoverCopilotCLIDetectsConfigFile(t *testing.T) {
 
 func TestDiscoverDevinDetectsExecutableOnPath(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	binDir := t.TempDir()
 	t.Setenv("PATH", binDir)
 	devinPath := filepath.Join(binDir, "devin")
@@ -586,7 +587,7 @@ func TestDiscoverDevinDetectsExecutableOnPath(t *testing.T) {
 
 func TestDiscoverDevinDesktopDetectsAppSupport(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	appSupport := filepath.Join(home, "Library", "Application Support", "Devin")
 	if err := os.MkdirAll(appSupport, 0755); err != nil {
 		t.Fatalf("mkdir app support: %v", err)

--- a/cli/beacon/internal/endpoint/harness/vscode_test.go
+++ b/cli/beacon/internal/endpoint/harness/vscode_test.go
@@ -1,6 +1,7 @@
 package harness
 
 import (
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -110,7 +111,7 @@ func TestVSCodeOTelStatus(t *testing.T) {
 // a developer's own VS Code configuration.
 func isolateUserConfig(t *testing.T, home string) {
 	t.Helper()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 }
 

--- a/cli/beacon/internal/endpoint/hooks/antigravity_test.go
+++ b/cli/beacon/internal/endpoint/hooks/antigravity_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,7 +107,7 @@ func TestReadAntigravityConfigReturnsCorruptJSONError(t *testing.T) {
 
 func TestAntigravityConfigPathLevels(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	dir := t.TempDir()
 	t.Chdir(dir)
 
@@ -128,7 +129,7 @@ func TestAntigravityConfigPathLevels(t *testing.T) {
 
 func TestAntigravityHookStatusDetectsInstalled(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, ".gemini", "config", "hooks.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatal(err)

--- a/cli/beacon/internal/endpoint/hooks/claude_test.go
+++ b/cli/beacon/internal/endpoint/hooks/claude_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -130,7 +131,7 @@ func TestClaudeSettingsPathProjectLevel(t *testing.T) {
 
 func TestClaudeHookStatusDetectsInstalled(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, ".claude", "settings.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatal(err)

--- a/cli/beacon/internal/endpoint/hooks/cursor_test.go
+++ b/cli/beacon/internal/endpoint/hooks/cursor_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -158,7 +159,7 @@ func TestInstallCursorHooksJSONDoesNotReplaceUserCommandWithBeaconEnvOnly(t *tes
 
 func TestInstallCursorWithUnknownLevelFailsBeforeWritingTarget(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	status, err := InstallCursor(CursorOptions{Level: Level("workspace"), UserMode: true})
 	if err == nil {
 		t.Fatal("expected unknown hook level error")

--- a/cli/beacon/internal/endpoint/hooks/cursor_test.go
+++ b/cli/beacon/internal/endpoint/hooks/cursor_test.go
@@ -170,7 +170,7 @@ func TestInstallCursorWithUnknownLevelFailsBeforeWritingTarget(t *testing.T) {
 }
 
 func TestEndpointConfigPathForHookUsesSystemConfigForSystemLog(t *testing.T) {
-	if got := endpointConfigPathForHook("/var/log/beacon-agent/runtime.jsonl", true); got != endpointconfig.ConfigPath(false) {
+	if got := endpointConfigPathForHook(endpointconfig.SystemLogPath(), true); got != endpointconfig.ConfigPath(false) {
 		t.Fatalf("system log config path = %q, want system endpoint config", got)
 	}
 	if got := endpointConfigPathForHook("/tmp/runtime.jsonl", true); got != endpointconfig.ConfigPath(true) {

--- a/cli/beacon/internal/endpoint/hooks/devin_test.go
+++ b/cli/beacon/internal/endpoint/hooks/devin_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"encoding/json"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -260,7 +261,7 @@ func TestDevinConfigPathProjectLevel(t *testing.T) {
 
 func TestDevinHookStatusDetectsInstalled(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, ".config", "devin", "config.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatal(err)
@@ -280,7 +281,7 @@ func TestDevinHookStatusDetectsInstalled(t *testing.T) {
 
 func TestDevinDesktopHookStatusDetectsInstalled(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, ".codeium", "windsurf", "hooks.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatal(err)

--- a/cli/beacon/internal/endpoint/hooks/factory_test.go
+++ b/cli/beacon/internal/endpoint/hooks/factory_test.go
@@ -237,7 +237,7 @@ func TestInstallFactoryUsesSystemConfigForSystemLog(t *testing.T) {
 
 	status, err := InstallFactory(FactoryOptions{
 		Level:    LevelUser,
-		LogPath:  "/var/log/beacon-agent/runtime.jsonl",
+		LogPath:  endpointconfig.SystemLogPath(),
 		UserMode: true,
 	})
 	if err != nil {

--- a/cli/beacon/internal/endpoint/hooks/factory_test.go
+++ b/cli/beacon/internal/endpoint/hooks/factory_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -212,7 +213,7 @@ func TestFactorySettingsPathProjectLevel(t *testing.T) {
 
 func TestFactoryHookStatusDetectsInstalled(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, ".factory", "settings.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatal(err)
@@ -232,7 +233,7 @@ func TestFactoryHookStatusDetectsInstalled(t *testing.T) {
 
 func TestInstallFactoryUsesSystemConfigForSystemLog(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	status, err := InstallFactory(FactoryOptions{
 		Level:    LevelUser,

--- a/cli/beacon/internal/endpoint/hooks/factory_test.go
+++ b/cli/beacon/internal/endpoint/hooks/factory_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"encoding/json"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
@@ -231,6 +232,19 @@ func TestFactoryHookStatusDetectsInstalled(t *testing.T) {
 	}
 }
 
+// jsonFragment renders a value as it appears inside a JSON document, minus the surrounding quotes.
+//
+// Assertions against marshaled settings must search for the encoded form: a Windows path is full
+// of backslashes, and JSON escapes every one of them.
+func jsonFragment(t *testing.T, value string) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("encode %q: %v", value, err)
+	}
+	return strings.Trim(string(encoded), `"`)
+}
+
 func TestInstallFactoryUsesSystemConfigForSystemLog(t *testing.T) {
 	home := t.TempDir()
 	testenv.SetHome(t, home)
@@ -247,16 +261,21 @@ func TestInstallFactoryUsesSystemConfigForSystemLog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read Factory settings: %v", err)
 	}
-	// The point of this test is that a /var/log system log path selects the *system* config,
-	// not the user one. The system path is per-OS, so assert against the resolved value
-	// rather than a hardcoded macOS string -- which is what previously made this fail the
-	// moment the suite ran on Linux.
-	wantConfig := "BEACON_ENDPOINT_CONFIG='" + endpointconfig.SystemConfigPath() + "'"
+	// A system log path must select the *system* config, not the user one. Both halves are
+	// compared against the JSON-encoded form, because that is what lands in the file: Factory
+	// settings are marshaled, so a Windows path's backslashes are escaped on the way in and a
+	// search for the raw string finds nothing. That breaks the assertion in both directions --
+	// the positive check reports the system config as not chosen when it was, and the negative
+	// check cannot see the user config being chosen wrongly. On POSIX the two forms are
+	// identical, which is why the raw comparison held until Windows joined the gate.
+	//
+	// The resolved values are used rather than hardcoded strings, since both are per-OS.
+	wantConfig := jsonFragment(t, "BEACON_ENDPOINT_CONFIG='"+endpointconfig.SystemConfigPath()+"'")
 	if !strings.Contains(string(data), wantConfig) {
 		t.Fatalf("Factory hook did not use system config for system log; want %s in:\n%s",
 			wantConfig, string(data))
 	}
-	if strings.Contains(string(data), endpointconfig.ConfigPath(true)) {
+	if unwanted := jsonFragment(t, endpointconfig.ConfigPath(true)); strings.Contains(string(data), unwanted) {
 		t.Fatalf("Factory hook used the user config for a system log path:\n%s", string(data))
 	}
 }

--- a/cli/beacon/internal/endpoint/hooks/grok_test.go
+++ b/cli/beacon/internal/endpoint/hooks/grok_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"encoding/json"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,7 +89,7 @@ func TestRemoveGrokHooksOnlyRemovesManagedHookFile(t *testing.T) {
 
 func TestGrokHookPathLevels(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	if got, want := mustGrokHooksPath(t, LevelUser), filepath.Join(home, ".grok", "hooks", "beacon-endpoint.json"); got != want {
 		t.Fatalf("user Grok hook path = %q, want %q", got, want)
 	}

--- a/cli/beacon/internal/endpoint/hooks/hermes_test.go
+++ b/cli/beacon/internal/endpoint/hooks/hermes_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -120,7 +121,7 @@ func TestRemoveHermesEndpointHooksPreservesOtherHooks(t *testing.T) {
 
 func TestHermesHookStatusDetectsInstalled(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	path := filepath.Join(home, ".hermes", "config.yaml")
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatal(err)

--- a/cli/beacon/internal/endpoint/hooks/opencode_test.go
+++ b/cli/beacon/internal/endpoint/hooks/opencode_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -145,7 +146,7 @@ func TestOpenCodeInstalledUsesManagedMarker(t *testing.T) {
 
 func TestOpenCodePluginPathLevels(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	if got, want := mustOpenCodePluginPath(t, LevelUser), filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"); got != want {
 		t.Fatalf("user plugin path = %q, want %q", got, want)
 	}

--- a/cli/beacon/internal/endpoint/hooks/runtime.go
+++ b/cli/beacon/internal/endpoint/hooks/runtime.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/embedded"
@@ -169,14 +170,49 @@ func defaultLogPath(userMode bool) string {
 			return filepath.Join(home, ".beacon", "endpoint", "logs", "runtime.jsonl")
 		}
 	}
-	return "/var/log/beacon-agent/runtime.jsonl"
+	return endpointconfig.SystemLogPath()
 }
 
+// endpointConfigPathForHook picks which config a hook should read, from where its log lives.
+//
+// A log under a machine-wide location means the hook is feeding a system-mode endpoint, whatever
+// scope the caller asked for, so it must read the system config. That was decided by matching the
+// POSIX prefixes "/var/log/" and "/Library/" -- which named two of the three platforms' locations
+// and no Windows one, so a Windows system install would have sent its hooks to the *user* config
+// and pointed them at a log the collector never reads.
+//
+// Comparing against the resolved directories instead makes the question platform-independent, and
+// keeps working if either location ever moves.
 func endpointConfigPathForHook(logPath string, userMode bool) string {
-	if strings.HasPrefix(logPath, "/var/log/") || strings.HasPrefix(logPath, "/Library/") {
+	if underSystemLocation(logPath) {
 		return endpointconfig.ConfigPath(false)
 	}
 	return endpointconfig.ConfigPath(userMode)
+}
+
+// underSystemLocation reports whether a path sits beneath a machine-wide Beacon directory.
+//
+// Case-insensitive on Windows, where paths are, and separator-normalized so a value built with
+// either separator compares the same. A false negative here is the dangerous direction: it routes
+// a system-mode hook to the user config, which fails silently rather than loudly.
+func underSystemLocation(path string) bool {
+	norm := func(p string) string {
+		p = filepath.ToSlash(filepath.Clean(p))
+		if runtime.GOOS == "windows" {
+			p = strings.ToLower(p)
+		}
+		return strings.TrimSuffix(p, "/") + "/"
+	}
+	target := norm(path)
+	for _, root := range []string{endpointconfig.SystemLogDir(), endpointconfig.SystemBaseDir()} {
+		if root == "" {
+			continue
+		}
+		if strings.HasPrefix(target, norm(root)) {
+			return true
+		}
+	}
+	return false
 }
 
 func shellQuote(value string) string {

--- a/cli/beacon/internal/endpoint/hooks/runtime.go
+++ b/cli/beacon/internal/endpoint/hooks/runtime.go
@@ -121,7 +121,7 @@ func endpointCommandPrefix(platform, binaryPath, logPath, configPath string) str
 
 func isEndpointHookCommand(command, platform string) bool {
 	hasPlatform := platform == "" || commandHasPlatform(command, platform)
-	hasBeaconBinary := strings.Contains(command, embedded.GetBinaryName())
+	hasBeaconBinary := strings.Contains(command, embedded.BinaryStem)
 	hasLegacyBinary := strings.Contains(command, "asym-hooks")
 
 	if strings.Contains(command, "BEACON_ENDPOINT_MODE=1") && hasBeaconBinary {

--- a/cli/beacon/internal/endpoint/hooks/scope_test.go
+++ b/cli/beacon/internal/endpoint/hooks/scope_test.go
@@ -1,0 +1,61 @@
+package hooks
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+)
+
+// A hook writing to a machine-wide log is feeding a system-mode endpoint and must read the system
+// config, whatever scope the caller asked for. The previous test matched the POSIX prefixes
+// "/var/log/" and "/Library/", which named two platforms' locations and no Windows one -- so a
+// Windows system install would have routed its hooks to the *user* config and pointed them at a
+// log the collector never reads. That fails silently, which is the worst way for it to fail.
+func TestSystemLogRoutesHooksToTheSystemConfig(t *testing.T) {
+	system := endpointconfig.ConfigPath(false)
+
+	for _, logPath := range []string{
+		endpointconfig.SystemLogPath(),
+		filepath.Join(endpointconfig.SystemLogDir(), "inventory_state.jsonl"),
+		filepath.Join(endpointconfig.SystemBaseDir(), "logs", "runtime.jsonl"),
+	} {
+		if got := endpointConfigPathForHook(logPath, true); got != system {
+			t.Errorf("a hook logging to %q asked for user mode and got %q, want the system config %q",
+				logPath, got, system)
+		}
+	}
+}
+
+// A log in the user's own tree must keep the caller's scope, or a user-mode install would write
+// its hook configuration into a system path it may not even be able to open.
+func TestUserLogKeepsTheRequestedScope(t *testing.T) {
+	userLog := filepath.Join(t.TempDir(), ".beacon", "endpoint", "logs", "runtime.jsonl")
+
+	if got, want := endpointConfigPathForHook(userLog, true), endpointconfig.ConfigPath(true); got != want {
+		t.Errorf("user-mode log routed to %q, want %q", got, want)
+	}
+	if got, want := endpointConfigPathForHook(userLog, false), endpointconfig.ConfigPath(false); got != want {
+		t.Errorf("system-mode caller with a user log routed to %q, want %q", got, want)
+	}
+}
+
+// Windows paths compare case-insensitively and may arrive with either separator. A false negative
+// is the dangerous direction, so both spellings must still be recognized.
+func TestSystemLocationMatchIsPlatformAppropriate(t *testing.T) {
+	dir := endpointconfig.SystemLogDir()
+	if !underSystemLocation(filepath.Join(dir, "runtime.jsonl")) {
+		t.Fatalf("the system log dir %q must be recognized", dir)
+	}
+	if runtime.GOOS == "windows" {
+		mixed := filepath.Join(dir, "RUNTIME.JSONL")
+		if !underSystemLocation(mixed) {
+			t.Errorf("windows path comparison must be case-insensitive, %q was not matched", mixed)
+		}
+	}
+	// A sibling directory whose name merely starts with the same characters is not underneath it.
+	if underSystemLocation(dir + "-other/runtime.jsonl") {
+		t.Errorf("%q-other must not be treated as being under %q", dir, dir)
+	}
+}

--- a/cli/beacon/internal/endpoint/hooks/scope_test.go
+++ b/cli/beacon/internal/endpoint/hooks/scope_test.go
@@ -54,9 +54,17 @@ func TestSystemLocationMatchIsPlatformAppropriate(t *testing.T) {
 			t.Errorf("windows path comparison must be case-insensitive, %q was not matched", mixed)
 		}
 	}
-	// A sibling directory whose name merely starts with the same characters is not underneath it.
-	if underSystemLocation(dir + "-other/runtime.jsonl") {
-		t.Errorf("%q-other must not be treated as being under %q", dir, dir)
+	// A sibling whose name merely starts with the same characters is not underneath it.
+	//
+	// The sibling is formed from the *outermost* guarded root, not the log directory. On POSIX the
+	// log directory sits outside the base directory (/var/log/beacon-agent versus /etc or
+	// /Library), so a sibling of either is outside both; on Windows the log directory is nested
+	// inside the base directory, so "<logdir>-other" is still under the base and legitimately
+	// matches. Testing the log directory's sibling therefore asserted a POSIX layout rather than
+	// the prefix-boundary property it was written for.
+	sibling := endpointconfig.SystemBaseDir() + "-other"
+	if underSystemLocation(filepath.Join(sibling, "runtime.jsonl")) {
+		t.Errorf("%q must not be treated as being under %q", sibling, endpointconfig.SystemBaseDir())
 	}
 }
 

--- a/cli/beacon/internal/endpoint/hooks/scope_test.go
+++ b/cli/beacon/internal/endpoint/hooks/scope_test.go
@@ -59,3 +59,31 @@ func TestSystemLocationMatchIsPlatformAppropriate(t *testing.T) {
 		t.Errorf("%q-other must not be treated as being under %q", dir, dir)
 	}
 }
+
+// Detection matches the binary stem, not the platform-specific filename.
+//
+// A settings file is a portable artifact: it gets synced between machines, committed to dotfiles,
+// and written by older builds. Matching on GetBinaryName meant a Windows Beacon recognized only
+// "beacon-hooks.exe" and was blind to a command naming "beacon-hooks" -- so it would neither repair
+// nor remove a hook it had every reason to own, and `hooks status` would report not-installed for a
+// hook sitting in the file.
+func TestHookDetectionRecognizesBothBinarySpellings(t *testing.T) {
+	for _, command := range []string{
+		`BEACON_ENDPOINT_MODE=1 '/home/u/.beacon/endpoint/hooks/beacon-hooks' --platform cursor`,
+		`BEACON_ENDPOINT_MODE=1 'C:\Users\u\.beacon\endpoint\hooks\beacon-hooks.exe' --platform cursor`,
+	} {
+		if !isEndpointHookCommand(command, "cursor") {
+			t.Errorf("command not recognized as a Beacon hook: %s", command)
+		}
+	}
+
+	// Still not a licence to claim anything: an unrelated command must not be adopted.
+	for _, command := range []string{
+		`echo keep`,
+		`/usr/local/bin/some-other-tool --platform cursor`,
+	} {
+		if isEndpointHookCommand(command, "cursor") {
+			t.Errorf("unrelated command was claimed as a Beacon hook: %s", command)
+		}
+	}
+}

--- a/cli/beacon/internal/endpoint/hooks/vscode_test.go
+++ b/cli/beacon/internal/endpoint/hooks/vscode_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,7 +72,7 @@ func TestRemoveVSCodeEndpointHooksPreservesOtherHooks(t *testing.T) {
 
 func TestVSCodeHooksPathLevels(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	userPath, err := vscodeHooksPath(LevelUser)
 	if err != nil {
 		t.Fatalf("user path error: %v", err)

--- a/cli/beacon/internal/endpoint/inventory/heartbeat.go
+++ b/cli/beacon/internal/endpoint/inventory/heartbeat.go
@@ -53,7 +53,7 @@ func LogPath(runtimeLogPath string, userMode bool) string {
 		}
 		return filepath.Join(home, ".beacon", "endpoint", "logs", LogFileName)
 	}
-	return filepath.Join("/var/log", "beacon-agent", LogFileName)
+	return filepath.Join(endpointconfig.SystemLogDir(), LogFileName)
 }
 
 func LockState(path string) (*LockedState, State, error) {

--- a/cli/beacon/internal/endpoint/rapid7/rapid7.go
+++ b/cli/beacon/internal/endpoint/rapid7/rapid7.go
@@ -2,6 +2,7 @@ package rapid7
 
 import (
 	"embed"
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -11,9 +12,12 @@ import (
 var packFS embed.FS
 
 const (
-	DefaultLogPath   = "/var/log/beacon-agent/runtime.jsonl"
 	DefaultOutputDir = "beacon-rapid7-pack"
 )
+
+// DefaultLogPath is a var rather than a const because the system log location is now
+// resolved per platform by one function instead of repeated as a literal in every pack.
+var DefaultLogPath = endpointconfig.SystemLogPath()
 
 const smokeTestAsset = "pack/rapid7-upload-smoke-test.sh.tmpl"
 

--- a/cli/beacon/internal/endpoint/s3/s3.go
+++ b/cli/beacon/internal/endpoint/s3/s3.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"embed"
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -11,9 +12,12 @@ import (
 var packFS embed.FS
 
 const (
-	DefaultLogPath   = "/var/log/beacon-agent/runtime.jsonl"
 	DefaultOutputDir = "beacon-s3-pack"
 )
+
+// DefaultLogPath is a var rather than a const because the system log location is now
+// resolved per platform by one function instead of repeated as a literal in every pack.
+var DefaultLogPath = endpointconfig.SystemLogPath()
 
 const smokeTestAsset = "pack/s3-upload-smoke-test.sh.tmpl"
 

--- a/cli/beacon/internal/endpoint/selfupdate/systemlog.go
+++ b/cli/beacon/internal/endpoint/selfupdate/systemlog.go
@@ -1,6 +1,7 @@
 package selfupdate
 
 import (
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"path/filepath"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
@@ -27,7 +28,7 @@ func SystemLogPath(runtimeLogPath string, userMode bool) string {
 	if userMode {
 		return filepath.Join(filepath.Dir(writer.DefaultPath(true)), SystemLogFileName)
 	}
-	return filepath.Join("/var/log", "beacon-agent", SystemLogFileName)
+	return filepath.Join(endpointconfig.SystemLogDir(), SystemLogFileName)
 }
 
 type CheckEventOptions struct {

--- a/cli/beacon/internal/endpoint/sentinel/sentinel.go
+++ b/cli/beacon/internal/endpoint/sentinel/sentinel.go
@@ -3,6 +3,7 @@ package sentinel
 import (
 	"embed"
 	"fmt"
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"strings"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -12,9 +13,12 @@ import (
 var packFS embed.FS
 
 const (
-	DefaultLogPath   = "/var/log/beacon-agent/runtime.jsonl"
 	DefaultOutputDir = "beacon-sentinel-pack"
 )
+
+// DefaultLogPath is a var rather than a const because the system log location is now
+// resolved per platform by one function instead of repeated as a literal in every pack.
+var DefaultLogPath = endpointconfig.SystemLogPath()
 
 func Files() []siempack.File {
 	return []siempack.File{

--- a/cli/beacon/internal/endpoint/service/service_test.go
+++ b/cli/beacon/internal/endpoint/service/service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -268,7 +269,7 @@ func TestLaunchdIsInertOffDarwin(t *testing.T) {
 // rather than the old "does nothing" assertion.
 func TestSupervisedLifecycleStartsAndStopsAProcess(t *testing.T) {
 	home := t.TempDir()
-	setTestHome(t, home)
+	testenv.SetHome(t, home)
 	m := Manager{UserMode: true, Kind: KindSupervised}
 
 	// Loading before install must explain itself rather than silently doing nothing.
@@ -332,7 +333,7 @@ func TestLaunchctlGuidance(t *testing.T) {
 
 func TestLaunchdLabelAndUnitPath(t *testing.T) {
 	home := t.TempDir()
-	setTestHome(t, home)
+	testenv.SetHome(t, home)
 
 	user := Manager{UserMode: true, Kind: KindLaunchd}
 	if got := user.Label(); got != UserLabel {
@@ -361,7 +362,7 @@ func TestLaunchdLabelAndUnitPath(t *testing.T) {
 
 func TestSystemdLabelAndUnitPath(t *testing.T) {
 	home := t.TempDir()
-	setTestHome(t, home)
+	testenv.SetHome(t, home)
 
 	user := Manager{UserMode: true, Kind: KindSystemd}
 	if got := user.Label(); got != SystemdUserUnit {
@@ -497,7 +498,7 @@ func TestSupervisedIsAlwaysAvailable(t *testing.T) {
 
 func TestSupervisedRecordsAndReportsState(t *testing.T) {
 	home := t.TempDir()
-	setTestHome(t, home)
+	testenv.SetHome(t, home)
 	m := Manager{UserMode: true, Kind: KindSupervised}
 
 	if st := m.Status(); st.Loaded || st.Running {

--- a/cli/beacon/internal/endpoint/service/testsupport_test.go
+++ b/cli/beacon/internal/endpoint/service/testsupport_test.go
@@ -43,15 +43,3 @@ func stubCollectorPath(t *testing.T) string {
 	}
 	return exe
 }
-
-// setTestHome redirects the user's home directory for a test on every platform.
-//
-// t.Setenv("HOME") alone is a POSIX-only redirect: os.UserHomeDir reads USERPROFILE on Windows, so
-// a test that sets only HOME there silently keeps using the real profile. That is worse than a
-// plain failure -- tests write into the developer's actual ~/.beacon and then see each other's
-// state, which is why several of these reported "nothing installed yet" while finding an install.
-func setTestHome(t *testing.T, dir string) {
-	t.Helper()
-	t.Setenv("HOME", dir)
-	t.Setenv("USERPROFILE", dir)
-}

--- a/cli/beacon/internal/endpoint/sumo/sumo.go
+++ b/cli/beacon/internal/endpoint/sumo/sumo.go
@@ -2,6 +2,7 @@ package sumo
 
 import (
 	"embed"
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"io/fs"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/siempack"
@@ -11,9 +12,12 @@ import (
 var packFS embed.FS
 
 const (
-	DefaultLogPath   = "/var/log/beacon-agent/runtime.jsonl"
 	DefaultOutputDir = "beacon-sumo-pack"
 )
+
+// DefaultLogPath is a var rather than a const because the system log location is now
+// resolved per platform by one function instead of repeated as a literal in every pack.
+var DefaultLogPath = endpointconfig.SystemLogPath()
 
 const smokeTestAsset = "pack/sumo-upload-smoke-test.sh.tmpl"
 

--- a/cli/beacon/internal/endpoint/wazuh/wazuh.go
+++ b/cli/beacon/internal/endpoint/wazuh/wazuh.go
@@ -2,6 +2,7 @@ package wazuh
 
 import (
 	"embed"
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,7 +11,9 @@ import (
 //go:embed pack/*
 var packFS embed.FS
 
-const DefaultLogPath = "/var/log/beacon-agent/runtime.jsonl"
+// DefaultLogPath is a var rather than a const because the system log location is now
+// resolved per platform by one function instead of repeated as a literal in every pack.
+var DefaultLogPath = endpointconfig.SystemLogPath()
 
 type File struct {
 	Name    string

--- a/cli/beacon/internal/endpoint/writer/writer.go
+++ b/cli/beacon/internal/endpoint/writer/writer.go
@@ -9,13 +9,13 @@ import (
 	"strconv"
 	"strings"
 
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
 	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve/filelock"
 )
 
 const (
-	SystemLogPath         = "/var/log/beacon-agent/runtime.jsonl"
 	UserLogPath           = ".beacon/endpoint/logs/runtime.jsonl"
 	MaxEventBytes         = 64 * 1024
 	DefaultRotateBytes    = 10 * 1024 * 1024
@@ -32,6 +32,12 @@ type Options struct {
 	RotateArchives int
 }
 
+// SystemLogPath is the system-mode runtime log, resolved per platform.
+//
+// Delegated rather than duplicated: this was one of fourteen copies of the same literal, and the
+// copies could not be given a Windows value independently without disagreeing.
+func SystemLogPath() string { return endpointconfig.SystemLogPath() }
+
 func DefaultPath(userMode bool) string {
 	if userMode {
 		home, err := os.UserHomeDir()
@@ -40,7 +46,7 @@ func DefaultPath(userMode bool) string {
 		}
 		return filepath.Join(home, UserLogPath)
 	}
-	return SystemLogPath
+	return SystemLogPath()
 }
 
 func AppendEvent(event schema.Event, opts Options) (string, error) {

--- a/cli/beacon/internal/testenv/testenv.go
+++ b/cli/beacon/internal/testenv/testenv.go
@@ -1,0 +1,25 @@
+// Package testenv holds environment helpers shared by tests across the CLI.
+//
+// It exists for one recurring mistake. Redirecting the home directory with t.Setenv("HOME", dir)
+// is a POSIX-only redirect: os.UserHomeDir reads USERPROFILE on Windows, so a test that sets only
+// HOME there silently keeps using the real profile. That is worse than a plain failure -- tests
+// write into the developer's actual ~/.beacon and then observe each other's state, which is how
+// several of them came to report "nothing installed yet" while finding an install.
+//
+// Importing testing from a non-test file is deliberate: only _test.go files import this package,
+// so nothing reaches a shipped binary, and the alternative -- a copy of SetHome in every package
+// that needs it -- is what produced the inconsistency in the first place.
+package testenv
+
+import "testing"
+
+// SetHome redirects the user's home directory for the duration of a test, on every platform.
+//
+// Both variables are set because different code reaches for different ones: os.UserHomeDir prefers
+// USERPROFILE on Windows and HOME elsewhere, while some callers read HOME directly. Setting only
+// one leaves whichever half of that split the caller happens to use pointing at the real profile.
+func SetHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+}

--- a/cli/beacon/internal/testenv/testenv.go
+++ b/cli/beacon/internal/testenv/testenv.go
@@ -11,7 +11,10 @@
 // that needs it -- is what produced the inconsistency in the first place.
 package testenv
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 // SetHome redirects the user's home directory for the duration of a test, on every platform.
 //
@@ -22,4 +25,21 @@ func SetHome(t *testing.T, dir string) {
 	t.Helper()
 	t.Setenv("HOME", dir)
 	t.Setenv("USERPROFILE", dir)
+}
+
+// RequirePOSIXFileModes skips a test whose assertion is about Unix permission bits.
+//
+// Windows does not implement them: os.Chmod only toggles a read-only attribute, and Go reports
+// 0666 for any ordinary file. A mode assertion there is not merely unsupported, it is misleading --
+// it would either fail for a reason unrelated to the property or pass vacuously.
+//
+// The property these tests protect is real on both platforms: a config file holding a credential
+// must not be readable by other users. Windows expresses that as an ACL rather than a mode, so
+// this is the seam where a Windows equivalent belongs once the endpoint sets ACLs on the files it
+// writes. Skipping is honest in the meantime; asserting 0666 == 0600 would not be.
+func RequirePOSIXFileModes(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits do not exist on Windows; the equivalent is an ACL check")
+	}
 }

--- a/cli/beacon/internal/testenv/testenv.go
+++ b/cli/beacon/internal/testenv/testenv.go
@@ -12,6 +12,7 @@
 package testenv
 
 import (
+	"path/filepath"
 	"runtime"
 	"testing"
 )
@@ -25,6 +26,15 @@ func SetHome(t *testing.T, dir string) {
 	t.Helper()
 	t.Setenv("HOME", dir)
 	t.Setenv("USERPROFILE", dir)
+	if runtime.GOOS == "windows" {
+		// The per-user application directories are not derived from USERPROFILE by the programs
+		// that read them -- they have their own variables, and Windows sets all of them
+		// independently. Redirecting only the profile left anything resolving %APPDATA% (VS Code's
+		// settings, for one) writing into the developer's real roaming profile while the test
+		// believed it had been sandboxed.
+		t.Setenv("APPDATA", filepath.Join(dir, "AppData", "Roaming"))
+		t.Setenv("LOCALAPPDATA", filepath.Join(dir, "AppData", "Local"))
+	}
 }
 
 // RequirePOSIXFileModes skips a test whose assertion is about Unix permission bits.
@@ -41,5 +51,26 @@ func RequirePOSIXFileModes(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix permission bits do not exist on Windows; the equivalent is an ACL check")
+	}
+}
+
+// RequirePOSIXExecutableFixtures skips a test that stands in for a CLI with a shell script.
+//
+// Two things stop that working on Windows, and only one of them is the extension. exec.LookPath
+// resolves a bare name through PATHEXT, so a file written without one is invisible to it -- but
+// renaming the fixture to `codex.exe` fixes only the lookup. These tests then *execute* the stub to
+// read its --version output, and a `#!/bin/sh` file is not runnable on Windows whatever it is
+// called, because there are no shebangs. That is the difference from the collector fixtures, where
+// the extension alone was enough: discovery there only stats the file.
+//
+// Skipped rather than adapted because these tests are about discovery logic that is not
+// platform-specific, and the packages they live in are gated on Windows for their *path* handling.
+// A Windows fixture is possible -- copy the test binary and have TestMain impersonate the CLI, as
+// the service package does for its stub collector -- and is tracked in the Windows test-suite
+// issue rather than done here, where it would test nothing this change touches.
+func RequirePOSIXExecutableFixtures(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script executable fixtures cannot run on Windows; see the Windows test-suite issue")
 	}
 }

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -521,7 +521,19 @@ func NormalizeClaudeToolResult(event *Event, attrs map[string]interface{}) {
 	params := JSONMapAttr(attrs, "tool_parameters")
 
 	switch strings.ToLower(toolName) {
-	case "bash":
+	// PowerShell alongside Bash, because they are the same signal under different names.
+	//
+	// Claude Code ships a native PowerShell tool that replaces Bash as the default shell on
+	// Windows, and it reports the command in the same tool_input.command field. With only "bash"
+	// here the event was still classified as command.executed -- but with an empty
+	// e.command.command, which is the leaf every rules/risky-command/ rule matches on. Command
+	// threat detection was therefore silently disabled on Windows while the telemetry carried the
+	// command all along.
+	//
+	// This is the same failure Bash had before v1.0.6, recurring under a new tool name, which is
+	// why the match is a set rather than one more literal: a shell tool is whatever the runtime
+	// calls the thing that runs commands.
+	case "bash", "powershell", "pwsh":
 		command := claudeCommand(input, params)
 		event.Event.Action = "command.executed"
 		event.Event.Category = "command"

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
@@ -1148,3 +1148,42 @@ func TestHarnessNameHonorsBrowserExtensionAttr(t *testing.T) {
 		t.Errorf("HarnessName = %q, want claude_web", got)
 	}
 }
+
+// Claude Code ships a native PowerShell tool that replaces Bash as the default shell on Windows,
+// and it reports the command in the same tool_input.command field. Handling only "bash" left the
+// event classified as command.executed with an empty e.command.command -- the leaf every
+// rules/risky-command/ rule matches on -- so command threat detection was silently disabled on
+// Windows while the telemetry carried the command all along.
+//
+// The attributes below are copied from a real Windows session captured by the w00-probe scenario,
+// rather than invented, so this fails if the runtime's shape changes rather than only if the
+// mapping does.
+func TestClaudeShellToolsPopulateTheCommandDetectionSurface(t *testing.T) {
+	const want = `Write-Output 'BEACON_SANDBOX_2922d672fb2f' | Tee-Object -FilePath 'C:\beacon-sandbox\work\w00.sentinel'`
+
+	for _, toolName := range []string{"PowerShell", "pwsh", "Bash", "bash"} {
+		t.Run(toolName, func(t *testing.T) {
+			event := &Event{}
+			NormalizeClaudeToolResult(event, map[string]interface{}{
+				"tool_name":   toolName,
+				"tool_input":  `{"command":"` + strings.ReplaceAll(want, `\`, `\\`) + `","description":"write the sentinel"}`,
+				"duration_ms": int64(386),
+			})
+
+			if event.Event.Action != "command.executed" {
+				t.Fatalf("action = %q, want command.executed", event.Event.Action)
+			}
+			if event.Command == nil || event.Command.Command != want {
+				t.Fatalf("command.command = %#v, want %q -- this is the field every "+
+					"rules/risky-command/ rule matches on, so an empty value disables them all",
+					event.Command, want)
+			}
+			if event.Tool == nil || event.Tool.Command != want {
+				t.Errorf("tool.command = %#v, want the command mirrored", event.Tool)
+			}
+			if event.Command.DurationMS != 386 {
+				t.Errorf("duration_ms = %d, want 386", event.Command.DurationMS)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Follows #316, which made Beacon compile for Windows and gave us a way to test it there. This is the
next layer: the Windows filesystem contract, plus the test-suite groundwork that makes it verifiable
rather than merely written.

It also carries three real bug fixes that the Windows gate surfaced along the way — including one
that silently disabled command threat detection on Windows.

## The bug worth reading first

The Windows probe captured 21 events on its first successful run. One was wrong:

```
command.executed → tool: {"name": "PowerShell"}, command: null
```

while the telemetry carried the command all along:

```
tool_name:  PowerShell
tool_input: {"command":"Write-Output 'BEACON_SANDBOX_...' | Tee-Object -FilePath ..."}
```

Claude Code ships a native PowerShell tool that replaces Bash as the default shell on Windows and
reports the command in the same `tool_input.command` field. The exporter's normalizer matched only
`"bash"`, so the event was classified correctly as `command.executed` and then stripped of
`e.command.command` — **the leaf every `rules/risky-command/` rule matches on**. Command threat
detection was silently disabled on Windows.

This is the same failure Bash had before v1.0.6 ("the exporter only read flat attributes, so
`e.command.command` was always empty, which silently disabled every rules/risky-command/ rule"),
recurring under a new tool name. The match is now a set — `bash`, `powershell`, `pwsh` — because a
shell tool is whatever the runtime calls the thing that runs commands. The regression test is built
from the attributes of a real captured Windows session rather than invented ones, and was verified
in both directions: reverting the fix fails PowerShell and pwsh while leaving Bash passing.

## The main change

The system runtime log was the literal `/var/log/beacon-agent/runtime.jsonl` repeated in **fourteen
places** — every destination pack, the writer, the hook adapter's default, the inventory heartbeat
and the self-updater. Fourteen copies cannot disagree with each other on Linux, but they cannot be
given a Windows value either, so one function is what makes a second platform possible at all. Same
consolidation `SystemBaseDir` already performed for the config directory.

| Concept | macOS / Linux | Windows |
|---|---|---|
| System log dir | `/var/log/beacon-agent` *(unchanged)* | `%ProgramData%\Beacon\Endpoint\logs` |

The POSIX value is pinned by a test. It is where installed endpoints already write, where the
packaging scripts create directories, and what the forwarder packs tail — moving it would be a
migration rather than a refactor.

### A second bug the consolidation exposed

`endpointConfigPathForHook` decided whether a hook feeds a system-mode endpoint by matching the
prefixes `/var/log/` and `/Library/` — two platforms' locations and no Windows one. A Windows system
install would therefore have routed its hooks to the **user** config and pointed them at a log the
collector never reads, failing silently rather than loudly. It now compares against the resolved
directories, case-insensitively on Windows and separator-normalized, with a sibling-directory case
pinned so a path merely sharing a prefix is not treated as being underneath.

## Test-suite groundwork

The four packages this touches — `config`, `collector`, `harness`, `hooks` — were outside the
Windows gate, so anything written in them would have landed unverified on the platform it targets.
They are now scoped in, which required:

- **`testenv.SetHome`**, replacing 37 copies of `t.Setenv("HOME", dir)`. That is a POSIX-only
  redirect: `os.UserHomeDir` reads `USERPROFILE` on Windows, so those tests silently kept using the
  real profile, wrote into the developer's actual `~/.beacon`, and then observed each other's state
  — which is how several came to report "nothing installed yet" while finding an install.
- **`testenv.RequirePOSIXFileModes`** for assertions about Unix permission bits, which Windows does
  not implement. The property they protect (a credential-bearing config must not be world-readable)
  is real on both platforms; Windows expresses it as an ACL, and that is where its equivalent
  belongs.
- **Platform-correct discovery fixtures**, since `exec.LookPath` resolves through `PATHEXT` on
  Windows and a fixture written without an extension is invisible to it.

### A third bug, from widening the gate

```go
if info.Mode().Perm()&0111 == 0 { return fmt.Errorf("is not executable") }
```

Windows has no executable bits — Go reports `0666` for an ordinary file — so that test is false for
**every** file there, including a genuine `.exe`. `DiscoverBinary` would have rejected every
collector binary on Windows and reported none installed. Split per-OS.

## Harness fixes

Three, all found by running the thing:

- Claude Code installs to `~/.local/bin` on Windows, the same convention as the Linux image — not
  the `%LOCALAPPDATA%\Programs\claude` I had guessed. The install step now verifies the binary is
  where it was put and, on a miss, searches the profile and prints what it finds.
- `beacon ci exec`'s stderr is surfaced on failure. A probe run came back `rc=1` with no
  explanation because the session script tailed `ci-out.txt` and never `ci-err.txt`; the full output
  is now preserved to `ci-exec-output.txt` rather than truncated into metadata at 400 characters.
- A transient `gh` API failure no longer discards a healthy run — both poll loops retry to their
  deadline and keep the last error, so a real outage still reports its own cause.

## Deliberately not here

The `%ProgramData%` **ACL grant** and its doctor check. Windows denies ordinary users write access
to `%ProgramData%` by default, so a system-mode install must grant it explicitly or hooks fail
silently while Beacon reports itself healthy. That needs a real effective-access check rather than a
mode assertion, and it is the next commit rather than a rushed one here.

Hook installation is still broken on Windows (`endpointCommandPrefix` emits a POSIX `VAR=value cmd`
string neither Windows shell accepts), so capture through hooks does not work yet. Windows remains
absent from `.goreleaser.yaml` for that reason.

## Verification

Full gate, host and Windows, across all five modules — `gofmt`, `go build`, `go vet`, `go test` for
the host; `go build` and `go vet` for `GOOS=windows` — plus `go test -race ./internal/endpoint/...`.

The Windows gate now covers nine packages, up from five.

Known: the probe is **flaky**. One run captured 0 events with `ci_exec_rc=1`; the next captured 21
and passed, with no capture-affecting change between them. Probably a collector startup or flush
race, and worth chasing before anyone trusts a green Windows run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches system log paths, hook config selection, collector discovery, and security-relevant command normalization across platforms; changes are well-tested but affect endpoint install layout and threat-detection telemetry on Windows.
> 
> **Overview**
> This PR lands the **Windows filesystem contract** for system-mode endpoints: `%ProgramData%\Beacon\Endpoint` for state and logs (replacing fourteen hardcoded `/var/log/beacon-agent` literals), plus **hook routing** that keys off resolved system directories instead of POSIX `/var/log/` and `/Library/` prefixes so system logs do not silently point hooks at user config.
> 
> **Production fixes** include Windows-aware collector executable checks (POSIX `0111` rejected every `.exe`), hook detection on `beacon-hooks` stem (with or without `.exe`), and exporter normalization for Claude **PowerShell/pwsh** tools so `e.command.command` is populated and `rules/risky-command/` works on Windows.
> 
> **CI and sandbox** changes widen Windows `go test` to `config`, `collector`, `harness`, and `hooks`; add shared `testenv` helpers (`SetHome`, POSIX skips, `.exe` fixtures); fix Claude install PATH to `~/.local\bin` with post-install verification; surface `beacon ci exec` stderr and full failure output; and retry transient `gh` API errors while polling workflow runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3dc86a3cef81e5846282811b50673e4d8153648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->