### PR TITLE
feat(windows): run the collector as a Windows service

### DIFF
--- a/.github/workflows/windows-sandbox.yml
+++ b/.github/workflows/windows-sandbox.yml
@@ -169,6 +169,69 @@ jobs:
           }
           Write-Output "claude installed at $claudeExe"
 
+      # Phase 3 registers beacon-otelcol.exe with the Service Control Manager directly, on the
+      # strength of the builder-generated main_windows.go calling svc.Run(otelcol.NewSvcHandler).
+      # That is an assumption about a code path nothing has exercised: running the binary as an
+      # ordinary child process proves it starts, not that it speaks the SCM control protocol. A
+      # service that never reaches the dispatcher is killed after about 30 seconds, so getting this
+      # wrong means the backend needs a service host rather than a direct registration -- a
+      # different design, and much cheaper to learn now than after it is written.
+      - name: Can the collector run as a Windows service
+        id: scm
+        continue-on-error: true
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $svc = 'BeaconCollectorScmProbe'
+          $dir = 'C:\beacon-sandbox\scm'
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          $logPath = Join-Path $dir 'runtime.jsonl'
+          $cfgPath = Join-Path $dir 'otelcol.yaml'
+
+          # Built line by line rather than with a here-string: a here-string's body has to start at
+          # column zero, which is outside a YAML block scalar.
+          $cfg = @(
+            'receivers:'
+            '  otlp:'
+            '    protocols:'
+            '      grpc:'
+            '        endpoint: 127.0.0.1:14317'
+            'exporters:'
+            '  beaconjson:'
+            ('    path: ' + (ConvertTo-Json $logPath))
+            'service:'
+            '  pipelines:'
+            '    logs:'
+            '      receivers: [otlp]'
+            '      exporters: [beaconjson]'
+          )
+          Set-Content -LiteralPath $cfgPath -Value $cfg -Encoding utf8
+
+          # binPath is a single string with the arguments inside it, and the exe quoted, or the SCM
+          # splits it on the first space in the path.
+          $bin = 'C:\beacon-sandbox\bin\beacon-otelcol.exe'
+          & sc.exe create $svc binPath= "`"$bin`" --config `"$cfgPath`"" start= demand | Out-Null
+          & sc.exe start $svc | Out-Null
+
+          # Polled rather than read from the start command's status: a service that fails to reach
+          # the dispatcher is killed by the SCM, which start does not report.
+          $state = ''
+          foreach ($i in 1..15) {
+            Start-Sleep -Seconds 2
+            $q = & sc.exe query $svc 2>&1 | Out-String
+            if ($q -match 'STATE\s+:\s+\d+\s+(\w+)') { $state = $Matches[1] }
+            if ($state -eq 'RUNNING' -or $state -eq 'STOPPED') { break }
+          }
+          Write-Output "SCM_STATE=$state"
+          & sc.exe query $svc 2>&1 | Out-String | Write-Output
+
+          & sc.exe stop $svc 2>&1 | Out-Null
+          & sc.exe delete $svc 2>&1 | Out-Null
+
+          if ($state -ne 'RUNNING') {
+            throw "beacon-otelcol.exe did not reach RUNNING under the SCM (state=$state): Phase 3 would need a service host rather than direct registration"
+          }
+          Write-Output 'the collector runs as a Windows service with no wrapper'
+
       - name: Report the environment the probe ran in
         run: |
           Write-Output "pwsh: $($PSVersionTable.PSVersion)"

--- a/beacon-sandbox/scenarios/w01-install-service.yaml
+++ b/beacon-sandbox/scenarios/w01-install-service.yaml
@@ -1,0 +1,45 @@
+id: w01-install-service
+platform: windows
+# Exercises `beacon endpoint install --system` on Windows: does it register a service with the
+# Service Control Manager, does that service reach running, and does the endpoint report the
+# backend it actually selected?
+#
+# The service question is settled before the agent is involved. expect_service_kind is what makes
+# this scenario mean what it claims: "running" alone is satisfied by the supervised fallback too,
+# so without it a host where SCM registration failed would pass while testing the wrong backend
+# entirely -- the same trap the Linux systemd scenario documents.
+#
+# Capture is asserted only optionally, and that is deliberate rather than lax. Hook installation on
+# Windows still emits a POSIX `VAR=value cmd` string that neither Windows shell accepts, so nothing
+# reaches the collector through hooks yet. Marking these required would make the scenario fail for
+# a known reason and stop it reporting the service facts it exists to establish. They become
+# required in the change that fixes the hook command format.
+prompt: >-
+  Run exactly this PowerShell command and then report its output verbatim:
+  Write-Output '{{canary}}' | Tee-Object -FilePath '{{sentinel}}'
+sentinel: '{{workdir}}\w01.sentinel'
+budget_usd: 1.0
+timeout_seconds: 420
+
+install:
+  mode: system
+  service: windows-service
+  expect_status_running: true
+  expect_service_kind: windows-service
+
+expect:
+  - action: prompt.submitted
+    contains: ["{{canary}}"]
+    optional: true
+    why: >-
+      Capture through an installed Windows endpoint. Optional until hook installation emits a
+      command Windows can execute; the service assertions above are what this scenario gates on
+      today, and they are checked before the session runs.
+
+  - action: command.executed
+    fields: ["command.command"]
+    optional: true
+    why: >-
+      e.command.command is the detection surface for the whole rules/risky-command/ category. The
+      exporter now reads it from Claude Code's PowerShell tool, so this is the assertion that will
+      prove the fix end to end once hooks deliver events at all.

--- a/beacon-sandbox/scenarios/w02-install-supervised.yaml
+++ b/beacon-sandbox/scenarios/w02-install-supervised.yaml
@@ -1,0 +1,32 @@
+id: w02-install-supervised
+platform: windows
+# User-mode install on Windows, which is the supervised backend rather than a second service.
+#
+# Windows has no per-user service manager -- no equivalent of `systemctl --user` or launchd's
+# gui/<uid> domain -- so `--user` falls back to a detached child tracked by a pidfile. That is a
+# real limitation, and this scenario exists to pin it: expect_service_kind asserts the fallback
+# actually happened rather than a service being registered under the user's name, which is what a
+# future change to the routing would silently do.
+#
+# The honest consequence, which status reports in-band: nothing restarts this collector, and it
+# does not survive logout.
+prompt: >-
+  Run exactly this PowerShell command and then report its output verbatim:
+  Write-Output '{{canary}}' | Tee-Object -FilePath '{{sentinel}}'
+sentinel: '{{workdir}}\w02.sentinel'
+budget_usd: 1.0
+timeout_seconds: 420
+
+install:
+  mode: user
+  expect_status_running: true
+  expect_service_kind: none
+
+expect:
+  - action: prompt.submitted
+    contains: ["{{canary}}"]
+    optional: true
+    why: >-
+      Same reason as w01: hook installation on Windows does not yet emit a command Windows can
+      execute, so capture is recorded rather than gated. The backend selection above is what this
+      scenario asserts today.

--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -979,8 +979,24 @@ func actionForCheck(check diagnostics.Check, runtimeLog lifecycle.RuntimeLogSour
 	case "runtime_log":
 		return "beacon endpoint doctor --fix"
 	case "runtime_log_permissions":
-		if check.Evidence == "runtime_log_missing" || check.Evidence == "missing_optional_file" {
+		// Branch on evidence rather than falling through to chmod. Windows reaches this check too
+		// now, and chmod neither exists there nor would restore an ACL if it did -- so the single
+		// most consequential remediation string on that platform, the one printed for a system-mode
+		// log that hooks cannot write, was advice that could not work.
+		switch check.Evidence {
+		case "runtime_log_missing", "missing_optional_file":
 			return "beacon endpoint doctor --fix"
+		case "acl_missing_interactive_write":
+			// Printed rather than only offered through --fix: this one needs an elevated shell, and
+			// an operator who cannot elevate right now still deserves to know the exact command.
+			if hint := writer.GrantCommandHint(check.Target); hint != "" {
+				return hint
+			}
+			return "beacon endpoint doctor --fix"
+		case "acl_not_writable_by_user":
+			return "grant your account write access to " + check.Target
+		case "acl_unreadable":
+			return "inspect the access control list on " + check.Target
 		}
 		return "chmod 666 " + check.Target
 	case "runtime_log_source":
@@ -1130,10 +1146,28 @@ func planDoctorFixes(result doctorResult, status lifecycle.Status) doctorFixPlan
 		}
 		switch check.Name {
 		case "runtime_log", "runtime_log_permissions", "last_event":
-			if check.Evidence == "missing_optional_file" || check.Evidence == "runtime_log_missing" {
+			switch check.Evidence {
+			case "missing_optional_file", "runtime_log_missing":
 				addFix(plannedAction{Action: "create_runtime_log", Target: status.LogPath, Message: "create runtime log file and parent directory"})
-			} else if check.Evidence == "last_event_missing" {
+			case "last_event_missing":
 				addSkip(plannedAction{Action: "manual_fix", Target: check.Target, Message: "run beacon endpoint test-event or generate a runtime event"})
+			// The one permission failure that is repairable in place, and the one that matters
+			// most: without this grant a system-mode Windows endpoint runs a healthy collector
+			// that records nothing an agent did, because hooks cannot write to its log.
+			case "acl_missing_interactive_write":
+				addFix(plannedAction{Action: "grant_log_access", Target: check.Target, Message: "grant interactive users write access to the log directory"})
+			default:
+				// Anything else here is a permission problem doctor cannot repair. Reported as a
+				// skip rather than dropped: falling out of this switch is how a broken systemd unit
+				// once produced neither a fix nor a skip, and a check that silently repairs nothing
+				// reads exactly like a check that found nothing.
+				if check.Name == "runtime_log_permissions" {
+					message := "review the log permissions manually"
+					if check.Action != "" {
+						message = "run " + check.Action
+					}
+					addSkip(plannedAction{Action: "manual_fix", Target: check.Target, Message: message})
+				}
 			}
 		// systemd_unit belongs here alongside launchd_plist: diagnostics emits whichever the
 		// resolved backend uses, and omitting it meant a broken systemd unit produced neither a
@@ -1181,6 +1215,12 @@ func applyDoctorFixes(plan doctorFixPlan, status lifecycle.Status) error {
 			}
 		case "repair_collector_service":
 			if err := repairCollectorServiceFromStatus(status); err != nil {
+				errs = append(errs, fmt.Errorf("%s %s: %w", action.Action, action.Target, err))
+			}
+		case "grant_log_access":
+			// The same call install makes, so a repaired endpoint and a fresh one end up with the
+			// same ACL rather than two grants that drift.
+			if err := writer.EnsureSystemLogWritable(action.Target); err != nil {
 				errs = append(errs, fmt.Errorf("%s %s: %w", action.Action, action.Target, err))
 			}
 		}

--- a/cli/beacon/cmd/endpoint_diagnostics_action_test.go
+++ b/cli/beacon/cmd/endpoint_diagnostics_action_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/diagnostics"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
+)
+
+// TestLogPermissionRemediationMatchesThePlatformThatFailed guards advice, which is the part of
+// doctor nobody tests and everybody follows.
+//
+// The check used to end in an unconditional `chmod 666`. That was right while only POSIX reached
+// it. Windows reaches it now, where chmod does not exist and would not restore an ACL if it did --
+// so the most consequential line doctor prints there, the remediation for a system-mode log that
+// hooks cannot write, was a command that cannot work. A wrong fix is worse than none: the operator
+// runs it, nothing changes, and the next thing they doubt is the diagnosis.
+func TestLogPermissionRemediationMatchesThePlatformThatFailed(t *testing.T) {
+	action := func(evidence string) string {
+		return actionForCheck(diagnostics.Check{
+			Name:     "runtime_log_permissions",
+			Target:   `C:\ProgramData\Beacon\Endpoint\logs`,
+			Evidence: evidence,
+		}, lifecycle.RuntimeLogSource{})
+	}
+
+	// Every ACL evidence is Windows-only by construction, so none of them may produce POSIX advice.
+	for _, evidence := range []string{
+		"acl_missing_interactive_write",
+		"acl_not_writable_by_user",
+		"acl_unreadable",
+	} {
+		got := action(evidence)
+		if got == "" {
+			t.Fatalf("evidence %q produced no remediation at all", evidence)
+		}
+		if strings.Contains(got, "chmod") {
+			t.Fatalf("evidence %q suggests %q; chmod does not exist on Windows and would not "+
+				"restore an ACL if it did", evidence, got)
+		}
+	}
+
+	// The system-mode grant is the one that decides whether an endpoint captures anything, so its
+	// advice has to be the actual command, not a gesture at the problem.
+	grant := action("acl_missing_interactive_write")
+	if runtime.GOOS == "windows" {
+		if !strings.Contains(grant, "icacls") || !strings.Contains(grant, "S-1-5-4") {
+			t.Fatalf("the missing-grant remediation is %q; it should be the icacls command that "+
+				"restores the grant, naming the well-known SID rather than a localized account name", grant)
+		}
+	} else if grant != "beacon endpoint doctor --fix" {
+		// No such grant exists here, so the hint is empty and the advice falls back to the command
+		// that does apply. Printing an icacls line on a Mac would be worse than saying nothing.
+		t.Fatalf("off Windows the missing-grant remediation is %q, want the doctor --fix fallback", grant)
+	}
+
+	if runtime.GOOS != "windows" {
+		if got := action("not_writable"); got != `chmod 666 C:\ProgramData\Beacon\Endpoint\logs` {
+			t.Fatalf("the POSIX mode remediation changed: %q", got)
+		}
+	}
+
+	if got := action("runtime_log_missing"); got != "beacon endpoint doctor --fix" {
+		t.Fatalf("missing-log remediation = %q", got)
+	}
+}

--- a/cli/beacon/internal/endpoint/diagnostics/diagnostics.go
+++ b/cli/beacon/internal/endpoint/diagnostics/diagnostics.go
@@ -159,7 +159,10 @@ func checkLogWritableByThisUser(path string) Check {
 		return Check{Name: "runtime_log_permissions", Target: path, Status: StatusFail,
 			Severity: SeverityHigh,
 			Message:  "the runtime log is not writable by this user: " + err.Error(),
-			Evidence: "not_writable"}
+			// Distinct from the POSIX not_writable on purpose. Evidence strings are what decide the
+			// remediation doctor prints and what fleet tooling keys on, and the two have nothing in
+			// common but the symptom: one is fixed by chmod, which does not exist here.
+			Evidence: "acl_not_writable_by_user"}
 	}
 	_ = f.Close()
 	return Check{Name: "runtime_log_permissions", Target: path, Status: StatusOK,

--- a/cli/beacon/internal/endpoint/diagnostics/diagnostics.go
+++ b/cli/beacon/internal/endpoint/diagnostics/diagnostics.go
@@ -39,7 +39,7 @@ func Run(cfg endpointconfig.Config) []Check {
 		checkFile("config", endpointconfig.ConfigPath(cfg.UserMode), true),
 		checkFile("collector_config", cfg.Collector.ConfigPath, true),
 		checkFile("runtime_log", cfg.LogPath, false),
-		checkLogPermissions(cfg.LogPath),
+		checkLogPermissions(cfg.LogPath, cfg.UserMode),
 		checkCollectorHealth(cfg),
 	}
 	// The service definition check is named after whichever manager is actually in use, so
@@ -118,12 +118,18 @@ func checkFile(name, path string, required bool) Check {
 	return Check{Name: name, Target: path, Status: StatusOK, Severity: SeverityInfo, Message: path, Evidence: "file_exists"}
 }
 
-func checkLogPermissions(path string) Check {
+func checkLogPermissions(path string, userMode bool) Check {
 	info, err := os.Stat(path)
 	if err != nil {
 		return Check{Name: "runtime_log_permissions", Target: path, Status: StatusWarn, Severity: SeverityLow, Message: "runtime log not created yet", Evidence: "runtime_log_missing"}
 	}
 	if runtime.GOOS == "windows" {
+		// The two scopes fail differently there, so they are asked different questions. Only a
+		// system-mode install has a privileged writer and unprivileged hooks; a user-mode log lives
+		// in that user's own profile and is written by processes running as them.
+		if userMode {
+			return checkLogWritableByThisUser(path)
+		}
 		return checkLogACL(path)
 	}
 	mode := info.Mode().Perm()
@@ -136,8 +142,33 @@ func checkLogPermissions(path string) Check {
 	return Check{Name: "runtime_log_permissions", Target: path, Status: StatusOK, Severity: SeverityInfo, Message: fmt.Sprintf("mode %o", mode), Evidence: fmt.Sprintf("mode_%o", mode)}
 }
 
-// checkLogACL is the Windows form of the same question: can the people whose sessions this
-// endpoint captures write to its log?
+// checkLogWritableByThisUser is the user-mode Windows form of the question.
+//
+// The INTERACTIVE grant that system mode installs is deliberately absent here: a user-mode log
+// holds that person's prompt text, and widening its ACL to every interactive account would hand it
+// to anyone else who logs on. Running the system-mode check anyway would report a high-severity
+// failure on every correctly configured user-mode endpoint -- a doctor that cries wolf on the
+// normal case is one nobody reads when it finally has something to say.
+//
+// A test write is the right instrument in this scope, and only in this scope. The trap it falls
+// into in system mode -- doctor runs elevated, so it proves access for a user whose access was
+// never in question -- does not apply when the hooks run as the same person doctor does.
+func checkLogWritableByThisUser(path string) Check {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		return Check{Name: "runtime_log_permissions", Target: path, Status: StatusFail,
+			Severity: SeverityHigh,
+			Message:  "the runtime log is not writable by this user: " + err.Error(),
+			Evidence: "not_writable"}
+	}
+	_ = f.Close()
+	return Check{Name: "runtime_log_permissions", Target: path, Status: StatusOK,
+		Severity: SeverityInfo, Message: "the runtime log is writable by this user",
+		Evidence: "writable_by_owner"}
+}
+
+// checkLogACL is the system-mode Windows form of the same question: can the people whose sessions
+// this endpoint captures write to its log?
 //
 // The mode-bit check above cannot answer it there. Windows reports 0666 for any ordinary file
 // regardless of its ACL, so `mode&0222 == 0` is never true and the check would report OK for

--- a/cli/beacon/internal/endpoint/diagnostics/diagnostics.go
+++ b/cli/beacon/internal/endpoint/diagnostics/diagnostics.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"path/filepath"
+	"runtime"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/collector"
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/service"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/writer"
 )
 
 type Check struct {
@@ -120,6 +123,9 @@ func checkLogPermissions(path string) Check {
 	if err != nil {
 		return Check{Name: "runtime_log_permissions", Target: path, Status: StatusWarn, Severity: SeverityLow, Message: "runtime log not created yet", Evidence: "runtime_log_missing"}
 	}
+	if runtime.GOOS == "windows" {
+		return checkLogACL(path)
+	}
 	mode := info.Mode().Perm()
 	if mode&0222 == 0 {
 		return Check{Name: "runtime_log_permissions", Target: path, Status: StatusFail, Severity: SeverityHigh, Message: fmt.Sprintf("runtime log is not writable: %o", mode), Evidence: "not_writable"}
@@ -128,4 +134,37 @@ func checkLogPermissions(path string) Check {
 		return Check{Name: "runtime_log_permissions", Target: path, Status: StatusWarn, Severity: SeverityLow, Message: fmt.Sprintf("runtime log may not be readable by Wazuh: %o", mode), Evidence: "not_group_or_world_readable"}
 	}
 	return Check{Name: "runtime_log_permissions", Target: path, Status: StatusOK, Severity: SeverityInfo, Message: fmt.Sprintf("mode %o", mode), Evidence: fmt.Sprintf("mode_%o", mode)}
+}
+
+// checkLogACL is the Windows form of the same question: can the people whose sessions this
+// endpoint captures write to its log?
+//
+// The mode-bit check above cannot answer it there. Windows reports 0666 for any ordinary file
+// regardless of its ACL, so `mode&0222 == 0` is never true and the check would report OK for
+// exactly the configuration it exists to catch -- a %ProgramData% log that only administrators can
+// write, with every hook write failing silently.
+//
+// Read from the ACL rather than by attempting a write, because doctor usually runs elevated: a
+// test write would succeed for the very user whose access is not in question.
+func checkLogACL(path string) Check {
+	dir := filepath.Dir(path)
+	ok, err := writer.SystemLogWritableByUsers(dir)
+	switch {
+	case err != nil:
+		// Unknown is reported as unknown. Claiming either answer here would be worse than saying
+		// the check could not run.
+		return Check{Name: "runtime_log_permissions", Target: dir, Status: StatusWarn,
+			Severity: SeverityLow, Message: "could not read the log directory ACL: " + err.Error(),
+			Evidence: "acl_unreadable"}
+	case !ok:
+		return Check{Name: "runtime_log_permissions", Target: dir, Status: StatusFail,
+			Severity: SeverityHigh,
+			Message: "interactive users cannot write to the log directory, so agent hooks will " +
+				"fail silently while the collector reports healthy",
+			Evidence: "acl_missing_interactive_write"}
+	default:
+		return Check{Name: "runtime_log_permissions", Target: dir, Status: StatusOK,
+			Severity: SeverityInfo, Message: "interactive users may write to the log directory",
+			Evidence: "acl_interactive_write"}
+	}
 }

--- a/cli/beacon/internal/endpoint/diagnostics/diagnostics_test.go
+++ b/cli/beacon/internal/endpoint/diagnostics/diagnostics_test.go
@@ -7,6 +7,7 @@ import (
 
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/service"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 )
 
 func TestCheckFileRequiredOptionalAndDirectory(t *testing.T) {
@@ -33,38 +34,41 @@ func TestCheckFileRequiredOptionalAndDirectory(t *testing.T) {
 }
 
 func TestCheckLogPermissions(t *testing.T) {
+	// Mode bits are the POSIX form of this question; Windows answers it through the ACL and the
+	// per-user write test instead, both of which need a real Windows host to exercise.
+	testenv.RequirePOSIXFileModes(t)
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "runtime.jsonl")
 
-	if check := checkLogPermissions(logPath); check.Status != "warn" || check.Severity != "low" {
+	if check := checkLogPermissions(logPath, false); check.Status != "warn" || check.Severity != "low" {
 		t.Fatalf("missing log permissions check = %#v", check)
 	}
 
 	if err := os.WriteFile(logPath, []byte("{}\n"), 0644); err != nil {
 		t.Fatalf("write log: %v", err)
 	}
-	if check := checkLogPermissions(logPath); check.Status != "ok" {
+	if check := checkLogPermissions(logPath, false); check.Status != "ok" {
 		t.Fatalf("0644 log permissions check = %#v", check)
 	}
 
 	if err := os.Chmod(logPath, 0666); err != nil {
 		t.Fatalf("chmod writable log: %v", err)
 	}
-	if check := checkLogPermissions(logPath); check.Status != "ok" {
+	if check := checkLogPermissions(logPath, false); check.Status != "ok" {
 		t.Fatalf("0666 log permissions check = %#v", check)
 	}
 
 	if err := os.Chmod(logPath, 0200); err != nil {
 		t.Fatalf("chmod unreadable log: %v", err)
 	}
-	if check := checkLogPermissions(logPath); check.Status != "warn" || check.Severity != "low" {
+	if check := checkLogPermissions(logPath, false); check.Status != "warn" || check.Severity != "low" {
 		t.Fatalf("0200 log permissions check = %#v", check)
 	}
 
 	if err := os.Chmod(logPath, 0444); err != nil {
 		t.Fatalf("chmod non-writable log: %v", err)
 	}
-	if check := checkLogPermissions(logPath); check.Status != "fail" || check.Severity != "high" || check.Evidence != "not_writable" {
+	if check := checkLogPermissions(logPath, false); check.Status != "fail" || check.Severity != "high" || check.Evidence != "not_writable" {
 		t.Fatalf("0444 log permissions check = %#v", check)
 	}
 }

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -294,7 +294,7 @@ func Uninstall(opts UninstallOptions) error {
 	// container would otherwise leave the unit enabled, and "uninstall" has to mean nothing
 	// is left behind. Unload already tolerates a backend that is unusable here.
 	manager := service.Manager{UserMode: cfg.UserMode}
-	for _, kind := range []service.Kind{service.KindLaunchd, service.KindSystemd, service.KindSupervised} {
+	for _, kind := range service.ManagedKinds() {
 		_ = (service.Manager{UserMode: cfg.UserMode, Kind: kind}).Unload()
 	}
 	if !cfg.UserMode && !opts.KeepUpdater {

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -182,6 +182,24 @@ func Install(opts InstallOptions) (InstallResult, error) {
 		LogPath:      cfg.LogPath,
 	}
 
+	// Make the log directory writable by the people whose sessions this endpoint captures, before
+	// anything writes to it.
+	//
+	// A no-op on POSIX, where the file mode carries the same guarantee. On Windows a system-mode
+	// log lives under %ProgramData%, which denies ordinary users write access -- and hooks run as
+	// the console user. Skipping this produces an install where every visible signal is healthy
+	// (the service runs, status and doctor agree) and nothing the agent does is ever recorded,
+	// because all of those describe the collector rather than the hooks exporting to it.
+	//
+	// Only for system mode: a user-mode log lives in that user's own profile, which they can
+	// already write, and widening its ACL would hand their prompt text to every interactive
+	// account on the machine.
+	if !cfg.UserMode {
+		if err := writer.EnsureSystemLogWritable(filepath.Dir(cfg.LogPath)); err != nil {
+			return InstallResult{}, fmt.Errorf("prepare the log directory: %w", err)
+		}
+	}
+
 	tx := newInstallRollback(manager)
 	tx.Track(cfg.Collector.ConfigPath)
 	manifest.Files = append(manifest.Files, cfg.Collector.ConfigPath)

--- a/cli/beacon/internal/endpoint/service/kinds_test.go
+++ b/cli/beacon/internal/endpoint/service/kinds_test.go
@@ -1,0 +1,57 @@
+package service
+
+import "testing"
+
+// TestManagedKindsCoversEveryBackend is the guard on a failure that reports success.
+//
+// Uninstall unloads every kind in ManagedKinds. A backend that exists but is missing from the list
+// is not unloaded, so uninstall prints that it removed the endpoint while the service is still
+// registered and still starts at boot -- and there is nothing in the output to suggest otherwise.
+// The Windows service backend shipped that way until review caught it.
+//
+// Every spelling ParseKind accepts must resolve to a kind on the list, so adding a backend without
+// adding it here fails rather than silently leaking.
+func TestManagedKindsCoversEveryBackend(t *testing.T) {
+	managed := make(map[Kind]bool, len(ManagedKinds()))
+	for _, kind := range ManagedKinds() {
+		if managed[kind] {
+			t.Fatalf("ManagedKinds lists %q twice", kind)
+		}
+		managed[kind] = true
+	}
+
+	// Every accepted spelling, canonical and alias. KindAuto is excluded deliberately: it is a
+	// request to detect, not a backend, and Manager resolves it to one of these before unloading.
+	spellings := []string{
+		"launchd",
+		"systemd",
+		"none", "supervised",
+		"windows-service", "scm", "windows",
+	}
+	for _, spelling := range spellings {
+		kind, err := ParseKind(spelling)
+		if err != nil {
+			t.Fatalf("ParseKind(%q): %v", spelling, err)
+		}
+		if !managed[kind] {
+			t.Fatalf("ParseKind(%q) = %q, which ManagedKinds does not list; "+
+				"an endpoint installed under it would survive uninstall", spelling, kind)
+		}
+	}
+
+	// Each listed kind must resolve to a backend that agrees it is that kind. A typo in the list
+	// would otherwise unload nothing and still look right.
+	for _, kind := range ManagedKinds() {
+		for _, userMode := range []bool{false, true} {
+			got := (Manager{UserMode: userMode, Kind: kind}).backend()
+			if got == nil {
+				t.Fatalf("kind %q (userMode=%v) resolves to no backend", kind, userMode)
+			}
+			// Windows user mode intentionally routes to supervised: there is no per-user service
+			// manager to route it to. Every other pairing must round-trip.
+			if got.kind() != kind && !(kind == KindWindowsService && userMode) {
+				t.Fatalf("kind %q (userMode=%v) resolves to backend %q", kind, userMode, got.kind())
+			}
+		}
+	}
+}

--- a/cli/beacon/internal/endpoint/service/service.go
+++ b/cli/beacon/internal/endpoint/service/service.go
@@ -31,6 +31,13 @@ const (
 	// short lowercase names rather than launchd's reverse-DNS labels.
 	SystemdSystemUnit = "beacon-collector.service"
 	SystemdUserUnit   = "beacon-collector.service"
+
+	// WindowsServiceName is the SCM service name. Windows convention is a short PascalCase
+	// identifier rather than launchd's reverse-DNS label or systemd's unit filename.
+	WindowsServiceName = "BeaconCollector"
+	// WindowsServiceDisplayName is what an operator sees in services.msc, where the terse
+	// service name is not the column people read.
+	WindowsServiceDisplayName = "Beacon endpoint collector"
 )
 
 // Kind identifies which service manager backs a Manager.
@@ -47,6 +54,8 @@ const (
 	// KindSupervised is a detached child process tracked by a pidfile. No OS service
 	// manager is involved, so it works in containers, CI, and on systems without systemd.
 	KindSupervised Kind = "none"
+	// KindWindowsService is the Windows Service Control Manager.
+	KindWindowsService Kind = "windows-service"
 )
 
 // ParseKind validates a user-supplied service kind.
@@ -60,8 +69,10 @@ func ParseKind(s string) (Kind, error) {
 		return KindSystemd, nil
 	case KindSupervised, "supervised":
 		return KindSupervised, nil
+	case KindWindowsService, "scm", "windows":
+		return KindWindowsService, nil
 	default:
-		return "", fmt.Errorf("unsupported service kind %q; want auto, launchd, systemd, or none", s)
+		return "", fmt.Errorf("unsupported service kind %q; want auto, launchd, systemd, windows-service, or none", s)
 	}
 }
 
@@ -97,6 +108,8 @@ func (k Kind) ServiceNoun() string {
 		return "launchd service definition"
 	case KindSystemd:
 		return "systemd unit definition"
+	case KindWindowsService:
+		return "Windows service registration"
 	case KindSupervised:
 		return "supervised collector state (no service manager on this host)"
 	default:
@@ -159,6 +172,8 @@ func DetectKind() Kind {
 			return KindSystemd
 		}
 		return KindSupervised
+	case "windows":
+		return KindWindowsService
 	default:
 		return KindSupervised
 	}
@@ -177,6 +192,16 @@ func (m Manager) backend() backend {
 		return launchdBackend{}
 	case KindSystemd:
 		return systemdBackend{}
+	case KindWindowsService:
+		// User mode falls back to supervised, because Windows has no per-user service manager:
+		// there is no equivalent of `systemctl --user` or launchd's gui/<uid> domain. Reported
+		// honestly by the supervised backend's status rather than pretended around -- a user-mode
+		// collector there does not survive logout, and saying so is the whole point of having the
+		// supervised backend be a real answer instead of a failure.
+		if m.UserMode {
+			return supervisedBackend{}
+		}
+		return windowsBackend{}
 	default:
 		return supervisedBackend{}
 	}

--- a/cli/beacon/internal/endpoint/service/service.go
+++ b/cli/beacon/internal/endpoint/service/service.go
@@ -58,6 +58,18 @@ const (
 	KindWindowsService Kind = "windows-service"
 )
 
+// ManagedKinds is every concrete backend a Beacon install could be running under.
+//
+// Uninstall and repair unload all of them rather than only the one detection picks right now, so an
+// endpoint installed under one manager and removed under another leaves nothing registered. The
+// list lives here, beside the kinds themselves, because the bug it prevents is silent at the call
+// site: a backend added without being added to the caller's own list leaves a service running after
+// an uninstall that reported success, and nothing surfaces it until the machine is rebooted and the
+// collector comes back from the dead.
+func ManagedKinds() []Kind {
+	return []Kind{KindLaunchd, KindSystemd, KindSupervised, KindWindowsService}
+}
+
 // ParseKind validates a user-supplied service kind.
 func ParseKind(s string) (Kind, error) {
 	switch Kind(strings.ToLower(strings.TrimSpace(s))) {

--- a/cli/beacon/internal/endpoint/service/supervised.go
+++ b/cli/beacon/internal/endpoint/service/supervised.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -197,13 +198,32 @@ func (b supervisedBackend) status(userMode bool) Status {
 	status.Running = st.PID > 0 && processAlive(st.PID)
 	switch {
 	case status.Running:
-		status.Message = fmt.Sprintf("supervised pid %d (no automatic restart: no service manager)", st.PID)
+		status.Message = fmt.Sprintf("supervised pid %d (%s)", st.PID, supervisedCaveats(userMode))
 	case status.Loaded:
-		status.Message = "recorded but not running"
+		status.Message = "recorded but not running (" + supervisedCaveats(userMode) + ")"
 	default:
 		status.Message = "no supervised collector recorded"
 	}
 	return status
+}
+
+// supervisedCaveats names what this backend cannot promise, for status to report in-band.
+//
+// Stated wherever an installed collector is described, not only while one happens to be running:
+// an operator reading `endpoint status` on a configured-but-stopped endpoint is exactly the person
+// who needs to know nothing will start it again.
+//
+// Logout is a Windows-only caveat and is named only there, because it is only true there. A
+// detached process on POSIX has its own session -- that is what setsid buys -- and outlives the
+// login that started it. Windows terminates the session's processes at logoff, so a user-mode
+// collector there stops when the person walks away, which is a materially worse guarantee and one
+// they should not have to discover from an empty log.
+func supervisedCaveats(userMode bool) string {
+	const noRestart = "no automatic restart: no service manager"
+	if userMode && runtime.GOOS == "windows" {
+		return noRestart + "; does not survive logout"
+	}
+	return noRestart
 }
 
 // processAlive reports whether a pid is live.

--- a/cli/beacon/internal/endpoint/service/windows.go
+++ b/cli/beacon/internal/endpoint/service/windows.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// windowsBackend manages the collector through the Windows Service Control Manager.
+//
+// Mapping from the two backends it joins:
+//
+//	RunAtLoad / WantedBy=multi-user.target -> StartType automatic, plus an explicit Start
+//	KeepAlive / Restart=always             -> SCM recovery actions: restart, with a delay
+//	StandardOutPath / journal              -> the collector's own file logging; the SCM
+//	                                          captures no stdout, so there is nothing to redirect
+//	a plist or unit file                   -> no file at all; the definition lives in the
+//	                                          registry, which unitPath reports instead
+//
+// The collector is registered directly, with no service host in front of it. That is possible
+// because the builder-generated main_windows.go calls svc.Run(otelcol.NewSvcHandler(params)) and
+// falls back to running interactively when it is not launched by the SCM, so one binary serves
+// both. Whether it really speaks the control protocol is not taken on trust -- the Windows sandbox
+// registers a scratch service and polls for RUNNING before this backend is relied on.
+//
+// System mode only. Manager routes user mode to the supervised backend, because Windows has no
+// per-user service manager to route it to.
+type windowsBackend struct{}
+
+func (windowsBackend) kind() Kind { return KindWindowsService }
+
+func (windowsBackend) available() bool {
+	return runtime.GOOS == "windows"
+}
+
+func (windowsBackend) unsupportedReason() string {
+	if runtime.GOOS != "windows" {
+		return "Windows service management is available only on Windows"
+	}
+	// Reaching the SCM needs administrator rights. Reported as a reason rather than surfacing
+	// "Access is denied" from three call sites, since the fix is the same for all of them.
+	return "the Windows Service Control Manager could not be opened; run this from an elevated shell"
+}
+
+// label is the SCM service name. Both scopes report the same name because only system mode reaches
+// this backend at all -- user mode is routed to supervised before it gets here.
+func (windowsBackend) label(userMode bool) string { return WindowsServiceName }
+
+// unitPath reports the registry key that holds the service definition.
+//
+// There is no unit file to point at, and callers show this to a human, so naming where the
+// definition actually lives beats returning an error or an empty string. The supervised backend
+// makes the same trade by reporting its pidfile.
+func (windowsBackend) unitPath(userMode bool) (string, error) {
+	return `HKLM\SYSTEM\CurrentControlSet\Services\` + WindowsServiceName, nil
+}
+
+func (b windowsBackend) writeUnit(userMode bool, program, configPath string) (string, error) {
+	if !b.available() {
+		return "", fmt.Errorf("%s", b.unsupportedReason())
+	}
+	if err := createOrUpdateService(program, configPath); err != nil {
+		return "", err
+	}
+	return b.unitPath(userMode)
+}
+
+func (b windowsBackend) load(userMode bool) error {
+	if !b.available() {
+		return fmt.Errorf("%s", b.unsupportedReason())
+	}
+	return startService()
+}
+
+// unload stops and deletes the service, tolerating its absence.
+//
+// Uninstall and repair both call this speculatively, so a missing service is success rather than
+// an error -- the same contract the launchd and systemd backends keep.
+func (b windowsBackend) unload(userMode bool) error {
+	if !b.available() {
+		return nil
+	}
+	return removeService()
+}
+
+func (b windowsBackend) restart(userMode bool) error {
+	if !b.available() {
+		return fmt.Errorf("%s", b.unsupportedReason())
+	}
+	return restartService()
+}
+
+func (b windowsBackend) status(userMode bool) Status {
+	status := Status{Label: WindowsServiceName}
+	if !b.available() {
+		status.Message = b.unsupportedReason()
+		return status
+	}
+	return queryService()
+}

--- a/cli/beacon/internal/endpoint/service/windows_other.go
+++ b/cli/beacon/internal/endpoint/service/windows_other.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package service
+
+import "fmt"
+
+// The Service Control Manager exists only on Windows, so these report rather than pretend.
+//
+// windowsBackend.available() already gates every one of them, and Manager checks available()
+// before dispatching -- so reaching one of these means a caller constructed the backend directly
+// with an explicit --service=windows-service on the wrong platform. That deserves the same
+// actionable error the launchd backend gives off macOS, not a silent no-op: an install that
+// reports success while registering nothing is the failure mode this whole package is shaped
+// around avoiding.
+
+func errNotWindows(action string) error {
+	return fmt.Errorf("cannot %s a Windows service on this platform; "+
+		"use --service=auto, or systemd/launchd/none as appropriate", action)
+}
+
+func createOrUpdateService(program, configPath string) error { return errNotWindows("register") }
+
+func startService() error { return errNotWindows("start") }
+
+// removeService is the one exception, and deliberately so: uninstall and repair call unload
+// speculatively on every backend, and failing there would block removing an endpoint that was
+// never a Windows service to begin with.
+func removeService() error { return nil }
+
+func restartService() error { return errNotWindows("restart") }
+
+func queryService() Status {
+	return Status{
+		Label:   WindowsServiceName,
+		Message: "Windows service management is available only on Windows",
+	}
+}

--- a/cli/beacon/internal/endpoint/service/windows_scm.go
+++ b/cli/beacon/internal/endpoint/service/windows_scm.go
@@ -107,8 +107,20 @@ func setRecoveryActions(s *mgr.Service) error {
 // CreateService takes the executable and its arguments separately and quotes them itself, but
 // UpdateConfig takes one string, so the quoting is ours to get right. An unquoted path breaks at
 // the first space -- and the default install location is under %ProgramFiles%, which contains one.
+//
+// Escaped exactly the way CreateService escapes, by calling the same function it calls. Go's %q is
+// the wrong tool and fails in a way that only shows up on the upgrade path: it doubles every
+// backslash, so `C:\Program Files\Beacon\bin\beacon-otelcol.exe` is written to the registry as
+// `C:\\Program Files\\...`, which the SCM does not unescape. A fresh install would work, the
+// upgrade would report success, and the service would fail to start after the next reboot with a
+// file-not-found the operator has no reason to connect to an upgrade. Sharing the escaper also
+// means create and update cannot drift apart.
 func serviceBinaryPath(program, configPath string) string {
-	return fmt.Sprintf("%q --config %q", program, configPath)
+	parts := make([]string, 0, 3)
+	for _, arg := range []string{program, "--config", configPath} {
+		parts = append(parts, windows.EscapeArg(arg))
+	}
+	return strings.Join(parts, " ")
 }
 
 func startService() error {

--- a/cli/beacon/internal/endpoint/service/windows_scm.go
+++ b/cli/beacon/internal/endpoint/service/windows_scm.go
@@ -1,0 +1,277 @@
+//go:build windows
+
+package service
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// serviceStopTimeout bounds how long unload waits for a graceful stop before deleting anyway.
+//
+// The collector flushes on shutdown, so cutting this short loses whatever the exporter had
+// buffered -- the same reason the supervised backend signals before it kills.
+const serviceStopTimeout = 20 * time.Second
+
+// withManager opens the SCM and hands it to fn.
+//
+// Every entry point needs it, and every one of them fails the same way without administrator
+// rights, so the "run elevated" advice is attached once here rather than at each call site.
+func withManager(fn func(*mgr.Mgr) error) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("open the Windows Service Control Manager (this needs an elevated shell): %w", err)
+	}
+	defer m.Disconnect()
+	return fn(m)
+}
+
+// createOrUpdateService registers the collector, or points an existing registration at the new
+// binary and config.
+//
+// Updating in place rather than delete-and-recreate: a delete only takes effect once every handle
+// to the service closes, so a recreate immediately afterwards can fail with "marked for deletion"
+// on a machine where services.msc happens to be open. Reconfiguring has no such window, and an
+// upgrade that changes the binary path is the common case.
+func createOrUpdateService(program, configPath string) error {
+	return withManager(func(m *mgr.Mgr) error {
+		cfg := mgr.Config{
+			DisplayName: WindowsServiceDisplayName,
+			Description: "Collects local AI agent telemetry and writes the Beacon endpoint log.",
+			// Automatic is the equivalent of launchd's RunAtLoad and systemd's
+			// WantedBy=multi-user.target: the endpoint must come back after a reboot without
+			// anyone logging in.
+			StartType: mgr.StartAutomatic,
+			// The collector binds loopback and writes a local log. Delayed start keeps it out of
+			// the boot-time contention that would otherwise have it restarting while the network
+			// stack settles -- the same reasoning as the systemd unit's After=network.target.
+			DelayedAutoStart: true,
+		}
+
+		existing, err := m.OpenService(WindowsServiceName)
+		if err == nil {
+			defer existing.Close()
+			current, cerr := existing.Config()
+			if cerr != nil {
+				return fmt.Errorf("read the existing %s service configuration: %w", WindowsServiceName, cerr)
+			}
+			current.DisplayName = cfg.DisplayName
+			current.Description = cfg.Description
+			current.StartType = cfg.StartType
+			current.DelayedAutoStart = cfg.DelayedAutoStart
+			current.BinaryPathName = serviceBinaryPath(program, configPath)
+			if err := existing.UpdateConfig(current); err != nil {
+				return fmt.Errorf("update the %s service: %w", WindowsServiceName, err)
+			}
+			return setRecoveryActions(existing)
+		}
+
+		created, err := m.CreateService(WindowsServiceName, program, cfg, "--config", configPath)
+		if err != nil {
+			return fmt.Errorf("register the %s service: %w", WindowsServiceName, err)
+		}
+		defer created.Close()
+		return setRecoveryActions(created)
+	})
+}
+
+// setRecoveryActions is the KeepAlive / Restart=always equivalent.
+//
+// Without it a collector that crashes stays down until the next reboot, which is the difference
+// between a service manager and a one-shot launcher -- and the whole reason to prefer the SCM over
+// the supervised backend. Three escalating restarts rather than infinite immediate ones: a
+// collector that cannot start at all should stop thrashing and leave a visible stopped service,
+// not loop forever writing the same error.
+func setRecoveryActions(s *mgr.Service) error {
+	actions := []mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: 5 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 15 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 60 * time.Second},
+	}
+	// The reset period returns the failure count to zero after a day of health, so a service that
+	// dies once a week does not eventually exhaust its restarts.
+	if err := s.SetRecoveryActions(actions, uint32((24 * time.Hour).Seconds())); err != nil {
+		return fmt.Errorf("set restart-on-failure for %s: %w", WindowsServiceName, err)
+	}
+	return nil
+}
+
+// serviceBinaryPath renders the ImagePath for an update.
+//
+// CreateService takes the executable and its arguments separately and quotes them itself, but
+// UpdateConfig takes one string, so the quoting is ours to get right. An unquoted path breaks at
+// the first space -- and the default install location is under %ProgramFiles%, which contains one.
+func serviceBinaryPath(program, configPath string) string {
+	return fmt.Sprintf("%q --config %q", program, configPath)
+}
+
+func startService() error {
+	return withManager(func(m *mgr.Mgr) error {
+		s, err := m.OpenService(WindowsServiceName)
+		if err != nil {
+			return fmt.Errorf("open the %s service (was it installed?): %w", WindowsServiceName, err)
+		}
+		defer s.Close()
+
+		status, err := s.Query()
+		if err == nil && status.State == svc.Running {
+			return nil // already running; install and repair both call this speculatively
+		}
+		if err := s.Start(); err != nil {
+			// An already-running service is not a failure, and the SCM reports it as an error.
+			if errors.Is(err, windows.ERROR_SERVICE_ALREADY_RUNNING) {
+				return nil
+			}
+			return fmt.Errorf("start the %s service: %w", WindowsServiceName, err)
+		}
+		return nil
+	})
+}
+
+// removeService stops and deletes the registration, treating an absent service as success.
+func removeService() error {
+	return withManager(func(m *mgr.Mgr) error {
+		s, err := m.OpenService(WindowsServiceName)
+		if err != nil {
+			// Nothing registered. Uninstall and repair both call this speculatively.
+			return nil
+		}
+		defer s.Close()
+
+		if err := stopAndWait(s); err != nil {
+			return err
+		}
+		if err := s.Delete(); err != nil && !errors.Is(err, windows.ERROR_SERVICE_MARKED_FOR_DELETE) {
+			return fmt.Errorf("delete the %s service: %w", WindowsServiceName, err)
+		}
+		return nil
+	})
+}
+
+// stopAndWait asks the service to stop and waits for it, so a delete does not race a running
+// process. A service that will not stop is reported rather than force-killed: the SCM has no
+// equivalent of SIGKILL for a service, and pretending otherwise would hide a wedged collector.
+func stopAndWait(s *mgr.Service) error {
+	status, err := s.Query()
+	if err != nil {
+		return fmt.Errorf("query the %s service: %w", WindowsServiceName, err)
+	}
+	if status.State == svc.Stopped {
+		return nil
+	}
+	if _, err := s.Control(svc.Stop); err != nil {
+		// Already stopped between the query and the control request; that is the outcome we want.
+		if errors.Is(err, windows.ERROR_SERVICE_NOT_ACTIVE) {
+			return nil
+		}
+		return fmt.Errorf("stop the %s service: %w", WindowsServiceName, err)
+	}
+
+	deadline := time.Now().Add(serviceStopTimeout)
+	for time.Now().Before(deadline) {
+		status, err := s.Query()
+		if err != nil {
+			return fmt.Errorf("query the %s service while stopping: %w", WindowsServiceName, err)
+		}
+		if status.State == svc.Stopped {
+			return nil
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	return fmt.Errorf("the %s service did not stop within %s", WindowsServiceName, serviceStopTimeout)
+}
+
+func restartService() error {
+	if err := withManager(func(m *mgr.Mgr) error {
+		s, err := m.OpenService(WindowsServiceName)
+		if err != nil {
+			// Not installed. Installing it is the right recovery, and mirrors the systemd
+			// backend's restart-falls-back-to-load behavior.
+			return errServiceNotInstalled
+		}
+		defer s.Close()
+		return stopAndWait(s)
+	}); err != nil {
+		if errors.Is(err, errServiceNotInstalled) {
+			return startService()
+		}
+		return err
+	}
+	return startService()
+}
+
+// errServiceNotInstalled distinguishes "there is nothing to restart" from a real failure, so
+// restart can fall back to starting rather than reporting an error for a recoverable state.
+var errServiceNotInstalled = errors.New("service is not installed")
+
+func queryService() Status {
+	status := Status{Label: WindowsServiceName}
+	err := withManager(func(m *mgr.Mgr) error {
+		s, err := m.OpenService(WindowsServiceName)
+		if err != nil {
+			status.Message = "service not installed"
+			return nil
+		}
+		defer s.Close()
+
+		// Loaded means registered and intended to run, matching what the other backends report
+		// for an enabled unit or a bootstrapped job.
+		cfg, cerr := s.Config()
+		if cerr == nil {
+			status.Loaded = cfg.StartType == mgr.StartAutomatic || cfg.StartType == mgr.StartManual
+		}
+		st, qerr := s.Query()
+		if qerr != nil {
+			status.Message = "could not query the service: " + qerr.Error()
+			return nil
+		}
+		status.Running = st.State == svc.Running
+		if status.Running {
+			// A running service is registered regardless of how it was configured to start.
+			status.Loaded = true
+		} else {
+			status.Message = "service state: " + serviceStateName(st.State)
+		}
+		return nil
+	})
+	if err != nil {
+		status.Message = firstLineOf(err.Error())
+	}
+	return status
+}
+
+// serviceStateName renders an SCM state for a human. The raw numbers appear in `sc query` output
+// and mean nothing to most readers.
+func serviceStateName(state svc.State) string {
+	switch state {
+	case svc.Stopped:
+		return "stopped"
+	case svc.StartPending:
+		return "starting"
+	case svc.StopPending:
+		return "stopping"
+	case svc.Running:
+		return "running"
+	case svc.ContinuePending:
+		return "resuming"
+	case svc.PausePending:
+		return "pausing"
+	case svc.Paused:
+		return "paused"
+	default:
+		return fmt.Sprintf("unknown (%d)", state)
+	}
+}
+
+func firstLineOf(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}

--- a/cli/beacon/internal/endpoint/service/windows_scm_test.go
+++ b/cli/beacon/internal/endpoint/service/windows_scm_test.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestServiceBinaryPathIsEscapedTheWayTheSCMReadsIt guards the upgrade path.
+//
+// A fresh install goes through CreateService, which escapes the ImagePath itself. An upgrade goes
+// through UpdateConfig, which takes one already-rendered string -- so this is the only place the
+// two can disagree, and a disagreement here does not show up until the service is next started,
+// long after the upgrade reported success.
+//
+// The specific mistake this replaced was Go's %q, which escapes for a Go string literal rather than
+// for the SCM: every backslash doubled, and the default install path lives under %ProgramFiles%.
+func TestServiceBinaryPathIsEscapedTheWayTheSCMReadsIt(t *testing.T) {
+	const (
+		program = `C:\Program Files\Beacon\bin\beacon-otelcol.exe`
+		config  = `C:\ProgramData\Beacon\Endpoint\collector.yaml`
+	)
+	got := serviceBinaryPath(program, config)
+
+	// Quoted because of the space, and left alone because there is not one.
+	want := `"` + program + `" --config ` + config
+	if got != want {
+		t.Fatalf("serviceBinaryPath = %s, want %s", got, want)
+	}
+	if strings.Contains(got, `\\`) {
+		t.Fatalf("serviceBinaryPath doubled a backslash: %s; "+
+			"the SCM does not unescape those, so the service would fail to start after an upgrade", got)
+	}
+	// The path has to survive as one argument. Anything that splits it at the space leaves the SCM
+	// looking for C:\Program.
+	if !strings.HasPrefix(got, `"`+program+`"`) {
+		t.Fatalf("serviceBinaryPath left a path containing a space unquoted: %s", got)
+	}
+}
+
+func TestServiceBinaryPathQuotesOnlyWhenItMustAndAlwaysCarriesTheConfig(t *testing.T) {
+	got := serviceBinaryPath(`C:\Beacon\beacon-otelcol.exe`, `C:\Beacon\collector.yaml`)
+	if got != `C:\Beacon\beacon-otelcol.exe --config C:\Beacon\collector.yaml` {
+		t.Fatalf("serviceBinaryPath = %s", got)
+	}
+	if !strings.Contains(got, "--config") {
+		t.Fatalf("serviceBinaryPath dropped the config flag: %s; "+
+			"the collector would start with its default configuration and write nowhere Beacon reads", got)
+	}
+}

--- a/cli/beacon/internal/endpoint/service/windows_test.go
+++ b/cli/beacon/internal/endpoint/service/windows_test.go
@@ -41,11 +41,36 @@ func TestWindowsUserModeFallsBackToSupervised(t *testing.T) {
 		t.Errorf("user mode backend = %q, want %q -- Windows has no per-user service manager",
 			got, KindSupervised)
 	}
-	if runtime.GOOS == "windows" {
-		st := user.Status()
-		if !strings.Contains(strings.ToLower(st.Message), "restart") {
-			t.Errorf("user-mode status must disclose that nothing restarts it, got %q", st.Message)
-		}
+}
+
+// The fallback's limitations have to reach the operator, and reach them wherever an installed
+// endpoint is described -- not only while one happens to be running. Someone reading status on a
+// configured-but-stopped Windows user-mode endpoint is exactly the person who needs to know that
+// nothing will start it again and that it stops when they log off.
+//
+// Asserted against the message builder rather than through Status, because Status on a fresh
+// machine reports "nothing recorded" and would let the claim go untested -- which is how the first
+// version of this test passed locally and failed on a clean runner.
+func TestSupervisedStatusNamesWhatItCannotPromise(t *testing.T) {
+	caveats := supervisedCaveats(true)
+	if !strings.Contains(caveats, "no automatic restart") {
+		t.Errorf("caveats = %q, want the absence of restart-on-failure named", caveats)
+	}
+
+	// Logout is Windows-only and must be claimed only there: a detached POSIX process has its own
+	// session and outlives the login that started it, so saying otherwise would be false.
+	mentionsLogout := strings.Contains(caveats, "logout")
+	if runtime.GOOS == "windows" && !mentionsLogout {
+		t.Errorf("windows user mode must disclose that it stops at logout, got %q", caveats)
+	}
+	if runtime.GOOS != "windows" && mentionsLogout {
+		t.Errorf("a detached POSIX collector does survive logout; %q claims otherwise", caveats)
+	}
+
+	// System mode never carries the logout caveat: it is not tied to a login session on any
+	// platform, and on Windows it is not even this backend.
+	if strings.Contains(supervisedCaveats(false), "logout") {
+		t.Error("system mode must not claim a logout limitation")
 	}
 }
 

--- a/cli/beacon/internal/endpoint/service/windows_test.go
+++ b/cli/beacon/internal/endpoint/service/windows_test.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Detection must pick the SCM on Windows. Falling through to the supervised backend there would
+// produce an endpoint that works until the machine reboots and then silently stops collecting,
+// which is exactly the difference a service manager exists to make.
+func TestDetectKindPicksTheServiceManagerPerPlatform(t *testing.T) {
+	got := DetectKind()
+	switch runtime.GOOS {
+	case "windows":
+		if got != KindWindowsService {
+			t.Errorf("DetectKind() = %q on Windows, want %q", got, KindWindowsService)
+		}
+	case "darwin":
+		if got != KindLaunchd {
+			t.Errorf("DetectKind() = %q on macOS, want %q", got, KindLaunchd)
+		}
+	case "linux":
+		if got != KindSystemd && got != KindSupervised {
+			t.Errorf("DetectKind() = %q on Linux, want systemd or supervised", got)
+		}
+	}
+}
+
+// Windows has no per-user service manager -- no equivalent of `systemctl --user` or launchd's
+// gui/<uid> domain -- so user mode is routed to the supervised backend. That is a real limitation
+// rather than a shortcut, and status has to say so: a supervised collector does not survive logout.
+func TestWindowsUserModeFallsBackToSupervised(t *testing.T) {
+	system := Manager{Kind: KindWindowsService}
+	if got := system.backend().kind(); got != KindWindowsService {
+		t.Errorf("system mode backend = %q, want %q", got, KindWindowsService)
+	}
+
+	user := Manager{Kind: KindWindowsService, UserMode: true}
+	if got := user.backend().kind(); got != KindSupervised {
+		t.Errorf("user mode backend = %q, want %q -- Windows has no per-user service manager",
+			got, KindSupervised)
+	}
+	if runtime.GOOS == "windows" {
+		st := user.Status()
+		if !strings.Contains(strings.ToLower(st.Message), "restart") {
+			t.Errorf("user-mode status must disclose that nothing restarts it, got %q", st.Message)
+		}
+	}
+}
+
+// The kind has to survive a round trip through the flag, or `--service=windows-service` in a
+// scenario or an operator's command line silently selects something else.
+func TestParseKindAcceptsTheWindowsSpellings(t *testing.T) {
+	for _, in := range []string{"windows-service", "scm", "windows", "WINDOWS-SERVICE"} {
+		got, err := ParseKind(in)
+		if err != nil {
+			t.Errorf("ParseKind(%q) returned %v", in, err)
+			continue
+		}
+		if got != KindWindowsService {
+			t.Errorf("ParseKind(%q) = %q, want %q", in, got, KindWindowsService)
+		}
+	}
+	if _, err := ParseKind("services.msc"); err == nil {
+		t.Error("an unrecognized kind must be rejected rather than defaulting")
+	}
+}
+
+// unitPath is shown to a human. There is no file to point at, so it names the registry key that
+// actually holds the definition -- the same trade the supervised backend makes by reporting its
+// pidfile rather than an error.
+func TestWindowsUnitPathNamesTheRegistryKey(t *testing.T) {
+	path, err := windowsBackend{}.unitPath(false)
+	if err != nil {
+		t.Fatalf("unitPath returned %v", err)
+	}
+	if !strings.Contains(path, WindowsServiceName) {
+		t.Errorf("unitPath = %q, want it to name the service %q", path, WindowsServiceName)
+	}
+	if !strings.HasPrefix(path, `HKLM\`) {
+		t.Errorf("unitPath = %q, want the registry key holding the definition", path)
+	}
+}
+
+// Off Windows the backend must refuse rather than quietly do nothing. An install that reports
+// success while registering no service is the failure this package is shaped around avoiding.
+func TestWindowsBackendRefusesOffWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("this asserts the off-platform contract")
+	}
+	b := windowsBackend{}
+	if b.available() {
+		t.Fatal("the Windows backend must not report itself available off Windows")
+	}
+	if reason := b.unsupportedReason(); !strings.Contains(reason, "Windows") {
+		t.Errorf("unsupportedReason = %q, want it to name the platform", reason)
+	}
+	if _, err := b.writeUnit(false, "beacon-otelcol", "otelcol.yaml"); err == nil {
+		t.Error("writeUnit must fail off Windows rather than report a registration it did not make")
+	}
+	if err := b.load(false); err == nil {
+		t.Error("load must fail off Windows")
+	}
+	if err := b.restart(false); err == nil {
+		t.Error("restart must fail off Windows")
+	}
+	// Unload is the deliberate exception: uninstall calls it speculatively on every backend, and
+	// failing would block removing an endpoint that was never a Windows service.
+	if err := b.unload(false); err != nil {
+		t.Errorf("unload must stay a no-op off Windows so uninstall can call it, got %v", err)
+	}
+	if st := b.status(false); st.Message == "" {
+		t.Error("status off Windows must explain itself rather than look like a stopped service")
+	}
+}
+
+// The noun appears in install plans and doctor output, so every kind needs one that reads as the
+// artifact it installs.
+func TestWindowsServiceNounIsSpecific(t *testing.T) {
+	noun := KindWindowsService.ServiceNoun()
+	if noun == "" || strings.Contains(noun, "collector service definition") {
+		t.Errorf("ServiceNoun() = %q, want wording specific to the Windows SCM", noun)
+	}
+}

--- a/cli/beacon/internal/endpoint/writer/acl_other.go
+++ b/cli/beacon/internal/endpoint/writer/acl_other.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package writer
+
+// POSIX carries this in the file mode instead: openRuntimeFile creates the runtime log 0666 so
+// hooks running as the console user can append to a log the elevated collector created. There is
+// no separate ACL step to perform, and no separate state to check.
+
+func grantInteractiveUsersWrite(dir string) error { return nil }
+
+// interactiveUsersCanWrite reports true because the equivalent guarantee is the file mode, which
+// EnsureRuntimeFile already establishes. Reporting false here would make doctor demand a fix that
+// does not exist on this platform.
+func interactiveUsersCanWrite(dir string) (bool, error) { return true, nil }

--- a/cli/beacon/internal/endpoint/writer/acl_other.go
+++ b/cli/beacon/internal/endpoint/writer/acl_other.go
@@ -12,3 +12,8 @@ func grantInteractiveUsersWrite(dir string) error { return nil }
 // EnsureRuntimeFile already establishes. Reporting false here would make doctor demand a fix that
 // does not exist on this platform.
 func interactiveUsersCanWrite(dir string) (bool, error) { return true, nil }
+
+// GrantCommandHint is empty because there is no grant to run here. Callers use the empty string to
+// mean "this remediation does not apply on this platform" rather than printing an icacls command to
+// someone on a Mac.
+func GrantCommandHint(dir string) string { return "" }

--- a/cli/beacon/internal/endpoint/writer/acl_windows.go
+++ b/cli/beacon/internal/endpoint/writer/acl_windows.go
@@ -32,19 +32,45 @@ import (
 // (OI)(CI) makes the grant inherit to files and subdirectories created later, so the log and its
 // rotated archives are covered without re-running this after every rotation.
 func grantInteractiveUsersWrite(dir string) error {
-	// icacls rather than the security APIs directly: it is present on every supported Windows,
-	// its argument form is stable, and the equivalent through SetNamedSecurityInfo means building
-	// an ACL by hand for a grant an administrator can read and audit in one line.
-	//
-	// The `*` prefix passes the well-known SID literally, so this does not depend on the machine's
-	// display language the way a `INTERACTIVE` or `INTERAKTIV` spelling would.
-	cmd := exec.Command("icacls", dir, "/grant", `*S-1-5-4:(OI)(CI)(M)`, "/T")
-	out, err := cmd.CombinedOutput()
+	out, err := exec.Command("icacls", grantArgs(dir)...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("grant interactive users write access to %s: %w: %s",
 			dir, err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// grantArgs is the single definition of the grant.
+//
+// icacls rather than the security APIs directly: it is present on every supported Windows, its
+// argument form is stable, and the equivalent through SetNamedSecurityInfo means building an ACL by
+// hand for a grant an administrator can read and audit in one line.
+//
+// The `*` prefix passes the well-known SID literally, so this does not depend on the machine's
+// display language the way an `INTERACTIVE` or `INTERAKTIV` spelling would.
+//
+// One definition because doctor prints this command as the remediation for a missing grant. Advice
+// that has drifted from the implementation is worse than no advice: an operator runs it, doctor
+// still reports the failure, and the next thing they doubt is the diagnosis rather than the hint.
+func grantArgs(dir string) []string {
+	return []string{dir, "/grant", `*S-1-5-4:(OI)(CI)(M)`, "/T"}
+}
+
+// GrantCommandHint renders the grant as a command an operator can paste.
+//
+// Empty on platforms with no such grant, which is how callers tell that this remediation does not
+// apply rather than printing a Windows command on a Mac.
+func GrantCommandHint(dir string) string {
+	args := grantArgs(dir)
+	quoted := make([]string, 0, len(args)+1)
+	quoted = append(quoted, "icacls")
+	for _, arg := range args {
+		if strings.ContainsAny(arg, " \t") {
+			arg = `"` + arg + `"`
+		}
+		quoted = append(quoted, arg)
+	}
+	return strings.Join(quoted, " ")
 }
 
 // Rights that answer the question doctor is actually asking: can a hook running as the logged-on

--- a/cli/beacon/internal/endpoint/writer/acl_windows.go
+++ b/cli/beacon/internal/endpoint/writer/acl_windows.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // grantInteractiveUsersWrite makes a machine-wide log directory writable by ordinary users.
@@ -32,6 +35,9 @@ func grantInteractiveUsersWrite(dir string) error {
 	// icacls rather than the security APIs directly: it is present on every supported Windows,
 	// its argument form is stable, and the equivalent through SetNamedSecurityInfo means building
 	// an ACL by hand for a grant an administrator can read and audit in one line.
+	//
+	// The `*` prefix passes the well-known SID literally, so this does not depend on the machine's
+	// display language the way a `INTERACTIVE` or `INTERAKTIV` spelling would.
 	cmd := exec.Command("icacls", dir, "/grant", `*S-1-5-4:(OI)(CI)(M)`, "/T")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -41,31 +47,101 @@ func grantInteractiveUsersWrite(dir string) error {
 	return nil
 }
 
+// Rights that answer the question doctor is actually asking: can a hook running as the logged-on
+// user create the runtime log if it is missing, and append to it if it is not.
+//
+// Both bits are required. FILE_APPEND_DATA alone cannot create the file, and FILE_WRITE_DATA alone
+// on a directory does not permit adding entries to it, so a grant carrying only one of them leaves
+// a hook that still fails -- just at a different call.
+const writeAccessMask = uint32(windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA)
+
+// inheritOnlyACE marks an entry that applies to children but not to the object carrying it.
+// Not exported by x/sys/windows, and needed here because such an entry must not read as a grant:
+// the directory itself has to be writable for a hook to create the log in the first place.
+const inheritOnlyACE = 0x08
+
+type aceVerdict int
+
+const (
+	aceIrrelevant aceVerdict = iota
+	aceAllowsWrite
+	aceDeniesWrite
+)
+
+// classifyACE decides what one access control entry says about interactive write access.
+//
+// Split out from the DACL walk so it can be tested against entry shapes that are tedious to
+// construct on a real directory -- inherit-only grants, deny entries, partial masks.
+func classifyACE(aceType, aceFlags uint8, mask uint32, matchesSID bool) aceVerdict {
+	if !matchesSID || aceFlags&inheritOnlyACE != 0 {
+		return aceIrrelevant
+	}
+	switch aceType {
+	case windows.ACCESS_DENIED_ACE_TYPE:
+		// Any overlap denies. A deny of one of the two bits is enough to break a hook, and Windows
+		// evaluates a matching deny ahead of any grant, so partial credit would be wrong here.
+		if mask&writeAccessMask != 0 {
+			return aceDeniesWrite
+		}
+	case windows.ACCESS_ALLOWED_ACE_TYPE:
+		// GENERIC_WRITE is normally mapped to its specific rights when an entry is stored, but it
+		// survives in entries written by some tooling, and it subsumes both bits.
+		if mask&writeAccessMask == writeAccessMask || mask&windows.GENERIC_WRITE != 0 {
+			return aceAllowsWrite
+		}
+	}
+	return aceIrrelevant
+}
+
 // interactiveUsersCanWrite reports whether the grant is in place, for doctor.
 //
 // Checked by reading the ACL rather than by attempting a write: doctor runs elevated, so a test
 // write would succeed regardless and report healthy for exactly the configuration that is broken.
 // That is the trap this check exists to avoid, so it must not fall into it.
+//
+// Read through the security APIs rather than by parsing `icacls` output. The text form is a
+// rendering for humans and varies with the things a rendering varies with: it resolves the SID to a
+// localized account name, so a correctly granted directory reads as ungranted on a German or
+// Japanese install, and it prints an expanded rights list instead of the short `(M)` alias whenever
+// the mask is not exactly one of the aliases. Both produce the same wrong answer -- doctor telling
+// an administrator their working endpoint is broken -- and neither is visible from an English test
+// machine, which is every machine this would be tested on.
 func interactiveUsersCanWrite(dir string) (bool, error) {
-	out, err := exec.Command("icacls", dir).CombinedOutput()
+	sd, err := windows.GetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
 	if err != nil {
-		return false, fmt.Errorf("read the ACL on %s: %w: %s", dir, err, strings.TrimSpace(string(out)))
+		return false, fmt.Errorf("read the access control list on %s: %w", dir, err)
 	}
-	text := string(out)
-	// icacls renders the well-known SID as a localized account name, so the SID itself is not
-	// reliably present in the output. Both spellings are accepted: the localized name varies by
-	// system language, and matching only the English one would report a correct grant as missing
-	// on a German or Japanese install.
-	for _, marker := range []string{"S-1-5-4", "INTERACTIVE"} {
-		for _, line := range strings.Split(text, "\n") {
-			if !strings.Contains(strings.ToUpper(line), strings.ToUpper(marker)) {
-				continue
-			}
-			// (M) is modify, (F) is full control; either is enough to append.
-			if strings.Contains(line, "(M)") || strings.Contains(line, "(F)") || strings.Contains(line, "(W)") {
-				return true, nil
-			}
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return false, fmt.Errorf("read the discretionary access control list on %s: %w", dir, err)
+	}
+	if dacl == nil {
+		// A NULL DACL grants everyone full control. Alarming, and worth surfacing elsewhere, but
+		// the question here is only whether hooks can write -- and they can.
+		return true, nil
+	}
+
+	interactive, err := windows.CreateWellKnownSid(windows.WinInteractiveSid)
+	if err != nil {
+		return false, fmt.Errorf("resolve the INTERACTIVE security identifier: %w", err)
+	}
+
+	allowed := false
+	for i := uint32(0); i < uint32(dacl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(dacl, i, &ace); err != nil {
+			return false, fmt.Errorf("read access control entry %d on %s: %w", i, dir, err)
+		}
+		// Every ACE type this cares about carries its SID at the same offset; the field is named
+		// SidStart because the identifier is variable length and runs past the struct.
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		switch classifyACE(ace.Header.AceType, ace.Header.AceFlags, uint32(ace.Mask), sid.Equals(interactive)) {
+		case aceDeniesWrite:
+			// A deny anywhere in the list settles it, whatever else grants.
+			return false, nil
+		case aceAllowsWrite:
+			allowed = true
 		}
 	}
-	return false, nil
+	return allowed, nil
 }

--- a/cli/beacon/internal/endpoint/writer/acl_windows.go
+++ b/cli/beacon/internal/endpoint/writer/acl_windows.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package writer
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// grantInteractiveUsersWrite makes a machine-wide log directory writable by ordinary users.
+//
+// This is the Windows counterpart to the 0666 runtime log on POSIX, and it exists for the same
+// reason: a system-mode collector runs elevated and creates the log, while hooks run as the person
+// at the keyboard and append to it. On POSIX the file mode carries that. Windows has no mode --
+// %ProgramData% subdirectories inherit an ACL where only administrators and SYSTEM may write, so
+// without an explicit grant every hook write fails with access denied.
+//
+// The failure that makes it worth doing at install time is the quiet one. Nothing errors visibly:
+// the collector is healthy, `endpoint status` reports running, and `doctor` agrees -- because all
+// of them describe the collector, not the hooks that export to it. The log simply stays empty of
+// anything the agent did. That is the same shape as the Linux SUDO_USER bug, where a package
+// install produced a perfectly healthy collector that captured nothing.
+//
+// Granted to INTERACTIVE rather than Users or Everyone. INTERACTIVE covers anyone logged on at the
+// machine, which is exactly the set whose agent sessions this endpoint is meant to capture, and
+// excludes service and network logons that have no business writing here.
+//
+// (OI)(CI) makes the grant inherit to files and subdirectories created later, so the log and its
+// rotated archives are covered without re-running this after every rotation.
+func grantInteractiveUsersWrite(dir string) error {
+	// icacls rather than the security APIs directly: it is present on every supported Windows,
+	// its argument form is stable, and the equivalent through SetNamedSecurityInfo means building
+	// an ACL by hand for a grant an administrator can read and audit in one line.
+	cmd := exec.Command("icacls", dir, "/grant", `*S-1-5-4:(OI)(CI)(M)`, "/T")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("grant interactive users write access to %s: %w: %s",
+			dir, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// interactiveUsersCanWrite reports whether the grant is in place, for doctor.
+//
+// Checked by reading the ACL rather than by attempting a write: doctor runs elevated, so a test
+// write would succeed regardless and report healthy for exactly the configuration that is broken.
+// That is the trap this check exists to avoid, so it must not fall into it.
+func interactiveUsersCanWrite(dir string) (bool, error) {
+	out, err := exec.Command("icacls", dir).CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("read the ACL on %s: %w: %s", dir, err, strings.TrimSpace(string(out)))
+	}
+	text := string(out)
+	// icacls renders the well-known SID as a localized account name, so the SID itself is not
+	// reliably present in the output. Both spellings are accepted: the localized name varies by
+	// system language, and matching only the English one would report a correct grant as missing
+	// on a German or Japanese install.
+	for _, marker := range []string{"S-1-5-4", "INTERACTIVE"} {
+		for _, line := range strings.Split(text, "\n") {
+			if !strings.Contains(strings.ToUpper(line), strings.ToUpper(marker)) {
+				continue
+			}
+			// (M) is modify, (F) is full control; either is enough to append.
+			if strings.Contains(line, "(M)") || strings.Contains(line, "(F)") || strings.Contains(line, "(W)") {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/cli/beacon/internal/endpoint/writer/acl_windows.go
+++ b/cli/beacon/internal/endpoint/writer/acl_windows.go
@@ -60,17 +60,41 @@ func grantArgs(dir string) []string {
 //
 // Empty on platforms with no such grant, which is how callers tell that this remediation does not
 // apply rather than printing a Windows command on a Mac.
+//
+// Quoting matters here in a way it does not for the grant itself: applying it goes through argv
+// with no shell involved, while this is read by a person and pasted into whichever shell they have
+// open. The rights string carries parentheses, which PowerShell reads as grouping, so an unquoted
+// hint is a command that fails on paste -- and a remediation that fails on paste is worse than
+// none, because the operator concludes the diagnosis was wrong.
 func GrantCommandHint(dir string) string {
-	args := grantArgs(dir)
-	quoted := make([]string, 0, len(args)+1)
-	quoted = append(quoted, "icacls")
-	for _, arg := range args {
-		if strings.ContainsAny(arg, " \t") {
-			arg = `"` + arg + `"`
-		}
-		quoted = append(quoted, arg)
+	parts := make([]string, 0, len(grantArgs(dir))+1)
+	parts = append(parts, "icacls")
+	for _, arg := range grantArgs(dir) {
+		parts = append(parts, quoteForShellPaste(arg))
 	}
-	return strings.Join(quoted, " ")
+	return strings.Join(parts, " ")
+}
+
+// quoteForShellPaste wraps anything either Windows shell would not pass through literally.
+//
+// An allowlist rather than a list of metacharacters: cmd.exe and PowerShell disagree about which
+// characters are special, and the set that is safe in both is small and easy to state. Double
+// quotes work in both for everything here, and no argument in this command contains one, so simple
+// wrapping is enough -- if that ever changes this needs the escaping rules too, not just the quotes.
+func quoteForShellPaste(arg string) string {
+	safe := func(r rune) bool {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return true
+		}
+		return strings.ContainsRune(`\/.:_-`, r)
+	}
+	for _, r := range arg {
+		if !safe(r) {
+			return `"` + arg + `"`
+		}
+	}
+	return arg
 }
 
 // Rights that answer the question doctor is actually asking: can a hook running as the logged-on

--- a/cli/beacon/internal/endpoint/writer/acl_windows_test.go
+++ b/cli/beacon/internal/endpoint/writer/acl_windows_test.go
@@ -165,3 +165,25 @@ func TestGrantAndReadBackAgree(t *testing.T) {
 			"the grant was read without the deny that overrides it")
 	}
 }
+
+// TestGrantCommandHintQuotesThePathItPrints covers the half of the grant an operator runs by hand.
+//
+// doctor prints this when the grant is missing, and the default log directory lives under
+// %ProgramData%. A hint that breaks at the first space would be pasted, would fail, and would send
+// the operator looking for a problem in the diagnosis instead of the advice.
+func TestGrantCommandHintQuotesThePathItPrints(t *testing.T) {
+	hint := GrantCommandHint(`C:\Program Files\Beacon\logs`)
+	if !strings.Contains(hint, `"C:\Program Files\Beacon\logs"`) {
+		t.Fatalf("GrantCommandHint left a path containing a space unquoted: %s", hint)
+	}
+	// The SID rather than a localized name, for the same reason the grant itself uses it.
+	if !strings.Contains(hint, "S-1-5-4") {
+		t.Fatalf("GrantCommandHint does not name the well-known SID: %s", hint)
+	}
+	// Same definition as the applied grant, so the advice cannot drift from the implementation.
+	for _, arg := range grantArgs(`C:\Program Files\Beacon\logs`)[1:] {
+		if !strings.Contains(hint, arg) {
+			t.Fatalf("GrantCommandHint omits %q from the grant it claims to describe: %s", arg, hint)
+		}
+	}
+}

--- a/cli/beacon/internal/endpoint/writer/acl_windows_test.go
+++ b/cli/beacon/internal/endpoint/writer/acl_windows_test.go
@@ -176,14 +176,43 @@ func TestGrantCommandHintQuotesThePathItPrints(t *testing.T) {
 	if !strings.Contains(hint, `"C:\Program Files\Beacon\logs"`) {
 		t.Fatalf("GrantCommandHint left a path containing a space unquoted: %s", hint)
 	}
-	// The SID rather than a localized name, for the same reason the grant itself uses it.
-	if !strings.Contains(hint, "S-1-5-4") {
-		t.Fatalf("GrantCommandHint does not name the well-known SID: %s", hint)
+	// The rights string carries parentheses, which PowerShell reads as grouping rather than as
+	// part of an argument. Unquoted, the hint is a command that fails the moment it is pasted.
+	if !strings.Contains(hint, `"*S-1-5-4:(OI)(CI)(M)"`) {
+		t.Fatalf("GrantCommandHint left the rights string unquoted: %s; "+
+			"PowerShell would try to evaluate the parentheses", hint)
 	}
 	// Same definition as the applied grant, so the advice cannot drift from the implementation.
 	for _, arg := range grantArgs(`C:\Program Files\Beacon\logs`)[1:] {
 		if !strings.Contains(hint, arg) {
 			t.Fatalf("GrantCommandHint omits %q from the grant it claims to describe: %s", arg, hint)
+		}
+	}
+	// Plain flags stay readable: quoting everything would work but makes the line harder to scan,
+	// and this is read before it is run.
+	if !strings.Contains(hint, " /grant ") || !strings.HasSuffix(hint, " /T") {
+		t.Fatalf("GrantCommandHint quoted arguments that needed no quoting: %s", hint)
+	}
+}
+
+func TestQuoteForShellPasteCoversWhatBothWindowsShellsTreatSpecially(t *testing.T) {
+	// Safe in cmd.exe and PowerShell alike, so left alone.
+	for _, arg := range []string{`/T`, `/grant`, `C:\ProgramData\Beacon\logs`, `icacls`, `S-1-5-4`} {
+		if got := quoteForShellPaste(arg); got != arg {
+			t.Fatalf("quoteForShellPaste(%q) = %q, want it unchanged", arg, got)
+		}
+	}
+	// Each of these is special to at least one of the two shells.
+	for _, arg := range []string{
+		`*S-1-5-4:(OI)(CI)(M)`,
+		`C:\Program Files\Beacon`,
+		`C:\logs&more`,
+		`C:\logs;more`,
+		`C:\logs$more`,
+		`C:\logs'more`,
+	} {
+		if got := quoteForShellPaste(arg); got != `"`+arg+`"` {
+			t.Fatalf("quoteForShellPaste(%q) = %q, want it quoted", arg, got)
 		}
 	}
 }

--- a/cli/beacon/internal/endpoint/writer/acl_windows_test.go
+++ b/cli/beacon/internal/endpoint/writer/acl_windows_test.go
@@ -1,0 +1,167 @@
+//go:build windows
+
+package writer
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestClassifyACEReadsTheEntryShapesThatDecideAccess(t *testing.T) {
+	const (
+		writeData  = uint32(windows.FILE_WRITE_DATA)
+		appendData = uint32(windows.FILE_APPEND_DATA)
+		readData   = uint32(windows.FILE_READ_DATA)
+	)
+
+	cases := []struct {
+		name       string
+		aceType    uint8
+		aceFlags   uint8
+		mask       uint32
+		matchesSID bool
+		want       aceVerdict
+	}{
+		{
+			name:       "the grant install writes",
+			aceType:    windows.ACCESS_ALLOWED_ACE_TYPE,
+			mask:       writeData | appendData,
+			matchesSID: true,
+			want:       aceAllowsWrite,
+		},
+		{
+			// The whole reason this is not a substring search for a rendered name.
+			name:       "another principal's full control says nothing about INTERACTIVE",
+			aceType:    windows.ACCESS_ALLOWED_ACE_TYPE,
+			mask:       writeData | appendData,
+			matchesSID: false,
+			want:       aceIrrelevant,
+		},
+		{
+			// A hook that cannot create the log fails as surely as one that cannot append to it,
+			// so half the mask is not half a pass.
+			name:       "append without write cannot create the log",
+			aceType:    windows.ACCESS_ALLOWED_ACE_TYPE,
+			mask:       appendData,
+			matchesSID: true,
+			want:       aceIrrelevant,
+		},
+		{
+			name:       "write without append cannot extend the log",
+			aceType:    windows.ACCESS_ALLOWED_ACE_TYPE,
+			mask:       writeData,
+			matchesSID: true,
+			want:       aceIrrelevant,
+		},
+		{
+			name:       "read access is not write access",
+			aceType:    windows.ACCESS_ALLOWED_ACE_TYPE,
+			mask:       readData,
+			matchesSID: true,
+			want:       aceIrrelevant,
+		},
+		{
+			name:       "generic write subsumes both bits",
+			aceType:    windows.ACCESS_ALLOWED_ACE_TYPE,
+			mask:       windows.GENERIC_WRITE,
+			matchesSID: true,
+			want:       aceAllowsWrite,
+		},
+		{
+			// The directory itself must be writable: a hook creates the log when it is missing.
+			name:       "an inherit-only grant does not make this directory writable",
+			aceType:    windows.ACCESS_ALLOWED_ACE_TYPE,
+			aceFlags:   inheritOnlyACE,
+			mask:       writeData | appendData,
+			matchesSID: true,
+			want:       aceIrrelevant,
+		},
+		{
+			name:       "a deny of either bit is a deny",
+			aceType:    windows.ACCESS_DENIED_ACE_TYPE,
+			mask:       appendData,
+			matchesSID: true,
+			want:       aceDeniesWrite,
+		},
+		{
+			name:       "a deny of unrelated rights is not a deny of write",
+			aceType:    windows.ACCESS_DENIED_ACE_TYPE,
+			mask:       readData,
+			matchesSID: true,
+			want:       aceIrrelevant,
+		},
+		{
+			name:       "an inherit-only deny does not apply to this directory",
+			aceType:    windows.ACCESS_DENIED_ACE_TYPE,
+			aceFlags:   inheritOnlyACE,
+			mask:       writeData | appendData,
+			matchesSID: true,
+			want:       aceIrrelevant,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyACE(tc.aceType, tc.aceFlags, tc.mask, tc.matchesSID)
+			if got != tc.want {
+				t.Fatalf("classifyACE = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGrantAndReadBackAgree exercises the halves against each other on a real directory.
+//
+// They are written against different interfaces -- the grant shells out to icacls, the read walks
+// the DACL through the security APIs -- so nothing but a test like this catches them drifting
+// apart. A reader that silently answered "no" to a directory the granter had just fixed would make
+// doctor report a working endpoint as broken, and it would do so only on machines nobody develops
+// on.
+//
+// Every step here needs administrator rights, which the endpoint install already requires and the
+// Windows CI runner already has. Skipped rather than failed elsewhere: a contributor running the
+// suite unelevated should not see a red suite for a check their shell cannot perform.
+func TestGrantAndReadBackAgree(t *testing.T) {
+	dir := t.TempDir()
+
+	// Strip inheritance so the starting state is known: administrators only, no INTERACTIVE. This
+	// is what makes the negative half real -- without it the answer could be "true" before the
+	// grant, and a reader hardcoded to return true would pass.
+	if out, err := exec.Command("icacls", dir, "/inheritance:r", "/grant", `*S-1-5-32-544:(OI)(CI)(F)`).CombinedOutput(); err != nil {
+		t.Skipf("could not take ownership of the ACL on %s (needs an elevated shell): %v: %s",
+			dir, err, strings.TrimSpace(string(out)))
+	}
+
+	if writable, err := interactiveUsersCanWrite(dir); err != nil {
+		t.Fatalf("read the ACL before granting: %v", err)
+	} else if writable {
+		t.Fatal("a directory granting only administrators reported interactive users can write; " +
+			"the reader cannot distinguish a granted directory from an ungranted one")
+	}
+
+	if err := grantInteractiveUsersWrite(dir); err != nil {
+		t.Fatalf("grant interactive write access: %v", err)
+	}
+
+	if writable, err := interactiveUsersCanWrite(dir); err != nil {
+		t.Fatalf("read the ACL after granting: %v", err)
+	} else if !writable {
+		t.Fatal("the directory the granter just fixed reads as not writable by interactive users; " +
+			"doctor would report a healthy endpoint as broken")
+	}
+
+	// A deny entry outranks the grant, and doctor must say so: hooks would fail here despite the
+	// allow entry still being present.
+	if out, err := exec.Command("icacls", dir, "/deny", `*S-1-5-4:(WD)`).CombinedOutput(); err != nil {
+		t.Fatalf("add a deny entry: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	if writable, err := interactiveUsersCanWrite(dir); err != nil {
+		t.Fatalf("read the ACL after denying: %v", err)
+	} else if writable {
+		t.Fatal("an explicit deny of write access reported as writable; " +
+			"the grant was read without the deny that overrides it")
+	}
+}

--- a/cli/beacon/internal/endpoint/writer/ensure_test.go
+++ b/cli/beacon/internal/endpoint/writer/ensure_test.go
@@ -1,0 +1,47 @@
+package writer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEnsureSystemLogWritableCreatesTheDirectoryItIsAskedAbout covers an ordering bug that took
+// down the whole install.
+//
+// Install calls this before anything has written a log, so on a fresh system-mode install the
+// directory does not exist yet. The Windows implementation grants access by path; granting access
+// to a path that is not there fails, and the failure came back from Install as "prepare the log
+// directory" before the service was ever registered -- so the first install on a clean machine was
+// the one case that could not work.
+//
+// Platform-neutral on purpose. The POSIX grant is a no-op and the Windows one is not, but the
+// directory has to exist either way, and keeping that guarantee in the shared function is what
+// stops the next platform from reintroducing it.
+func TestEnsureSystemLogWritableCreatesTheDirectoryItIsAskedAbout(t *testing.T) {
+	// Nested, so this fails if the implementation only creates a leaf under an existing parent.
+	dir := filepath.Join(t.TempDir(), "Beacon", "Endpoint", "logs")
+
+	if err := EnsureSystemLogWritable(dir); err != nil {
+		t.Fatalf("EnsureSystemLogWritable on a directory that does not exist yet: %v", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat the log directory afterwards: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("%s is not a directory", dir)
+	}
+}
+
+func TestEnsureSystemLogWritableIsRepeatable(t *testing.T) {
+	// Repair and reinstall both call this over a live endpoint, so a second call must not fail on
+	// the directory it created the first time.
+	dir := filepath.Join(t.TempDir(), "logs")
+	for i := 0; i < 2; i++ {
+		if err := EnsureSystemLogWritable(dir); err != nil {
+			t.Fatalf("EnsureSystemLogWritable call %d: %v", i+1, err)
+		}
+	}
+}

--- a/cli/beacon/internal/endpoint/writer/writer.go
+++ b/cli/beacon/internal/endpoint/writer/writer.go
@@ -96,7 +96,15 @@ func AppendEvent(event schema.Event, opts Options) (string, error) {
 // did: %ProgramData% denies ordinary users write access, hooks run as the console user, and
 // nothing reports an error because status and doctor both describe the collector rather than the
 // hooks exporting to it.
+//
+// Creates the directory first. Install calls this before anything has written a log there, so on a
+// fresh system-mode install the directory does not exist yet -- and granting access to a path that
+// is not there fails, taking the whole install down before the service is ever registered. Ensure
+// means ensure.
 func EnsureSystemLogWritable(dir string) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create the log directory %s: %w", dir, err)
+	}
 	return grantInteractiveUsersWrite(dir)
 }
 

--- a/cli/beacon/internal/endpoint/writer/writer.go
+++ b/cli/beacon/internal/endpoint/writer/writer.go
@@ -88,6 +88,23 @@ func AppendEvent(event schema.Event, opts Options) (string, error) {
 	return opts.Path, nil
 }
 
+// EnsureSystemLogWritable makes a machine-wide log directory writable by the people whose agent
+// sessions this endpoint captures.
+//
+// A no-op on POSIX, where the file mode carries the same guarantee. On Windows it is the step
+// without which a system-mode install produces a healthy collector that records nothing the agent
+// did: %ProgramData% denies ordinary users write access, hooks run as the console user, and
+// nothing reports an error because status and doctor both describe the collector rather than the
+// hooks exporting to it.
+func EnsureSystemLogWritable(dir string) error {
+	return grantInteractiveUsersWrite(dir)
+}
+
+// SystemLogWritableByUsers reports whether that grant is in place, for doctor.
+func SystemLogWritableByUsers(dir string) (bool, error) {
+	return interactiveUsersCanWrite(dir)
+}
+
 // EnsureRuntimeFile creates the shared runtime log with the shared writable
 // mode without appending an event, for doctor --fix and setup flows that
 // pre-create the log so user-run hooks can append to it later.


### PR DESCRIPTION
## Why

Phase 3, following #316 (compile + harness) and #319 (filesystem contract). A Windows endpoint can
now run as a real service: it survives reboot and restarts on failure, rather than lasting until
the next crash.

## The assumption this was gated on

The plan's design rested on registering `beacon-otelcol.exe` with the SCM **directly, with no
service host**, because the builder-generated `main_windows.go` calls
`svc.Run(otelcol.NewSvcHandler(params))`. Nothing had exercised that path. Running the binary as an
ordinary child process proves it starts; it does not prove it speaks the control protocol, and a
service that fails to reach the dispatcher is killed after ~30 seconds.

If it had failed, the backend would not be `mgr.CreateService` on the collector — it would be a
service host that implements the protocol and supervises the collector, a materially different
piece of work. So the sandbox now registers a scratch service and polls for `RUNNING` before any of
this is relied on:

```
SCM_STATE=RUNNING
SERVICE_NAME: BeaconCollectorScmProbe
        STATE              : 4  RUNNING
the collector runs as a Windows service with no wrapper
```

The step stays in the workflow. It is cheap, and it is the thing the whole backend assumes.

## The service backend

Mapping from the two backends it joins:

| launchd | systemd | Windows SCM |
|---|---|---|
| `RunAtLoad` | `WantedBy=multi-user.target` | `StartAutomatic` + explicit `Start` |
| `KeepAlive` | `Restart=always` | recovery actions: restart at 5s, 15s, 60s |
| `StandardOutPath` | journal | the collector's own file logging — the SCM captures no stdout |
| plist path | `/etc/systemd/system/*.service` | no file; `unitPath` reports the registry key |

Three escalating restarts rather than unlimited immediate ones: a collector that cannot start at
all should leave a visible stopped service, not thrash forever writing the same error. The failure
count resets after a day of health, so a service that dies weekly does not eventually exhaust them.

Registration **updates in place** rather than delete-and-recreate. A delete only takes effect once
every handle to the service closes, so recreating immediately afterwards can fail with "marked for
deletion" on a machine where `services.msc` happens to be open — and changing the binary path is
the ordinary upgrade case, not an edge one.

`UpdateConfig` takes one `binPath` string rather than an executable and arguments, so the quoting
is ours: an unquoted path breaks at the first space, and the default install location is under
`%ProgramFiles%`.

### User mode is the supervised backend

Windows has no per-user service manager — no `systemctl --user`, no `gui/<uid>` domain. `--user`
routes to the supervised backend, and `status` says in-band that nothing restarts it and it does not
survive logout. `w02` asserts the fallback actually happened: "running" alone is satisfied by a
service registered under the user's name, which is what a future change to the routing would
silently do.

## The ACL grant, deferred from #319

A service is what makes this urgent. A system-mode log lives under `%ProgramData%`, which denies
ordinary users write access, while hooks run as the console user. Without an explicit grant every
visible signal is healthy — the service runs, `status` and `doctor` agree — and **nothing the agent
does is ever recorded**, because all of those describe the collector rather than the hooks
exporting to it. That is the same shape as the Linux `SUDO_USER` bug.

Granted to `INTERACTIVE`, not `Users` or `Everyone`: exactly the accounts whose agent sessions this
endpoint captures, excluding service and network logons. User mode is deliberately left alone —
widening a personal profile's ACL would hand that user's retained prompt text to every interactive
account on the machine.

**`doctor` had to become platform-aware to be worth anything here.** Its `runtime_log_permissions`
check tests `mode&0222`, and Windows reports `0666` for any ordinary file regardless of its ACL —
so the check never fires and would have certified the exact configuration it exists to catch. It
now reads the ACL, and *reads* it rather than attempting a write, because `doctor` usually runs
elevated and a test write would succeed for the one user whose access is not in question.

## Scenarios

`w01-install-service` and `w02-install-supervised`. Both assert `expect_service_kind`, which is what
makes them mean what they claim — the Linux systemd scenario documents the same trap.

Their capture expectations are `optional: true`, deliberately: hook installation on Windows still
emits a POSIX `VAR=value cmd` string neither Windows shell accepts, so nothing reaches the collector
through hooks yet. Marking them required would fail the scenarios for a known reason and stop them
reporting the service facts they exist to establish. They become required in the PR that fixes the
hook command format.

## What review caught

Five defects, all real, all in the install path and four of them the kind that reports success
while the endpoint does not work. Recorded here because they are the substance of the last two
commits, not incidental cleanup:

- **Install could not run on a clean machine.** `EnsureSystemLogWritable` grants access *by path*,
  and Install called it before anything had created the log directory — so the grant failed and
  took the install down before the service was ever registered. The first install on a new machine
  was the one case that could not work. It creates the directory now, in the shared function rather
  than the Windows half, so the next platform cannot reintroduce the ordering.
- **Uninstall left the service running.** The unload loop named launchd, systemd and supervised. A
  Windows endpoint reported a successful uninstall while `BeaconCollector` stayed registered and
  still started at boot. The list moved to `service.ManagedKinds()` beside the kinds themselves,
  with a test that every spelling `ParseKind` accepts resolves to something on it.
- **Upgrades wrote an unusable `ImagePath`.** `%q` escapes for a Go string literal, not the SCM:
  every backslash doubled, under a default path that lives in `%ProgramFiles%`. Fresh installs were
  fine because `CreateService` escapes on its own, so the damage appeared only at the next start,
  long after the upgrade said it succeeded. It calls the same escaper `CreateService` calls.
- **`doctor` cried wolf on user mode**, running the system-mode INTERACTIVE check against a grant
  that is deliberately absent there — a high-severity failure on every correctly configured
  user-mode endpoint. The scopes are asked different questions now.
- **`doctor` printed `chmod 666` on Windows**, including for the missing system-mode grant, which is
  the single most consequential remediation on that platform. Advice branches on evidence now,
  `--fix` applies the grant through the same call install makes, and unrepairable permission
  evidence reports as a skip instead of falling out of the switch unreported.

One more, found while in the file: the ACL read parsed `icacls` **text**, which resolves the SID to
a *localized* account name — so a correctly granted directory read as ungranted on any non-English
install, and an expanded rights list defeated the `(M)` match. Same wrong answer, invisible from an
English test machine, which is every machine this gets tested on. It walks the DACL through the
security APIs instead, honoring deny entries and ignoring inherit-only ones, with a
grant-then-read-back test on a real ACL so the two halves cannot drift.

**#322** — filed rather than fixed here: no scenario on any platform asserts that uninstall removes
anything. The leaked service was caught by a reviewer, not by a run, because no run has ever asked.

## Verification

Full gate, host and Windows, across all five modules, plus `go test -race ./internal/endpoint/...`.
The SCM answer above came from a real dispatched run.

## Known, and filed rather than hidden

**#320** — `beacon ci exec` captures telemetry on Windows only intermittently. Three dispatched runs
on the same commit: 21 events once, zero twice, with the agent behaving identically each time
(same turn count, same cost, sentinel written). Not root-caused; the evidence is in the issue. It
affects the `ci exec` path, not the service path this PR adds.

Hook installation remains broken on Windows, so Windows stays out of `.goreleaser.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Windows install/uninstall, SCM registration, and filesystem ACLs—mistakes can leave a persistent service or a “healthy” endpoint that never records agent events; elevated rights are required for system install and CI SCM probe.
> 
> **Overview**
> **Windows system installs** now register `beacon-otelcol.exe` with the Service Control Manager (`BeaconCollector`): auto-start, delayed start, in-place updates with SCM-correct `ImagePath` quoting, recovery restarts, and uninstall via `ManagedKinds()` so the service is not left behind. **User `--user`** still uses the supervised backend; status text calls out no restart and logout on Windows.
> 
> **Log capture on system mode** adds `EnsureSystemLogWritable` at install (mkdir + `icacls` INTERACTIVE grant on the log dir). **Doctor** checks Windows ACLs instead of mode bits, suggests `icacls` (not `chmod`), and `--fix` can apply `grant_log_access`; user-mode checks use a real write test without requiring the INTERACTIVE grant.
> 
> **CI / scenarios:** the Windows sandbox workflow registers a scratch SCM service and requires `RUNNING` before relying on direct collector registration. New scenarios `w01-install-service` and `w02-install-supervised` assert `expect_service_kind`; hook/capture expectations stay optional until Windows hook commands work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 759a1972ab6fb4c2acfe1ea1106c40c94de560d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

