### PR TITLE
test(windows): gate user-mode capture now that a run has demonstrated it

### DIFF
--- a/beacon-sandbox/scenarios/w02-install-supervised.yaml
+++ b/beacon-sandbox/scenarios/w02-install-supervised.yaml
@@ -25,12 +25,10 @@ install:
 expect:
   - action: prompt.submitted
     contains: ["{{canary}}"]
-    optional: true
     why: >-
-      Recorded rather than gated, and for a narrower reason than it used to be. w01 and w03 have both
-      captured through installed hooks in system mode, so the hook command itself works on Windows.
-      What no run has yet observed is capture in *user* mode: the only attempt failed before the
-      session on an OTLP port conflict with a system collector the previous scenario left running.
-      That is fixed in the runner rather than here, but this stays optional until a run has actually
-      demonstrated it -- promoting it on the strength of the system-mode result would be assuming the
-      thing this scenario exists to check.
+      Capture through a user-mode endpoint, which is a different path from the system-mode scenarios:
+      a supervised collector rather than a service, and a log in the user's own profile rather than
+      under %ProgramData%. It stayed optional until a run demonstrated it, because the system-mode
+      result did not imply it -- the first attempt never reached the session, dying on an OTLP port
+      conflict with a collector the previous scenario left behind. With that fixed the scenario
+      captured 33 events, so the gap it was hedging against is closed.


### PR DESCRIPTION
## Why

A one-commit follow-up to #323. It was pushed a minute after that PR merged, so it missed the train.

The final Windows suite run, with each scenario judging its own log, reported:

```
FAIL  w00-probe                0 events   (known ci exec flakiness, #320)
PASS  w01-install-service     38 events
PASS  w02-install-supervised  33 events
PASS  w03-hook-capture        54 events
PASS  w04-denied-tool         50 events
```

The counts are the point: **38, 33, 54, 50** rather than the earlier 38, 87, 129. The accumulation is
gone, so every scenario passed on its own evidence rather than partly on the previous one's.

That settles what `w02` was hedging against. User mode is a genuinely different path from the
system-mode scenarios — a supervised collector rather than a service, and a log in the user's own
profile rather than under `%ProgramData%` — so the system-mode result did not imply it, and its one
earlier attempt died before the session on an OTLP port conflict. It captured 33 events, so the
`optional: true` is no longer honest and comes off.

`w00` still fails on the intermittent `beacon ci exec` capture tracked in #320. That is a different
code path from the installed-hook one every other Windows scenario exercises, and nothing here touches
it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only YAML change tightening one sandbox expectation; no production or runtime behavior.
> 
> **Overview**
> **Windows sandbox scenario `w02-install-supervised`** now **requires** `prompt.submitted` with the canary text instead of treating it as optional.
> 
> The expectation’s `why` comment is rewritten to note that user-mode capture (supervised collector + per-user log) was validated in a full suite run (33 events) after the OTLP port-conflict fix, so the earlier hedge no longer applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50f1ecdc37c0e886cf286bd5d10cdb68ff61d99d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->