### PR TITLE
fix(ci): export telemetry on a timer that fits the session

### DIFF
--- a/.github/workflows/windows-sandbox.yml
+++ b/.github/workflows/windows-sandbox.yml
@@ -290,6 +290,105 @@ jobs:
             throw 'no hook ran at all: this says nothing about command forms, only that UserPromptSubmit did not fire'
           }
 
+      # Splits #320 in half instead of guessing at it.
+      #
+      # `beacon ci exec` on Windows captures sometimes and not others, with the agent doing identical
+      # work either way. Two very different things could produce that, and no amount of reading tells
+      # them apart: either the collector never receives what the agent sends, or the agent never sends
+      # it. Fixing the wrong half is free to do and expensive to discover.
+      #
+      # So this asks the first half on its own, with no agent involved: start the collector, send it
+      # one OTLP request by hand, and see whether a line appears in the log. A pass here says the
+      # receiver and the Beacon exporter work on Windows and moves the whole question onto the agent's
+      # exporter. A failure says the opposite, and would explain the intermittency directly.
+      - name: Does the collector record an OTLP request at all
+        id: otlp
+        continue-on-error: true
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $dir = 'C:\beacon-sandbox\otlp'
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          $logPath = Join-Path $dir 'runtime.jsonl'
+          $cfgPath = Join-Path $dir 'otelcol.yaml'
+
+          # HTTP rather than gRPC, deliberately: it can be driven with Invoke-WebRequest and no client
+          # library, so this step tests Beacon's receiving side without importing whatever the agent's
+          # gRPC stack might be doing wrong. If HTTP lands and the agent's gRPC does not, that
+          # difference is itself the finding.
+          $cfg = @(
+            'receivers:'
+            '  otlp:'
+            '    protocols:'
+            '      http:'
+            '        endpoint: 127.0.0.1:14318'
+            'exporters:'
+            '  beaconjson:'
+            ('    path: ' + (ConvertTo-Json $logPath))
+            'service:'
+            '  pipelines:'
+            '    logs:'
+            '      receivers: [otlp]'
+            '      exporters: [beaconjson]'
+          )
+          Set-Content -LiteralPath $cfgPath -Value $cfg -Encoding utf8
+
+          $proc = Start-Process -FilePath 'C:\beacon-sandbox\bin\beacon-otelcol.exe' `
+            -ArgumentList @('--config', $cfgPath) -PassThru -WindowStyle Hidden
+          try {
+            # Polled rather than slept: a fixed sleep is how a slow start becomes a mystery failure.
+            $ready = $false
+            foreach ($i in 1..30) {
+              Start-Sleep -Milliseconds 500
+              try {
+                $c = New-Object System.Net.Sockets.TcpClient
+                $c.Connect('127.0.0.1', 14318)
+                $c.Close()
+                $ready = $true
+                break
+              } catch { }
+            }
+            if (-not $ready) { throw 'the collector never listened on 127.0.0.1:14318' }
+
+            $body = @{
+              resourceLogs = @(@{
+                resource = @{ attributes = @(@{ key = 'service.name'; value = @{ stringValue = 'otlp-probe' } }) }
+                scopeLogs = @(@{ logRecords = @(@{
+                  timeUnixNano = '1700000000000000000'
+                  body = @{ stringValue = 'BEACON_OTLP_PROBE' }
+                  attributes = @(@{ key = 'event.name'; value = @{ stringValue = 'probe' } })
+                }) })
+              })
+            } | ConvertTo-Json -Depth 12
+
+            $resp = Invoke-WebRequest -Uri 'http://127.0.0.1:14318/v1/logs' -Method Post `
+              -ContentType 'application/json' -Body $body -UseBasicParsing
+            Write-Output "OTLP_POST_STATUS=$($resp.StatusCode)"
+
+            # The exporter writes on its own schedule, so the log is polled rather than read once.
+            $landed = $false
+            foreach ($i in 1..20) {
+              Start-Sleep -Seconds 1
+              if ((Test-Path -LiteralPath $logPath) -and
+                  (Select-String -LiteralPath $logPath -Pattern 'BEACON_OTLP_PROBE' -Quiet)) {
+                $landed = $true
+                break
+              }
+            }
+            Write-Output "OTLP_LANDED=$landed"
+            if (Test-Path -LiteralPath $logPath) {
+              Write-Output "log bytes: $((Get-Item -LiteralPath $logPath).Length)"
+              Get-Content -LiteralPath $logPath -TotalCount 2 | Write-Output
+            } else {
+              Write-Output 'the exporter never created the log file'
+            }
+            if (-not $landed) {
+              throw 'the collector accepted an OTLP request and no event reached the log: the receiving half is broken, not the agent'
+            }
+            Write-Output 'the collector receives OTLP and writes Beacon JSONL on Windows'
+          } finally {
+            if ($proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force }
+          }
+
       # Phase 3 registers beacon-otelcol.exe with the Service Control Manager directly, on the
       # strength of the builder-generated main_windows.go calling svc.Run(otelcol.NewSvcHandler).
       # That is an assumption about a code path nothing has exercised: running the binary as an

--- a/cli/beacon/internal/ci/harness.go
+++ b/cli/beacon/internal/ci/harness.go
@@ -40,6 +40,33 @@ func ClaudeEnv(base []string, endpoint string) []string {
 	delete(env, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
 	env["OTEL_LOG_TOOL_DETAILS"] = "1"
 	env["OTEL_LOG_USER_PROMPTS"] = "1"
+
+	// Export on a timer that fits the session, instead of relying on the flush at shutdown.
+	//
+	// The OpenTelemetry default metric interval is 60 seconds, and `ci exec` wraps sessions that
+	// finish in five or ten. Nothing is exported on a timer in that window, so every event depends on
+	// the exporter flushing during shutdown, before the process exits and before `ci exec` stops the
+	// collector behind it. That is a race, and it was being lost about two runs in three: three
+	// dispatched runs of the same commit captured 21 events once and zero twice, with the agent doing
+	// identical work each time and the passing run being the longest of the three (#320).
+	//
+	// A shutdown flush is still the backstop and still has to work. This just stops it being the only
+	// thing between a captured session and an empty log.
+	//
+	// Set only when the caller has not. Someone who has deliberately tuned these has a reason, and
+	// this is a wrapper around their session rather than an owner of their telemetry configuration.
+	for key, value := range map[string]string{
+		"OTEL_METRIC_EXPORT_INTERVAL": "5000",
+		// The batch processors default to 1s and 5s respectively, which is already inside a short
+		// session -- pinned anyway so the whole pipeline's timing is stated in one place rather than
+		// inherited from three different SDK defaults.
+		"OTEL_BLRP_SCHEDULE_DELAY": "1000",
+		"OTEL_BSP_SCHEDULE_DELAY":  "1000",
+	} {
+		if strings.TrimSpace(env[key]) == "" {
+			env[key] = value
+		}
+	}
 	return flattenEnv(env)
 }
 

--- a/cli/beacon/internal/ci/harness_test.go
+++ b/cli/beacon/internal/ci/harness_test.go
@@ -60,3 +60,47 @@ func TestNormalizeHarnessesSupportsClaudeAndCodexAliases(t *testing.T) {
 		t.Fatalf("NormalizeHarnesses = %q, want claude,codex", joined)
 	}
 }
+
+// TestClaudeEnvExportsOnATimerShorterThanASession covers the intermittency in #320.
+//
+// The OpenTelemetry default metric interval is 60 seconds and `ci exec` wraps sessions that finish in
+// five or ten, so without these nothing is exported on a timer and every event rides on the flush at
+// shutdown -- a race that three dispatched runs of the same commit lost twice.
+func TestClaudeEnvExportsOnATimerShorterThanASession(t *testing.T) {
+	env := envMap(ClaudeEnv(nil, "http://127.0.0.1:4317"))
+
+	for key, want := range map[string]string{
+		"OTEL_METRIC_EXPORT_INTERVAL": "5000",
+		"OTEL_BLRP_SCHEDULE_DELAY":    "1000",
+		"OTEL_BSP_SCHEDULE_DELAY":     "1000",
+	} {
+		if env[key] != want {
+			t.Fatalf("%s = %q, want %q; a session shorter than the export interval captures nothing "+
+				"unless the shutdown flush wins a race", key, env[key], want)
+		}
+	}
+}
+
+// TestClaudeEnvDoesNotOverrideDeliberateExportTuning keeps this a wrapper rather than an owner.
+//
+// Someone who set these has a reason -- a long-running session, a slow collector, a cost concern --
+// and `ci exec` runs their session rather than administering their telemetry.
+func TestClaudeEnvDoesNotOverrideDeliberateExportTuning(t *testing.T) {
+	base := flattenEnv(map[string]string{
+		"OTEL_METRIC_EXPORT_INTERVAL": "30000",
+		"OTEL_BSP_SCHEDULE_DELAY":     "250",
+	})
+	env := envMap(ClaudeEnv(base, "http://127.0.0.1:4317"))
+
+	if env["OTEL_METRIC_EXPORT_INTERVAL"] != "30000" {
+		t.Fatalf("OTEL_METRIC_EXPORT_INTERVAL = %q, want the caller's 30000", env["OTEL_METRIC_EXPORT_INTERVAL"])
+	}
+	if env["OTEL_BSP_SCHEDULE_DELAY"] != "250" {
+		t.Fatalf("OTEL_BSP_SCHEDULE_DELAY = %q, want the caller's 250", env["OTEL_BSP_SCHEDULE_DELAY"])
+	}
+	// The one it did not set still gets the default, so a partially-tuned environment is completed
+	// rather than left with a 60-second gap in it.
+	if env["OTEL_BLRP_SCHEDULE_DELAY"] != "1000" {
+		t.Fatalf("OTEL_BLRP_SCHEDULE_DELAY = %q, want it filled in", env["OTEL_BLRP_SCHEDULE_DELAY"])
+	}
+}


### PR DESCRIPTION
Closes #320.

## The symptom

`beacon ci exec` captured on Windows about one run in three. Three dispatched `w00-probe` runs on the
same commit produced **21 events once and zero twice**, with the agent doing identical work each time
— same turn count, same cost, sentinel written — and the collector logging "Everything is ready" in
all three.

## The cause is a default nobody set

`ClaudeEnv` configures the exporters, the protocol and the endpoint. It says nothing about intervals,
so Claude Code uses the OpenTelemetry default **`OTEL_METRIC_EXPORT_INTERVAL` of 60 seconds**.

`ci exec` wraps sessions that finish in five or ten. Nothing is exported on a timer inside that
window, so every event rides on the exporter flushing during shutdown — before the process exits, and
before `ci exec` stops the collector behind it. That is a race.

The evidence in the issue fits: the run that captured was the **longest of the three**
(`duration_api_ms` 7901 vs 6212), and the failing runs showed `quiescent: false` after the full
90-second wait, meaning the log never grew at all rather than growing and being truncated.

**This is not a Windows bug**, though Windows is where it showed. A short session on any platform has
the same gap; Linux runs are longer or the flush lands more often, which is why it read as a Windows
problem for as long as it did.

## What changed

Export intervals short enough that a five-second session exports on a timer. The shutdown flush is
still the backstop and still has to work — this stops it being the *only* thing between a captured
session and an empty log.

Values the caller already set are left alone: someone who tuned these has a reason, and `ci exec` runs
their session rather than administering their telemetry. A partially tuned environment is completed
rather than left with a 60-second hole in it.

## Verification

Unit tests cover both directions — the defaults land, and deliberate tuning survives.

**The real confirmation needs runs, not reasoning.** The failure is intermittent at roughly 2-in-3, so
a single green run proves nothing; I am dispatching repeats of `w00-probe` and will post the tally
here before this is worth merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default OpenTelemetry export timing for all Claude `ci exec` harness runs (behavioral, cross-platform), though overrides are respected; the new Windows probe only affects CI diagnostics.
> 
> **Overview**
> Addresses **intermittent empty captures** in `beacon ci exec` (#320) by no longer depending on a shutdown-only OTLP flush during 5–10 second sessions.
> 
> **`ClaudeEnv`** now fills in short export/batch delays when the caller left them unset: `OTEL_METRIC_EXPORT_INTERVAL=5000` plus `OTEL_BSP_SCHEDULE_DELAY` / `OTEL_BLRP_SCHEDULE_DELAY` at 1000ms. Existing values are preserved so deliberate tuning still wins; partial tuning gets the missing keys filled in. Unit tests lock in both behaviors.
> 
> The **Windows sandbox workflow** gains a **continue-on-error OTLP probe** that starts `beacon-otelcol`, posts a hand-built HTTP `/v1/logs` payload, and asserts `BEACON_OTLP_PROBE` lands in Beacon JSONL—splitting “collector receive path broken” from “agent never exported” without involving Claude.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 047564d6d7fda979324a66a82b8784398dc7eb7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->