### PR TITLE
feat(release): publish Windows archives, and find the collector inside one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,11 +299,17 @@ jobs:
             mkdir -p dist/beacon-otelcol/linux_$arch
             cp dist/beacon-otelcol/beacon-otelcol dist/beacon-otelcol/linux_$arch/beacon-otelcol
           done
-          # The goreleaser before-hook stages all four targets, so darwin must exist too.
+          # The goreleaser before-hook stages every target, so each one must exist here. These are
+          # stand-ins: this job checks that packaging works, not that the binaries run, so a Linux
+          # build stood in a darwin directory is enough to exercise the archive and package steps.
           for arch in amd64 arm64; do
             mkdir -p dist/beacon-otelcol/darwin_$arch
             cp dist/beacon-otelcol/linux_$arch/beacon-otelcol dist/beacon-otelcol/darwin_$arch/beacon-otelcol
           done
+          # Windows is amd64 only, and carries the .exe the release archive ships -- the same name
+          # build-release-collectors.sh stages, so the before-hook finds it under either script.
+          mkdir -p dist/beacon-otelcol/windows_amd64
+          cp dist/beacon-otelcol/linux_amd64/beacon-otelcol dist/beacon-otelcol/windows_amd64/beacon-otelcol.exe
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest

--- a/cli/beacon/.goreleaser.yaml
+++ b/cli/beacon/.goreleaser.yaml
@@ -8,11 +8,14 @@ before:
     - go mod tidy
     - bash -c 'cd ../beacon-hooks && go mod tidy'
     - rm -rf ./release-collectors
-    - mkdir -p ./release-collectors/darwin_amd64 ./release-collectors/darwin_arm64 ./release-collectors/linux_amd64 ./release-collectors/linux_arm64
+    - mkdir -p ./release-collectors/darwin_amd64 ./release-collectors/darwin_arm64 ./release-collectors/linux_amd64 ./release-collectors/linux_arm64 ./release-collectors/windows_amd64
     - cp ../../collector-builder/dist/beacon-otelcol/darwin_amd64/beacon-otelcol ./release-collectors/darwin_amd64/beacon-otelcol
     - cp ../../collector-builder/dist/beacon-otelcol/darwin_arm64/beacon-otelcol ./release-collectors/darwin_arm64/beacon-otelcol
     - cp ../../collector-builder/dist/beacon-otelcol/linux_amd64/beacon-otelcol ./release-collectors/linux_amd64/beacon-otelcol
     - cp ../../collector-builder/dist/beacon-otelcol/linux_arm64/beacon-otelcol ./release-collectors/linux_arm64/beacon-otelcol
+    # .exe because that is the name the target needs, which build-release-collectors.sh already
+    # stages -- the collector builder itself emits an extensionless PE binary.
+    - cp ../../collector-builder/dist/beacon-otelcol/windows_amd64/beacon-otelcol.exe ./release-collectors/windows_amd64/beacon-otelcol.exe
     # Package the external threat-rule pack (repo rules/, not embedded in the binary)
     # as a release asset users install with `beacon rules pull <asset-url>`.
     - bash -c 'mkdir -p release-rules && COPYFILE_DISABLE=1 tar --exclude="._*" --exclude=".DS_Store" -czf release-rules/threat-rules.tar.gz -C ../.. rules'
@@ -33,9 +36,17 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
+    ignore:
+      # No Windows ARM build, because there is no Windows ARM collector to put in the archive.
+      # build-release-collectors.sh builds windows/amd64 only, and an archive containing the CLI but
+      # not the collector is worse than no archive: `endpoint install` would report that no collector
+      # is installed, on a machine where the user had just installed Beacon.
+      - goos: windows
+        goarch: arm64
     hooks:
       pre:
         # Build the hooks binary for this target platform and embed it.
@@ -59,21 +70,38 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
+    ignore:
+      # Matches the beacon build above. The two are packaged into one archive, so a target either
+      # has both or neither.
+      - goos: windows
+        goarch: arm64
 
 archives:
   - formats:
       - tar.gz
+    # zip on Windows, which is what the platform can extract without installing anything. A tar.gz
+    # is a worse first impression than a missing build for someone who has to go find a tool to open
+    # it before they can run anything.
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     ids:
       - beacon
       - beacon-hooks
     files:
       - README*
-      - src: release-collectors/{{ .Os }}_{{ .Arch }}/beacon-otelcol
-        dst: beacon-otelcol
+      # Globbed and flattened rather than named, because the collector is beacon-otelcol on POSIX and
+      # beacon-otelcol.exe on Windows, and a `dst` cannot vary by platform. strip_parent puts it at
+      # the archive root next to the two binaries, which is the layout DiscoverBinary looks for: a
+      # collector sitting beside the CLI that was run.
+      - src: release-collectors/{{ .Os }}_{{ .Arch }}/beacon-otelcol*
+        strip_parent: true
 
 nfpms:
   # Native packages are the Linux counterpart of the signed macOS .pkg: installing one should

--- a/cli/beacon/internal/endpoint/collector/candidates_other.go
+++ b/cli/beacon/internal/endpoint/collector/candidates_other.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package collector
+
+// binaryFileName is the on-disk name of the collector.
+//
+// The same as BinaryName here: POSIX executables carry no extension, so the name used for a PATH
+// lookup and the name used for a direct stat are the same string.
+func binaryFileName() string { return BinaryName }
+
+// packagedBinaryPaths is the machine-wide install location.
+//
+// /opt rather than an FHS bindir, deliberately: it is the correct home for a self-contained vendor
+// bundle, it matches the macOS package layout, and selfupdate's install classification keys off it.
+func packagedBinaryPaths() []string { return []string{PackagedBinaryPath} }

--- a/cli/beacon/internal/endpoint/collector/candidates_test.go
+++ b/cli/beacon/internal/endpoint/collector/candidates_test.go
@@ -1,0 +1,90 @@
+package collector
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestDefaultBinaryCandidatesLooksForTheNameOnDisk covers the release archive's whole reason to exist.
+//
+// An extracted archive is beacon and beacon-otelcol sitting next to each other in a directory the
+// user chose, which is almost never on PATH. So the sibling candidate is the one that has to work,
+// and it has to ask for the file by the name the file actually has.
+//
+// On Windows those differ. BinaryName has no extension because it is what exec.LookPath is given, so
+// PATHEXT can resolve it; the file on disk is beacon-otelcol.exe. Using the PATH spelling for a direct
+// stat meant `beacon endpoint install` reported that no collector was installed, on a machine where
+// the user had just extracted one next to the CLI.
+func TestDefaultBinaryCandidatesLooksForTheNameOnDisk(t *testing.T) {
+	candidates := defaultBinaryCandidates()
+	if len(candidates) == 0 {
+		t.Fatal("no candidate paths at all")
+	}
+
+	// The sibling of the running executable comes first: an extracted archive should win over a
+	// machine-wide install, because it is the more specific answer to "which collector did this CLI
+	// come with".
+	first := candidates[0]
+	if got := filepath.Base(first); got != binaryFileName() {
+		t.Fatalf("first candidate is %q, want a file named %q", got, binaryFileName())
+	}
+
+	if runtime.GOOS == "windows" {
+		if !strings.HasSuffix(first, ".exe") {
+			t.Fatalf("first candidate %q has no .exe; os.Stat will not find the extracted collector", first)
+		}
+	} else if strings.HasSuffix(first, ".exe") {
+		t.Fatalf("first candidate %q has a .exe on a POSIX platform", first)
+	}
+}
+
+func TestPackagedBinaryPathsAreAbsoluteAndPlatformShaped(t *testing.T) {
+	paths := packagedBinaryPaths()
+	if len(paths) == 0 {
+		t.Fatal("no packaged install location to look in")
+	}
+	for _, path := range paths {
+		if !filepath.IsAbs(path) {
+			t.Fatalf("packaged path %q is not absolute", path)
+		}
+		if filepath.Base(path) != binaryFileName() {
+			t.Fatalf("packaged path %q does not end in %q", path, binaryFileName())
+		}
+	}
+
+	if runtime.GOOS != "windows" {
+		// The POSIX location is a release contract: selfupdate classifies a package install by it.
+		if paths[0] != PackagedBinaryPath {
+			t.Fatalf("packaged path = %q, want %q", paths[0], PackagedBinaryPath)
+		}
+		return
+	}
+
+	// The POSIX constant is /opt/beacon/bin/..., which is not a path on Windows. Looking there would
+	// always miss, and the miss would read as "no collector installed".
+	for _, path := range paths {
+		if strings.HasPrefix(path, "/opt/") {
+			t.Fatalf("packaged path %q is the POSIX location", path)
+		}
+	}
+}
+
+// TestWindowsPackagedPathsHonorARelocatedProgramFiles guards against a hardcoded C:\Program Files.
+//
+// A machine with a relocated or localized program-files root must not be told its collector is
+// missing, which is the same reason SystemBaseDir reads %ProgramData% instead of assuming it.
+func TestWindowsPackagedPathsHonorARelocatedProgramFiles(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only path resolution")
+	}
+	t.Setenv("ProgramW6432", `D:\Apps`)
+	t.Setenv("ProgramFiles", `D:\Apps`)
+
+	paths := packagedBinaryPaths()
+	want := filepath.Join(`D:\Apps`, "Beacon", "bin", binaryFileName())
+	if len(paths) != 1 || paths[0] != want {
+		t.Fatalf("packaged paths = %#v, want exactly [%q] (deduplicated when both roots agree)", paths, want)
+	}
+}

--- a/cli/beacon/internal/endpoint/collector/candidates_windows.go
+++ b/cli/beacon/internal/endpoint/collector/candidates_windows.go
@@ -1,0 +1,57 @@
+//go:build windows
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// binaryFileName is what the collector is actually called on disk here.
+//
+// BinaryName has no extension because that is the name callers ask exec.LookPath for, and LookPath
+// applies PATHEXT to resolve it. Every other lookup names the file directly, where the extension is
+// not optional: os.Stat of "beacon-otelcol" does not find "beacon-otelcol.exe".
+//
+// That distinction is exactly what the release archive walks into. It ships beacon.exe and
+// beacon-otelcol.exe side by side, and the first thing a user does is extract it somewhere that is
+// not on PATH and run `beacon endpoint install` -- which searched for an extensionless sibling,
+// found nothing, and reported that no collector was installed.
+func binaryFileName() string {
+	return BinaryName + ".exe"
+}
+
+// packagedBinaryPaths are the machine-wide install locations to look in.
+//
+// The POSIX constant is /opt/beacon/bin/beacon-otelcol, which is not a path on this platform. Read
+// from the environment rather than hardcoded, with a fallback, for the same reason SystemBaseDir
+// does: a machine with a relocated or localized %ProgramFiles% must not be told its collector is
+// missing.
+//
+// Both program-files roots are checked. A 64-bit Beacon installs under %ProgramFiles%, but an
+// installer running from a 32-bit context sees that variable redirected, and %ProgramW6432% is the
+// one that always names the 64-bit directory -- so looking in only one of them finds nothing on a
+// machine where the other was used.
+func packagedBinaryPaths() []string {
+	var roots []string
+	for _, key := range []string{"ProgramW6432", "ProgramFiles"} {
+		if value := os.Getenv(key); value != "" {
+			roots = append(roots, value)
+		}
+	}
+	if len(roots) == 0 {
+		roots = append(roots, `C:\Program Files`)
+	}
+
+	seen := make(map[string]bool, len(roots))
+	paths := make([]string, 0, len(roots))
+	for _, root := range roots {
+		path := filepath.Join(root, "Beacon", "bin", binaryFileName())
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+		paths = append(paths, path)
+	}
+	return paths
+}

--- a/cli/beacon/internal/endpoint/collector/collector.go
+++ b/cli/beacon/internal/endpoint/collector/collector.go
@@ -66,10 +66,20 @@ func DiscoverBinary(configured string) string {
 	return ""
 }
 
+// defaultBinaryCandidates lists where to look for the collector when it is not on PATH.
+//
+// A sibling of the running CLI comes first, because that is what an extracted release archive looks
+// like: beacon and beacon-otelcol next to each other in whatever directory the user unpacked them
+// into. The machine-wide install location follows, for a package install.
+//
+// Both are asked for by their on-disk name rather than by BinaryName. Those differ on Windows -- the
+// file is beacon-otelcol.exe, while BinaryName is what exec.LookPath is given so PATHEXT can resolve
+// it -- and using the PATH spelling for a direct stat meant an extracted archive reported no
+// collector at all.
 func defaultBinaryCandidates() []string {
-	paths := []string{PackagedBinaryPath}
+	paths := packagedBinaryPaths()
 	if executable, err := currentExecutable(); err == nil {
-		paths = append([]string{filepath.Join(filepath.Dir(executable), BinaryName)}, paths...)
+		paths = append([]string{filepath.Join(filepath.Dir(executable), binaryFileName())}, paths...)
 	}
 	return paths
 }


### PR DESCRIPTION
## Why this before the MSI

Everything the Windows port proved works has been **unreachable**. `.goreleaser.yaml` built darwin and
linux only:

```
goos: [darwin, linux]
```

So no release has ever contained a `beacon.exe`. A Windows user's only option was to clone the repo and
build it. The port was finished and undelivered — and this is a much smaller change than the installer.

The collector was already ready: `build-release-collectors.sh` has built `windows/amd64` since the
compile work, and already stages it as `beacon-otelcol.exe` because that is the name the target needs.
Only the release config never asked for it.

## The part that would have shipped broken

`DiscoverBinary` looked for a sibling of the running CLI named `beacon-otelcol` — no extension. That
name exists so `exec.LookPath` can apply `PATHEXT` when resolving it *from PATH*. Every other lookup
stats the file directly, and `os.Stat` does not do `PATHEXT`.

So: extract the archive, run `beacon endpoint install` from that directory — the first thing anyone
does, and almost never on PATH — and it reports **no collector installed**, standing next to the
collector. The machine-wide fallback had the same shape: `/opt/beacon/bin/beacon-otelcol` is not a path
on Windows.

It now asks for the on-disk name, reads `%ProgramFiles%`, and checks `%ProgramW6432%` alongside it —
a 32-bit install context sees the first redirected and would look in the wrong directory.

## Decisions, stated rather than implied

- **amd64 only.** There is no `windows/arm64` collector, and an archive holding the CLI but not the
  collector is worse than no archive. The build `ignore`s that pair instead of shipping half of it.
- **zip, not tar.gz.** A tar.gz is a worse first impression than a missing build for someone who has
  to go find a tool to open it.

## Verification — built, not inferred

A local snapshot produces:

```
beacon_1.1.0-SNAPSHOT_windows_amd64.zip
  README.md
  beacon-otelcol.exe
  beacon.exe
  beacon-hooks.exe
```

All three flattened to the archive root, which is the layout `DiscoverBinary` now looks for. No
`windows_arm64` artifact. And the Linux `.deb`/`.rpm` still built from the same run, so nfpm was not
disturbed by adding a non-Linux target.

Plus the usual gate: host and `GOOS=windows` build, vet and test across both modules, and
`go test -race ./internal/endpoint/...`.

The CI `release-check` job stages a stand-in collector per target, so it gains a `windows_amd64` one —
without it the before-hook's copy fails and that job breaks on a missing file rather than anything real.

## Not in scope

No MSI and no signing yet. This makes Beacon *obtainable* on Windows; the installer is the next step,
and per your call it ships unsigned first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release packaging and endpoint install’s collector resolution on Windows; mistakes would ship broken Windows archives or fail `endpoint install` after extract, but scope is limited to discovery paths and GoReleaser/CI staging—not auth or data handling.
> 
> **Overview**
> **Windows releases** are now part of GoReleaser: `beacon` and `beacon-hooks` build for `windows/amd64` (with `windows/arm64` explicitly ignored so archives always include a collector), Windows archives ship as **zip**, and each archive bundles **`beacon-otelcol.exe`** via a globbed `release-collectors` copy. CI’s package smoke job stages a stand-in **`windows_amd64`** collector so the before-hook matches production layout.
> 
> **Collector discovery** no longer stats an extensionless sibling on Windows. Platform-specific helpers choose the **on-disk filename** (`beacon-otelcol.exe` vs POSIX) and **packaged install paths** (`%ProgramW6432%` / `%ProgramFiles%` under `Beacon\bin`, not `/opt/beacon/...`), with tests locking that behavior for extracted archives and relocated Program Files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d14272b3e89d395e0c93eff5273640e42163baa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->