### PR TITLE
ci(windows): widen the Windows test scope from 9 packages to 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,58 +201,47 @@ jobs:
         run: |
           go build -ldflags "-s -w" -o beacon-hooks.exe .
           Copy-Item beacon-hooks.exe ..\beacon\internal\embedded\hooks.bin -Force
-      # Scoped to the packages this port actually gives Windows implementations, not `./...`.
+      # Scoped rather than `./...`, and the list is measured rather than assumed.
       #
-      # The scope grows as packages are made portable. config, collector, harness and hooks joined
-      # when the Windows filesystem work needed them gated -- which immediately paid for itself by
-      # surfacing a production bug: validateExecutable tested the POSIX executable bit, which is
-      # never set on Windows, so DiscoverBinary rejected every collector binary there.
+      # A survey run on this runner tested every package and reported 25 passing and 16 failing, so
+      # every one of these is here because it was observed to pass on Windows -- not because it looked
+      # portable. That distinction matters: internal/endpoint/hooks shows the most POSIX-looking
+      # assertions in the repository and passes, because most of those hits are literal path strings
+      # inside assertions rather than paths the test uses. Guessing from grep would have scoped in the
+      # wrong set in both directions.
       #
-      # The remaining cli/beacon packages still assume a POSIX host and are not scoped in. Running
-      # them here would produce a permanently red gate that says nothing about the code under test,
-      # and a red gate nobody can fix is one nobody reads.
+      # Widening has repeatedly paid for itself by surfacing production bugs rather than test noise:
+      # validateExecutable tested the POSIX executable bit, which is never set on Windows, so
+      # DiscoverBinary rejected every collector binary there.
       #
-      # Tracked as follow-up work rather than dropped -- see #318. The scope
-      # widens as those packages are made portable; it must not widen by adding `./...` back while
-      # the assumptions remain.
+      # The 16 that still fail are listed in #318 with the reason each one fails. They are excluded
+      # rather than tolerated: a permanently red gate is one nobody reads. The scope widens as they are
+      # fixed, and must not widen by adding `./...` back while the assumptions remain.
       - name: Test the ported packages on Windows
         working-directory: cli/beacon
         run: |
           go test `
-            ./internal/endpoint/writer/... `
-            ./internal/endpoint/inventory/... `
-            ./internal/ingest/endpoint/... `
-            ./internal/endpoint/service/... `
-            ./internal/endpoint/selfupdate/... `
-            ./internal/endpoint/config/... `
+            ./internal/devincloud/... `
+            ./internal/embedded/... `
+            ./internal/endpoint/activity/... `
             ./internal/endpoint/collector/... `
+            ./internal/endpoint/config/... `
+            ./internal/endpoint/detect/... `
             ./internal/endpoint/harness/... `
-            ./internal/endpoint/hooks/...
-      # One-off diagnostic while widening the scope (#318). Informational: it runs the whole suite to
-      # find out which packages actually pass on Windows, rather than guessing from grep. Not a gate --
-      # the scoped run above is the gate -- and it is removed once the scope has been widened.
-      - name: Which packages pass on Windows (informational)
-        id: survey
-        continue-on-error: true
-        working-directory: cli/beacon
-        run: |
-          $ErrorActionPreference = 'Continue'
-          # -count=1 defeats the cache so a previously-green package is re-run, and JSON output lets the
-          # per-package result be summarized rather than read out of thousands of lines.
-          go test ./... -count=1 -json 2>&1 | Tee-Object -FilePath survey.jsonl | Out-Null
-          $results = @{}
-          foreach ($line in Get-Content survey.jsonl) {
-            try { $e = $line | ConvertFrom-Json } catch { continue }
-            if (-not $e.Package) { continue }
-            if ($e.Action -in @('pass','fail','skip')) { $results[$e.Package] = $e.Action }
-          }
-          $failed = $results.GetEnumerator() | Where-Object { $_.Value -eq 'fail' } | Sort-Object Name
-          $passed = $results.GetEnumerator() | Where-Object { $_.Value -eq 'pass' } | Sort-Object Name
-          Write-Output "=== PASS ($($passed.Count)) ==="
-          $passed | ForEach-Object { Write-Output "  $($_.Name)" }
-          Write-Output "=== FAIL ($($failed.Count)) ==="
-          $failed | ForEach-Object { Write-Output "  $($_.Name)" }
-
+            ./internal/endpoint/hooks/... `
+            ./internal/endpoint/integrations/... `
+            ./internal/endpoint/inventory/... `
+            ./internal/endpoint/schema/... `
+            ./internal/endpoint/selfupdate/... `
+            ./internal/endpoint/sentinel/... `
+            ./internal/endpoint/service/... `
+            ./internal/endpoint/wazuh/... `
+            ./internal/endpoint/writer/... `
+            ./internal/ingest/... `
+            ./internal/mcpserver/... `
+            ./internal/tokens/... `
+            ./internal/updatecheck/... `
+            ./internal/version/...
       - name: Test the ported packages with the race detector
         working-directory: cli/beacon
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,31 @@ jobs:
             ./internal/endpoint/collector/... `
             ./internal/endpoint/harness/... `
             ./internal/endpoint/hooks/...
+      # One-off diagnostic while widening the scope (#318). Informational: it runs the whole suite to
+      # find out which packages actually pass on Windows, rather than guessing from grep. Not a gate --
+      # the scoped run above is the gate -- and it is removed once the scope has been widened.
+      - name: Which packages pass on Windows (informational)
+        id: survey
+        continue-on-error: true
+        working-directory: cli/beacon
+        run: |
+          $ErrorActionPreference = 'Continue'
+          # -count=1 defeats the cache so a previously-green package is re-run, and JSON output lets the
+          # per-package result be summarized rather than read out of thousands of lines.
+          go test ./... -count=1 -json 2>&1 | Tee-Object -FilePath survey.jsonl | Out-Null
+          $results = @{}
+          foreach ($line in Get-Content survey.jsonl) {
+            try { $e = $line | ConvertFrom-Json } catch { continue }
+            if (-not $e.Package) { continue }
+            if ($e.Action -in @('pass','fail','skip')) { $results[$e.Package] = $e.Action }
+          }
+          $failed = $results.GetEnumerator() | Where-Object { $_.Value -eq 'fail' } | Sort-Object Name
+          $passed = $results.GetEnumerator() | Where-Object { $_.Value -eq 'pass' } | Sort-Object Name
+          Write-Output "=== PASS ($($passed.Count)) ==="
+          $passed | ForEach-Object { Write-Output "  $($_.Name)" }
+          Write-Output "=== FAIL ($($failed.Count)) ==="
+          $failed | ForEach-Object { Write-Output "  $($_.Name)" }
+
       - name: Test the ported packages with the race detector
         working-directory: cli/beacon
         run: |


### PR DESCRIPTION
Advances #318 — from a stale count to a measured scope.

## What the survey found

A one-off diagnostic step ran the whole `cli/beacon` suite on the Windows runner and reported
per-package results:

**25 pass, 16 fail.**

#318 recorded *107 failures across 22 packages*. That number came from pointing the suite at Windows
once and was never rechecked after several packages were made portable, so it was badly out of date.

## Why the survey was worth a run

Grep points the wrong way in **both** directions. `internal/endpoint/hooks` has the most POSIX-looking
assertions in the repository — 108 hits for `/tmp`, `/var/log`, `chmod`, `HOME` — and **passes on
Windows**, because most of those are literal path strings inside assertions rather than paths the test
uses. Meanwhile packages with few such hits fail for reasons a grep never shows.

Every package added to the scope here was *observed* to pass, not judged portable by reading it.

## Newly covered (16 packages)

```
devincloud   embedded   endpoint/activity   endpoint/detect   endpoint/integrations
endpoint/integrations/{cowork,openclaw,vscode}   endpoint/schema   endpoint/sentinel
endpoint/wazuh   ingest   mcpserver   tokens   updatecheck   version
```

## Still failing (16), and excluded on purpose

```
cmd   auth   ci   endpoint/cloudwatch   endpoint/dashboard   endpoint/datadog
endpoint/diagnostics   endpoint/elastic   endpoint/falcon   endpoint/gcs
endpoint/lifecycle   endpoint/rapid7   endpoint/s3   endpoint/siempack
endpoint/sumo   onboarding
```

A permanently red gate is one nobody reads, and the point of a scoped list is that going red means
something. These stay out until fixed, recorded in #318 with what each needs rather than as a count
that ages.

## The survey step is removed in the same PR

It existed to answer one question. It answered it. Leaving a whole-suite run in place would
reintroduce exactly the red noise the scoping exists to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1db6af2ce0a06b0af8a962731d26ebc692a13b2a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->