### PR TITLE
docs(linux): add a deployment profile, and make its central claim enforceable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,28 @@ jobs:
         working-directory: cli/beacon
         run: make ${{ matrix.make_target }}
 
+      # Linux binaries must be statically linked, and this runner is where that can regress: a
+      # linux target here is a native build with a C toolchain present, so cgo defaults on and the
+      # net package selects the libc resolver. The result carries a glibc version floor that works
+      # on this runner and fails on an older or stripped host -- exactly the customers who cannot
+      # easily diagnose it. Checked on the ELF header rather than by running ldd, which reports
+      # "not a dynamic executable" to stdout or stderr depending on version.
+      - name: Linux binaries must be statically linked
+        if: matrix.goos == 'linux'
+        working-directory: cli/beacon
+        run: |
+          set -eu
+          for bin in "beacon-linux-${{ matrix.goarch }}" \
+                     "../beacon-hooks/beacon-hooks-linux-${{ matrix.goarch }}"; do
+            if readelf -l "$bin" | grep -q INTERP; then
+              echo "$bin is dynamically linked: it has a PT_INTERP segment naming a dynamic loader." >&2
+              echo "A release built this way fails on hosts whose glibc predates the build host's." >&2
+              readelf -l "$bin" | grep -A1 INTERP >&2
+              exit 1
+            fi
+            echo "ok: $bin is statically linked"
+          done
+
   linux-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,15 +157,29 @@ jobs:
         if: matrix.goos == 'linux'
         working-directory: cli/beacon
         run: |
-          set -eu
+          set -euo pipefail
           for bin in "beacon-linux-${{ matrix.goarch }}" \
                      "../beacon-hooks/beacon-hooks-linux-${{ matrix.goarch }}"; do
-            if readelf -l "$bin" | grep -q INTERP; then
-              echo "$bin is dynamically linked: it has a PT_INTERP segment naming a dynamic loader." >&2
-              echo "A release built this way fails on hosts whose glibc predates the build host's." >&2
-              readelf -l "$bin" | grep -A1 INTERP >&2
-              exit 1
-            fi
+            # Each step below fails closed. Piping readelf straight into `grep -q INTERP` would
+            # not: a missing binary or a runner without readelf produces empty input, grep matches
+            # nothing, and the check reports success for a binary it never looked at.
+            [ -f "$bin" ] || { echo "no binary at $bin -- the build step did not produce what this checks" >&2; exit 1; }
+
+            headers="$(readelf -l "$bin")" || { echo "readelf failed on $bin, so its linkage is unknown" >&2; exit 1; }
+
+            case "$headers" in
+              *"Program Headers"*) ;;
+              *) echo "readelf produced no program headers for $bin, so its linkage is unknown" >&2; exit 1 ;;
+            esac
+
+            case "$headers" in
+              *INTERP*)
+                echo "$bin is dynamically linked: it carries a PT_INTERP segment naming a loader." >&2
+                echo "Built this way, it fails on any host whose glibc predates the build host's." >&2
+                printf '%s\n' "$headers" | grep -A1 INTERP >&2
+                exit 1 ;;
+            esac
+
             echo "ok: $bin is statically linked"
           done
 

--- a/beacon-sandbox/runner/runner.go
+++ b/beacon-sandbox/runner/runner.go
@@ -449,6 +449,18 @@ func Run(ctx context.Context, p sandbox.Provider, sc scenario.Scenario, opts Opt
 	art.Meta["quiescence_seconds"] = fmt.Sprintf("%.0f", waited.Seconds())
 	art.Meta["quiescent"] = fmt.Sprintf("%v", stable)
 
+	// Measured after quiescence, so the collector is resident and idle rather than mid-batch.
+	// Only for install scenarios: a `ci exec` collector is torn down with the command and has no
+	// steady state to describe. Recorded rather than asserted -- these are the numbers a customer
+	// evaluating footprint asks for, and publishing an estimate instead of a measurement is how a
+	// resource claim quietly stops being true.
+	if sc.Install != nil {
+		if snap := collectorFootprint(ctx, g, agent); snap != "" {
+			art.Meta["collector_footprint"] = snap
+			logf("collector footprint: %s", snap)
+		}
+	}
+
 	localLog := filepath.Join(runDir, "runtime.jsonl")
 	if err := g.Get(ctx, logPath, localLog); err != nil {
 		return art, fmt.Errorf("collect runtime log: %w", err)
@@ -586,6 +598,45 @@ func imageSpecFor(p sandbox.Platform, sc scenario.Scenario, opts Options,
 		WithDocker:    sc.NeedsRealSystemd(),
 		NSSOnlyUser:   sc.NeedsNSSOnlyUser(),
 	}, logf)
+}
+
+// collectorFootprint measures the resident collector: memory, threads, descriptors, and the CPU it
+// consumes while idle.
+//
+// Read from /proc rather than from ps output formats that differ between distributions, and
+// sampled over a fixed interval because idle CPU is a rate, not a value -- the total ticks a
+// process has ever used says nothing about what it costs to leave running.
+//
+// Best-effort by design: this describes a run, it does not gate one. A shell that cannot produce
+// the numbers returns an empty string and the scenario proceeds, because a footprint measurement
+// failing is not a reason to fail a capture test.
+func collectorFootprint(ctx context.Context, g guest, opts sandbox.ExecOpts) string {
+	// Sampled over 30s rather than 10s: at 100 ticks/second an idle collector accumulates about
+	// one tick per 10s, so a 10s window reports 0 or 1 and cannot distinguish "almost nothing"
+	// from "nothing". 30s buys a figure with more than one significant digit.
+	//
+	// The descriptor count needs sudo. In system mode the collector runs as root while this shell
+	// runs as the agent user, so /proc/<pid>/fd is not readable and a plain `ls` yields zero --
+	// a number that is not merely imprecise but impossible, since every process holds at least
+	// stdin, stdout, and stderr. "unreadable" is reported instead, because publishing a resource
+	// figure that is obviously false costs more credibility than omitting one.
+	const script = `
+pid=$(pgrep -n beacon-otelcol 2>/dev/null) || exit 0
+[ -n "$pid" ] || exit 0
+read_ticks() { awk '{print $14+$15}' /proc/$1/stat 2>/dev/null; }
+t0=$(read_ticks "$pid"); sleep 30; t1=$(read_ticks "$pid")
+hz=$(getconf CLK_TCK 2>/dev/null || echo 100)
+rss=$(awk '/^VmRSS:/{print $2}' /proc/$pid/status 2>/dev/null)
+thr=$(awk '/^Threads:/{print $2}' /proc/$pid/status 2>/dev/null)
+fds=$(sudo ls /proc/$pid/fd 2>/dev/null | wc -l | tr -d ' ')
+[ "${fds:-0}" -gt 0 ] 2>/dev/null || fds=unreadable
+echo "rss_kb=${rss:-?} threads=${thr:-?} fds=${fds} cpu_ticks_per_30s=$((t1-t0)) clk_tck=$hz"
+`
+	res, err := g.Exec(ctx, script, opts)
+	if err != nil || res.ExitCode != 0 {
+		return ""
+	}
+	return oneLine(res.Stdout)
 }
 
 func randomToken() string {

--- a/cli/beacon-hooks/Makefile
+++ b/cli/beacon-hooks/Makefile
@@ -1,5 +1,10 @@
 # Beacon Hooks Makefile
 
+# Static binaries, always. See cli/beacon/Makefile for why; this binary is the one that matters
+# most, because it is embedded in the CLI and extracted at install time, so a dynamic build here
+# fails on the target host rather than on the build host.
+export CGO_ENABLED = 0
+
 # Build variables
 BINARY := beacon-hooks
 LDFLAGS := -s -w

--- a/cli/beacon/.goreleaser.yaml
+++ b/cli/beacon/.goreleaser.yaml
@@ -54,7 +54,12 @@ builds:
         # --parallelism 1 so target builds cannot race here. The -a flag above
         # forces a full rebuild for each target so Go re-reads the freshly-built
         # hooks.bin instead of serving a stale copy from cache.
-        - cmd: bash -c 'cd ../beacon-hooks && GOOS={{ .Os }} GOARCH={{ .Arch }} go build -ldflags "-s -w -X github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/version.Version={{ .Version }}" -o ../beacon/internal/embedded/hooks.bin .'
+        # CGO_ENABLED=0 matters here as much as it does in the builds above. Releases are built on
+        # Linux, so a linux/amd64 target is a native build with a C toolchain present, and cgo
+        # would default on. beacon-hooks pulls in net, which selects the cgo resolver and links
+        # libc -- producing a dynamically linked hooks binary embedded inside a statically linked
+        # CLI, with a glibc version floor that only shows up on an older or stripped host.
+        - cmd: bash -c 'cd ../beacon-hooks && CGO_ENABLED=0 GOOS={{ .Os }} GOARCH={{ .Arch }} go build -ldflags "-s -w -X github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/version.Version={{ .Version }}" -o ../beacon/internal/embedded/hooks.bin .'
           output: true
   - id: beacon-hooks
     dir: ../beacon-hooks

--- a/cli/beacon/Makefile
+++ b/cli/beacon/Makefile
@@ -1,5 +1,13 @@
 # Beacon CLI Makefile
 
+# Static binaries, always, matching what the release builds.
+#
+# Not cosmetic: cgo defaults on for a native build, so `make build-linux-amd64` produced a static
+# binary when cross-compiled from macOS and a dynamic one when run on Linux. The dynamic form
+# carries a glibc version floor that only fails on an older or stripped host -- the machines least
+# likely to be the one you tested on. Exported so every target gets it, including new ones.
+export CGO_ENABLED = 0
+
 # Build variables
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -292,6 +292,7 @@
                 "pages": [
                   "platforms/macos",
                   "platforms/linux",
+                  "platforms/linux-deployment-profile",
                   "platforms/windows"
                 ]
               },

--- a/docs/platforms/linux-deployment-profile.mdx
+++ b/docs/platforms/linux-deployment-profile.mdx
@@ -1,0 +1,159 @@
+---
+title: "Linux Deployment Profile"
+description: "What the Beacon endpoint agent depends on, what it costs to run, and how to verify both yourself"
+---
+
+A reference for reviewing Beacon before deploying it. Every claim names the command that checks it,
+so nothing here has to be taken on trust.
+
+## Kernel surface
+
+**Beacon loads nothing into the kernel and requires no kernel feature beyond a standard POSIX
+system.**
+
+| | |
+|---|---|
+| Kernel modules | None loaded, none required |
+| eBPF / netlink / audit subsystem | Not used |
+| ptrace, process injection | Not used |
+| cgroups, `/sys`, udev | Not read |
+| Capabilities, setuid, setcap | None |
+| `/proc` | One file: `/proc/1/comm`, to detect whether systemd is PID 1 |
+
+Everything it uses from the kernel:
+
+| Facility | Used for | If unavailable |
+|---|---|---|
+| TCP loopback | Three listeners on `127.0.0.1` | Collector cannot start |
+| `flock(2)` | Serializing writes to the runtime log | Degrades on some network filesystems; fine on local disk |
+| `fork`/`exec` | One short-lived hook process per agent event | Hook capture stops; OpenTelemetry capture continues |
+| Ordinary file I/O | Config and log | — |
+| `/proc/1/comm` | systemd detection | Falls back to a supervised collector, which does not restart on exit or start at boot |
+
+Verify the syscall surface on your own hardware rather than taking ours:
+
+```bash
+sudo strace -f -c -p "$(pgrep -n beacon-otelcol)"   # collector, steady state
+sudo strace -f -c -o /tmp/install.trace beacon endpoint install --system --dry-run
+```
+
+## Binaries
+
+Three static executables, no shared libraries, no glibc version floor. An older or stripped
+userland cannot produce a missing-library or wrong-symbol-version failure.
+
+| Binary | Role | Resident? |
+|---|---|---|
+| `beacon-otelcol` | Collector | Yes — the only long-running process |
+| `beacon-hooks` | Records one agent event | No — forks and exits |
+| `beacon` | CLI | No |
+
+```bash
+file /opt/beacon/bin/beacon-otelcol     # ... statically linked
+ldd  /opt/beacon/bin/beacon-otelcol     # not a dynamic executable
+readelf -l /opt/beacon/bin/beacon-otelcol | grep INTERP   # no output = static
+```
+
+CI fails the build if any Linux binary gains a dynamic loader, so this cannot regress quietly.
+
+## Footprint
+
+Measured on Ubuntu 24.04 / amd64 after a live Claude Code session, not estimated.
+
+| | Measured | Notes |
+|---|---|---|
+| Resident memory | ~57 MiB | Hard ceiling 128 MiB (`memory_limiter`) |
+| CPU, idle | 0.1–0.3% of one core | Two timers: 1s memory check, 5s batch flush |
+| Threads | 15 | Go runtime, scales with available cores |
+| Disk | ≤60 MB | 10 MiB × 5 rotations, oldest discarded |
+| Per agent event | one `fork`/`exec`, one `flock`, one append | Process exits immediately |
+
+Two caveats worth stating rather than hiding, since you will measure this yourself:
+
+- The CPU figure is a **range across runs**, not a single number. Repeated 30-second samples landed
+  between 0.1% and 0.3% of one core; publishing the midpoint would imply a precision the
+  measurement does not have.
+- It was measured inside a virtualized sandbox, where syscalls cost more than on bare metal. Treat
+  it as an **upper bound** for your hardware, not a prediction.
+
+Reproduce:
+
+```bash
+pid=$(pgrep -n beacon-otelcol)
+grep -E 'VmRSS|Threads' /proc/$pid/status
+awk '{print $14+$15}' /proc/$pid/stat    # sample twice, 30s apart; (delta/100)/30 = fraction of a core
+```
+
+## Network
+
+Loopback only. Nothing is sent off the machine by normal collection.
+
+| Listener | Port | Bind |
+|---|---|---|
+| OTLP gRPC | 4317 | `127.0.0.1` |
+| OTLP HTTP | 4318 | `127.0.0.1` |
+| Health check | 13133 | `127.0.0.1` |
+
+Outbound, for an egress allowlist. None occurs during collection:
+
+| Host | When | Suppress with |
+|---|---|---|
+| `auth.asymptotelabs.ai` | Once per machine, interactive install only | `BEACON_ONBOARDING=0` (already skipped for `--system` and package installs) |
+| `api.github.com`, `github.com` | Version check and self-update | Off by default; leave it off and deploy through your config management |
+
+```bash
+ss -ltnp | grep beacon-otelcol
+```
+
+## Privileges and data
+
+- System mode runs the collector as **root**, because hooks running as the logged-in user append to
+  the same log. `/var/log/beacon-agent/runtime.jsonl` is mode `0666` for that reason.
+- User mode runs entirely as you, under `~/.beacon`, and needs no privileges.
+- The log holds **prompt text, command lines, file paths, and tool inputs**, subject to redaction and
+  a 64 KiB per-event cap. Treat it as sensitive.
+- Account lookup uses `getent`, so directory-backed accounts (OpenLDAP, SSSD, AD) resolve.
+
+## Confining it to housekeeping cores
+
+If you isolate cores for latency-sensitive work, pin Beacon away from them. Beacon's timers are few
+and slow, but a timer landing on an `isolcpus`/`nohz_full` core defeats the point of isolating it.
+
+```ini
+# /etc/systemd/system/beacon-collector.service.d/10-resources.conf
+[Service]
+CPUAffinity=0-3          # your housekeeping cores, NOT the isolated set
+CPUQuota=5%
+MemoryMax=192M
+Nice=19
+IOSchedulingClass=idle
+```
+
+```bash
+sudo systemctl daemon-reload && sudo systemctl restart beacon-collector
+systemctl show beacon-collector -p CPUAffinity -p CPUQuota -p MemoryMax
+```
+
+Use a drop-in, not an edit to the unit file: `beacon endpoint doctor --fix` rewrites the unit and
+would discard changes made there. Drop-ins survive.
+
+## Uninstall
+
+```bash
+sudo apt remove beacon     # keeps config and collected logs
+sudo apt purge beacon      # removes them
+```
+
+On RPM systems, `dnf remove` keeps `/etc/beacon/endpoint` and `/var/log/beacon-agent`. Remove them
+with `sudo beacon endpoint uninstall --system` if you want the data gone.
+
+## Related
+
+<Columns cols={2}>
+  <Card title="Linux install" icon="download" href="/platforms/linux">
+    Packages, user-mode installs, and service management.
+  </Card>
+  <Card title="Data inventory" icon="database" href="/security/data-inventory">
+    Exactly which fields are recorded and retained.
+  </Card>
+</Columns>

--- a/docs/platforms/linux-deployment-profile.mdx
+++ b/docs/platforms/linux-deployment-profile.mdx
@@ -3,13 +3,12 @@ title: "Linux Deployment Profile"
 description: "What the Beacon endpoint agent depends on, what it costs to run, and how to verify both yourself"
 ---
 
-A reference for reviewing Beacon before deploying it. Every claim names the command that checks it,
-so nothing here has to be taken on trust.
+A reference for reviewing Beacon before deploying it. Each claim comes with the command that checks
+it, so you can confirm any of this yourself.
 
 ## Kernel surface
 
-**Beacon loads nothing into the kernel and requires no kernel feature beyond a standard POSIX
-system.**
+Beacon loads nothing into the kernel and needs nothing beyond a standard POSIX system.
 
 | | |
 |---|---|
@@ -30,7 +29,7 @@ Everything it uses from the kernel:
 | Ordinary file I/O | Config and log | — |
 | `/proc/1/comm` | systemd detection | Falls back to a supervised collector, which does not restart on exit or start at boot |
 
-Verify the syscall surface on your own hardware rather than taking ours:
+To see the syscalls for yourself:
 
 ```bash
 sudo strace -f -c -p "$(pgrep -n beacon-otelcol)"   # collector, steady state
@@ -39,8 +38,8 @@ sudo strace -f -c -o /tmp/install.trace beacon endpoint install --system --dry-r
 
 ## Binaries
 
-Three static executables, no shared libraries, no glibc version floor. An older or stripped
-userland cannot produce a missing-library or wrong-symbol-version failure.
+Three static executables, no shared libraries, no minimum glibc version. They run the same on a
+minimal or older userland as on a full one.
 
 | Binary | Role | Resident? |
 |---|---|---|
@@ -54,11 +53,11 @@ ldd  /opt/beacon/bin/beacon-otelcol     # not a dynamic executable
 readelf -l /opt/beacon/bin/beacon-otelcol | grep INTERP   # no output = static
 ```
 
-CI fails the build if any Linux binary gains a dynamic loader, so this cannot regress quietly.
+CI fails the build if a Linux binary is ever dynamically linked.
 
 ## Footprint
 
-Measured on Ubuntu 24.04 / amd64 after a live Claude Code session, not estimated.
+Measured on Ubuntu 24.04 / amd64 after a live Claude Code session.
 
 | | Measured | Notes |
 |---|---|---|
@@ -68,15 +67,14 @@ Measured on Ubuntu 24.04 / amd64 after a live Claude Code session, not estimated
 | Disk | ≤60 MB | 10 MiB × 5 rotations, oldest discarded |
 | Per agent event | one `fork`/`exec`, one `flock`, one append | Process exits immediately |
 
-Two caveats worth stating rather than hiding, since you will measure this yourself:
+### Caveats
 
-- The CPU figure is a **range across runs**, not a single number. Repeated 30-second samples landed
-  between 0.1% and 0.3% of one core; publishing the midpoint would imply a precision the
-  measurement does not have.
-- It was measured inside a virtualized sandbox, where syscalls cost more than on bare metal. Treat
-  it as an **upper bound** for your hardware, not a prediction.
+- The CPU figure is a range, not an average. Repeated 30-second samples came out between 0.1% and
+  0.3% of one core.
+- These numbers come from a virtualized sandbox, where syscalls are slower than on bare metal.
+  Expect equal or better on your own hardware.
 
-Reproduce:
+### Measuring it yourself
 
 ```bash
 pid=$(pgrep -n beacon-otelcol)
@@ -86,7 +84,7 @@ awk '{print $14+$15}' /proc/$pid/stat    # sample twice, 30s apart; (delta/100)/
 
 ## Network
 
-Loopback only. Nothing is sent off the machine by normal collection.
+Beacon listens on loopback only, and collection never sends anything off the machine.
 
 | Listener | Port | Bind |
 |---|---|---|
@@ -94,7 +92,7 @@ Loopback only. Nothing is sent off the machine by normal collection.
 | OTLP HTTP | 4318 | `127.0.0.1` |
 | Health check | 13133 | `127.0.0.1` |
 
-Outbound, for an egress allowlist. None occurs during collection:
+The only outbound connections Beacon ever makes, for an egress allowlist:
 
 | Host | When | Suppress with |
 |---|---|---|
@@ -107,17 +105,18 @@ ss -ltnp | grep beacon-otelcol
 
 ## Privileges and data
 
-- System mode runs the collector as **root**, because hooks running as the logged-in user append to
-  the same log. `/var/log/beacon-agent/runtime.jsonl` is mode `0666` for that reason.
-- User mode runs entirely as you, under `~/.beacon`, and needs no privileges.
-- The log holds **prompt text, command lines, file paths, and tool inputs**, subject to redaction and
-  a 64 KiB per-event cap. Treat it as sensitive.
-- Account lookup uses `getent`, so directory-backed accounts (OpenLDAP, SSSD, AD) resolve.
+- In system mode the collector runs as root. Hooks run as the logged-in user and append to the same
+  log, which is why `/var/log/beacon-agent/runtime.jsonl` is mode `0666`.
+- In user mode everything runs as you under `~/.beacon`, with no privileges required.
+- The log contains prompt text, command lines, file paths, and tool inputs, after redaction and a
+  64 KiB per-event limit. Treat it as sensitive data.
+- Account lookup goes through `getent`, so accounts from OpenLDAP, SSSD, or AD resolve normally.
 
-## Confining it to housekeeping cores
+## Pinning it to housekeeping cores
 
-If you isolate cores for latency-sensitive work, pin Beacon away from them. Beacon's timers are few
-and slow, but a timer landing on an `isolcpus`/`nohz_full` core defeats the point of isolating it.
+If you isolate cores for latency-sensitive work, keep Beacon off them. It only has two slow timers,
+but a timer firing on an `isolcpus` or `nohz_full` core is exactly what isolating that core was
+meant to prevent.
 
 ```ini
 # /etc/systemd/system/beacon-collector.service.d/10-resources.conf
@@ -134,8 +133,8 @@ sudo systemctl daemon-reload && sudo systemctl restart beacon-collector
 systemctl show beacon-collector -p CPUAffinity -p CPUQuota -p MemoryMax
 ```
 
-Use a drop-in, not an edit to the unit file: `beacon endpoint doctor --fix` rewrites the unit and
-would discard changes made there. Drop-ins survive.
+Put this in a drop-in rather than editing the unit file directly. `beacon endpoint doctor --fix`
+rewrites the unit, which would wipe out your changes; drop-ins are left alone.
 
 ## Uninstall
 

--- a/docs/platforms/linux.mdx
+++ b/docs/platforms/linux.mdx
@@ -294,6 +294,9 @@ sudo beacon endpoint uninstall --system
 ## Related
 
 <Columns cols={2}>
+  <Card title="Deployment profile" icon="shield-check" href="/platforms/linux-deployment-profile">
+    What it depends on, what it costs to run, and how to verify both — for a security review.
+  </Card>
   <Card title="Endpoint status" icon="circle-info" href="/cli/endpoint-status">
     Inspect collector health, runtime log state, harnesses, and diagnostics.
   </Card>


### PR DESCRIPTION
A one-page reference for reviewing Beacon before deploying it — aimed at the two questions a latency-sensitive shop asks first: **what does it need from the kernel**, and **what does it cost to leave running**. Written as a cheatsheet (tables, plus the command that verifies each claim) because that audience checks rather than reads.

Prompted by a prospect running stripped Ubuntu with custom kernels, but nothing in it is customer-specific.

## The static-linkage claim was resting on an accident

The profile leads with "statically linked, no glibc floor", so that claim needed to be enforceable. **Three places had to be pinned, not one** — the goreleaser pre-hook that builds the embedded hooks binary, and both Makefiles.

Releases build on Linux, so a linux target is a *native* build with a C toolchain present and cgo defaults on. `beacon-hooks` pulls in `net`, which selects the libc resolver. So `make build-linux-amd64` produced:

- a **static** binary when cross-compiled from macOS (what I'd been testing)
- a **dynamic** binary when run on Linux (what CI does)

The difference is invisible on the build host and fatal on an older or stripped one. CI now rejects any Linux binary carrying a `PT_INTERP` segment — checked on the ELF header rather than through `ldd`, whose output stream varies by version.

## Measuring honestly turned up two things worth keeping

**The first attempt reported zero open file descriptors.** Every process holds at least three, so that number wasn't imprecise, it was impossible — `/proc/<pid>/fd` is unreadable when the collector runs as root and the measuring shell doesn't. It now reports `unreadable`, and the profile **omits the row** rather than printing a figure that would fail the first time a reader checked it.

**The CPU figure is published as a range** (0.1–0.3% of a core) because repeated samples disagreed threefold. A midpoint would imply precision the measurement doesn't have. The sampling window also moved 10s → 30s: at 100 ticks/second an idle collector accumulates about one tick per 10s, so the short window could only report 0 or 1 and couldn't distinguish "almost nothing" from "nothing".

The profile states plainly that the range is a range, and that a virtualized sandbox inflates syscall cost — so a reader treats it as an **upper bound** for their hardware rather than a prediction.

## Deliberately not included

- **A syscall inventory from our `strace` run.** The profile gives the command instead. A security team trusts a list generated on their own hardware more than one we hand them, and it's shorter.
- **`--cpu-quota`/`--memory-max` CLI flags.** Shops with this concern run config management and would rather drop a systemd file than learn our flags. The drop-in snippet covers it.

## Measured values

| | |
|---|---|
| Resident memory | ~57 MiB (ceiling 128 MiB) |
| CPU, idle | 0.1–0.3% of one core |
| Threads | 15 |
| Disk | ≤60 MB |

## Testing

- `go test ./...` green in `cli/beacon`, `cli/beacon-hooks`, `beacon-sandbox`
- Local `make build-linux-amd64` verified still static after pinning
- Footprint captured from two `i03-install-nss-only-user` runs, both PASS
- `docs.json` validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a3daaf39e3ddddccb5b9f3ca8d5720eea67106e9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->