### PR TITLE
fix(docs): restore the star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ For setup, deployment, integrations, and command details, see the
 ## Star Growth
 
 <p align="center">
-  <a href="https://www.star-history.com/#asymptote-labs/agent-beacon&Date">
-    <img src="https://api.star-history.com/svg?repos=asymptote-labs/agent-beacon&type=Date" alt="Beacon GitHub star growth" width="860">
+  <a href="https://star-history.dera.page/#asymptote-labs/agent-beacon&Date">
+    <img src="https://star-history.dera.page/svg?repos=asymptote-labs/agent-beacon&type=Date" alt="Beacon GitHub star growth" width="860">
   </a>
 </p>
 


### PR DESCRIPTION
The current star history chart is broken and no longer renders reliably. Update the README chart links so the project star growth remains visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7bd2ccf65d2e2d94073f99462466585443e6f7d0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->