### PR TITLE
chore(deps): bump nanoid to 3.3.18 in asymptote-sdk-js lockfile

### DIFF
--- a/packages/asymptote-sdk-js/package-lock.json
+++ b/packages/asymptote-sdk-js/package-lock.json
@@ -1525,9 +1525,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Remediates the open Dependabot alerts for **nanoid** in `packages/asymptote-sdk-js/package-lock.json`:

- [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv) — non-secure generators can loop indefinitely with negative size (fixed in 3.3.16)
- [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators can loop indefinitely when size is zero (fixed in 3.3.18)

Both advisories are fixed by the single bump 3.3.12 → 3.3.18, so they share this PR.

nanoid is a dev-only transitive dependency (via postcss); this is a lockfile-only change with no runtime or published-package impact.

Verified locally: `npm ci && npm test && npm run check` all pass, and `npm audit` no longer reports nanoid.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xnn227h2Xuox59wcyoGekJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only bump of a dev transitive dependency; no application or published SDK code is modified.
> 
> **Overview**
> Bumps the **dev-only** transitive `nanoid` pin in `packages/asymptote-sdk-js/package-lock.json` from **3.3.12** to **3.3.18** (via postcss).
> 
> This closes Dependabot alerts for infinite-loop issues in custom/non-secure generators (`GHSA-28wg-ghj8-5hjv`, `GHSA-2v37-7h3g-55p8`). Lockfile-only; no runtime or published-package change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 283cc5d127301f98f0f5d6390a26d872d1227ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->