### PR TITLE
chore(deps): bump postcss to 8.5.26 in asymptote-sdk-js lockfile

### DIFF
--- a/packages/asymptote-sdk-js/package-lock.json
+++ b/packages/asymptote-sdk-js/package-lock.json
@@ -1525,9 +1525,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1591,9 +1591,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1611,7 +1611,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Remediates the open Dependabot alerts for **postcss** in `packages/asymptote-sdk-js/package-lock.json`:

- [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) — path traversal in previous-source-map auto-loading (`sourceMappingURL`) leads to arbitrary `.map` file disclosure (fixed in 8.5.18)
- [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) — incomplete fix of the above; attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset (fixed in 8.5.23)

Both advisories are fixed by the single bump 8.5.15 → 8.5.26, so they share this PR. postcss 8.5.26 requires nanoid `^3.3.17`, so the lockfile's nanoid entry moves to 3.3.18 alongside it (the same change #338 makes independently — the overlap merges cleanly in either order).

postcss is a dev-only transitive dependency (via vitest); this is a lockfile-only change with no runtime or published-package impact.

Verified locally: `npm ci && npm test && npm run check` pass and `npm audit` reports 0 vulnerabilities on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xnn227h2Xuox59wcyoGekJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only lockfile dependency bump with no runtime or published-package impact. Addresses known postcss source-map disclosure CVEs in the toolchain.
> 
> **Overview**
> Lockfile-only bump of the **dev** transitive `postcss` (via Vite/Vitest) from 8.5.15 to **8.5.26** in `packages/asymptote-sdk-js`, with `nanoid` 3.3.12 → **3.3.18** to satisfy postcss’s `^3.3.17` range.
> 
> This closes the source-map path-traversal advisories (GHSA-r28c-9q8g-f849, GHSA-fxqj-rqcc-2cmp). No application or published-package code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df7540704459c1558399c002fdf5a7055ecd0b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->