### PR TITLE
fix(selfupdate): reject any '..' sequence in archive entry names

### DIFF
--- a/cli/beacon/internal/endpoint/selfupdate/fsutil.go
+++ b/cli/beacon/internal/endpoint/selfupdate/fsutil.go
@@ -36,17 +36,17 @@ func acquireLock(path string) (func(), error) {
 
 // safeJoin resolves an archive entry name against dest and rejects anything that
 // would escape dest (path traversal / "zip slip"). It rejects absolute paths,
-// any ".." path segment (including backslash-separated ones), and any entry
-// whose cleaned, joined path is not contained within dest.
+// any name containing a ".." sequence (stricter than rejecting only ".."
+// segments, which is fine because release archives never carry ".." in entry
+// names, and a direct check on the raw name is what taint analyzers recognize
+// as a sanitizer), and any entry whose cleaned, joined path is not contained
+// within dest.
 func safeJoin(dest, name string) (string, error) {
 	if filepath.IsAbs(name) || strings.HasPrefix(name, "/") || strings.HasPrefix(name, "\\") {
 		return "", fmt.Errorf("absolute path in archive entry: %q", name)
 	}
-	normalized := strings.ReplaceAll(name, "\\", "/")
-	for _, seg := range strings.Split(normalized, "/") {
-		if seg == ".." {
-			return "", fmt.Errorf("path traversal in archive entry: %q", name)
-		}
+	if strings.Contains(name, "..") {
+		return "", fmt.Errorf("path traversal in archive entry: %q", name)
 	}
 	cleanDest := filepath.Clean(dest)
 	target := filepath.Clean(filepath.Join(cleanDest, name))

--- a/cli/beacon/internal/endpoint/selfupdate/fsutil_test.go
+++ b/cli/beacon/internal/endpoint/selfupdate/fsutil_test.go
@@ -21,6 +21,7 @@ func TestSafeJoinRejectsTraversal(t *testing.T) {
 		"a/..",
 		"a\\..\\..\\escape",
 		"..\\escape",
+		"a..b",
 		"/etc/passwd",
 		"\\windows\\system32",
 	}


### PR DESCRIPTION
Addresses the `go/zipslip` code scanning alert on `cli/beacon/internal/endpoint/selfupdate/fsutil.go` — one of the two open alerts (https://github.com/Asymptote-Labs/agent-beacon/security/code-scanning/12 / https://github.com/Asymptote-Labs/agent-beacon/security/code-scanning/13; the security UI is not reachable from this session, so I reproduced the scan locally with the same CodeQL 2.26.3 default suites CI uses, which surfaced exactly these two findings).

## What

`safeJoin` rejected traversal by checking `..` **segments** on a backslash-normalized copy of the archive entry name. That is behaviorally sound, but CodeQL's taint analysis doesn't recognize a check on a derived string as sanitizing the raw `hdr.Name`, so the alert stayed open (the earlier attempt in cbae2c7 hit the same problem). This change replaces the segment loop with a direct rejection of any entry name containing `..`.

- Stricter than before: a name like `a..b` is now refused too. That is safe here — Beacon release archives never carry `..` inside entry names.
- The absolute-path rejection and the cleaned-prefix containment check on the joined result are unchanged, so the actual security posture is the same or tighter.
- Added `a..b` to the rejection test cases to lock in the new contract.

## Verification

- `go test ./internal/endpoint/selfupdate/...`, and the full `go test ./...` in `cli/beacon`, pass (with the gitignored `hooks.bin` embed prerequisite built locally).
- Re-ran CodeQL 2.26.3 `codeql/go-queries Security/CWE-022/ZipSlip.ql` against a database built from this branch: 0 findings (was 1 with three flow paths into `os.MkdirAll`/`os.OpenFile`).

The companion ReDoS alert is fixed separately in the `claude/code-scan-issues-docadw-redos` PR, per the request to address the alerts in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxXk1Z9afMwmx5fdAtSR71

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxXk1Z9afMwmx5fdAtSR71)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches path-traversal sanitization for archive extraction, a security-sensitive area, but only tightens an existing check rather than changing extraction or install flow.
> 
> **Overview**
> Tightens zip-slip sanitization in `safeJoin` so archive entry names are rejected if they contain `..` anywhere, not only as a path segment. That makes the check apply to the raw name (what CodeQL recognizes as a sanitizer) and is slightly stricter than before (e.g. `a..b` is now refused). Absolute-path and destination-containment checks are unchanged.
> 
> Tests now include `a..b` as a rejection case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39523c9cf4863871634446fdedad2f827cc6543c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->