### PR TITLE
Pi support 4/7: install and uninstall the Pi extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ CI, and cloud surfaces.
 | [GitHub Copilot CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-github-copilot-cli) | MDM-managed OTLP HTTP | Prompt, session, tool, and approval-like activity emitted through Copilot CLI spans |
 | [Grok Build](https://docs.asymptotelabs.ai/cli/supported-runtimes-grok-build) | Native hooks | Session, prompt, pre-tool, post-tool, failed tool, stop, session-end, command, and file telemetry |
 | [OpenCode](https://docs.asymptotelabs.ai/cli/supported-runtimes-opencode) | Managed plugin hooks | Prompts, assistant output/reasoning, model usage/cost, tool lifecycle/results, commands, file/web/MCP activity, approvals, and session errors |
+| [Pi](https://docs.asymptotelabs.ai/cli/supported-runtimes-pi) | Managed extension | Session lifecycle, prompts, tool calls and results, commands, file reads/edits with diffs, MCP activity, agent reasoning, and per-message token usage and cost |
 | [VS Code](https://docs.asymptotelabs.ai/cli/supported-runtimes-vscode) | Copilot Chat OTel plus optional preview hooks | Copilot session, prompt, model, and tool activity through OTel; optional hooks for extra lifecycle and cross-agent detail |
 
 ##### Knowledge Worker Agent Harnesses

--- a/cli/beacon/cmd/endpoint_hooks.go
+++ b/cli/beacon/cmd/endpoint_hooks.go
@@ -130,6 +130,16 @@ func installEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 			return err
 		}
 		fmt.Printf("opencode plugin installed: %s\n", status.PluginPath)
+	case "pi":
+		status, err := endpointhooks.InstallPi(endpointhooks.PiOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Pi extension installed: %s\n", status.ExtensionPath)
 	case "grok":
 		status, err := endpointhooks.InstallGrok(endpointhooks.GrokOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -275,6 +285,16 @@ func uninstallEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 			return err
 		}
 		fmt.Println(status.Message)
+	case "pi":
+		status, err := endpointhooks.UninstallPi(endpointhooks.PiOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
 	case "grok":
 		status, err := endpointhooks.UninstallGrok(endpointhooks.GrokOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -373,6 +393,12 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
+		case "pi":
+			statuses["pi"] = endpointhooks.PiHookStatus(endpointhooks.PiOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
 		case "grok":
 			statuses["grok"] = endpointhooks.GrokHookStatus(endpointhooks.GrokOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -430,6 +456,10 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 		case "opencode":
 			status := statuses["opencode"].(endpointhooks.OpenCodeStatus)
 			fmt.Printf("opencode plugin: installed=%t path=%s\n", status.Installed, status.PluginPath)
+			fmt.Println(status.Message)
+		case "pi":
+			status := statuses["pi"].(endpointhooks.PiStatus)
+			fmt.Printf("Pi extension: installed=%t path=%s\n", status.Installed, status.ExtensionPath)
 			fmt.Println(status.Message)
 		case "grok":
 			status := statuses["grok"].(endpointhooks.GrokStatus)

--- a/cli/beacon/cmd/endpoint_targets.go
+++ b/cli/beacon/cmd/endpoint_targets.go
@@ -45,6 +45,7 @@ var harnessTargets = []harnessTarget{
 	{name: "cursor", endpointKind: endpointTargetHook, endpointAliases: []string{"cursor"}, hookAliases: []string{"cursor"}},
 	{name: "factory", endpointKind: endpointTargetHook, endpointAliases: []string{"factory", "droid"}, hookAliases: []string{"factory", "droid"}},
 	{name: "opencode", endpointKind: endpointTargetHook, endpointAliases: []string{"opencode"}, hookAliases: []string{"opencode"}},
+	{name: "pi", endpointKind: endpointTargetHook, endpointAliases: []string{"pi", "pi-cli"}, hookAliases: []string{"pi", "pi-cli"}},
 	{name: "grok", endpointKind: endpointTargetHook, endpointAliases: []string{"grok"}, hookAliases: []string{"grok"}},
 	{name: "hermes", endpointKind: endpointTargetHook, endpointAliases: []string{"hermes", "hermes-agent"}, hookAliases: []string{"hermes", "hermes-agent"}},
 	{name: "antigravity", endpointKind: endpointTargetHook, endpointAliases: []string{"antigravity", "antigravity-cli"}, hookAliases: []string{"antigravity", "antigravity-cli"}},

--- a/cli/beacon/cmd/endpoint_targets_characterization_test.go
+++ b/cli/beacon/cmd/endpoint_targets_characterization_test.go
@@ -32,6 +32,9 @@ func TestNormalizeEndpointTargetCharacterization(t *testing.T) {
 		"factory":         {"factory", endpointTargetHook, true},
 		"droid":           {"factory", endpointTargetHook, true},
 		"opencode":        {"opencode", endpointTargetHook, true},
+		"pi":              {"pi", endpointTargetHook, true},
+		"pi-cli":          {"pi", endpointTargetHook, true},
+		"pi_cli":          {"pi", endpointTargetHook, true},
 		"grok":            {"grok", endpointTargetHook, true},
 		"hermes":          {"hermes", endpointTargetHook, true},
 		"hermes-agent":    {"hermes", endpointTargetHook, true},
@@ -44,9 +47,11 @@ func TestNormalizeEndpointTargetCharacterization(t *testing.T) {
 		"  Claude_Code  ": {"claude", endpointTargetOTLP, true},
 		"DEVIN_DESKTOP":   {"devin-desktop", endpointTargetHook, true},
 		// Unsupported
-		"":              {"", "", false},
-		"unknown":       {"", "", false},
-		"vscode-hooks":  {"", "", false},
+		"":             {"", "", false},
+		"unknown":      {"", "", false},
+		"vscode-hooks": {"", "", false},
+		// "copilot" contains "pi"; neither may collapse into the other's target.
+		"copilot":       {"", "", false},
 		"claude-cowork": {"", "", false},
 	}
 	for in, w := range cases {
@@ -82,6 +87,9 @@ func TestNormalizeHookTargetCharacterization(t *testing.T) {
 		"factory":       {"factory", true},
 		"droid":         {"factory", true},
 		"opencode":      {"opencode", true},
+		"pi":            {"pi", true},
+		"pi-cli":        {"pi", true},
+		"pi_cli":        {"pi", true},
 		"grok":          {"grok", true},
 		"hermes":        {"hermes", true},
 		"hermes-agent":  {"hermes", true},

--- a/cli/beacon/internal/endpoint/hooks/pi.go
+++ b/cli/beacon/internal/endpoint/hooks/pi.go
@@ -1,9 +1,13 @@
 package hooks
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	piextension "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks/assets/pi"
 )
 
 // Pi (pi.dev) has no hooks configuration file and no OpenTelemetry support, so neither of Beacon's
@@ -41,6 +45,172 @@ func PiExtensionPath(level Level) (string, error) {
 		return "", err
 	}
 	return filepath.Join(dir, piExtensionFileName), nil
+}
+
+var piExtensionTemplate = piextension.Template
+
+type PiOptions struct {
+	Level    Level
+	LogPath  string
+	UserMode bool
+}
+
+type PiStatus struct {
+	Installed     bool   `json:"installed"`
+	BinaryPath    string `json:"binary_path,omitempty"`
+	ExtensionPath string `json:"extension_path,omitempty"`
+	Message       string `json:"message,omitempty"`
+}
+
+var piRuntime = hookRuntime{
+	displayName: "Pi",
+	configPath:  PiExtensionPath,
+	install:     installPiExtension,
+	uninstall:   removePiExtension,
+	isInstalled: isPiInstalledAt,
+}
+
+func InstallPi(opts PiOptions) (PiStatus, error) {
+	status, err := installRuntimeHooks(piRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return PiStatus{}, err
+	}
+	return piStatusFromRuntime(status), nil
+}
+
+func UninstallPi(opts PiOptions) (PiStatus, error) {
+	status, err := uninstallRuntimeHooks(piRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return PiStatus{}, err
+	}
+	return piStatusFromRuntime(status), nil
+}
+
+func PiHookStatus(opts PiOptions) PiStatus {
+	return piStatusFromRuntime(runtimeHookStatus(piRuntime, RuntimeOptions(opts)))
+}
+
+func IsPiInstalled(opts PiOptions) bool {
+	return isRuntimeInstalled(piRuntime, RuntimeOptions(opts))
+}
+
+// piStatusFromRuntime downgrades "installed" to false when the extension cannot actually work.
+//
+// Carrying the marker is not enough. Two states look installed and collect nothing: the hook binary
+// the extension names has been removed (an uninstall of a different scope, or a wiped state
+// directory), and the extension on disk points at a *previous* binary path, which happens when a
+// user-mode install is followed by a system-mode one. Reporting those as installed is the failure
+// where status is green and the log stays empty.
+func piStatusFromRuntime(status runtimeStatus) PiStatus {
+	out := PiStatus{
+		Installed:     status.Installed,
+		BinaryPath:    status.BinaryPath,
+		ExtensionPath: status.ConfigPath,
+		Message:       status.Message,
+	}
+	if !out.Installed || out.BinaryPath == "" {
+		return out
+	}
+	if _, err := os.Stat(out.BinaryPath); err != nil {
+		out.Installed = false
+		out.Message = fmt.Sprintf("Pi extension is installed, but Beacon hook binary is missing at %s", out.BinaryPath)
+		return out
+	}
+	data, err := os.ReadFile(out.ExtensionPath)
+	if err != nil || !piExtensionReferencesBinary(string(data), out.BinaryPath) {
+		out.Installed = false
+		out.Message = fmt.Sprintf("Pi extension at %s does not reference the active Beacon hook binary", out.ExtensionPath)
+	}
+	return out
+}
+
+// piExtensionReferencesBinary reports whether the extension's argv names this binary.
+//
+// The comparison is against the JSON-encoded path, not the raw one, and that is not a detail. The
+// argv is embedded as a JSON array, so a Windows path is stored with its separators escaped --
+// "C:\\Program Files\\..." -- and searching for the unescaped path finds nothing. A plain substring
+// check would therefore report every Windows install as pointing at the wrong binary, and status
+// and repair would both act on it.
+func piExtensionReferencesBinary(source, binaryPath string) bool {
+	if strings.Contains(source, "__BEACON_") {
+		return false
+	}
+	encoded, err := json.Marshal(binaryPath)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(source, string(encoded))
+}
+
+func installPiExtension(path, binaryPath, logPath, configPath string) error {
+	if existing, err := os.ReadFile(path); err == nil {
+		if !strings.Contains(string(existing), PiManagedExtensionMarker) {
+			return fmt.Errorf("refusing to overwrite unmanaged Pi extension at %s", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	extension, err := renderPiExtension(binaryPath, logPath, configPath)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(extension), 0644)
+}
+
+func removePiExtension(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !strings.Contains(string(data), PiManagedExtensionMarker) {
+		return false, nil
+	}
+	return true, os.Remove(path)
+}
+
+func isPiInstalledAt(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), PiManagedExtensionMarker)
+}
+
+func renderPiExtension(binaryPath, logPath, configPath string) (string, error) {
+	return renderPiExtensionTemplate(piExtensionTemplate, binaryPath, logPath, configPath)
+}
+
+// renderPiExtensionTemplate substitutes the marker and the argv into the extension source.
+//
+// The argv replaces the whole `["__BEACON_ARGV__"]` literal rather than a bare token, so the
+// template is valid TypeScript before and after substitution -- which is what lets the plugin's own
+// `bun --check` parse the checked-in source instead of only a rendered copy.
+func renderPiExtensionTemplate(template, binaryPath, logPath, configPath string) (string, error) {
+	argv := endpointCommandArgv("pi", binaryPath, logPath, configPath, "pi-event")
+	encoded, err := json.Marshal(argv)
+	if err != nil {
+		return "", fmt.Errorf("encode Pi extension argv: %w", err)
+	}
+	source := strings.ReplaceAll(template, "__BEACON_MANAGED_MARKER__", PiManagedExtensionMarker)
+	source = strings.ReplaceAll(source, `["__BEACON_ARGV__"]`, string(encoded))
+	// A template whose placeholders did not all resolve would install as a file that either fails to
+	// parse or spawns the literal string "__BEACON_ARGV__". Failing here makes that an install error
+	// rather than a runtime one nobody sees.
+	if strings.Contains(source, "__BEACON_") {
+		return "", fmt.Errorf("Pi extension template contains unresolved Beacon placeholders")
+	}
+	return source, nil
+}
+
+func piEmbeddedExtensionSourcePath() string {
+	return filepath.Clean(filepath.Join("assets", "pi", "beacon.ts"))
+}
+
+func piRootExtensionSourcePath() string {
+	return filepath.Clean(filepath.Join("..", "..", "..", "..", "..", "plugins", "pi-beacon", "src", "beacon.ts"))
 }
 
 func piExtensionDir(level Level) (string, error) {

--- a/cli/beacon/internal/endpoint/hooks/pi_test.go
+++ b/cli/beacon/internal/endpoint/hooks/pi_test.go
@@ -1,7 +1,10 @@
 package hooks
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
@@ -58,5 +61,265 @@ func TestPiManagedExtensionMarkerIsStable(t *testing.T) {
 	if PiManagedExtensionMarker != "beacon-managed-pi-extension:v1" {
 		t.Fatalf("PiManagedExtensionMarker = %q; changing it strands extensions installed by "+
 			"earlier builds, which uninstall then refuses to remove", PiManagedExtensionMarker)
+	}
+}
+
+func TestInstallPiExtensionWritesManagedExtension(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beacon.ts")
+	if err := installPiExtension(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installPiExtension returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read extension: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		PiManagedExtensionMarker,
+		"beaconEndpointExtension",
+		"BEACON_PI_DEBUG",
+		`"--platform","pi"`,
+		`"pi-event"`,
+		`"--log","/tmp/runtime.jsonl"`,
+		`"--config","/tmp/config.json"`,
+		"session_shutdown",
+		"tool_call",
+		"tool_result",
+		"message_end",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("extension missing %q", want)
+		}
+	}
+}
+
+// The argv is a JSON array, so nothing in the rendered file may be shell-quoted. A single-quoted
+// path would be spawned literally, with the quotes as part of the filename.
+func TestRenderPiExtensionEmitsArgvNotShellQuoting(t *testing.T) {
+	source, err := renderPiExtension("/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json")
+	if err != nil {
+		t.Fatalf("renderPiExtension returned error: %v", err)
+	}
+	if strings.Contains(source, "'/tmp/beacon-hooks'") {
+		t.Fatal("rendered extension shell-quotes the binary path; argv elements must be literal")
+	}
+	if !strings.Contains(source, `["/tmp/beacon-hooks","--platform","pi"`) {
+		t.Fatalf("rendered extension does not begin the argv with the binary and platform:\n%s", source)
+	}
+}
+
+// A path containing a space is the ordinary case on Windows (%ProgramFiles%, a user profile) and
+// happens on macOS too. It has to survive as one argv element, which is the whole reason this
+// runtime uses argv rather than a shell string.
+func TestRenderPiExtensionKeepsPathsWithSpacesIntact(t *testing.T) {
+	binary := `C:\Program Files\Beacon\beacon-hooks.exe`
+	source, err := renderPiExtension(binary, "/tmp/runtime.jsonl", "/tmp/config.json")
+	if err != nil {
+		t.Fatalf("renderPiExtension returned error: %v", err)
+	}
+	encoded, err := json.Marshal(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(source, string(encoded)) {
+		t.Fatalf("rendered extension does not carry the JSON-encoded binary path:\n%s", source)
+	}
+	// The rendered argv must still be a parseable JSON array; a raw backslash would break it.
+	start := strings.Index(source, "[\"")
+	end := strings.Index(source[start:], "]") + start + 1
+	var argv []string
+	if err := json.Unmarshal([]byte(source[start:end]), &argv); err != nil {
+		t.Fatalf("rendered argv is not valid JSON: %v\n%s", err, source[start:end])
+	}
+	if argv[0] != binary {
+		t.Fatalf("argv[0] = %q, want the binary path unchanged", argv[0])
+	}
+}
+
+func TestInstallPiExtensionRefusesToOverwriteUnmanagedExtension(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beacon.ts")
+	original := "export default function (pi) { /* someone else's extension */ }"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := installPiExtension(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json")
+	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite unmanaged") {
+		t.Fatalf("install error = %v, want a refusal", err)
+	}
+	data, readErr := os.ReadFile(path)
+	if readErr != nil || string(data) != original {
+		t.Fatalf("unmanaged extension changed: err=%v body=%q", readErr, data)
+	}
+}
+
+// Reinstalling over Beacon's own extension must work: that is what repair does, and what an upgrade
+// to a new marker version relies on.
+func TestInstallPiExtensionOverwritesItsOwnExtension(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beacon.ts")
+	if err := installPiExtension(path, "/tmp/beacon-hooks", "/tmp/a.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if err := installPiExtension(path, "/tmp/beacon-hooks", "/tmp/b.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("reinstall over managed extension: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), `"--log","/tmp/b.jsonl"`) {
+		t.Fatal("reinstall did not update the log path")
+	}
+}
+
+func TestRenderPiExtensionRejectsUnresolvedPlaceholders(t *testing.T) {
+	if _, err := renderPiExtensionTemplate("__BEACON_UNKNOWN__", "/tmp/beacon-hooks", "/tmp/r.jsonl", "/tmp/c.json"); err == nil {
+		t.Fatal("renderPiExtensionTemplate accepted a template with an unresolved placeholder; it " +
+			"would install a file that spawns a literal placeholder string")
+	}
+}
+
+func TestRemovePiExtensionOnlyRemovesManagedFiles(t *testing.T) {
+	dir := t.TempDir()
+	managed := filepath.Join(dir, "managed.ts")
+	if err := installPiExtension(managed, "/tmp/beacon-hooks", "/tmp/r.jsonl", "/tmp/c.json"); err != nil {
+		t.Fatal(err)
+	}
+	unmanaged := filepath.Join(dir, "unmanaged.ts")
+	if err := os.WriteFile(unmanaged, []byte("export default () => {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := removePiExtension(managed)
+	if err != nil || !removed {
+		t.Fatalf("removePiExtension(managed) = %t, %v; want true, nil", removed, err)
+	}
+	if _, err := os.Stat(managed); !os.IsNotExist(err) {
+		t.Fatal("managed extension was not removed")
+	}
+
+	removed, err = removePiExtension(unmanaged)
+	if err != nil || removed {
+		t.Fatalf("removePiExtension(unmanaged) = %t, %v; want false, nil", removed, err)
+	}
+	if _, err := os.Stat(unmanaged); err != nil {
+		t.Fatal("an extension Beacon did not write was removed")
+	}
+}
+
+// Uninstalling something that was never installed is a normal operation -- `endpoint uninstall`
+// runs over every target -- and must not be an error.
+func TestRemovePiExtensionIsQuietWhenAbsent(t *testing.T) {
+	removed, err := removePiExtension(filepath.Join(t.TempDir(), "missing.ts"))
+	if err != nil || removed {
+		t.Fatalf("removePiExtension(absent) = %t, %v; want false, nil", removed, err)
+	}
+}
+
+// Carrying the marker is not enough to be working. An extension pointing at a binary that is gone
+// collects nothing, and reporting it as installed is the failure where status is green and the log
+// stays empty.
+func TestPiStatusReportsNotInstalledWhenBinaryIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "beacon.ts")
+	missingBinary := filepath.Join(dir, "gone", "beacon-hooks")
+	if err := installPiExtension(path, missingBinary, "/tmp/r.jsonl", "/tmp/c.json"); err != nil {
+		t.Fatal(err)
+	}
+
+	status := piStatusFromRuntime(runtimeStatus{Installed: true, BinaryPath: missingBinary, ConfigPath: path})
+	if status.Installed {
+		t.Fatal("status reported installed with no hook binary on disk")
+	}
+	if !strings.Contains(status.Message, "missing") {
+		t.Fatalf("message = %q, want it to name the missing binary", status.Message)
+	}
+}
+
+// An extension left over from an install at a different scope points at that scope's binary. It
+// still carries the marker, so only the argv distinguishes it.
+func TestPiStatusReportsNotInstalledWhenExtensionNamesAnotherBinary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "beacon.ts")
+	active := filepath.Join(dir, "beacon-hooks")
+	if err := os.WriteFile(active, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := installPiExtension(path, filepath.Join(dir, "other-beacon-hooks"), "/tmp/r.jsonl", "/tmp/c.json"); err != nil {
+		t.Fatal(err)
+	}
+
+	status := piStatusFromRuntime(runtimeStatus{Installed: true, BinaryPath: active, ConfigPath: path})
+	if status.Installed {
+		t.Fatal("status reported installed for an extension naming a different binary")
+	}
+}
+
+func TestPiStatusReportsInstalledForCurrentExtension(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "beacon.ts")
+	binary := filepath.Join(dir, "beacon-hooks")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := installPiExtension(path, binary, "/tmp/r.jsonl", "/tmp/c.json"); err != nil {
+		t.Fatal(err)
+	}
+
+	status := piStatusFromRuntime(runtimeStatus{Installed: true, BinaryPath: binary, ConfigPath: path, Message: "ok"})
+	if !status.Installed {
+		t.Fatalf("status reported not installed for a current extension: %+v", status)
+	}
+	if status.ExtensionPath != path {
+		t.Fatalf("ExtensionPath = %q, want %q", status.ExtensionPath, path)
+	}
+}
+
+// The extension Go embeds and the one the plugin directory tests are the same file. If they drift,
+// the tested source is not the installed source -- so the drift is a test failure, not a surprise
+// discovered from a user's machine.
+func TestPiEmbeddedExtensionMatchesPluginSource(t *testing.T) {
+	embedded, err := os.ReadFile(piEmbeddedExtensionSourcePath())
+	if err != nil {
+		t.Fatalf("read embedded extension: %v", err)
+	}
+	root, err := os.ReadFile(piRootExtensionSourcePath())
+	if err != nil {
+		t.Fatalf("read plugin source: %v", err)
+	}
+	if string(embedded) != string(root) {
+		t.Fatal("the embedded Pi extension and plugins/pi-beacon/src/beacon.ts have drifted; " +
+			"run `bun run sync` in plugins/pi-beacon")
+	}
+}
+
+// Install and uninstall through the exported entry points, at the level a user actually gets.
+func TestInstallAndUninstallPiRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+
+	installed, err := InstallPi(PiOptions{Level: LevelUser, LogPath: filepath.Join(home, "runtime.jsonl"), UserMode: true})
+	if err != nil {
+		t.Fatalf("InstallPi returned error: %v", err)
+	}
+	want := filepath.Join(home, ".pi", "agent", "extensions", "beacon.ts")
+	if installed.ExtensionPath != want {
+		t.Fatalf("ExtensionPath = %q, want %q", installed.ExtensionPath, want)
+	}
+	if !installed.Installed {
+		t.Fatalf("InstallPi reported not installed: %+v", installed)
+	}
+	if !IsPiInstalled(PiOptions{Level: LevelUser, UserMode: true}) {
+		t.Fatal("IsPiInstalled = false right after a successful install")
+	}
+	if status := PiHookStatus(PiOptions{Level: LevelUser, UserMode: true}); !status.Installed {
+		t.Fatalf("PiHookStatus reported not installed: %+v", status)
+	}
+
+	removed, err := UninstallPi(PiOptions{Level: LevelUser, UserMode: true})
+	if err != nil {
+		t.Fatalf("UninstallPi returned error: %v", err)
+	}
+	if removed.Installed {
+		t.Fatalf("UninstallPi reported still installed: %+v", removed)
+	}
+	if _, err := os.Stat(want); !os.IsNotExist(err) {
+		t.Fatal("the extension file survived uninstall")
 	}
 }

--- a/cli/beacon/internal/endpoint/hooks/runtime.go
+++ b/cli/beacon/internal/endpoint/hooks/runtime.go
@@ -140,6 +140,37 @@ func endpointCommandPrefix(platform, binaryPath, logPath, configPath string) str
 	return strings.Join(args, " ")
 }
 
+// endpointCommandArgv builds the same command as endpointCommandPrefix, as argv rather than as a
+// string for a shell to parse.
+//
+// For a runtime that spawns a process itself, this is the better form and the reason is the whole
+// comment above: there is no quoting that works in a POSIX shell and in both Windows shells, so
+// endpointCommandPrefix has to pick one and accept that a runtime using the other cannot run it.
+// argv sidesteps the question -- a path containing a space, a `$`, or a backslash is one element of
+// an array, and nothing re-splits it.
+//
+// Kept beside its string counterpart rather than in the one runtime that uses it, because the two
+// must stay in step: the flags a hook needs are decided here, and a value added to one and not the
+// other is a runtime silently missing an endpoint setting.
+func endpointCommandArgv(platform, binaryPath, logPath, configPath, subcommand string) []string {
+	argv := []string{binaryPath, "--platform", platform}
+	if logPath != "" {
+		argv = append(argv, "--log", logPath)
+	}
+	if configPath != "" {
+		argv = append(argv, "--config", configPath)
+	}
+	// Best-effort, as in the string form: the CLI path only enables the inventory heartbeat, and a
+	// hook with no --cli still captures everything else.
+	if cliPath, err := os.Executable(); err == nil && cliPath != "" {
+		argv = append(argv, "--cli", cliPath)
+	}
+	if subcommand != "" {
+		argv = append(argv, subcommand)
+	}
+	return argv
+}
+
 // hookCommandQuote quotes one value for the shell that will parse this command.
 //
 // Single quotes, on every platform. In a POSIX shell they are fully literal, which is what a Windows


### PR DESCRIPTION
Fourth of seven. **Base is `pi-pr3-extension` (#349).** This is the one that makes Pi support usable: `beacon endpoint hooks install --harness pi` now works end to end.

## Scope

`hooks/pi.go` gains the `hookRuntime` and the renderer; one row in the `harnessTargets` registry; the four switch sites the other hook runtimes already occupy in `endpoint_hooks.go` (install, uninstall, status collection, status printing); README runtime table.

## `endpointCommandArgv` beside `endpointCommandPrefix`

The extension is rendered with an argv array rather than a shell command string (see #349 for why). The new function sits next to its string counterpart deliberately: the flags a hook needs are decided in one place, and a value added to one and not the other is a runtime silently missing an endpoint setting.

## Status does not trust the marker alone

Two states carry the marker and collect nothing:

- The hook binary the extension names has been removed — an uninstall at a different scope, or a wiped state directory.
- The extension points at a *previous* binary path, which happens when a user-mode install is followed by a system-mode one.

Both now report `installed=false` with a message naming the cause. The alternative is a green status over an empty log, which is the worst failure mode a status command has.

## The JSON-path detail

The binary reference is compared as **JSON-encoded**, not as a raw path. The argv is embedded as a JSON array, so a Windows path is stored with its separators escaped (`"C:\\Program Files\\..."`) — searching for the unescaped path finds nothing. A plain substring check would have reported every Windows install as pointing at the wrong binary, and status *and repair* would both have acted on it. `TestRenderPiExtensionKeepsPathsWithSpacesIntact` round-trips a `C:\Program Files\...` path through the renderer and re-parses the argv as JSON.

## Verified against the real CLI, not only in tests

```
$ beacon endpoint hooks install --harness pi --user --log-path $H/runtime.jsonl
Pi extension installed: …/.pi/agent/extensions/beacon.ts

$ beacon endpoint hooks status --harness pi --user
Pi extension: installed=true path=…/.pi/agent/extensions/beacon.ts

$ beacon endpoint discover --json     # telemetry_status: "enabled"
```

Then driving the **installed** file under Node:

```
session.started          pi_cli  inst-1
prompt.submitted         pi_cli  inst-1  audit the repo
tool.invoked             pi_cli  inst-1  cat ~/.ssh/id_rsa
command.executed         pi_cli  inst-1  cat ~/.ssh/id_rsa
session.ended            pi_cli  inst-1
```

Uninstall removes the file. Installing over an unmanaged `beacon.ts` refuses and leaves it byte-identical. `--dry-run` reports the planned action.

## What the end-to-end run caught that unit tests could not

On the first attempt no events were written at all. Cause: the embedded hooks binary predated `pi-event` (#348), so every spawn exited non-zero. The extension logged each failure under `BEACON_PI_DEBUG=1` and Pi kept running — the fail-open path doing exactly its job, and the debug path diagnosing it in one command. Worth knowing that a stale `hooks.bin` presents as silence plus debug lines, not as a crash.

## Testing

17 new tests in the hooks package, the characterization tests extended with Pi's aliases (including that `copilot` still resolves to nothing near Pi), plus all five suites and the plugin's `bun run check && bun test`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFCTrDvdDQxFpuj9by8vJd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes and removes a user-home agent extension that spawns the Beacon hooks binary, so a bad render or overwrite would affect local telemetry collection. Safeguards (managed marker, argv JSON encoding, status binary checks) follow existing harness patterns.
> 
> **Overview**
> Makes Pi a first-class hook harness: `beacon endpoint hooks install/uninstall/status --harness pi` now writes, removes, and reports a managed `beacon.ts` extension under `~/.pi/agent/extensions` (or the project-level path).
> 
> Install renders the embedded TypeScript template with a JSON **argv** (via new `endpointCommandArgv`, kept in lockstep with the shell-string prefix) so paths with spaces and Windows separators survive spawn. Uninstall and overwrite only files that carry `beacon-managed-pi-extension:v1`; unmanaged `beacon.ts` is left untouched.
> 
> Status is not marker-only: a missing hook binary or an extension that does not JSON-reference the *active* binary reports `installed=false` with a cause, so a stale user-vs-system path cannot look healthy over an empty log. README lists Pi coverage; characterization tests pin `pi`/`pi-cli` aliases and that `copilot` does not collapse into Pi.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 834ee5d466c1655af7936a7c154819d961c2eb0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->