### PR TITLE
Pi support 5/7: report Pi in every hook status surface

### DIFF
--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -869,7 +869,7 @@ func hookTargets() ([]string, error) {
 }
 
 func allHookTargetsForLevel() []string {
-	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "grok", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "pi", "grok", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 	if endpointOpts.hookLevel != "project" {
 		return all
 	}
@@ -917,6 +917,9 @@ func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[str
 		case "opencode":
 			status := endpointhooks.OpenCodeHookStatus(endpointhooks.OpenCodeOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.PluginPath, Raw: status}
+		case "pi":
+			status := endpointhooks.PiHookStatus(endpointhooks.PiOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ExtensionPath, Raw: status}
 		case "grok":
 			status := endpointhooks.GrokHookStatus(endpointhooks.GrokOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}

--- a/cli/beacon/cmd/endpoint_hooks_repair.go
+++ b/cli/beacon/cmd/endpoint_hooks_repair.go
@@ -148,7 +148,7 @@ func installedHookTargetsForUser(homeDir, logPath string) ([]string, error) {
 }
 
 func repairTargetOrder() []string {
-	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "grok", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "pi", "grok", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 }
 
 // withUserHome runs fn as if it were executing inside another user's profile.

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -343,6 +343,8 @@ func hookStatuses(logPath string, userMode bool) []HookStatus {
 	add("hermes", hermes.Installed, hermes.ConfigPath, hermes.BinaryPath, hermes.Message)
 	opencode := endpointhooks.OpenCodeHookStatus(endpointhooks.OpenCodeOptions{Level: level, LogPath: logPath, UserMode: userMode})
 	add("opencode", opencode.Installed, opencode.PluginPath, opencode.BinaryPath, opencode.Message)
+	pi := endpointhooks.PiHookStatus(endpointhooks.PiOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("pi", pi.Installed, pi.ExtensionPath, pi.BinaryPath, pi.Message)
 	vscode := endpointhooks.VSCodeHookStatus(endpointhooks.VSCodeOptions{Level: level, LogPath: logPath, UserMode: userMode})
 	add("vscode", vscode.Installed, vscode.HooksPath, vscode.BinaryPath, vscode.Message)
 	return out

--- a/cli/beacon/internal/endpoint/dashboard/server_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/server_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/diagnostics"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/tokens"
 )
 
@@ -583,5 +584,37 @@ func TestStaticDashboardPagesServe(t *testing.T) {
 				t.Fatalf("body did not contain %q", tc.want)
 			}
 		})
+	}
+}
+
+// The dashboard's hook rows are assembled by hand, one call per runtime, so a new runtime is
+// invisible here until it is added -- and invisible means an operator reading the dashboard
+// concludes Pi is not instrumented while events are arriving in the log.
+func TestHookStatusesIncludesPi(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+
+	rows := hookStatuses(filepath.Join(home, "runtime.jsonl"), true)
+
+	var found *HookStatus
+	for i := range rows {
+		if rows[i].Target == "pi" {
+			found = &rows[i]
+			break
+		}
+	}
+	if found == nil {
+		targets := make([]string, 0, len(rows))
+		for _, row := range rows {
+			targets = append(targets, row.Target)
+		}
+		t.Fatalf("hookStatuses has no pi row; targets=%v", targets)
+	}
+	if found.Status != "not_installed" {
+		t.Fatalf("pi status = %q, want not_installed with nothing installed", found.Status)
+	}
+	want := filepath.Join(home, ".pi", "agent", "extensions", "beacon.ts")
+	if found.Path != want {
+		t.Fatalf("pi path = %q, want %q", found.Path, want)
 	}
 }

--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
 	"github.com/pelletier/go-toml/v2"
 	"gopkg.in/yaml.v3"
 )
@@ -201,6 +202,7 @@ func candidates(home, wd string) []candidate {
 	items = append(items, factoryCandidates(home, wd)...)
 	items = append(items, copilotCandidates(home)...)
 	items = append(items, opencodeCandidates(home, wd)...)
+	items = append(items, piCandidates(home, wd)...)
 	items = append(items, hermesCandidates(home)...)
 	items = append(items, devinCandidates(home, wd)...)
 	items = append(items, grokCandidates(home, wd)...)
@@ -280,6 +282,16 @@ func opencodeCandidates(home, wd string) []candidate {
 	return []candidate{
 		{runtime: "opencode", path: filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
 		{runtime: "opencode", path: filepath.Join(wd, ".opencode", "plugins", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
+	}
+}
+
+// piCandidates covers both locations Pi loads extensions from. The project path omits the "agent"
+// segment that the user path has -- that segment exists only under the home directory -- so the two
+// cannot be derived from one another.
+func piCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "pi_cli", path: filepath.Join(home, ".pi", "agent", "extensions", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
+		{runtime: "pi_cli", path: filepath.Join(wd, ".pi", "extensions", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
 	}
 }
 
@@ -612,6 +624,11 @@ func beaconManaged(item candidate, data []byte) bool {
 		}
 	case "opencode":
 		return strings.Contains(text, "beacon-managed-opencode-plugin:v1")
+	case "pi_cli":
+		// The marker constant rather than a literal, unlike the two cases above. The writer and the
+		// reader disagreeing means inventory reports Beacon's own extension as unmanaged, which is
+		// what an audit of "what is instrumented on this machine" is for.
+		return strings.Contains(text, endpointhooks.PiManagedExtensionMarker)
 	case "grok":
 		return strings.Contains(text, "beacon-managed-grok-hooks:v1")
 	}

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
 )
 
 func TestScanCurrentUserMCPInventory(t *testing.T) {
@@ -338,6 +340,8 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 		{runtime: "copilot_cli", path: filepath.Join(home, ".bash_profile"), scope: ScopeUser, format: formatMetadataOnly, kind: KindProfile},
 		{runtime: "opencode", path: filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
 		{runtime: "opencode", path: filepath.Join(work, ".opencode", "plugins", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
+		{runtime: "pi_cli", path: filepath.Join(home, ".pi", "agent", "extensions", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
+		{runtime: "pi_cli", path: filepath.Join(work, ".pi", "extensions", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
 		{runtime: "hermes", path: filepath.Join(home, ".hermes", "config.yaml"), scope: ScopeUser, format: formatYAML, kind: KindNativeConfig},
 		{runtime: "devin-cli", path: filepath.Join(home, ".config", "devin", "config.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
 		{runtime: "devin-cli", path: filepath.Join(work, ".devin", "hooks.v1.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
@@ -360,6 +364,41 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 		if config.ParserMode != item.format || config.ConfigKind != item.kind {
 			t.Fatalf("%s %s mode/kind = %s/%s, want %s/%s", item.runtime, item.path, config.ParserMode, config.ConfigKind, item.format, item.kind)
 		}
+	}
+}
+
+// Inventory answers "what on this machine is instrumented, and by whom". A Beacon-written Pi
+// extension has to come back BeaconManaged, and one somebody else wrote must not -- the marker is
+// the only thing that separates them, which is why the check uses the exported constant rather than
+// a second copy of the string.
+func TestScanReportsPiExtensionManagementFromTheMarker(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("SHELL", "/bin/bash")
+	writeFile(t, filepath.Join(home, ".pi", "agent", "extensions", "beacon.ts"),
+		"// "+endpointhooks.PiManagedExtensionMarker+"\nexport default () => {}\n")
+	writeFile(t, filepath.Join(work, ".pi", "extensions", "beacon.ts"),
+		"export default function (pi) { /* not Beacon's */ }\n")
+
+	result := Scan(Options{HomeDir: home, WorkingDir: work, Now: fixedNow})
+
+	managed := findConfig(result.Configs, "pi_cli", filepath.Join(home, ".pi", "agent", "extensions", "beacon.ts"))
+	if managed == nil {
+		t.Fatal("user-level Pi extension was not scanned")
+	}
+	if !managed.BeaconManaged {
+		t.Fatalf("Beacon's own Pi extension reported unmanaged: %+v", managed)
+	}
+	if managed.ParserMode != formatMetadataOnly || managed.ConfigKind != KindPlugin {
+		t.Fatalf("mode/kind = %s/%s, want %s/%s", managed.ParserMode, managed.ConfigKind, formatMetadataOnly, KindPlugin)
+	}
+
+	foreign := findConfig(result.Configs, "pi_cli", filepath.Join(work, ".pi", "extensions", "beacon.ts"))
+	if foreign == nil {
+		t.Fatal("project-level Pi extension was not scanned")
+	}
+	if foreign.BeaconManaged {
+		t.Fatal("an extension Beacon did not write was reported as Beacon-managed")
 	}
 }
 


### PR DESCRIPTION
Fifth of seven. **Base is `pi-pr4-install` (#351).** Additive registration only — no new logic.

## Why this is a separate PR

Pi became installable in #351 but stayed invisible to the four places that enumerate hook runtimes by hand: repair, diagnostics, the local dashboard, and inventory. Invisible here is not cosmetic — an operator reading the dashboard concludes Pi is not instrumented while its events are arriving in the log.

## Changes

| Surface | Change |
|---|---|
| `cmd/endpoint_hooks_repair.go` | `pi` in `repairTargetOrder()` |
| `cmd/endpoint_diagnostics.go` | `pi` in `allHookTargetsForLevel()` + the per-target status switch |
| `internal/endpoint/dashboard/server.go` | one `hookStatuses` row |
| `internal/endpoint/inventory/inventory.go` | `piCandidates()`, registered in `candidates()`, and a `beaconManaged` case |

## Two decisions worth a look

**Pi stays in the project-level list.** The only runtime filtered out there is Hermes, which has no project scope. Pi has one, and its project path (`.pi/extensions`) omits the `agent` segment the user path carries (`.pi/agent/extensions`) — so the two locations are listed explicitly rather than derived from one another.

**Inventory reads the marker through the exported constant**, not a second copy of the string, unlike the opencode and grok cases beside it. Inventory answers "what on this machine is instrumented, and by whom", so a marker that drifts between its writer and its reader makes it report Beacon's own extension as somebody else's.

## Verified against the real CLI

```
$ beacon endpoint hooks status --all --user
Pi extension: installed=true path=…/.pi/agent/extensions/beacon.ts
Pi endpoint hooks are installed

$ beacon endpoint inventory --all --json     # hooks.pi.status == "configured"
$ beacon endpoint inventory --json           # pi_cli scope=user managed=True kind=plugin
```

Plus a test asserting an extension Beacon did *not* write comes back unmanaged, and a dashboard test for the row (that one isn't reachable from the CLI without standing up the server).

`TestScanIncludesAllSupportedCurrentUserAndProjectConfigs` pins the candidate count, so it moves 32 → 34 here by design.

## Note for reviewers

The four lists this touches are the same duplication the `harnessTargets` registry was introduced to remove, and none of them derive from it. They also disagree with each other on membership today — `repairTargetOrder()` includes `claude`, `allHookTargetsForLevel()` does not — so unifying them would change behavior for existing runtimes. That's its own change, not a side effect of adding one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFCTrDvdDQxFpuj9by8vJd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive list/status wiring only; no install, auth, or hook-write changes. Wrong registration could hide or mis-label Pi in inventory, but tests cover the new paths.
> 
> **Overview**
> Makes already-installable Pi hooks visible on the four hand-maintained runtime lists so operators no longer miss an instrumented Pi runtime.
> 
> Adds `pi` to diagnostics (`allHookTargetsForLevel` plus the status switch), hook repair order, and the dashboard `hookStatuses` rows. Inventory now scans user (`~/.pi/agent/extensions/beacon.ts`) and project (`.pi/extensions/beacon.ts`) plugin paths as `pi_cli`, and treats Beacon ownership via `PiManagedExtensionMarker` rather than a duplicated string.
> 
> Pi stays in the project-level target list (unlike Hermes). Tests cover the dashboard row and marker-based managed vs unmanaged classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b9e0d07d8e897f96566d8b608c2f2fc56d82042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->