### PR TITLE
Pi support 6/7: honor policy denials on Pi tool calls

### DIFF
--- a/cli/beacon-hooks/cmd/pi_event.go
+++ b/cli/beacon-hooks/cmd/pi_event.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	hookdiff "github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/diff"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve/policycontract"
 	"github.com/spf13/cobra"
 )
 
@@ -43,8 +44,11 @@ import (
 // in the shim -- more code in the layer that is hardest to test and hardest to update once
 // installed.
 //
-// The response is a JSON object on stdout. Today it is always empty: this command observes and does
-// not decide anything, which is what keeps the open build free of enforcement of its own.
+// The response is a JSON object on stdout. It is empty except on one path: when BEACON_POLICY_PROVIDER
+// names an executable and that provider denies a tool_call, the response is Pi's native deny shape,
+// {"block":true,"reason":"..."}, which the extension returns to Pi unchanged. With no provider
+// configured -- the open build's default -- the seam is inert and the response is always empty, so
+// this binary ships no enforcement decisions of its own.
 var piEventCmd = &cobra.Command{
 	Use:   "pi-event",
 	Short: "Record Pi extension telemetry",
@@ -76,6 +80,22 @@ func runPiEvent(cmd *cobra.Command, args []string) {
 	}
 	sessionID := resolveSessionID(input, "pi")
 	logger := newHookLogger("pi-event", "pi", sessionID)
+
+	// The policy seam runs on tool_call and only on tool_call: that is the one Pi event that fires
+	// before the tool runs and whose handler Pi lets an extension block. Consulting it on a
+	// tool_result would ask about work already done.
+	//
+	// A deny returns immediately without writing tool.invoked. The tool does not run, so recording
+	// it as invoked would put an event in the log for something that never happened -- the same
+	// reason the pre-tool hook returns early here. enforcePolicy has already written the
+	// approval.denied event that does describe what happened.
+	if getFirstStr(input, "type", "event", "event_type") == "tool_call" {
+		if deny, denied := enforcePolicy(logger, input, sessionID, policycontract.PhasePreTool); denied {
+			outputJSON(deny)
+			return
+		}
+	}
+
 	for _, event := range piEndpointEvents(input, sessionID) {
 		if event.action == "" {
 			continue

--- a/cli/beacon-hooks/cmd/policy.go
+++ b/cli/beacon-hooks/cmd/policy.go
@@ -163,6 +163,13 @@ func policyDenyResponse(reason string) map[string]interface{} {
 		return map[string]interface{}{"decision": "reject"}
 	case platformFlag == "antigravity" || platformFlag == "grok":
 		return map[string]interface{}{"decision": "deny"}
+	case platformFlag == "pi":
+		// Pi's native deny is a tool_call handler returning {block, reason}, so that is emitted
+		// verbatim and the extension returns this object to Pi unchanged. Every other runtime here
+		// is a shape somebody else defined and Beacon matches; this one is a contract between two
+		// pieces of Beacon, and keeping the translation out of the extension is the point -- the
+		// extension is the layer that cannot be corrected without a reinstall.
+		return map[string]interface{}{"block": true, "reason": reason}
 	case platformFlag == "claude":
 		return map[string]interface{}{
 			"hookSpecificOutput": map[string]interface{}{

--- a/cli/beacon-hooks/cmd/policy_test.go
+++ b/cli/beacon-hooks/cmd/policy_test.go
@@ -148,3 +148,124 @@ func TestPermissionRequestPolicyDenyDevin(t *testing.T) {
 	}
 	assertDenialEvent(t, logPath)
 }
+
+// Pi's tool_call is its only blockable pre-execution event, so the seam can be honored there with
+// full fidelity: the response is Pi's native {block, reason} shape, which the extension returns to
+// Pi unchanged rather than translating.
+func TestPiEventPolicyDeny(t *testing.T) {
+	logPath := setupPolicyTest(t, "pi", denyResponse)
+	out := runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "tool_call",
+		"session_id": "pi-deny-1",
+		"cwd":        "/repo",
+		"tool_name":  "bash",
+		"tool_input": map[string]interface{}{"command": "claude --dangerously-skip-permissions -p go"},
+	})
+	if out["block"] != true {
+		t.Fatalf("pi deny response = %#v, want block=true", out)
+	}
+	if out["reason"] != "blocked by test" {
+		t.Fatalf("pi deny reason = %#v, want the provider's reason", out["reason"])
+	}
+	assertDenialEvent(t, logPath)
+}
+
+// A denied call never ran, so tool.invoked must not be written for it. The log would otherwise carry
+// an event for something that did not happen, next to the denial that says it did not.
+func TestPiEventPolicyDenyDoesNotRecordToolInvoked(t *testing.T) {
+	logPath := setupPolicyTest(t, "pi", denyResponse)
+	runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "tool_call",
+		"session_id": "pi-deny-2",
+		"tool_name":  "bash",
+		"tool_input": map[string]interface{}{"command": "codex --full-auto"},
+	})
+
+	for _, event := range endpointEvents(t, logPath) {
+		if action := eventAction(t, event); action == "tool.invoked" {
+			t.Fatal("a denied tool call was also recorded as invoked")
+		}
+	}
+}
+
+func TestPiEventPolicyAllowProceedsNormally(t *testing.T) {
+	logPath := setupPolicyTest(t, "pi", `{"decision":"allow"}`)
+	out := runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "tool_call",
+		"session_id": "pi-allow-1",
+		"cwd":        "/repo",
+		"tool_name":  "bash",
+		"tool_input": map[string]interface{}{"command": "ls -la"},
+	})
+	if len(out) != 0 {
+		t.Fatalf("pi allow response = %#v, want an empty object", out)
+	}
+	if got := eventAction(t, lastEndpointEvent(t, logPath)); got != "tool.invoked" {
+		t.Fatalf("event.action = %q, want tool.invoked on an allow", got)
+	}
+}
+
+// The seam runs on the pre-execution event only. Asking about a tool_result would be asking about
+// work already done, and a deny there could not stop anything while still blocking the telemetry
+// for it.
+func TestPiEventPolicyIgnoresToolResult(t *testing.T) {
+	logPath := setupPolicyTest(t, "pi", denyResponse)
+	out := runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "tool_result",
+		"session_id": "pi-result-1",
+		"tool_name":  "bash",
+		"tool_input": map[string]interface{}{"command": "ls -la"},
+	})
+	if len(out) != 0 {
+		t.Fatalf("tool_result response = %#v, want an empty object even with a denying provider", out)
+	}
+	if got := eventAction(t, lastEndpointEvent(t, logPath)); got != "command.executed" {
+		t.Fatalf("event.action = %q, want the result recorded normally", got)
+	}
+}
+
+// With no provider configured -- the open build's default -- the seam is inert and a tool_call is
+// pure observation. This is the property that keeps enforcement out of the shipped build.
+func TestPiEventWithoutProviderNeverBlocks(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "pi"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv(policy.ProviderEnv, "")
+
+	out := runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "tool_call",
+		"session_id": "pi-noprovider",
+		"tool_name":  "bash",
+		"tool_input": map[string]interface{}{"command": "rm -rf /"},
+	})
+	if len(out) != 0 {
+		t.Fatalf("response = %#v, want an empty object with no provider configured", out)
+	}
+	if got := eventAction(t, lastEndpointEvent(t, logPath)); got != "tool.invoked" {
+		t.Fatalf("event.action = %q, want tool.invoked", got)
+	}
+}
+
+// Fail-open on a broken provider. A provider that cannot run must not stop the agent, so a
+// non-executable path is an allow -- the same direction every other error path in the seam takes.
+func TestPiEventPolicyFailsOpenOnBrokenProvider(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "pi"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv(policy.ProviderEnv, filepath.Join(t.TempDir(), "does-not-exist"))
+
+	out := runHookWithInput(t, runPiEvent, map[string]interface{}{
+		"type":       "tool_call",
+		"session_id": "pi-broken",
+		"tool_name":  "bash",
+		"tool_input": map[string]interface{}{"command": "ls"},
+	})
+	if len(out) != 0 {
+		t.Fatalf("response = %#v, want an empty object when the provider cannot run", out)
+	}
+	if got := eventAction(t, lastEndpointEvent(t, logPath)); got != "tool.invoked" {
+		t.Fatalf("event.action = %q, want the call allowed and recorded", got)
+	}
+}

--- a/cli/beacon/internal/endpoint/harness/pi.go
+++ b/cli/beacon/internal/endpoint/harness/pi.go
@@ -47,10 +47,15 @@ func DiscoverPi() Harness {
 
 // piStatus classifies the extension file at path.
 //
-// The middle case is the one worth spelling out: a beacon.ts that exists without Beacon's marker is
-// somebody else's extension sharing the filename, so it is reported as disabled rather than
-// enabled. Reporting it as enabled would claim telemetry Beacon is not collecting, and install
-// refuses to overwrite the same file for the same reason.
+// Two of the four cases are worth spelling out. A beacon.ts without Beacon's marker prefix is
+// somebody else's extension sharing the filename, so it reports disabled rather than enabled:
+// claiming it would show the runtime as covered while no events arrive, and install refuses to
+// overwrite the same file for the same reason.
+//
+// A Beacon extension from an earlier version reports *enabled*, because it is: it collects the same
+// telemetry. What an older one may not do is honor a policy decision, and that is a different
+// question from whether telemetry is flowing -- so it is said in the message rather than by
+// reporting a runtime as uninstrumented when it is instrumented.
 func piStatus(path string) (TelemetryStatus, string) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -59,8 +64,13 @@ func piStatus(path string) (TelemetryStatus, string) {
 		}
 		return TelemetryMissing, err.Error()
 	}
-	if !strings.Contains(string(data), hooks.PiManagedExtensionMarker) {
+	source := string(data)
+	if !strings.Contains(source, hooks.PiManagedExtensionPrefix) {
 		return TelemetryDisabled, "Pi extension file exists but Beacon endpoint extension was not found"
+	}
+	if !strings.Contains(source, hooks.PiManagedExtensionMarker) {
+		return TelemetryEnabled, "Beacon Pi extension is configured but was written by an earlier version; " +
+			"reinstall it to pick up current behavior"
 	}
 	return TelemetryEnabled, "Beacon Pi extension is configured"
 }

--- a/cli/beacon/internal/endpoint/harness/pi_test.go
+++ b/cli/beacon/internal/endpoint/harness/pi_test.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
@@ -123,16 +124,32 @@ func TestDiscoverPiReportsDisabledForUnmanagedExtension(t *testing.T) {
 	}
 }
 
-// The marker is a version contract with the extension source. A file carrying an older marker must
-// not read as enabled, or a repair would leave a stale extension in place believing it current.
-func TestDiscoverPiReportsDisabledForStaleMarkerVersion(t *testing.T) {
+// An extension from an earlier Beacon version is still collecting telemetry, so it reports enabled
+// -- reporting a runtime as uninstrumented when events are arriving from it would be worse than
+// saying nothing. What an older one may not do is honor a policy decision, which is a different
+// question and belongs in the message.
+func TestDiscoverPiReportsEnabledWithAWarningForAnEarlierVersion(t *testing.T) {
 	home := setupPiDiscovery(t)
-	writePiExtension(t, home, "// beacon-managed-pi-extension:v0\nexport default () => {}\n")
+	writePiExtension(t, home, "// beacon-managed-pi-extension:v1\nexport default () => {}\n")
+
+	h := DiscoverPi()
+	if h.TelemetryStatus != TelemetryEnabled {
+		t.Fatalf("TelemetryStatus = %q, want %q; an older extension still reports telemetry",
+			h.TelemetryStatus, TelemetryEnabled)
+	}
+	if !strings.Contains(h.Message, "earlier version") {
+		t.Fatalf("message = %q, want it to name the superseded version", h.Message)
+	}
+}
+
+// A file that carries no Beacon marker at all is somebody else's, whatever it is named.
+func TestDiscoverPiReportsDisabledForAForeignExtension(t *testing.T) {
+	home := setupPiDiscovery(t)
+	writePiExtension(t, home, "// managed-by-someone-else\nexport default () => {}\n")
 
 	h := DiscoverPi()
 	if h.TelemetryStatus != TelemetryDisabled {
-		t.Fatalf("TelemetryStatus = %q, want %q for a superseded marker version; message=%q",
-			h.TelemetryStatus, TelemetryDisabled, h.Message)
+		t.Fatalf("TelemetryStatus = %q, want %q", h.TelemetryStatus, TelemetryDisabled)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/hooks/assets/pi/beacon.ts
+++ b/cli/beacon/internal/endpoint/hooks/assets/pi/beacon.ts
@@ -39,6 +39,28 @@ const decisionTimeoutMs = 6000
 
 const debugEnabled = process.env.BEACON_PI_DEBUG === "1"
 
+// policyProviderConfigured decides whether this event is worth waiting for an answer to.
+//
+// Without it, tool_call awaited a subprocess round-trip on every call in a build with no provider
+// configured -- the default -- to receive a reply that could not contain a deny. That is latency on
+// every tool call in service of a feature nobody turned on, and it is a cost the other runtimes
+// Beacon enforces on do not pay: their hook protocols are synchronous already, so the runtime is
+// waiting regardless. Pi's extension is not, so asking has to be opt-in exactly as the enforcement
+// itself is.
+//
+// This reads the same variable the hooks binary reads, and the binary remains the authority: if the
+// two ever disagree -- an environment the extension cannot see but the child can -- the effect is
+// that nothing is awaited and the call proceeds, which is the fail-open direction the seam already
+// specifies for every other error path.
+function policyProviderConfigured(): boolean {
+  try {
+    return (process.env.BEACON_POLICY_PROVIDER ?? "").trim() !== ""
+  } catch {
+    // A host that denies environment access is not a host with a policy provider configured.
+    return false
+  }
+}
+
 function debugLog(message: string, extra?: unknown): void {
   if (!debugEnabled) return
   // stderr, never stdout: Pi's print and JSON modes put machine-readable output on stdout, and a
@@ -287,30 +309,36 @@ export default function beaconEndpointExtension(pi: {
     void send({ ...base("input", event, ctx), prompt })
   })
 
-  // tool_call is the one handler that awaits its send and the one that can return a value.
+  // tool_call is the one handler that can wait for an answer, and the one that can return a value.
+  // It does neither unless a policy provider is configured.
   //
   // It is Pi's only blockable pre-execution event, so it is where Beacon's policy seam can be
-  // honored with full fidelity: the hooks binary consults the configured provider and answers with
-  // Pi's own {block, reason} shape, which is returned here unchanged. With no provider configured --
-  // the default for the open build -- the reply is empty, this returns undefined, and the behavior
-  // is identical to every other handler.
+  // honored with full fidelity: the hooks binary consults the provider and answers with Pi's own
+  // {block, reason} shape, which is returned here unchanged.
   //
-  // Awaiting adds the provider's latency to the tool call, which is inherent to asking a question
-  // before an action rather than reporting it afterwards. Every failure path resolves to no
-  // decision, so a slow or broken provider costs latency and never blocks a call.
+  // With no provider configured -- the default for the open build -- this is fire-and-forget and
+  // returns nothing, exactly like every observation handler. That gate is the point: the open build
+  // pays nothing for a feature it is not using, and enforcement is opt-in in behavior and not only
+  // in outcome.
+  //
+  // When a provider *is* configured, awaiting adds its latency to the tool call. That is inherent to
+  // asking a question before an action rather than reporting it afterwards, and it is a cost the
+  // operator opted into. Every failure path resolves to no decision, so a slow or broken provider
+  // costs latency and never blocks a call.
   pi.on("tool_call", async (event, ctx) => {
-    const decision = await send(
-      {
-        ...base("tool_call", event, ctx),
-        tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
-        tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
-        // event.input is mutable and Pi may hand the same object to other extensions after this
-        // one. A shallow copy keeps the payload describing the arguments as they were at this
-        // moment.
-        tool_input: { ...(toRecord(event?.input) ?? {}) },
-      },
-      true,
-    )
+    const payload = {
+      ...base("tool_call", event, ctx),
+      tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
+      tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
+      // event.input is mutable and Pi may hand the same object to other extensions after this one.
+      // A shallow copy keeps the payload describing the arguments as they were at this moment.
+      tool_input: { ...(toRecord(event?.input) ?? {}) },
+    }
+    if (!policyProviderConfigured()) {
+      void send(payload)
+      return undefined
+    }
+    const decision = await send(payload, true)
     if (decision?.block === true) {
       return { block: true, reason: decision.reason }
     }

--- a/cli/beacon/internal/endpoint/hooks/assets/pi/beacon.ts
+++ b/cli/beacon/internal/endpoint/hooks/assets/pi/beacon.ts
@@ -28,6 +28,15 @@ const beaconArgv: string[] = ["__BEACON_ARGV__"]
 // file.
 const sendTimeoutMs = 2000
 
+// The decision path gets a longer budget, and the margin is the point rather than caution.
+//
+// When a policy provider is configured, the hooks binary consults it with a 2s timeout of its own
+// before answering. Reusing the 2s budget here would mean this side frequently gives up first: the
+// spawn plus the provider's own work cannot fit in the same 2s the provider alone is allowed. A
+// timeout on this side is treated as allow, so the visible effect would be a provider that denies
+// and a tool that runs anyway -- an enforcement gap that looks like a flaky provider.
+const decisionTimeoutMs = 6000
+
 const debugEnabled = process.env.BEACON_PI_DEBUG === "1"
 
 function debugLog(message: string, extra?: unknown): void {
@@ -41,51 +50,72 @@ function debugLog(message: string, extra?: unknown): void {
   }
 }
 
+// A decision the hooks binary returned. Only the deny case carries anything: an allow is an empty
+// response, which is also what a failure of any kind produces.
+type BeaconDecision = { block?: boolean; reason?: string } | undefined
+
 // send hands one payload to the hooks binary and resolves when it is done.
 //
 // It never rejects. Telemetry that breaks the agent it is observing is worse than telemetry that
 // misses an event, so a missing binary, a non-zero exit, and a timeout are all logged and swallowed.
-function send(payload: Record<string, unknown>): Promise<void> {
+//
+// wantDecision makes it read the reply instead of discarding it. Passing it is what turns a
+// fire-and-forget observation into a blocking question, so it is set for exactly one event.
+function send(payload: Record<string, unknown>, wantDecision = false): Promise<BeaconDecision> {
   const testSender = (globalThis as Record<symbol, unknown>)[Symbol.for("beacon.pi.testSender")]
   if (typeof testSender === "function") {
-    return Promise.resolve((testSender as (value: unknown) => unknown)(payload)).then(
-      () => undefined,
+    return Promise.resolve((testSender as (value: unknown, wantDecision: boolean) => unknown)(payload, wantDecision)).then(
+      (value) => (wantDecision ? (value as BeaconDecision) : undefined),
       () => undefined,
     )
   }
   if (beaconArgv.length === 0) {
     debugLog("no beacon command configured")
-    return Promise.resolve()
+    return Promise.resolve(undefined)
   }
 
-  return new Promise<void>((resolve) => {
+  return new Promise<BeaconDecision>((resolve) => {
     let child: ReturnType<typeof spawn>
     try {
       child = spawn(beaconArgv[0], beaconArgv.slice(1), {
-        stdio: ["pipe", "ignore", "ignore"],
+        stdio: ["pipe", wantDecision ? "pipe" : "ignore", "ignore"],
         windowsHide: true,
       })
     } catch (err) {
       debugLog("spawn failed", { error: String(err), type: payload.type })
-      resolve()
+      resolve(undefined)
       return
+    }
+
+    let stdout = ""
+    if (wantDecision) {
+      child.stdout?.setEncoding("utf8")
+      child.stdout?.on("data", (chunk: string) => {
+        stdout += chunk
+      })
+      child.stdout?.on("error", () => {})
     }
 
     // settle() is guarded because more than one of these paths can fire for the same child -- a
     // timeout followed by the exit it caused is the normal case -- and resolving twice would leave
     // the timer running for a process that is already gone.
     let settled = false
-    const settle = () => {
+    const settle = (decision?: BeaconDecision) => {
       if (settled) return
       settled = true
       clearTimeout(timer)
-      resolve()
+      resolve(decision)
     }
-    const timer = setTimeout(() => {
-      debugLog("hook command timed out", { type: payload.type })
-      child.kill()
-      settle()
-    }, sendTimeoutMs)
+    const timer = setTimeout(
+      () => {
+        debugLog("hook command timed out", { type: payload.type })
+        child.kill()
+        // No decision on timeout, which means allow. Blocking a tool because Beacon was slow would
+        // make an observability tool into an outage.
+        settle()
+      },
+      wantDecision ? decisionTimeoutMs : sendTimeoutMs,
+    )
     // The timer must not be a reason for the process to stay alive: Pi exiting while a send is in
     // flight should not wait out the full timeout.
     timer.unref?.()
@@ -95,13 +125,43 @@ function send(payload: Record<string, unknown>): Promise<void> {
       settle()
     })
     child.on("close", (code) => {
-      if (code !== 0) debugLog("hook command exited non-zero", { code, type: payload.type })
-      settle()
+      if (code !== 0) {
+        debugLog("hook command exited non-zero", { code, type: payload.type })
+        // A non-zero exit is not a decision. Treating it as one would let a broken install block
+        // every tool call.
+        settle()
+        return
+      }
+      settle(wantDecision ? parseDecision(stdout, payload) : undefined)
     })
     // EPIPE if the child died before reading; already reported through the error handler above.
     child.stdin?.on("error", () => {})
     child.stdin?.end(JSON.stringify(payload))
   })
+}
+
+// parseDecision reads the hooks binary's reply.
+//
+// Only an explicit `block: true` is a deny. Unparseable output, an empty object, or any other shape
+// yields no decision and the call proceeds -- the fail-open direction the policy seam is specified
+// to take on every error path, kept identical on this side of it.
+function parseDecision(stdout: string, payload: Record<string, unknown>): BeaconDecision {
+  const text = stdout.trim()
+  if (!text) return undefined
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    debugLog("hook command returned unparseable output", { type: payload.type })
+    return undefined
+  }
+  if (!parsed || typeof parsed !== "object") return undefined
+  const decision = parsed as { block?: unknown; reason?: unknown }
+  if (decision.block !== true) return undefined
+  return {
+    block: true,
+    reason: typeof decision.reason === "string" && decision.reason !== "" ? decision.reason : "Denied by Beacon policy",
+  }
 }
 
 function firstString(...values: unknown[]): string {
@@ -200,13 +260,17 @@ export default function beaconEndpointExtension(pi: {
     return payload
   }
 
-  // Handlers return nothing, deliberately and in every case.
+  // Handlers return nothing, with exactly one deliberate exception.
   //
   // Pi reads a handler's return value as a directive: a truthy result from tool_call blocks the
-  // call, and one from tool_result or input rewrites what the agent sees. An observation-only
-  // extension that leaked its send() result would silently change the agent's behavior, which is
-  // exactly the failure a telemetry tool must not have. `void` on each call is what makes that
-  // impossible rather than merely unlikely.
+  // call, and one from tool_result or input rewrites what the agent sees. An extension that leaked
+  // its send() result would silently change the agent's behavior, which is exactly the failure a
+  // telemetry tool must not have. `void` on each call is what makes that impossible rather than
+  // merely unlikely.
+  //
+  // The exception is tool_call, which returns a deny when -- and only when -- an external policy
+  // provider said so. It is the one handler where a return value is the intent rather than an
+  // accident, and it is spelled out at the handler itself.
   pi.on("session_start", (event, ctx) => {
     void send(base("session_start", event, ctx))
   })
@@ -223,15 +287,34 @@ export default function beaconEndpointExtension(pi: {
     void send({ ...base("input", event, ctx), prompt })
   })
 
-  pi.on("tool_call", (event, ctx) => {
-    void send({
-      ...base("tool_call", event, ctx),
-      tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
-      tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
-      // event.input is mutable and Pi may hand the same object to other extensions after this one.
-      // A shallow copy keeps the payload describing the arguments as they were at this moment.
-      tool_input: { ...(toRecord(event?.input) ?? {}) },
-    })
+  // tool_call is the one handler that awaits its send and the one that can return a value.
+  //
+  // It is Pi's only blockable pre-execution event, so it is where Beacon's policy seam can be
+  // honored with full fidelity: the hooks binary consults the configured provider and answers with
+  // Pi's own {block, reason} shape, which is returned here unchanged. With no provider configured --
+  // the default for the open build -- the reply is empty, this returns undefined, and the behavior
+  // is identical to every other handler.
+  //
+  // Awaiting adds the provider's latency to the tool call, which is inherent to asking a question
+  // before an action rather than reporting it afterwards. Every failure path resolves to no
+  // decision, so a slow or broken provider costs latency and never blocks a call.
+  pi.on("tool_call", async (event, ctx) => {
+    const decision = await send(
+      {
+        ...base("tool_call", event, ctx),
+        tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
+        tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
+        // event.input is mutable and Pi may hand the same object to other extensions after this
+        // one. A shallow copy keeps the payload describing the arguments as they were at this
+        // moment.
+        tool_input: { ...(toRecord(event?.input) ?? {}) },
+      },
+      true,
+    )
+    if (decision?.block === true) {
+      return { block: true, reason: decision.reason }
+    }
+    return undefined
   })
 
   pi.on("tool_result", (event, ctx) => {

--- a/cli/beacon/internal/endpoint/hooks/pi.go
+++ b/cli/beacon/internal/endpoint/hooks/pi.go
@@ -27,11 +27,36 @@ const (
 	// instead; a marker that drifts between writer and reader turns install into a no-op that
 	// reports success, so this one has a single definition.
 	//
-	// The version suffix is part of the contract with the extension source, not decoration. Bump it
-	// when the extension's behavior changes in a way that makes an older installed copy wrong,
-	// which is what lets a repair recognize a stale file rather than leave it in place.
-	PiManagedExtensionMarker = "beacon-managed-pi-extension:v1"
+	// PiManagedExtensionPrefix answers "did Beacon write this file", independent of version.
+	//
+	// Ownership and currency are separate questions and conflating them breaks upgrades in both
+	// directions. Matching only the current version means install refuses to overwrite Beacon's own
+	// older extension as though it belonged to somebody else, and uninstall walks past it and leaves
+	// it running. Matching only the prefix means a superseded extension reports as current and is
+	// never replaced. Every decision below picks one deliberately.
+	PiManagedExtensionPrefix = "beacon-managed-pi-extension:"
+
+	// PiManagedExtensionMarker is the version this build installs.
+	//
+	// The suffix is part of the contract with the extension source, not decoration. Bump it when the
+	// extension's behavior changes in a way that makes an older installed copy wrong.
+	//
+	// v2 added the policy-seam decision path. A v1 extension is not merely older: it forwards a
+	// tool_call without reading the reply, so with BEACON_POLICY_PROVIDER configured the provider's
+	// deny is recorded in the log and the tool runs anyway. An operator who configured a provider
+	// would believe calls are being enforced while they are not.
+	PiManagedExtensionMarker = PiManagedExtensionPrefix + "v2"
 )
+
+// isPiManagedExtension reports whether Beacon wrote this file, at any version.
+func isPiManagedExtension(source string) bool {
+	return strings.Contains(source, PiManagedExtensionPrefix)
+}
+
+// isPiCurrentExtension reports whether the file is the version this build installs.
+func isPiCurrentExtension(source string) bool {
+	return strings.Contains(source, PiManagedExtensionMarker)
+}
 
 // PiExtensionPath returns the extension file Beacon manages for a given install level.
 //
@@ -120,6 +145,15 @@ func piStatusFromRuntime(status runtimeStatus) PiStatus {
 	if err != nil || !piExtensionReferencesBinary(string(data), out.BinaryPath) {
 		out.Installed = false
 		out.Message = fmt.Sprintf("Pi extension at %s does not reference the active Beacon hook binary", out.ExtensionPath)
+		return out
+	}
+	// A superseded extension stays reported as installed on purpose. Repair only reinstalls targets
+	// it sees as installed, so calling this one uninstalled would leave it in place permanently --
+	// the opposite of what bumping the version is for. The message is what tells an operator, and it
+	// names the consequence rather than the version number.
+	if !isPiCurrentExtension(string(data)) {
+		out.Message = fmt.Sprintf("Pi extension at %s was written by an earlier Beacon version and cannot honor policy decisions; "+
+			"run `beacon endpoint hooks install --harness pi` to update it", out.ExtensionPath)
 	}
 	return out
 }
@@ -144,7 +178,9 @@ func piExtensionReferencesBinary(source, binaryPath string) bool {
 
 func installPiExtension(path, binaryPath, logPath, configPath string) error {
 	if existing, err := os.ReadFile(path); err == nil {
-		if !strings.Contains(string(existing), PiManagedExtensionMarker) {
+		// Ownership, not currency: replacing Beacon's own older extension is exactly what an
+		// upgrade and a repair do.
+		if !isPiManagedExtension(string(existing)) {
 			return fmt.Errorf("refusing to overwrite unmanaged Pi extension at %s", path)
 		}
 	} else if !os.IsNotExist(err) {
@@ -165,18 +201,24 @@ func removePiExtension(path string) (bool, error) {
 		}
 		return false, err
 	}
-	if !strings.Contains(string(data), PiManagedExtensionMarker) {
+	// Ownership, not currency. An uninstall that only removed the current version would strand
+	// every extension written by an earlier build -- still loaded by Pi, still reporting.
+	if !isPiManagedExtension(string(data)) {
 		return false, nil
 	}
 	return true, os.Remove(path)
 }
 
+// isPiInstalledAt reports ownership rather than currency, and that choice is what makes an upgrade
+// automatic: repair reinstalls the targets it finds installed, so a superseded extension has to be
+// visible as installed for repair to replace it. Currency is reported separately, in the status
+// message.
 func isPiInstalledAt(path string) bool {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return false
 	}
-	return strings.Contains(string(data), PiManagedExtensionMarker)
+	return isPiManagedExtension(string(data))
 }
 
 func renderPiExtension(binaryPath, logPath, configPath string) (string, error) {

--- a/cli/beacon/internal/endpoint/hooks/pi_test.go
+++ b/cli/beacon/internal/endpoint/hooks/pi_test.go
@@ -58,7 +58,7 @@ func TestPiExtensionPathRejectsUnknownLevel(t *testing.T) {
 // not, and it is read by two other packages. Pinning the literal here means a change to it is a
 // deliberate edit to a test rather than a silent break of install/uninstall/status agreement.
 func TestPiManagedExtensionMarkerIsStable(t *testing.T) {
-	if PiManagedExtensionMarker != "beacon-managed-pi-extension:v1" {
+	if PiManagedExtensionMarker != "beacon-managed-pi-extension:v2" {
 		t.Fatalf("PiManagedExtensionMarker = %q; changing it strands extensions installed by "+
 			"earlier builds, which uninstall then refuses to remove", PiManagedExtensionMarker)
 	}
@@ -321,5 +321,93 @@ func TestInstallAndUninstallPiRoundTrip(t *testing.T) {
 	}
 	if _, err := os.Stat(want); !os.IsNotExist(err) {
 		t.Fatal("the extension file survived uninstall")
+	}
+}
+
+// writeVersionedPiExtension installs the current extension and then rewrites its marker to an
+// earlier version, which is what an extension written by an older Beacon build looks like: correct
+// argv, superseded behavior.
+func writeVersionedPiExtension(t *testing.T, path, binaryPath, version string) {
+	t.Helper()
+	if err := installPiExtension(path, binaryPath, "/tmp/r.jsonl", "/tmp/c.json"); err != nil {
+		t.Fatalf("install extension: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	staled := strings.ReplaceAll(string(data), PiManagedExtensionMarker, PiManagedExtensionPrefix+version)
+	if staled == string(data) {
+		t.Fatal("marker substitution did not change the extension; the prefix no longer matches")
+	}
+	if err := os.WriteFile(path, []byte(staled), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ownership and currency are separate questions. Matching only the current version would make
+// install refuse Beacon's own older extension as though it belonged to somebody else, which is
+// exactly the file an upgrade has to replace.
+func TestInstallPiExtensionUpgradesAnEarlierVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beacon.ts")
+	writeVersionedPiExtension(t, path, "/tmp/beacon-hooks", "v1")
+
+	if err := installPiExtension(path, "/tmp/beacon-hooks", "/tmp/r.jsonl", "/tmp/c.json"); err != nil {
+		t.Fatalf("install over an earlier version returned error: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), PiManagedExtensionMarker) {
+		t.Fatal("install did not upgrade the extension to the current version")
+	}
+}
+
+// An uninstall that only removed the current version would strand every extension written by an
+// earlier build -- still on disk, still loaded by Pi, still reporting.
+func TestRemovePiExtensionRemovesAnEarlierVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beacon.ts")
+	writeVersionedPiExtension(t, path, "/tmp/beacon-hooks", "v1")
+
+	removed, err := removePiExtension(path)
+	if err != nil || !removed {
+		t.Fatalf("removePiExtension(v1) = %t, %v; want true, nil", removed, err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("an extension written by an earlier Beacon version was left on disk")
+	}
+}
+
+// Repair reinstalls the targets it finds installed, so a superseded extension has to read as
+// installed for the upgrade to happen at all. Reporting it uninstalled would leave it in place
+// permanently -- the opposite of what bumping the version is for.
+func TestPiStatusKeepsAnEarlierVersionInstalledButSaysSo(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "beacon.ts")
+	binary := filepath.Join(dir, "beacon-hooks")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeVersionedPiExtension(t, path, binary, "v1")
+
+	status := piStatusFromRuntime(runtimeStatus{Installed: true, BinaryPath: binary, ConfigPath: path})
+	if !status.Installed {
+		t.Fatalf("a superseded extension reported uninstalled, so repair would skip it: %+v", status)
+	}
+	if !strings.Contains(status.Message, "earlier Beacon version") {
+		t.Fatalf("message = %q, want it to name the superseded version", status.Message)
+	}
+	if !strings.Contains(status.Message, "policy") {
+		t.Fatalf("message = %q, want it to name the consequence rather than a version number", status.Message)
+	}
+}
+
+// A file with no Beacon marker at all is still refused, whatever it is called. The ownership check
+// is a prefix match, not an "anything vaguely Beacon-shaped" match.
+func TestInstallPiExtensionStillRefusesForeignFiles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beacon.ts")
+	if err := os.WriteFile(path, []byte("// beacon-managed-something-else:v9\nexport default () => {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := installPiExtension(path, "/tmp/beacon-hooks", "/tmp/r.jsonl", "/tmp/c.json"); err == nil {
+		t.Fatal("install overwrote a file carrying a different product's marker")
 	}
 }

--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -625,10 +625,11 @@ func beaconManaged(item candidate, data []byte) bool {
 	case "opencode":
 		return strings.Contains(text, "beacon-managed-opencode-plugin:v1")
 	case "pi_cli":
-		// The marker constant rather than a literal, unlike the two cases above. The writer and the
-		// reader disagreeing means inventory reports Beacon's own extension as unmanaged, which is
-		// what an audit of "what is instrumented on this machine" is for.
-		return strings.Contains(text, endpointhooks.PiManagedExtensionMarker)
+		// The marker prefix, and shared constants rather than the literals the two cases above use.
+		// Inventory asks who wrote a file, so any Beacon version counts: matching only the current
+		// version would report an extension written by an earlier build as somebody else's, in the
+		// one report whose whole purpose is attributing what is installed on a machine.
+		return strings.Contains(text, endpointhooks.PiManagedExtensionPrefix)
 	case "grok":
 		return strings.Contains(text, "beacon-managed-grok-hooks:v1")
 	}

--- a/plugins/pi-beacon/README.md
+++ b/plugins/pi-beacon/README.md
@@ -18,11 +18,25 @@ cannot be fixed without rewriting installed copies, so it stays a forwarder.
 Local-only, like the rest of Beacon's endpoint execution. The extension makes no network calls; it
 spawns a local binary that appends to a local log.
 
+## Policy enforcement
+
+Pi's `tool_call` is its only blockable pre-execution event, which is what lets Beacon's optional
+policy seam be honored with full fidelity here. When `BEACON_POLICY_PROVIDER` names an executable,
+the hooks binary consults it and answers a denied `tool_call` with Pi's own `{block, reason}` shape,
+which the handler returns unchanged — no translation in this layer. The denial is recorded as
+`approval.denied` with `policy.enforcement=enforce`, and no `tool.invoked` event is written, because
+the tool never ran.
+
+With no provider configured — the default for the open build — the reply is empty, the handler
+returns `undefined`, and `tool_call` behaves exactly like every observation handler. Every failure
+path (timeout, non-zero exit, unparseable output, a reply that is not `block: true`) is an allow.
+
 ## Properties worth preserving
 
-- **Handlers return nothing.** Pi reads a handler's return value as a directive: truthy from
-  `tool_call` blocks the call, truthy from `input` or `tool_result` rewrites what the agent sees. An
-  observation-only extension must never leak a value into that channel.
+- **Observation handlers return nothing.** Pi reads a handler's return value as a directive: truthy
+  from `tool_call` blocks the call, truthy from `input` or `tool_result` rewrites what the agent
+  sees. Nothing may leak a value into that channel by accident, which is why every observation
+  handler `void`s its send. The single intentional exception is the policy deny below.
 - **Failures are swallowed.** A missing binary, a non-zero exit, or a timeout is logged (with
   `BEACON_PI_DEBUG=1`) and dropped. Telemetry that breaks the agent it observes is worse than
   telemetry that misses an event.
@@ -30,6 +44,10 @@ spawns a local binary that appends to a local log.
   containing spaces or backslashes work on Windows as well as POSIX.
 - **`session_shutdown` is awaited.** It is the last event of the session and Pi may exit as soon as
   the handler resolves.
+- **`tool_call` is the only handler that may return a value**, and only a policy deny. Its response
+  timeout is deliberately longer than the observation timeout: the hooks binary gives the provider
+  2s of its own, so reusing that budget here would make this side give up first and allow calls the
+  provider denied.
 
 ## Known gap
 

--- a/plugins/pi-beacon/README.md
+++ b/plugins/pi-beacon/README.md
@@ -27,9 +27,13 @@ which the handler returns unchanged — no translation in this layer. The denial
 `approval.denied` with `policy.enforcement=enforce`, and no `tool.invoked` event is written, because
 the tool never ran.
 
-With no provider configured — the default for the open build — the reply is empty, the handler
-returns `undefined`, and `tool_call` behaves exactly like every observation handler. Every failure
-path (timeout, non-zero exit, unparseable output, a reply that is not `block: true`) is an allow.
+With no provider configured — the default for the open build — the extension does not even ask: the
+`tool_call` handler is fire-and-forget like every other handler and returns `undefined`, so the
+default build pays nothing for a feature it is not using. Enforcement is opt-in in behavior, not only
+in outcome.
+
+When a provider *is* configured, every failure path (timeout, non-zero exit, unparseable output, a
+reply that is not `block: true`) is an allow.
 
 ## Properties worth preserving
 
@@ -44,10 +48,12 @@ path (timeout, non-zero exit, unparseable output, a reply that is not `block: tr
   containing spaces or backslashes work on Windows as well as POSIX.
 - **`session_shutdown` is awaited.** It is the last event of the session and Pi may exit as soon as
   the handler resolves.
-- **`tool_call` is the only handler that may return a value**, and only a policy deny. Its response
-  timeout is deliberately longer than the observation timeout: the hooks binary gives the provider
-  2s of its own, so reusing that budget here would make this side give up first and allow calls the
-  provider denied.
+- **`tool_call` is the only handler that may return a value**, and only a policy deny, and only when
+  `BEACON_POLICY_PROVIDER` is set. That gate is load-bearing: without it, every tool call in a
+  default install waited on a subprocess round-trip for a reply that could not contain a deny.
+- **The decision timeout is longer than the observation timeout.** The hooks binary gives the
+  provider 2s of its own, so reusing that budget here would make this side give up first and allow
+  calls the provider denied.
 
 ## Known gap
 

--- a/plugins/pi-beacon/src/beacon.test.ts
+++ b/plugins/pi-beacon/src/beacon.test.ts
@@ -5,6 +5,8 @@ const payloads: any[] = []
 const senderKey = Symbol.for("beacon.pi.testSender")
 
 beforeEach(() => {
+  // A stray value in the environment running the suite would change which branch tool_call takes.
+  delete process.env.BEACON_POLICY_PROVIDER
   payloads.length = 0
   ;(globalThis as any)[senderKey] = async (payload: any) => {
     payloads.push(structuredClone(payload))
@@ -27,6 +29,17 @@ function register(): Map<string, Handler> {
   return handlers
 }
 
+// withPolicyProvider configures the seam for one test and restores the environment afterwards.
+function withPolicyProvider(value: string | undefined) {
+  const previous = process.env.BEACON_POLICY_PROVIDER
+  if (value === undefined) delete process.env.BEACON_POLICY_PROVIDER
+  else process.env.BEACON_POLICY_PROVIDER = value
+  return () => {
+    if (previous === undefined) delete process.env.BEACON_POLICY_PROVIDER
+    else process.env.BEACON_POLICY_PROVIDER = previous
+  }
+}
+
 function context(overrides: Record<string, unknown> = {}) {
   return {
     cwd: "/repo",
@@ -34,6 +47,17 @@ function context(overrides: Record<string, unknown> = {}) {
     sessionManager: { sessionId: "pi-session-1", path: "/home/u/.pi/agent/sessions/x.jsonl" },
     ...overrides,
   }
+}
+
+// One event per handler, for the tests that drive all of them.
+const allEvents: Record<string, unknown> = {
+  session_start: { reason: "startup" },
+  session_shutdown: { reason: "exit" },
+  input: { text: "hi" },
+  tool_call: { toolName: "bash", toolCallId: "c1", input: { command: "ls" } },
+  tool_result: { toolName: "bash", toolCallId: "c1", content: "ok" },
+  message_end: { message: { role: "assistant", content: [], usage: { input: 1, output: 1 } } },
+  agent_end: {},
 }
 
 describe("beacon Pi extension", () => {
@@ -76,40 +100,68 @@ describe("beacon Pi extension", () => {
   // With no policy provider configured -- the default for the open build -- the hooks binary answers
   // with an empty object and tool_call must behave exactly like every observation handler.
   test("tool_call returns nothing when no decision comes back", async () => {
-    ;(globalThis as any)[senderKey] = async (payload: any) => {
-      payloads.push(structuredClone(payload))
-      return {}
+    const restore = withPolicyProvider("/usr/local/bin/beacon-policy")
+    try {
+      ;(globalThis as any)[senderKey] = async (payload: any) => {
+        payloads.push(structuredClone(payload))
+        return {}
+      }
+
+      const handlers = register()
+      const returned = await handlers.get("tool_call")!(
+        { toolName: "bash", toolCallId: "c1", input: { command: "ls" } },
+        context(),
+      )
+
+      expect(returned).toBeUndefined()
+      expect(payloads).toHaveLength(1)
+    } finally {
+      restore()
     }
+  })
+
+  // The gate is a fast path, not a second opinion: with no provider configured the handler cannot
+  // return a directive even if something on the other end produced one.
+  test("tool_call cannot block when no provider is configured", async () => {
+    ;(globalThis as any)[senderKey] = async () => ({ block: true, reason: "should not reach Pi" })
 
     const handlers = register()
     const returned = await handlers.get("tool_call")!(
-      { toolName: "bash", toolCallId: "c1", input: { command: "ls" } },
+      { toolName: "bash", input: { command: "rm -rf /" } },
       context(),
     )
 
     expect(returned).toBeUndefined()
-    expect(payloads).toHaveLength(1)
   })
 
   // Pi's tool_call is its only blockable pre-execution event, which is what lets the policy seam be
   // honored with full fidelity: the binary returns Pi's own {block, reason} shape and it is passed
   // back unchanged, with no translation in this layer.
   test("tool_call returns the deny verbatim when the binary blocks", async () => {
-    ;(globalThis as any)[senderKey] = async () => ({
-      block: true,
-      reason: "rm -rf denied by policy provider",
-    })
+    const restore = withPolicyProvider("/usr/local/bin/beacon-policy")
+    try {
+      ;(globalThis as any)[senderKey] = async () => ({
+        block: true,
+        reason: "rm -rf denied by policy provider",
+      })
 
-    const handlers = register()
-    const returned = await handlers.get("tool_call")!(
-      { toolName: "bash", toolCallId: "c1", input: { command: "rm -rf /" } },
-      context(),
-    )
+      const handlers = register()
+      const returned = await handlers.get("tool_call")!(
+        { toolName: "bash", toolCallId: "c1", input: { command: "rm -rf /" } },
+        context(),
+      )
 
-    expect(returned).toEqual({ block: true, reason: "rm -rf denied by policy provider" })
+      expect(returned).toEqual({ block: true, reason: "rm -rf denied by policy provider" })
+    } finally {
+      restore()
+    }
   })
 
-  test("tool_call asks for a decision, and no other handler does", async () => {
+  // The gate that keeps the default build's cost at zero. With no provider configured, tool_call is
+  // fire-and-forget like everything else: it must not wait for a reply that cannot contain a deny.
+  // Before this, every tool call in a default install paid a subprocess round-trip for a feature
+  // nobody had turned on.
+  test("no handler waits for a decision when no provider is configured", async () => {
     const asked: Array<[string, boolean]> = []
     ;(globalThis as any)[senderKey] = async (payload: any, wantDecision: boolean) => {
       asked.push([payload.type, wantDecision])
@@ -117,26 +169,60 @@ describe("beacon Pi extension", () => {
     }
 
     const handlers = register()
-    const events: Record<string, unknown> = {
-      session_start: {},
-      session_shutdown: {},
-      input: { text: "hi" },
-      tool_call: { toolName: "bash", input: {} },
-      tool_result: { toolName: "bash", content: "ok" },
-      message_end: { message: { role: "assistant", content: [] } },
-      agent_end: {},
-    }
     for (const [name, handler] of handlers) {
-      await handler(events[name], context())
+      await handler(allEvents[name], context())
     }
 
-    expect(asked.filter(([, want]) => want).map(([type]) => type)).toEqual(["tool_call"])
+    expect(asked.filter(([, want]) => want)).toEqual([])
+    // Still reported -- the gate removes the wait, not the telemetry.
+    expect(asked.map(([type]) => type)).toContain("tool_call")
+  })
+
+  test("tool_call asks for a decision when a provider is configured, and no other handler does", async () => {
+    const restore = withPolicyProvider("/usr/local/bin/beacon-policy")
+    try {
+      const asked: Array<[string, boolean]> = []
+      ;(globalThis as any)[senderKey] = async (payload: any, wantDecision: boolean) => {
+        asked.push([payload.type, wantDecision])
+        return {}
+      }
+
+      const handlers = register()
+      for (const [name, handler] of handlers) {
+        await handler(allEvents[name], context())
+      }
+
+      expect(asked.filter(([, want]) => want).map(([type]) => type)).toEqual(["tool_call"])
+    } finally {
+      restore()
+    }
+  })
+
+  // A variable set to whitespace is not a configured provider. Treating it as one would reintroduce
+  // the wait for anyone who exported the name and left it empty.
+  test("a blank provider value does not enable the decision path", async () => {
+    const restore = withPolicyProvider("   ")
+    try {
+      const asked: boolean[] = []
+      ;(globalThis as any)[senderKey] = async (_payload: any, wantDecision: boolean) => {
+        asked.push(wantDecision)
+        return {}
+      }
+
+      const handlers = register()
+      await handlers.get("tool_call")!({ toolName: "bash", input: {} }, context())
+
+      expect(asked).toEqual([false])
+    } finally {
+      restore()
+    }
   })
 
   // Every failure path is an allow. A deny that only happens when Beacon is healthy is a weaker
   // guarantee than no deny at all, but the reverse -- blocking because Beacon broke -- turns an
   // observability tool into an outage, so fail-open is the specified direction for the whole seam.
   test("tool_call allows the call on every failure shape", async () => {
+    const restore = withPolicyProvider("/usr/local/bin/beacon-policy")
     for (const outcome of [
       undefined,
       null,
@@ -158,6 +244,7 @@ describe("beacon Pi extension", () => {
       )
       expect(returned, `outcome ${JSON.stringify(outcome)} did not allow the call`).toBeUndefined()
     }
+    restore()
   })
 
   test("session_start carries session, workspace and model context", async () => {

--- a/plugins/pi-beacon/src/beacon.test.ts
+++ b/plugins/pi-beacon/src/beacon.test.ts
@@ -53,8 +53,11 @@ describe("beacon Pi extension", () => {
   // Pi reads a handler's return value as a directive: truthy from tool_call blocks the call, and
   // truthy from input or tool_result rewrites what the agent sees. An observation-only extension
   // that returned its send() result would silently change the agent's behavior.
-  test("no handler returns a value that Pi would act on", async () => {
+  test("no observation handler returns a value that Pi would act on", async () => {
     const handlers = register()
+    // tool_call is the one handler allowed to return a directive, and only on a provider deny. Its
+    // two outcomes are covered by the policy tests below.
+    handlers.delete("tool_call")
     const events: Record<string, unknown> = {
       session_start: { reason: "startup" },
       input: { text: "hello" },
@@ -67,6 +70,93 @@ describe("beacon Pi extension", () => {
     for (const [name, handler] of handlers) {
       const returned = await handler(events[name], context())
       expect(returned, `${name} returned a value Pi would treat as a directive`).toBeUndefined()
+    }
+  })
+
+  // With no policy provider configured -- the default for the open build -- the hooks binary answers
+  // with an empty object and tool_call must behave exactly like every observation handler.
+  test("tool_call returns nothing when no decision comes back", async () => {
+    ;(globalThis as any)[senderKey] = async (payload: any) => {
+      payloads.push(structuredClone(payload))
+      return {}
+    }
+
+    const handlers = register()
+    const returned = await handlers.get("tool_call")!(
+      { toolName: "bash", toolCallId: "c1", input: { command: "ls" } },
+      context(),
+    )
+
+    expect(returned).toBeUndefined()
+    expect(payloads).toHaveLength(1)
+  })
+
+  // Pi's tool_call is its only blockable pre-execution event, which is what lets the policy seam be
+  // honored with full fidelity: the binary returns Pi's own {block, reason} shape and it is passed
+  // back unchanged, with no translation in this layer.
+  test("tool_call returns the deny verbatim when the binary blocks", async () => {
+    ;(globalThis as any)[senderKey] = async () => ({
+      block: true,
+      reason: "rm -rf denied by policy provider",
+    })
+
+    const handlers = register()
+    const returned = await handlers.get("tool_call")!(
+      { toolName: "bash", toolCallId: "c1", input: { command: "rm -rf /" } },
+      context(),
+    )
+
+    expect(returned).toEqual({ block: true, reason: "rm -rf denied by policy provider" })
+  })
+
+  test("tool_call asks for a decision, and no other handler does", async () => {
+    const asked: Array<[string, boolean]> = []
+    ;(globalThis as any)[senderKey] = async (payload: any, wantDecision: boolean) => {
+      asked.push([payload.type, wantDecision])
+      return {}
+    }
+
+    const handlers = register()
+    const events: Record<string, unknown> = {
+      session_start: {},
+      session_shutdown: {},
+      input: { text: "hi" },
+      tool_call: { toolName: "bash", input: {} },
+      tool_result: { toolName: "bash", content: "ok" },
+      message_end: { message: { role: "assistant", content: [] } },
+      agent_end: {},
+    }
+    for (const [name, handler] of handlers) {
+      await handler(events[name], context())
+    }
+
+    expect(asked.filter(([, want]) => want).map(([type]) => type)).toEqual(["tool_call"])
+  })
+
+  // Every failure path is an allow. A deny that only happens when Beacon is healthy is a weaker
+  // guarantee than no deny at all, but the reverse -- blocking because Beacon broke -- turns an
+  // observability tool into an outage, so fail-open is the specified direction for the whole seam.
+  test("tool_call allows the call on every failure shape", async () => {
+    for (const outcome of [
+      undefined,
+      null,
+      {},
+      { block: false },
+      { block: "true" },
+      "not an object",
+      new Error("provider exploded"),
+    ]) {
+      ;(globalThis as any)[senderKey] = async () => {
+        if (outcome instanceof Error) throw outcome
+        return outcome
+      }
+
+      const handlers = register()
+      const returned = await handlers.get("tool_call")!(
+        { toolName: "bash", input: { command: "ls" } },
+        context(),
+      )
+      expect(returned, `outcome ${JSON.stringify(outcome)} did not allow the call`).toBeUndefined()
     }
   })
 

--- a/plugins/pi-beacon/src/beacon.ts
+++ b/plugins/pi-beacon/src/beacon.ts
@@ -39,6 +39,28 @@ const decisionTimeoutMs = 6000
 
 const debugEnabled = process.env.BEACON_PI_DEBUG === "1"
 
+// policyProviderConfigured decides whether this event is worth waiting for an answer to.
+//
+// Without it, tool_call awaited a subprocess round-trip on every call in a build with no provider
+// configured -- the default -- to receive a reply that could not contain a deny. That is latency on
+// every tool call in service of a feature nobody turned on, and it is a cost the other runtimes
+// Beacon enforces on do not pay: their hook protocols are synchronous already, so the runtime is
+// waiting regardless. Pi's extension is not, so asking has to be opt-in exactly as the enforcement
+// itself is.
+//
+// This reads the same variable the hooks binary reads, and the binary remains the authority: if the
+// two ever disagree -- an environment the extension cannot see but the child can -- the effect is
+// that nothing is awaited and the call proceeds, which is the fail-open direction the seam already
+// specifies for every other error path.
+function policyProviderConfigured(): boolean {
+  try {
+    return (process.env.BEACON_POLICY_PROVIDER ?? "").trim() !== ""
+  } catch {
+    // A host that denies environment access is not a host with a policy provider configured.
+    return false
+  }
+}
+
 function debugLog(message: string, extra?: unknown): void {
   if (!debugEnabled) return
   // stderr, never stdout: Pi's print and JSON modes put machine-readable output on stdout, and a
@@ -287,30 +309,36 @@ export default function beaconEndpointExtension(pi: {
     void send({ ...base("input", event, ctx), prompt })
   })
 
-  // tool_call is the one handler that awaits its send and the one that can return a value.
+  // tool_call is the one handler that can wait for an answer, and the one that can return a value.
+  // It does neither unless a policy provider is configured.
   //
   // It is Pi's only blockable pre-execution event, so it is where Beacon's policy seam can be
-  // honored with full fidelity: the hooks binary consults the configured provider and answers with
-  // Pi's own {block, reason} shape, which is returned here unchanged. With no provider configured --
-  // the default for the open build -- the reply is empty, this returns undefined, and the behavior
-  // is identical to every other handler.
+  // honored with full fidelity: the hooks binary consults the provider and answers with Pi's own
+  // {block, reason} shape, which is returned here unchanged.
   //
-  // Awaiting adds the provider's latency to the tool call, which is inherent to asking a question
-  // before an action rather than reporting it afterwards. Every failure path resolves to no
-  // decision, so a slow or broken provider costs latency and never blocks a call.
+  // With no provider configured -- the default for the open build -- this is fire-and-forget and
+  // returns nothing, exactly like every observation handler. That gate is the point: the open build
+  // pays nothing for a feature it is not using, and enforcement is opt-in in behavior and not only
+  // in outcome.
+  //
+  // When a provider *is* configured, awaiting adds its latency to the tool call. That is inherent to
+  // asking a question before an action rather than reporting it afterwards, and it is a cost the
+  // operator opted into. Every failure path resolves to no decision, so a slow or broken provider
+  // costs latency and never blocks a call.
   pi.on("tool_call", async (event, ctx) => {
-    const decision = await send(
-      {
-        ...base("tool_call", event, ctx),
-        tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
-        tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
-        // event.input is mutable and Pi may hand the same object to other extensions after this
-        // one. A shallow copy keeps the payload describing the arguments as they were at this
-        // moment.
-        tool_input: { ...(toRecord(event?.input) ?? {}) },
-      },
-      true,
-    )
+    const payload = {
+      ...base("tool_call", event, ctx),
+      tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
+      tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
+      // event.input is mutable and Pi may hand the same object to other extensions after this one.
+      // A shallow copy keeps the payload describing the arguments as they were at this moment.
+      tool_input: { ...(toRecord(event?.input) ?? {}) },
+    }
+    if (!policyProviderConfigured()) {
+      void send(payload)
+      return undefined
+    }
+    const decision = await send(payload, true)
     if (decision?.block === true) {
       return { block: true, reason: decision.reason }
     }

--- a/plugins/pi-beacon/src/beacon.ts
+++ b/plugins/pi-beacon/src/beacon.ts
@@ -28,6 +28,15 @@ const beaconArgv: string[] = ["__BEACON_ARGV__"]
 // file.
 const sendTimeoutMs = 2000
 
+// The decision path gets a longer budget, and the margin is the point rather than caution.
+//
+// When a policy provider is configured, the hooks binary consults it with a 2s timeout of its own
+// before answering. Reusing the 2s budget here would mean this side frequently gives up first: the
+// spawn plus the provider's own work cannot fit in the same 2s the provider alone is allowed. A
+// timeout on this side is treated as allow, so the visible effect would be a provider that denies
+// and a tool that runs anyway -- an enforcement gap that looks like a flaky provider.
+const decisionTimeoutMs = 6000
+
 const debugEnabled = process.env.BEACON_PI_DEBUG === "1"
 
 function debugLog(message: string, extra?: unknown): void {
@@ -41,51 +50,72 @@ function debugLog(message: string, extra?: unknown): void {
   }
 }
 
+// A decision the hooks binary returned. Only the deny case carries anything: an allow is an empty
+// response, which is also what a failure of any kind produces.
+type BeaconDecision = { block?: boolean; reason?: string } | undefined
+
 // send hands one payload to the hooks binary and resolves when it is done.
 //
 // It never rejects. Telemetry that breaks the agent it is observing is worse than telemetry that
 // misses an event, so a missing binary, a non-zero exit, and a timeout are all logged and swallowed.
-function send(payload: Record<string, unknown>): Promise<void> {
+//
+// wantDecision makes it read the reply instead of discarding it. Passing it is what turns a
+// fire-and-forget observation into a blocking question, so it is set for exactly one event.
+function send(payload: Record<string, unknown>, wantDecision = false): Promise<BeaconDecision> {
   const testSender = (globalThis as Record<symbol, unknown>)[Symbol.for("beacon.pi.testSender")]
   if (typeof testSender === "function") {
-    return Promise.resolve((testSender as (value: unknown) => unknown)(payload)).then(
-      () => undefined,
+    return Promise.resolve((testSender as (value: unknown, wantDecision: boolean) => unknown)(payload, wantDecision)).then(
+      (value) => (wantDecision ? (value as BeaconDecision) : undefined),
       () => undefined,
     )
   }
   if (beaconArgv.length === 0) {
     debugLog("no beacon command configured")
-    return Promise.resolve()
+    return Promise.resolve(undefined)
   }
 
-  return new Promise<void>((resolve) => {
+  return new Promise<BeaconDecision>((resolve) => {
     let child: ReturnType<typeof spawn>
     try {
       child = spawn(beaconArgv[0], beaconArgv.slice(1), {
-        stdio: ["pipe", "ignore", "ignore"],
+        stdio: ["pipe", wantDecision ? "pipe" : "ignore", "ignore"],
         windowsHide: true,
       })
     } catch (err) {
       debugLog("spawn failed", { error: String(err), type: payload.type })
-      resolve()
+      resolve(undefined)
       return
+    }
+
+    let stdout = ""
+    if (wantDecision) {
+      child.stdout?.setEncoding("utf8")
+      child.stdout?.on("data", (chunk: string) => {
+        stdout += chunk
+      })
+      child.stdout?.on("error", () => {})
     }
 
     // settle() is guarded because more than one of these paths can fire for the same child -- a
     // timeout followed by the exit it caused is the normal case -- and resolving twice would leave
     // the timer running for a process that is already gone.
     let settled = false
-    const settle = () => {
+    const settle = (decision?: BeaconDecision) => {
       if (settled) return
       settled = true
       clearTimeout(timer)
-      resolve()
+      resolve(decision)
     }
-    const timer = setTimeout(() => {
-      debugLog("hook command timed out", { type: payload.type })
-      child.kill()
-      settle()
-    }, sendTimeoutMs)
+    const timer = setTimeout(
+      () => {
+        debugLog("hook command timed out", { type: payload.type })
+        child.kill()
+        // No decision on timeout, which means allow. Blocking a tool because Beacon was slow would
+        // make an observability tool into an outage.
+        settle()
+      },
+      wantDecision ? decisionTimeoutMs : sendTimeoutMs,
+    )
     // The timer must not be a reason for the process to stay alive: Pi exiting while a send is in
     // flight should not wait out the full timeout.
     timer.unref?.()
@@ -95,13 +125,43 @@ function send(payload: Record<string, unknown>): Promise<void> {
       settle()
     })
     child.on("close", (code) => {
-      if (code !== 0) debugLog("hook command exited non-zero", { code, type: payload.type })
-      settle()
+      if (code !== 0) {
+        debugLog("hook command exited non-zero", { code, type: payload.type })
+        // A non-zero exit is not a decision. Treating it as one would let a broken install block
+        // every tool call.
+        settle()
+        return
+      }
+      settle(wantDecision ? parseDecision(stdout, payload) : undefined)
     })
     // EPIPE if the child died before reading; already reported through the error handler above.
     child.stdin?.on("error", () => {})
     child.stdin?.end(JSON.stringify(payload))
   })
+}
+
+// parseDecision reads the hooks binary's reply.
+//
+// Only an explicit `block: true` is a deny. Unparseable output, an empty object, or any other shape
+// yields no decision and the call proceeds -- the fail-open direction the policy seam is specified
+// to take on every error path, kept identical on this side of it.
+function parseDecision(stdout: string, payload: Record<string, unknown>): BeaconDecision {
+  const text = stdout.trim()
+  if (!text) return undefined
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    debugLog("hook command returned unparseable output", { type: payload.type })
+    return undefined
+  }
+  if (!parsed || typeof parsed !== "object") return undefined
+  const decision = parsed as { block?: unknown; reason?: unknown }
+  if (decision.block !== true) return undefined
+  return {
+    block: true,
+    reason: typeof decision.reason === "string" && decision.reason !== "" ? decision.reason : "Denied by Beacon policy",
+  }
 }
 
 function firstString(...values: unknown[]): string {
@@ -200,13 +260,17 @@ export default function beaconEndpointExtension(pi: {
     return payload
   }
 
-  // Handlers return nothing, deliberately and in every case.
+  // Handlers return nothing, with exactly one deliberate exception.
   //
   // Pi reads a handler's return value as a directive: a truthy result from tool_call blocks the
-  // call, and one from tool_result or input rewrites what the agent sees. An observation-only
-  // extension that leaked its send() result would silently change the agent's behavior, which is
-  // exactly the failure a telemetry tool must not have. `void` on each call is what makes that
-  // impossible rather than merely unlikely.
+  // call, and one from tool_result or input rewrites what the agent sees. An extension that leaked
+  // its send() result would silently change the agent's behavior, which is exactly the failure a
+  // telemetry tool must not have. `void` on each call is what makes that impossible rather than
+  // merely unlikely.
+  //
+  // The exception is tool_call, which returns a deny when -- and only when -- an external policy
+  // provider said so. It is the one handler where a return value is the intent rather than an
+  // accident, and it is spelled out at the handler itself.
   pi.on("session_start", (event, ctx) => {
     void send(base("session_start", event, ctx))
   })
@@ -223,15 +287,34 @@ export default function beaconEndpointExtension(pi: {
     void send({ ...base("input", event, ctx), prompt })
   })
 
-  pi.on("tool_call", (event, ctx) => {
-    void send({
-      ...base("tool_call", event, ctx),
-      tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
-      tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
-      // event.input is mutable and Pi may hand the same object to other extensions after this one.
-      // A shallow copy keeps the payload describing the arguments as they were at this moment.
-      tool_input: { ...(toRecord(event?.input) ?? {}) },
-    })
+  // tool_call is the one handler that awaits its send and the one that can return a value.
+  //
+  // It is Pi's only blockable pre-execution event, so it is where Beacon's policy seam can be
+  // honored with full fidelity: the hooks binary consults the configured provider and answers with
+  // Pi's own {block, reason} shape, which is returned here unchanged. With no provider configured --
+  // the default for the open build -- the reply is empty, this returns undefined, and the behavior
+  // is identical to every other handler.
+  //
+  // Awaiting adds the provider's latency to the tool call, which is inherent to asking a question
+  // before an action rather than reporting it afterwards. Every failure path resolves to no
+  // decision, so a slow or broken provider costs latency and never blocks a call.
+  pi.on("tool_call", async (event, ctx) => {
+    const decision = await send(
+      {
+        ...base("tool_call", event, ctx),
+        tool_name: firstString(event?.toolName, event?.tool_name, event?.name),
+        tool_call_id: firstString(event?.toolCallId, event?.toolCallID, event?.tool_call_id),
+        // event.input is mutable and Pi may hand the same object to other extensions after this
+        // one. A shallow copy keeps the payload describing the arguments as they were at this
+        // moment.
+        tool_input: { ...(toRecord(event?.input) ?? {}) },
+      },
+      true,
+    )
+    if (decision?.block === true) {
+      return { block: true, reason: decision.reason }
+    }
+    return undefined
   })
 
   pi.on("tool_result", (event, ctx) => {


### PR DESCRIPTION
Sixth of seven. **Base is `pi-pr5-status` (#352).** Kept separate from the observe-only work so that shipped and soaked first.

## Why Pi gets full deny fidelity

Pi's `tool_call` is its only blockable pre-execution event, which makes it the one place Beacon's optional policy seam can be honored completely. The hooks binary consults the provider and answers with Pi's **own** `{block, reason}` shape; the extension returns it unchanged.

Every other runtime's deny shape in `policyDenyResponse` is a format somebody else defined and Beacon matches. This one is a contract between two pieces of Beacon, and keeping the translation in Go rather than in the extension keeps it out of the layer that needs a reinstall to correct.

## A denied call is not recorded as invoked

The tool never ran, so the log carries only `approval.denied` (with `policy.enforcement=enforce` and the provider's rule id). Recording `tool.invoked` beside it would put an event in the log for something that did not happen. Same early return the pre-tool hook already does.

## Fail-open, in both processes

With no provider configured — the open build's default — the reply is empty, the handler returns `undefined`, and `tool_call` behaves exactly like every observation handler. Every failure path is an allow: timeout, non-zero exit, unparseable output, and any reply that is not literally `block: true`.

**The decision timeout is longer than the observation timeout on purpose** (6s vs 2s). The binary gives the provider 2s of its own, so reusing that budget on the extension side would make it give up first and allow calls the provider denied — an enforcement gap presenting as a flaky provider.

## The marker bump forced ownership and currency apart

`v2` marks the extension as able to honor decisions. A v1 extension is not merely older: with a provider configured it records the deny and lets the tool run, so an operator would believe calls are enforced when they are not.

But bumping a single marker naively breaks upgrades **in both directions**, and this is the part worth reviewing:

- Match only the current version → install refuses Beacon's own older extension as though it belonged to somebody else, and uninstall walks past it and leaves it running.
- Match only the prefix → a superseded extension reports as current and is never replaced.

So install, uninstall and installed-detection now ask **ownership** (`PiManagedExtensionPrefix`); the status message asks **currency** (`PiManagedExtensionMarker`).

Detection deliberately reports a superseded extension as `installed=true`, because repair only reinstalls what it sees installed — calling it uninstalled would leave it in place permanently, the opposite of what a version bump is for. The message carries the signal instead:

```
Pi extension: installed=true path=…/beacon.ts
Pi extension at …/beacon.ts was written by an earlier Beacon version and cannot honor
policy decisions; run `beacon endpoint hooks install --harness pi` to update it
```

Discovery reports an earlier version as **enabled**, not disabled — it does collect the same telemetry. What it may not do is honor a decision, which is a different question. This changes one assertion added in #347, which had assumed a stale marker meant disabled.

## Verified end to end

A real provider script (deny on `--dangerously-skip-permissions`, allow otherwise) with the **installed** extension driven under Node:

```
benign  -> undefined
bypass  -> {"block":true,"reason":"permission-bypass spawn blocked"}

tool.invoked      policy=-/-           ls -la
approval.denied   policy=deny/enforce  claude --dangerously-skip-permissions -p go
```

Upgrade paths too: installing over a v1 extension upgrades it in place; uninstalling a v1 extension removes it rather than stranding it.

## Testing

6 new Go tests (deny, no-tool.invoked, allow, tool_result ignored, no provider, broken provider) and 5 new extension tests including a table over every failure shape. Plus 4 new hooks tests for the ownership/currency split.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFCTrDvdDQxFpuj9by8vJd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an opt-in path that can block Pi tool execution via an external policy provider. Fail-open on every error, but a stale v1 extension can log denials while still letting tools run until reinstall.
> 
> **Overview**
> When `BEACON_POLICY_PROVIDER` is set, Pi `tool_call` now consults the existing policy seam and can block the tool by returning Pi’s native `{block, reason}` shape unchanged. With no provider (the default), the handler stays fire-and-forget so the open build pays no extra latency. Denied calls skip `tool.invoked` and only record `approval.denied`; `tool_result` is never asked.
> 
> The extension only awaits a reply on `tool_call` when the env var is non-blank, uses a 6s decision timeout vs 2s for observation, and treats timeout, non-zero exit, and any reply other than `block: true` as allow.
> 
> The managed-extension marker is bumped to **v2** and split into **ownership** (`PiManagedExtensionPrefix`) vs **currency** (`PiManagedExtensionMarker`). Install/uninstall/inventory match any Beacon version so upgrades and removals work; status still reports older copies as installed/enabled with a warning that they cannot honor policy until reinstall.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 915453f7fb4abf06793e32b608e3ba316186231f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->