### PR TITLE
Cline support 1/8: pin `cline` as the canonical harness name

### DIFF
--- a/pkg/asymptoteobserve/harness.go
+++ b/pkg/asymptoteobserve/harness.go
@@ -71,6 +71,20 @@ func NormalizeHarnessName(name string) string {
 	case lower == "pi" || lower == "pi.dev" || lower == "pi_cli" || lower == "pi-cli" ||
 		lower == "pi_agent" || lower == "pi-agent" || lower == "pi agent":
 		return "pi_cli"
+	// Cline reaches Beacon from more than one host -- a VS Code extension, a JetBrains plugin and a
+	// CLI, all over the same agent core -- so the spelling that arrives depends on which host
+	// reported it. Pinning the canonical name here is what keeps one Cline session from being
+	// recorded under two names when the hook path (`--platform cline`) and an OTLP resource
+	// attribute disagree about capitalization or suffix.
+	//
+	// Equality against a closed set, like Pi above and unlike the Contains rules further up.
+	// "cline" is a substring of Cline's own configuration names -- `.clinerules` is a directory
+	// every Cline user has -- so a Contains rule here would claim any harness whose name merely
+	// mentioned one of those paths. The set is closed rather than a prefix rule for the same
+	// reason.
+	case lower == "cline" || lower == "cline_cli" || lower == "cline-cli" || lower == "cline cli" ||
+		lower == "cline.bot":
+		return "cline"
 	case name != "":
 		// An unrecognized runtime keeps its own name rather than being coerced or dropped. A new
 		// harness should show up in the log as itself, not as "unknown".

--- a/pkg/asymptoteobserve/harness_test.go
+++ b/pkg/asymptoteobserve/harness_test.go
@@ -17,6 +17,7 @@ func TestHookPlatformsConvergeOnCanonicalNames(t *testing.T) {
 		"antigravity": "antigravity_cli",
 		"vscode":      "vscode_copilot",
 		"pi":          "pi_cli",
+		"cline":       "cline",
 	} {
 		t.Run(platform, func(t *testing.T) {
 			if got := NormalizeHarnessName(platform); got != want {
@@ -35,7 +36,7 @@ func TestCanonicalNamesAreStableUnderRenormalization(t *testing.T) {
 	for _, canonical := range []string{
 		"claude_code", "codex_cli", "gemini_cli", "antigravity_cli", "vscode_copilot",
 		"copilot_cli", "claude_web", "chatgpt_web", "claude_cowork", "claude_agent_sdk",
-		"openclaw_gateway", "pi_cli",
+		"openclaw_gateway", "pi_cli", "cline",
 	} {
 		t.Run(canonical, func(t *testing.T) {
 			if got := NormalizeHarnessName(canonical); got != canonical {
@@ -107,6 +108,47 @@ func TestNamesMerelyStartingWithPiAreNotPi(t *testing.T) {
 	for _, name := range []string{"pip-agent", "pipeline", "pixel-cli", "pied-piper"} {
 		if got := NormalizeHarnessName(name); got != name {
 			t.Errorf("NormalizeHarnessName(%q) = %q, want it preserved", name, got)
+		}
+	}
+}
+
+// Cline's canonical name has to be reachable from every spelling its hosts produce. It runs as a
+// VS Code extension, a JetBrains plugin and a CLI over one agent core, so the hook path
+// (--platform cline) and an OTLP service.name can each report a different capitalization or
+// suffix for the same session.
+func TestClineSpellingsConvergeOnCline(t *testing.T) {
+	for _, in := range []string{
+		"cline", "Cline", "CLINE", " cline ", "cline_cli", "cline-cli", "cline cli", "cline.bot",
+	} {
+		t.Run(in, func(t *testing.T) {
+			if got := NormalizeHarnessName(in); got != "cline" {
+				t.Errorf("NormalizeHarnessName(%q) = %q, want %q", in, got, "cline")
+			}
+		})
+	}
+}
+
+// "cline" appears inside names Cline itself puts on disk: every Cline user has a `.clinerules`
+// directory, and a harness reporting a name derived from one of those paths must keep it rather
+// than being recorded as Cline activity. This is what keeps the Cline case an equality match
+// rather than a Contains rule.
+func TestClineDoesNotSwallowNamesMentioningCline(t *testing.T) {
+	for _, name := range []string{".clinerules", "clinerules", "clinerules-sync", "decline-bot"} {
+		if got := NormalizeHarnessName(name); got != name {
+			t.Errorf("NormalizeHarnessName(%q) = %q, want it preserved", name, got)
+		}
+	}
+}
+
+// Cline is not a Claude surface. The generic `Contains(lower, "claude")` rule above returns
+// claude_code for anything it can see the word "claude" in, and the two product names are close
+// enough in writing that a future edit could plausibly route one through the other -- which would
+// file Cline sessions as Claude Code sessions in every dashboard and detection that groups by
+// harness.name.
+func TestClineIsNotAttributedToClaudeCode(t *testing.T) {
+	for _, in := range []string{"cline", "Cline", "cline_cli", "cline.bot"} {
+		if got := NormalizeHarnessName(in); got == "claude_code" {
+			t.Errorf("NormalizeHarnessName(%q) = %q, want Cline to keep its own harness", in, got)
 		}
 	}
 }


### PR DESCRIPTION
First of eight PRs adding [Cline](https://cline.bot/) as a supported runtime surface. This one is
deliberately the smallest: it pins the release contract before anything starts writing it.

## What changed

One case in `NormalizeHarnessName`, plus tests.

## Why this is its own PR, and why it goes first

`harness.name` is a release contract — customer dashboards, `beacon scan` rules, and forwarded SIEM
queries group by it. Two independent paths write it (the hook path from `--platform`, the OTLP path
from resource attributes), and when they disagreed in the past a single session was recorded under
two names. Pinning the name before either path can produce it means there is never a window where
Cline events land under an unpinned spelling that later has to be migrated.

Cline makes this sharper than usual because it is not one runtime: it runs as a VS Code extension, a
JetBrains plugin, and a CLI over the same agent core, so the spelling that arrives depends on which
host reported it.

## Canonical name: `cline`

Consistent with the other multi-surface runtimes already supported (`cursor`, `opencode`,
`factory`), rather than the `_cli` suffix used for CLI-only runtimes (`codex_cli`, `gemini_cli`,
`pi_cli`). Cline is not primarily a CLI.

## Equality match, not `Contains`

Following the `pi_cli` precedent directly above it. `"cline"` is a substring of names Cline itself
puts on disk — every Cline user has a `.clinerules` directory — so a `Contains` rule would claim any
harness whose reported name derived from one of those paths. `TestClineDoesNotSwallowNamesMentioningCline`
is what keeps it an equality match.

The case handles a real bug rather than a hypothetical one: the unrecognized-runtime branch returns
the original `name`, not the lowercased one, so without this case `Cline` and `cline` are two
harnesses for one session.

## Tests

- `TestClineSpellingsConvergeOnCline` — every spelling the two write paths can produce
  (`cline`, `Cline`, `CLINE`, ` cline `, `cline_cli`, `cline-cli`, `cline cli`, `cline.bot`)
  resolves to one name. Verified failing without the code change.
- `TestClineDoesNotSwallowNamesMentioningCline` — `.clinerules`, `clinerules`, `clinerules-sync`,
  `decline-bot` keep their own names.
- `TestClineIsNotAttributedToClaudeCode` — guards the generic `Contains(lower, "claude")` rule
  above; misrouting here would file Cline sessions as Claude Code in every grouped query.
- `cline` added to the existing convergence and re-normalization-stability tables.

## Blast radius

One added case; no existing case is touched. Because the sibling modules consume this package
through a local `replace`, all four affected modules were run:

```
pkg/asymptoteobserve                          go test ./...                     ok
collector-builder/exporter/beaconjsonexporter go test ./...                     ok
cli/beacon-hooks                              go test ./...                     ok
cli/beacon                                    go test ./...                     ok
cli/beacon                                    go test -race ./internal/endpoint/... ok
```

macOS packaging checks were not run — this change does not touch packaging, and the sandbox here is
Linux.

## Not in this PR

No `--platform cline`, no installer, no discovery, no docs. Nothing writes this name yet; PRs 2–8
add the paths that do.

---
_Generated by [Claude Code](https://claude.ai/code/session_011wJyrxj9Wf7cP23bap1K7E)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive mapping only; no existing harness cases or write paths change. Risk is limited to future Cline attribution if the closed spelling set is incomplete.
> 
> **Overview**
> Pins **`cline`** as the canonical `harness.name` before any Cline write path exists, so hook (`--platform cline`) and OTLP spellings cannot split one session.
> 
> `NormalizeHarnessName` now maps a closed equality set (`cline`, `cline_cli`, `cline-cli`, `cline cli`, `cline.bot`) to `cline`. Matching is equality, not `Contains`, so names like `.clinerules` stay themselves. Tests cover spelling convergence, re-normalization stability, substring non-capture, and not attributing Cline to `claude_code`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae319bff888ad55f590db85a3081d43e84debfa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->