### PR TITLE
Add Pi runtime to supported runtimes table

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ CI, and cloud surfaces.
 | [GitHub Copilot CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-github-copilot-cli) | MDM-managed OTLP HTTP | Prompt, session, tool, and approval-like activity emitted through Copilot CLI spans |
 | [Grok Build](https://docs.asymptotelabs.ai/cli/supported-runtimes-grok-build) | Native hooks | Session, prompt, pre-tool, post-tool, failed tool, stop, session-end, command, and file telemetry |
 | [OpenCode](https://docs.asymptotelabs.ai/cli/supported-runtimes-opencode) | Managed plugin hooks | Prompts, assistant output/reasoning, model usage/cost, tool lifecycle/results, commands, file/web/MCP activity, approvals, and session errors |
+| [Pi](https://docs.asymptotelabs.ai/cli/supported-runtimes-pi) | Managed extension hooks | Session, prompt, agent and turn lifecycle, tool call and result, command, and approval-decision telemetry where Pi's extension API exposes it |
 | [VS Code](https://docs.asymptotelabs.ai/cli/supported-runtimes-vscode) | Copilot Chat OTel plus optional preview hooks | Copilot session, prompt, model, and tool activity through OTel; optional hooks for extra lifecycle and cross-agent detail |
 
 ##### Knowledge Worker Agent Harnesses


### PR DESCRIPTION
## Summary
Adds Pi to the README's supported runtimes table, documenting its telemetry collection capabilities through managed extension hooks.

## Changes
- Added Pi runtime entry to the supported runtimes table in README.md with:
  - Link to Pi runtime documentation
  - Telemetry collection method: "Managed extension hooks"
  - Supported telemetry types: Session, prompt, agent and turn lifecycle, tool call and result, command, and approval-decision telemetry where Pi's extension API exposes it

This documents Pi as a newly supported runtime alongside existing runtimes like GitHub Copilot CLI, Grok Build, OpenCode, and VS Code.

https://claude.ai/code/session_01F73o5PYYKpQfh78qzsqejH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no code, security, or data-handling impact.
> 
> **Overview**
> Documents **Pi** as a supported local coding agent harness in the README table.
> 
> The new row links to the Pi runtime docs and describes collection via managed extension hooks, covering session, prompt, agent/turn lifecycle, tool call/result, command, and approval-decision telemetry when Pi’s extension API exposes it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af7e8f1ec91d33ca8b53808d395929cc47cd123f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->