### PR TITLE
Cline support 4/9: map Cline hook payloads onto endpoint events

### DIFF
--- a/cli/beacon-hooks/cmd/cline_event.go
+++ b/cli/beacon-hooks/cmd/cline_event.go
@@ -50,6 +50,7 @@ const (
 	clineStageToolBefore = "tool_before"
 	clineStageToolAfter  = "tool_after"
 	clineStageTaskEnd    = "task_end"
+	clineStageTaskCancel = "task_cancel"
 	clineStageTaskError  = "task_error"
 )
 
@@ -83,7 +84,9 @@ func clineStage(input map[string]interface{}) string {
 		return clineStageToolAfter
 	case "afterrun", "runend", "sessionshutdown", "taskcomplete":
 		return clineStageTaskEnd
-	case "stoperror", "error", "taskcancel":
+	case "taskcancel":
+		return clineStageTaskCancel
+	case "stoperror", "error":
 		return clineStageTaskError
 	default:
 		return ""
@@ -127,6 +130,16 @@ func clineEndpointEvents(input map[string]interface{}, sessionID string) []norma
 			fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{"usage": usage})
 		}
 		return one("session.ended", "session", "info", "Cline task completed", fields)
+	case clineStageTaskCancel:
+		if usage := clineUsage(input); len(usage) > 0 {
+			fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{"usage": usage})
+		}
+		reason := getFirstStr(input, "completionStatus", "completion_status", "reason")
+		if reason == "" {
+			reason = "cancelled"
+		}
+		fields["session"] = mergeNested(fields["session"], map[string]interface{}{"cancel_reason": reason})
+		return one("session.ended", "session", "info", "Cline task cancelled", fields)
 	case clineStageTaskError:
 		fields["error"] = map[string]interface{}{"type": clineErrorType(input)}
 		return one("session.error", "session", "high", "Cline task ended with an error", fields)
@@ -309,6 +322,9 @@ func clineToolError(input map[string]interface{}) string {
 	if errMap := firstMap(input, "error"); errMap != nil {
 		if text := getFirstStr(errMap, "message", "error", "errorMessage", "error_message"); text != "" {
 			return text
+		}
+		if name := getFirstStr(errMap, "name", "type", "code"); name != "" {
+			return name
 		}
 	}
 	if response := clineToolResponse(input); response != nil {

--- a/cli/beacon-hooks/cmd/cline_event.go
+++ b/cli/beacon-hooks/cmd/cline_event.go
@@ -488,6 +488,21 @@ func joinWorkspacePath(root, rel string) string {
 	// "..\..\..\x.ts" into the bare relative "x.ts", an absolute Windows path with no drive left
 	// on it.
 	volume, rootRest := splitPathVolume(root)
+	// A root of "C:" carries no separator for the rule above to read, but a drive letter is
+	// unambiguously Windows, so the recorded path should be Windows-shaped rather than defaulting to
+	// slashes. Only a bare drive reaches this: a UNC root always contains separators.
+	if separator == "/" && volume != "" && !strings.ContainsAny(root, "/\\") {
+		separator = "\\"
+	}
+	// A bare volume -- "\\\\server\\share" or "C:" with nothing after it -- leaves an empty remainder,
+	// and path.Join drops empty elements, so the separator between root and relative path
+	// disappeared: the share and the path ran together as "\\\\server\\sharesrc\\app.ts", naming a
+	// file nothing touched. Substituting the root directory is also the right reading of the value:
+	// a workspace root of "C:" means that drive's root, not a path relative to its working
+	// directory.
+	if volume != "" && rootRest == "" {
+		rootRest = "/"
+	}
 	joined := path.Join(toSlashPath(rootRest), toSlashPath(rel))
 	if separator != "/" {
 		joined = strings.ReplaceAll(joined, "/", separator)

--- a/cli/beacon-hooks/cmd/cline_event.go
+++ b/cli/beacon-hooks/cmd/cline_event.go
@@ -166,8 +166,22 @@ func supportedClineEventTypes() []string {
 }
 
 func clineBaseFields(input map[string]interface{}, sessionID string) map[string]interface{} {
-	fields := sessionFields(sessionID, input)
-	applyWorkspaceFields(fields, input, "")
+	fields := map[string]interface{}{}
+	session := map[string]interface{}{}
+	if sessionID != "" {
+		session["id"] = sessionID
+	}
+	cwd := resolveCwd(input, "cline")
+	if cwd != "" {
+		session["working_directory"] = cwd
+		fields["repository"] = cwd
+	}
+	if len(session) > 0 {
+		fields["session"] = session
+	}
+	if branch := resolveBranch(input, cwd); branch != "" {
+		fields["branch"] = branch
+	}
 	fields["raw"] = map[string]interface{}{"cline": input}
 	if model := clineModel(input); model != "" {
 		fields["model"] = model
@@ -299,11 +313,13 @@ func clineToolError(input map[string]interface{}) string {
 	if text := getFirstStr(input, "error", "errorMessage", "error_message"); text != "" {
 		return text
 	}
-	for _, source := range []map[string]interface{}{firstMap(input, "error"), clineToolResponse(input)} {
-		if source == nil {
-			continue
+	if errMap := firstMap(input, "error"); errMap != nil {
+		if text := getFirstStr(errMap, "message", "error", "errorMessage", "error_message"); text != "" {
+			return text
 		}
-		if text := getFirstStr(source, "message", "error", "errorMessage", "error_message"); text != "" {
+	}
+	if response := clineToolResponse(input); response != nil {
+		if text := getFirstStr(response, "error", "errorMessage", "error_message"); text != "" {
 			return text
 		}
 	}

--- a/cli/beacon-hooks/cmd/cline_event.go
+++ b/cli/beacon-hooks/cmd/cline_event.go
@@ -398,12 +398,59 @@ func clineToolMessage(action string) string {
 //
 // Joining is skipped when the path is already absolute, and when no workspace root was resolved:
 // a wrong root would be worse than a relative path, because it names a file that was never touched.
+//
+// Deliberately not implemented with filepath.IsAbs and filepath.Join, which answer for the host
+// Beacon is running on rather than for the path in the payload. Those are different questions here:
+// the hook binary runs on the host while Cline may be addressing a workspace somewhere else, which
+// is the ordinary case for VS Code Remote and WSL. On Windows, filepath.IsAbs("/home/u/repo/a.ts")
+// is false, so an absolute POSIX path was joined onto the workspace root and recorded as
+// "\\tmp\\project\\home\\u\\repo\\a.ts" -- a file nothing touched. Answering for the
+// path itself also makes the result identical on every host, which is what lets one test pin it.
 func clineWorkspacePath(path, root string) string {
 	path = hookdiff.NormalizePath(path)
-	if path == "" || root == "" || filepath.IsAbs(path) {
+	if path == "" || root == "" || isRootedPath(path) {
 		return path
 	}
-	return filepath.Join(root, path)
+	return joinWorkspacePath(root, path)
+}
+
+// isRootedPath reports whether a path names a location without needing a base, under either
+// platform's convention.
+//
+// Both conventions, always, because the payload decides the spelling and the host does not. A
+// Windows path treated as relative and a POSIX path treated as relative fail the same way: the
+// workspace root is prepended and the event names a file that was never touched.
+func isRootedPath(path string) bool {
+	switch {
+	case path == "":
+		return false
+	// POSIX absolute, a UNC share, and a Windows path rooted on the current volume.
+	case path[0] == '/' || path[0] == '\\':
+		return true
+	// A drive-qualified Windows path: C:\repo or C:/repo. "C:repo" is deliberately excluded --
+	// it is relative to that drive's working directory, not rooted.
+	case len(path) >= 3 && path[1] == ':' && (path[2] == '\\' || path[2] == '/'):
+		letter := path[0] | 0x20
+		return letter >= 'a' && letter <= 'z'
+	default:
+		return false
+	}
+}
+
+// joinWorkspacePath joins a relative path under a root using the root's own separator.
+//
+// filepath.Join would use the host's, which mangles the result whenever the two disagree: a POSIX
+// workspace root on a Windows host produced "\\tmp\\project\\src\\app.ts", a path that
+// matches nothing and belongs to no filesystem. Taking the separator from the root keeps the
+// recorded path in the same shape as the workspace it came from.
+func joinWorkspacePath(root, rel string) string {
+	separator := "/"
+	if strings.Contains(root, "\\") && !strings.Contains(root, "/") {
+		separator = "\\"
+	}
+	rel = strings.TrimPrefix(strings.TrimPrefix(rel, "./"), ".\\")
+	rel = strings.ReplaceAll(strings.ReplaceAll(rel, "\\", separator), "/", separator)
+	return strings.TrimRight(root, "/\\") + separator + strings.TrimLeft(rel, "/\\")
 }
 
 func clineToolPath(toolInput map[string]interface{}, root string) string {

--- a/cli/beacon-hooks/cmd/cline_event.go
+++ b/cli/beacon-hooks/cmd/cline_event.go
@@ -136,6 +136,22 @@ func clineEndpointEvents(input map[string]interface{}, sessionID string) []norma
 		}
 		reason := getFirstStr(input, "completionStatus", "completion_status", "reason")
 		if reason == "" {
+			for _, key := range []string{"taskCancel", "task_cancel", "taskMetadata", "task_metadata", "result", "metadata"} {
+				if nested := firstMap(input, key); nested != nil {
+					reason = getFirstStr(nested, "completionStatus", "completion_status", "reason")
+					if reason != "" {
+						break
+					}
+					if inner := firstMap(nested, "taskMetadata", "task_metadata", "metadata"); inner != nil {
+						reason = getFirstStr(inner, "completionStatus", "completion_status", "reason")
+						if reason != "" {
+							break
+						}
+					}
+				}
+			}
+		}
+		if reason == "" {
 			reason = "cancelled"
 		}
 		fields["session"] = mergeNested(fields["session"], map[string]interface{}{"cancel_reason": reason})
@@ -473,10 +489,11 @@ func isRootedPath(path string) bool {
 	}
 }
 
-// joinWorkspacePath joins a relative path under a root using the root's own separator.
+// joinWorkspacePath joins a relative path under a root using the root's own separator, then
+// collapses . and .. segments so the result is canonical.
 //
-// filepath.Join would use the host's, which mangles the result whenever the two disagree: a POSIX
-// workspace root on a Windows host produced "\\tmp\\project\\src\\app.ts", a path that
+// filepath.Join would use the host's separator, which mangles the result whenever the two disagree:
+// a POSIX workspace root on a Windows host produced "\\tmp\\project\\src\\app.ts", a path that
 // matches nothing and belongs to no filesystem. Taking the separator from the root keeps the
 // recorded path in the same shape as the workspace it came from.
 func joinWorkspacePath(root, rel string) string {
@@ -486,7 +503,28 @@ func joinWorkspacePath(root, rel string) string {
 	}
 	rel = strings.TrimPrefix(strings.TrimPrefix(rel, "./"), ".\\")
 	rel = strings.ReplaceAll(strings.ReplaceAll(rel, "\\", separator), "/", separator)
-	return strings.TrimRight(root, "/\\") + separator + strings.TrimLeft(rel, "/\\")
+	joined := strings.TrimRight(root, "/\\") + separator + strings.TrimLeft(rel, "/\\")
+	return cleanPathSegments(joined, separator)
+}
+
+// cleanPathSegments collapses . and .. segments in a path without using filepath.Clean (which
+// would impose the host's separator). The separator must be "/" or "\\".
+func cleanPathSegments(path, separator string) string {
+	parts := strings.Split(path, separator)
+	var cleaned []string
+	for _, part := range parts {
+		switch part {
+		case ".":
+			continue
+		case "..":
+			if len(cleaned) > 0 && cleaned[len(cleaned)-1] != "" && cleaned[len(cleaned)-1] != ".." {
+				cleaned = cleaned[:len(cleaned)-1]
+			}
+		default:
+			cleaned = append(cleaned, part)
+		}
+	}
+	return strings.Join(cleaned, separator)
 }
 
 func clineToolPath(toolInput map[string]interface{}, root string) string {

--- a/cli/beacon-hooks/cmd/cline_event.go
+++ b/cli/beacon-hooks/cmd/cline_event.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -134,27 +135,7 @@ func clineEndpointEvents(input map[string]interface{}, sessionID string) []norma
 		if usage := clineUsage(input); len(usage) > 0 {
 			fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{"usage": usage})
 		}
-		reason := getFirstStr(input, "completionStatus", "completion_status", "reason")
-		if reason == "" {
-			for _, key := range []string{"taskCancel", "task_cancel", "taskMetadata", "task_metadata", "result", "metadata"} {
-				if nested := firstMap(input, key); nested != nil {
-					reason = getFirstStr(nested, "completionStatus", "completion_status", "reason")
-					if reason != "" {
-						break
-					}
-					if inner := firstMap(nested, "taskMetadata", "task_metadata", "metadata"); inner != nil {
-						reason = getFirstStr(inner, "completionStatus", "completion_status", "reason")
-						if reason != "" {
-							break
-						}
-					}
-				}
-			}
-		}
-		if reason == "" {
-			reason = "cancelled"
-		}
-		fields["session"] = mergeNested(fields["session"], map[string]interface{}{"cancel_reason": reason})
+		fields["session"] = mergeNested(fields["session"], map[string]interface{}{"cancel_reason": clineCancelReason(input)})
 		return one("session.ended", "session", "info", "Cline task cancelled", fields)
 	case clineStageTaskError:
 		fields["error"] = map[string]interface{}{"type": clineErrorType(input)}
@@ -501,30 +482,53 @@ func joinWorkspacePath(root, rel string) string {
 	if strings.Contains(root, "\\") && !strings.Contains(root, "/") {
 		separator = "\\"
 	}
-	rel = strings.TrimPrefix(strings.TrimPrefix(rel, "./"), ".\\")
-	rel = strings.ReplaceAll(strings.ReplaceAll(rel, "\\", separator), "/", separator)
-	joined := strings.TrimRight(root, "/\\") + separator + strings.TrimLeft(rel, "/\\")
-	return cleanPathSegments(joined, separator)
+	// Cleaning happens in slash space with the volume held aside, then reattached. A volume prefix
+	// cannot go through path.Clean: a leading "//" collapses, turning a UNC share into a directory,
+	// and "C:" is an ordinary segment that ".." can walk past -- which turned "C:\repo" plus
+	// "..\..\..\x.ts" into the bare relative "x.ts", an absolute Windows path with no drive left
+	// on it.
+	volume, rootRest := splitPathVolume(root)
+	joined := path.Join(toSlashPath(rootRest), toSlashPath(rel))
+	if separator != "/" {
+		joined = strings.ReplaceAll(joined, "/", separator)
+	}
+	return volume + joined
 }
 
-// cleanPathSegments collapses . and .. segments in a path without using filepath.Clean (which
-// would impose the host's separator). The separator must be "/" or "\\".
-func cleanPathSegments(path, separator string) string {
-	parts := strings.Split(path, separator)
-	var cleaned []string
-	for _, part := range parts {
-		switch part {
-		case ".":
-			continue
-		case "..":
-			if len(cleaned) > 0 && cleaned[len(cleaned)-1] != "" && cleaned[len(cleaned)-1] != ".." {
-				cleaned = cleaned[:len(cleaned)-1]
-			}
-		default:
-			cleaned = append(cleaned, part)
+// splitPathVolume separates a Windows volume prefix -- a drive letter or a UNC share -- from the
+// rest of a path. Returns an empty volume for anything else, including every POSIX path.
+func splitPathVolume(p string) (string, string) {
+	if len(p) >= 2 && p[1] == ':' {
+		if letter := p[0] | 0x20; letter >= 'a' && letter <= 'z' {
+			return p[:2], p[2:]
 		}
 	}
-	return strings.Join(cleaned, separator)
+	if len(p) >= 2 && isPathSeparator(p[0]) && isPathSeparator(p[1]) {
+		rest := p[2:]
+		server := indexPathSeparator(rest)
+		if server < 0 {
+			return p, ""
+		}
+		share := indexPathSeparator(rest[server+1:])
+		if share < 0 {
+			return p, ""
+		}
+		end := 2 + server + 1 + share
+		return p[:end], p[end:]
+	}
+	return "", p
+}
+
+func toSlashPath(p string) string {
+	return strings.ReplaceAll(p, "\\", "/")
+}
+
+func isPathSeparator(c byte) bool {
+	return c == '/' || c == '\\'
+}
+
+func indexPathSeparator(p string) int {
+	return strings.IndexAny(p, "/\\")
 }
 
 func clineToolPath(toolInput map[string]interface{}, root string) string {
@@ -665,6 +669,39 @@ func clineToolAfterEvents(input map[string]interface{}, fields map[string]interf
 		action: action, category: category, severity: "info",
 		message: clineToolMessage(action), fields: fields,
 	}}
+}
+
+// clineCancelReason reports why a task ended without completing: cancelled, abandoned, or whatever
+// else the payload says.
+//
+// Searched across the nestings Cline's file-based hook payload is reported to use -- notably
+// taskCancel.taskMetadata.completionStatus -- as well as the top level, because the two hook
+// surfaces do not agree on shape. Those paths come from a review of this change rather than from a
+// payload captured from a running Cline, so the search is additive: a miss costs the
+// cancelled-versus-abandoned distinction and falls back to "cancelled", never to a wrong reason.
+//
+// A named function rather than a loop inside the event switch so it can be tested directly, which
+// is what a set of guessed field paths most needs.
+func clineCancelReason(input map[string]interface{}) string {
+	if reason := getFirstStr(input, "completionStatus", "completion_status", "reason"); reason != "" {
+		return reason
+	}
+	outers := []map[string]interface{}{input}
+	for _, key := range []string{"taskCancel", "task_cancel", "taskMetadata", "task_metadata", "result", "metadata"} {
+		if nested := firstMap(input, key); nested != nil {
+			outers = append(outers, nested)
+		}
+	}
+	for _, outer := range outers {
+		if reason := getFirstStr(outer, "completionStatus", "completion_status", "reason"); reason != "" {
+			return reason
+		}
+		inner := firstMap(outer, "taskMetadata", "task_metadata", "metadata")
+		if reason := getFirstStr(inner, "completionStatus", "completion_status", "reason"); reason != "" {
+			return reason
+		}
+	}
+	return "cancelled"
 }
 
 // clineUsage normalizes Cline's reported token counts into gen_ai.usage.

--- a/cli/beacon-hooks/cmd/cline_event.go
+++ b/cli/beacon-hooks/cmd/cline_event.go
@@ -165,23 +165,16 @@ func supportedClineEventTypes() []string {
 	}
 }
 
+// clineBaseFields builds the fields every Cline event carries.
+//
+// The workspace is resolved for "cline" by name rather than through platformFlag. The shared
+// helpers default to the flag, which made this depend on how the binary was invoked: without
+// --platform cline the default reader found none of Cline's keys and the event carried no working
+// directory, repository or branch, while the file path beside it resolved correctly because that
+// path already named the runtime.
 func clineBaseFields(input map[string]interface{}, sessionID string) map[string]interface{} {
-	fields := map[string]interface{}{}
-	session := map[string]interface{}{}
-	if sessionID != "" {
-		session["id"] = sessionID
-	}
-	cwd := resolveCwd(input, "cline")
-	if cwd != "" {
-		session["working_directory"] = cwd
-		fields["repository"] = cwd
-	}
-	if len(session) > 0 {
-		fields["session"] = session
-	}
-	if branch := resolveBranch(input, cwd); branch != "" {
-		fields["branch"] = branch
-	}
+	fields := sessionFieldsForPlatform(sessionID, input, "cline")
+	applyWorkspaceFieldsForPlatform(fields, input, "", "cline")
 	fields["raw"] = map[string]interface{}{"cline": input}
 	if model := clineModel(input); model != "" {
 		fields["model"] = model

--- a/cli/beacon-hooks/cmd/cline_event.go
+++ b/cli/beacon-hooks/cmd/cline_event.go
@@ -1,0 +1,592 @@
+package cmd
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+
+	hookdiff "github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/diff"
+	"github.com/spf13/cobra"
+)
+
+// cline-event is the single entry point for every Cline lifecycle payload.
+//
+// Cline delivers its hooks through an in-process plugin whose handlers all fire in the same
+// process, so one command that receives a typed envelope is a better fit than the
+// command-per-hook shape used for runtimes that exec a separate hook per event. This mirrors how
+// opencode is integrated.
+var clineEventCmd = &cobra.Command{
+	Use:   "cline-event",
+	Short: "Record Cline hook telemetry",
+	Long:  `cline-event receives raw Beacon Cline plugin payloads and writes local endpoint telemetry.`,
+	Run:   runClineEvent,
+}
+
+func init() {
+	rootCmd.AddCommand(clineEventCmd)
+}
+
+func runClineEvent(cmd *cobra.Command, args []string) {
+	input, err := readStdinJSON()
+	if err != nil {
+		outputJSON(emptyResponse)
+		return
+	}
+	sessionID := resolveSessionID(input, "cline")
+	logger := newHookLogger("cline-event", "cline", sessionID)
+	for _, event := range clineEndpointEvents(input, sessionID) {
+		if event.action == "" {
+			continue
+		}
+		_ = logger.EndpointEvent(event.action, event.category, event.severity, event.message, event.fields)
+	}
+	outputJSON(emptyResponse)
+}
+
+// The lifecycle points Beacon records, independent of which name Cline used to announce them.
+const (
+	clineStageTaskStart  = "task_start"
+	clineStagePrompt     = "prompt"
+	clineStageToolBefore = "tool_before"
+	clineStageToolAfter  = "tool_after"
+	clineStageTaskEnd    = "task_end"
+	clineStageTaskError  = "task_error"
+)
+
+// clineStage decides which lifecycle point a payload describes.
+//
+// Cline names the same points more than one way, and Beacon has to accept all of them because two
+// different surfaces produce these payloads. The plugin SDK exposes handlers (beforeRun,
+// beforeTool, afterTool, afterRun) over a documented stage list that spells them differently
+// (run_start, tool_call_before, tool_call_after, run_end), and Cline's file-based hooks name the
+// script after the hook itself (PreToolUse, PostToolUse, TaskStart) and pass the same name back in
+// the payload's `hookName` base field. Recognizing every spelling is what lets one mapper serve
+// both surfaces instead of two mappers disagreeing about the same task.
+//
+// Matching is done on letters and digits only, lowercased, so PreToolUse, pre_tool_use and
+// tool_call_before all reduce to a single comparison instead of a case list per spelling.
+func clineStage(input map[string]interface{}) string {
+	var normalized strings.Builder
+	for _, r := range strings.ToLower(getFirstStr(input, "type", "hookName", "hook_name", "stage", "event")) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			normalized.WriteRune(r)
+		}
+	}
+	switch normalized.String() {
+	case "beforerun", "runstart", "sessionstart", "taskstart", "taskresume":
+		return clineStageTaskStart
+	case "userpromptsubmit", "promptsubmit", "input":
+		return clineStagePrompt
+	case "beforetool", "toolcallbefore", "pretooluse":
+		return clineStageToolBefore
+	case "aftertool", "toolcallafter", "posttooluse":
+		return clineStageToolAfter
+	case "afterrun", "runend", "sessionshutdown", "taskcomplete":
+		return clineStageTaskEnd
+	case "stoperror", "error", "taskcancel":
+		return clineStageTaskError
+	default:
+		return ""
+	}
+}
+
+// clineEndpointEvents maps one Cline payload onto the endpoint events it justifies.
+//
+// An unrecognized stage returns nothing rather than a generic event. Cline streams runtime events
+// well beyond the lifecycle points above, and turning each into an undifferentiated
+// "something happened" record would fill the runtime log with rows no query asks for.
+func clineEndpointEvents(input map[string]interface{}, sessionID string) []normalizedEvent {
+	fields := clineBaseFields(input, sessionID)
+	one := func(action, category, severity, message string, values map[string]interface{}) []normalizedEvent {
+		return []normalizedEvent{{action: action, category: category, severity: severity, message: message, fields: values}}
+	}
+
+	switch clineStage(input) {
+	case clineStageTaskStart:
+		events := one("session.started", "session", "info", "Cline task started", fields)
+		// Cline's run-start context carries the message that started the task, so the prompt is
+		// recorded from the same payload rather than waiting for a prompt hook that only the
+		// file-based surface has.
+		if prompt := clinePromptText(input); prompt != "" {
+			events = append(events, clinePromptEvent(cloneFields(fields), prompt))
+		}
+		return events
+	case clineStagePrompt:
+		prompt := clinePromptText(input)
+		if prompt == "" {
+			return nil
+		}
+		return []normalizedEvent{clinePromptEvent(fields, prompt)}
+	case clineStageToolBefore:
+		mergeMap(fields, clineToolFields(input, false))
+		return one("tool.invoked", "tool", "info", "Cline tool invoked", fields)
+	case clineStageToolAfter:
+		return clineToolAfterEvents(input, fields)
+	case clineStageTaskEnd:
+		if usage := clineUsage(input); len(usage) > 0 {
+			fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{"usage": usage})
+		}
+		return one("session.ended", "session", "info", "Cline task completed", fields)
+	case clineStageTaskError:
+		fields["error"] = map[string]interface{}{"type": clineErrorType(input)}
+		return one("session.error", "session", "high", "Cline task ended with an error", fields)
+	default:
+		return nil
+	}
+}
+
+// supportedClineEventTypes lists every spelling clineStage recognizes.
+//
+// Exists so a test can assert that each one still maps to an event: these strings are the contract
+// between this mapper and the managed plugin, and a silent typo on either side produces no
+// telemetry rather than an error.
+func supportedClineEventTypes() []string {
+	return []string{
+		"PostToolUse",
+		"PreToolUse",
+		"TaskCancel",
+		"TaskComplete",
+		"TaskResume",
+		"TaskStart",
+		"UserPromptSubmit",
+		"afterRun",
+		"afterTool",
+		"beforeRun",
+		"beforeTool",
+		"error",
+		"input",
+		"run_end",
+		"run_start",
+		"session_shutdown",
+		"session_start",
+		"stop_error",
+		"tool_call_after",
+		"tool_call_before",
+	}
+}
+
+func clineBaseFields(input map[string]interface{}, sessionID string) map[string]interface{} {
+	fields := sessionFields(sessionID, input)
+	applyWorkspaceFields(fields, input, "")
+	fields["raw"] = map[string]interface{}{"cline": input}
+	if model := clineModel(input); model != "" {
+		fields["model"] = model
+	}
+	return fields
+}
+
+func clinePromptEvent(fields map[string]interface{}, prompt string) normalizedEvent {
+	fields["prompt"] = map[string]interface{}{"text": prompt}
+	fields["gen_ai"] = map[string]interface{}{
+		"input": map[string]interface{}{
+			"messages": []interface{}{map[string]interface{}{
+				"role":  "user",
+				"parts": []interface{}{map[string]interface{}{"type": "text", "content": prompt}},
+			}},
+		},
+	}
+	fields["content"] = retainedContentFields(prompt)
+	return normalizedEvent{
+		action: "prompt.submitted", category: "prompt", severity: "info",
+		message: "Prompt submitted to Cline", fields: fields,
+	}
+}
+
+// clinePromptText finds the user's message in a run-start or prompt payload.
+//
+// Reads a nested "input" key, which on a tool payload would be the tool's arguments instead. That
+// is safe because only the two prompt-bearing stages reach here, and stated because the collision
+// is not obvious to the next reader.
+func clinePromptText(input map[string]interface{}) string {
+	if text := getFirstStr(input, "prompt", "userMessage", "user_message", "message", "text"); text != "" {
+		return text
+	}
+	for _, key := range []string{"input", "message", "prompt", "run", "context"} {
+		nested := firstMap(input, key)
+		if nested == nil {
+			continue
+		}
+		if text := getFirstStr(nested, "text", "content", "message", "prompt"); text != "" {
+			return text
+		}
+		if text := clineTextParts(nested["content"]); text != "" {
+			return text
+		}
+	}
+	return clineTextParts(input["content"])
+}
+
+// clineTextParts joins the text of a structured message body, skipping non-text parts.
+func clineTextParts(value interface{}) string {
+	parts, ok := value.([]interface{})
+	if !ok {
+		return ""
+	}
+	var texts []string
+	for _, part := range parts {
+		partMap, ok := part.(map[string]interface{})
+		if !ok {
+			if text, ok := part.(string); ok && text != "" {
+				texts = append(texts, text)
+			}
+			continue
+		}
+		if partType := getFirstStr(partMap, "type"); partType != "" && partType != "text" {
+			continue
+		}
+		if text := getFirstStr(partMap, "text", "content"); text != "" {
+			texts = append(texts, text)
+		}
+	}
+	return strings.Join(texts, "\n")
+}
+
+// clineModel reports the model behind a payload, qualified by its provider when both are present.
+//
+// Provider-qualified because a bare model id is ambiguous once a runtime can reach the same model
+// through more than one provider, and because opencode already writes provider/model -- one shape
+// for this field across runtimes is worth more than matching each runtime's own spelling.
+func clineModel(input map[string]interface{}) string {
+	model := getFirstStr(input, "model", "modelId", "model_id")
+	provider := getFirstStr(input, "apiProvider", "api_provider", "provider", "providerId", "provider_id")
+	if model == "" {
+		info := firstMap(input, "modelInfo", "model_info", "model", "api", "apiConfiguration")
+		model = getFirstStr(info, "modelId", "model_id", "model", "id", "name")
+		provider = firstNonEmpty(provider, getFirstStr(info, "apiProvider", "api_provider", "provider", "providerId", "provider_id"))
+	}
+	if model == "" {
+		return ""
+	}
+	if provider != "" && !strings.Contains(model, "/") {
+		return provider + "/" + model
+	}
+	return model
+}
+
+func clineToolName(input map[string]interface{}) string {
+	if tool := getFirstStr(input, "toolName", "tool_name", "tool"); tool != "" {
+		return tool
+	}
+	call := firstMap(input, "toolCall", "tool_call")
+	if tool := getFirstStr(call, "name", "toolName", "tool_name", "tool"); tool != "" {
+		return tool
+	}
+	return getFirstStr(input, "name")
+}
+
+func clineToolInput(input map[string]interface{}) map[string]interface{} {
+	if args := firstMap(input, "input", "toolInput", "tool_input", "arguments", "args", "params"); args != nil {
+		return args
+	}
+	call := firstMap(input, "toolCall", "tool_call")
+	return firstMap(call, "input", "arguments", "args", "params")
+}
+
+func clineToolResponse(input map[string]interface{}) map[string]interface{} {
+	if response := firstMap(input, "result", "toolResult", "tool_result", "output", "response"); response != nil {
+		return response
+	}
+	// A tool that returns a bare string still has a result worth recording, so it is wrapped in the
+	// same shape the map case produces rather than being dropped.
+	if text := getFirstStr(input, "result", "output", "response"); text != "" {
+		return map[string]interface{}{"output": text}
+	}
+	return nil
+}
+
+// clineToolError reports the failure text on a completed tool call, or "" when it succeeded.
+func clineToolError(input map[string]interface{}) string {
+	if text := getFirstStr(input, "error", "errorMessage", "error_message"); text != "" {
+		return text
+	}
+	for _, source := range []map[string]interface{}{firstMap(input, "error"), clineToolResponse(input)} {
+		if source == nil {
+			continue
+		}
+		if text := getFirstStr(source, "message", "error", "errorMessage", "error_message"); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func clineErrorType(input map[string]interface{}) string {
+	if errorInfo := firstMap(input, "error"); errorInfo != nil {
+		if name := getFirstStr(errorInfo, "name", "type", "code"); name != "" {
+			return name
+		}
+	}
+	return firstNonEmpty(getFirstStr(input, "errorType", "error_type", "reason"), "task_error")
+}
+
+// clineToolAction classifies a Cline tool call into an endpoint action and category.
+//
+// Cline's built-in tool names are snake_case verbs -- read_file, write_to_file, execute_command,
+// use_mcp_tool -- so the token rules at the bottom classify almost all of them correctly, and they
+// also cover tools a plugin registers, whose names Beacon cannot know in advance. The explicit
+// cases above exist only for the built-ins those rules would get wrong: three read tools whose
+// names contain no reading verb at all.
+func clineToolAction(name string) (string, string) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "list_files", "search_files", "list_code_definition_names":
+		return "file.read", "file"
+	}
+	switch {
+	case toolNameHasToken(name, "mcp"):
+		return "mcp.tool_invoked", "mcp"
+	case toolNameHasToken(name, "command") || toolNameHasToken(name, "commands") ||
+		toolNameHasToken(name, "bash") || toolNameHasToken(name, "shell") || toolNameHasToken(name, "terminal"):
+		return "command.executed", "command"
+	case toolNameHasToken(name, "read"):
+		return "file.read", "file"
+	case toolNameHasToken(name, "write") || toolNameHasToken(name, "edit") ||
+		toolNameHasToken(name, "replace") || toolNameHasToken(name, "patch") || toolNameHasToken(name, "create"):
+		return "file.modified", "file"
+	default:
+		return "tool.completed", "tool"
+	}
+}
+
+// clineFileOperation reports what a tool did to a file, for the file.operation field.
+func clineFileOperation(name string) string {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "list_files", "search_files", "list_code_definition_names":
+		return "read"
+	}
+	switch {
+	case toolNameHasToken(name, "read") || toolNameHasToken(name, "view") || toolNameHasToken(name, "list"):
+		return "read"
+	case toolNameHasToken(name, "write") || toolNameHasToken(name, "create"):
+		return "create"
+	case toolNameHasToken(name, "edit") || toolNameHasToken(name, "replace") || toolNameHasToken(name, "patch"):
+		return "modify"
+	default:
+		return ""
+	}
+}
+
+func clineToolMessage(action string) string {
+	switch action {
+	case "command.executed":
+		return "Cline shell command executed"
+	case "file.read":
+		return "Cline file read"
+	case "file.modified":
+		return "Cline file modified"
+	case "mcp.tool_invoked":
+		return "Cline MCP tool executed"
+	default:
+		return "Cline tool completed"
+	}
+}
+
+// clineWorkspacePath resolves a Cline tool path against the workspace root.
+//
+// Cline addresses files relative to the workspace -- read_file receives "src/app.ts", not an
+// absolute path -- while every other runtime Beacon supports reports absolute paths. Left relative,
+// a Cline file path is not comparable with the same file seen through Cursor or Claude Code, and
+// threat rules that match on absolute paths never fire on Cline activity.
+//
+// Joining is skipped when the path is already absolute, and when no workspace root was resolved:
+// a wrong root would be worse than a relative path, because it names a file that was never touched.
+func clineWorkspacePath(path, root string) string {
+	path = hookdiff.NormalizePath(path)
+	if path == "" || root == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(root, path)
+}
+
+func clineToolPath(toolInput map[string]interface{}, root string) string {
+	return clineWorkspacePath(
+		firstToolString(toolInput, "path", "file_path", "filePath", "target_file", "targetFile"),
+		root,
+	)
+}
+
+func clineToolFields(input map[string]interface{}, completed bool) map[string]interface{} {
+	toolName := clineToolName(input)
+	toolInput := clineToolInput(input)
+	toolResponse := clineToolResponse(input)
+	fields := toolFieldsWithResponse(toolName, toolInput, toolResponse)
+
+	call := map[string]interface{}{}
+	if len(toolInput) > 0 {
+		call["arguments"] = toolInput
+	}
+	if completed && len(toolResponse) > 0 {
+		if output, ok := toolResponse["output"]; ok {
+			call["result"] = output
+		} else {
+			call["result"] = toolResponse
+		}
+	}
+	if callID := getFirstStr(input, "callId", "call_id", "toolCallId", "tool_call_id"); callID != "" {
+		call["id"] = callID
+	}
+	fields["gen_ai"] = map[string]interface{}{
+		"operation": map[string]interface{}{"name": "execute_tool"},
+		"tool": map[string]interface{}{
+			"name": toolName,
+			"call": call,
+		},
+	}
+	if duration, ok := firstToolIntAcross([]map[string]interface{}{input, toolResponse}, "durationMs", "duration_ms"); ok {
+		fields["tool"] = mergeNested(fields["tool"], map[string]interface{}{"duration_ms": duration})
+	}
+
+	// resolveCwd is asked for the cline shape explicitly rather than through platformFlag: this
+	// function only ever runs on Cline payloads, and reading the flag would make the resolved path
+	// depend on how the binary happened to be invoked.
+	root := resolveCwd(input, "cline")
+	path := clineToolPath(toolInput, root)
+	if path != "" {
+		operation := clineFileOperation(toolName)
+		if operation == "" {
+			// A path on a tool that does nothing to files -- a search root, a project directory --
+			// is not file activity, and recording it as such would put unread files in the log.
+			delete(fields, "file")
+			if tool, ok := fields["tool"].(map[string]interface{}); ok {
+				delete(tool, "path")
+			}
+		} else {
+			fields["file"] = map[string]interface{}{
+				"path":      path,
+				"operation": operation,
+				"language":  strings.TrimPrefix(filepath.Ext(path), "."),
+			}
+			fields["tool"] = mergeNested(fields["tool"], map[string]interface{}{"name": toolName, "path": path})
+		}
+	}
+
+	if completed {
+		action, _ := clineToolAction(toolName)
+		if action == "file.modified" && path != "" {
+			mergeMap(fields, clineDiffFields(toolName, toolInput, toolResponse, path))
+			if file, ok := fields["file"].(map[string]interface{}); ok {
+				// diffFields records every diff as a modification; a create stays a create.
+				file["operation"] = clineFileOperation(toolName)
+			}
+		}
+		if action == "command.executed" {
+			fields["command"] = clineCommandFields(input, toolInput, toolResponse)
+		}
+	}
+
+	if encoded, err := json.Marshal(map[string]interface{}{"input": toolInput, "response": toolResponse}); err == nil && len(encoded) > 0 {
+		fields["content"] = retainedContentFields(string(encoded))
+	}
+	return fields
+}
+
+// clineDiffFields builds the file diff for a mutation.
+//
+// write_to_file goes through the shared builder, which turns its `content` argument into an
+// added-lines diff. replace_in_file deliberately does not: its `diff` argument is already a diff,
+// so passing it through records what Cline actually applied instead of an approximation
+// reconstructed from the pieces.
+//
+// The path is only used for the event field. The shared builder names files by base name in diff
+// headers, the same for every runtime, so it needs nothing resolved.
+func clineDiffFields(toolName string, toolInput, toolResponse map[string]interface{}, path string) map[string]interface{} {
+	diffText := hookdiff.FromToolResponse(toolName, toolInput, toolResponse)
+	if diffText == "" {
+		diffText = firstToolString(toolInput, "diff", "content", "new_string", "newString")
+	}
+	return diffFields(path, diffText)
+}
+
+func clineCommandFields(input, toolInput, toolResponse map[string]interface{}) map[string]interface{} {
+	fields := map[string]interface{}{"command": firstToolString(toolInput, "command", "cmd")}
+	if output := firstToolString(toolResponse, "output", "stdout", "text", "result"); output != "" {
+		fields["output"] = output
+	}
+	if exitCode, ok := firstToolIntAcross([]map[string]interface{}{toolResponse, input}, "exit_code", "exitCode"); ok {
+		fields["exit_code"] = exitCode
+	}
+	if duration, ok := firstToolIntAcross([]map[string]interface{}{input, toolResponse}, "durationMs", "duration_ms"); ok {
+		fields["duration_ms"] = duration
+	}
+	return fields
+}
+
+func clineToolAfterEvents(input map[string]interface{}, fields map[string]interface{}) []normalizedEvent {
+	mergeMap(fields, clineToolFields(input, true))
+	if errText := clineToolError(input); errText != "" {
+		fields["error"] = map[string]interface{}{"type": "tool_error"}
+		fields["content"] = retainedContentFields(errText)
+		return []normalizedEvent{{
+			action: "tool.failed", category: "tool", severity: "high",
+			message: "Cline tool failed", fields: fields,
+		}}
+	}
+	action, category := clineToolAction(clineToolName(input))
+	// A file action with no file is not a file action. Cline's read tools accept a directory or a
+	// pattern instead of a path, and reporting those as file.read with no file field produces a row
+	// that every file-scoped query matches and none can explain.
+	if strings.HasPrefix(action, "file.") {
+		if _, ok := fields["file"]; !ok {
+			action, category = "tool.completed", "tool"
+		}
+	}
+	return []normalizedEvent{{
+		action: action, category: category, severity: "info",
+		message: clineToolMessage(action), fields: fields,
+	}}
+}
+
+// clineUsage normalizes Cline's reported token counts into gen_ai.usage.
+//
+// Read from the task-end payload only, and deliberately not from any per-model-call stage. Beacon's
+// token rollups sum gen_ai.usage across events, so emitting usage at both granularities would count
+// every token twice. Cline's documented usage lives on the run result, which makes task-end the one
+// place it can be read without guessing at a field path.
+//
+// Cost is taken only as Cline reports it. Beacon never derives cost from a local price table.
+func clineUsage(input map[string]interface{}) map[string]interface{} {
+	usage := firstMap(input, "usage", "tokens")
+	if usage == nil {
+		for _, key := range []string{"result", "run", "output", "metrics"} {
+			if nested := firstMap(input, key); nested != nil {
+				if usage = firstMap(nested, "usage", "tokens"); usage != nil {
+					break
+				}
+			}
+		}
+	}
+	if usage == nil {
+		return nil
+	}
+	sources := []map[string]interface{}{usage}
+	out := map[string]interface{}{}
+	if value, ok := firstToolIntAcross(sources, "inputTokens", "input_tokens", "tokensIn", "tokens_in", "promptTokens", "prompt_tokens"); ok {
+		out["input_tokens"] = value
+	}
+	if value, ok := firstToolIntAcross(sources, "outputTokens", "output_tokens", "tokensOut", "tokens_out", "completionTokens", "completion_tokens"); ok {
+		out["output_tokens"] = value
+	}
+	if value, ok := firstToolIntAcross(sources, "cacheReadTokens", "cache_read_tokens", "cachedTokens", "cached_tokens"); ok {
+		out["cache_read"] = map[string]interface{}{"input_tokens": value}
+	}
+	if value, ok := firstToolIntAcross(sources, "cacheWriteTokens", "cache_write_tokens", "cacheCreationTokens", "cache_creation_tokens"); ok {
+		out["cache_creation"] = map[string]interface{}{"input_tokens": value}
+	}
+	if value, ok := clineCost(usage, input); ok {
+		out["cost_usd"] = value
+	}
+	return out
+}
+
+func clineCost(sources ...map[string]interface{}) (float64, bool) {
+	for _, source := range sources {
+		if source == nil {
+			continue
+		}
+		for _, key := range []string{"totalCost", "total_cost", "costUsd", "cost_usd", "cost"} {
+			if value, ok := jsonFloat(source[key]); ok {
+				return value, true
+			}
+		}
+	}
+	return 0, false
+}

--- a/cli/beacon-hooks/cmd/cline_event.go
+++ b/cli/beacon-hooks/cmd/cline_event.go
@@ -314,25 +314,45 @@ func clineToolResponse(input map[string]interface{}) map[string]interface{} {
 	return nil
 }
 
-// clineToolError reports the failure text on a completed tool call, or "" when it succeeded.
-func clineToolError(input map[string]interface{}) string {
+// clineToolFailure reports whether a completed tool call failed, and the text describing it.
+//
+// Failure and its description are separate answers because a payload can carry one without the
+// other. Reading the text and treating "" as success left the reported bug half-open: an error
+// object of {"code": 2} has no string field at all, and an empty {} has no field, so both were
+// still recorded as successful tool calls -- the quietest way to be wrong, since the event writes
+// and reads as ordinary activity. The presence of the error object is the failure signal; its
+// contents only describe it.
+//
+// The response is read only for keys that name an error explicitly. It deliberately does not read
+// `message`: Cline results carry status text there on success ("File written successfully"), and
+// reading it turned every such completion into a high-severity failure.
+func clineToolFailure(input map[string]interface{}) (string, bool) {
 	if text := getFirstStr(input, "error", "errorMessage", "error_message"); text != "" {
-		return text
+		return text, true
 	}
 	if errMap := firstMap(input, "error"); errMap != nil {
-		if text := getFirstStr(errMap, "message", "error", "errorMessage", "error_message"); text != "" {
-			return text
+		return getFirstStr(errMap, "message", "error", "errorMessage", "error_message", "name", "type", "code"), true
+	}
+	if response := clineToolResponse(input); response != nil {
+		if text := getFirstStr(response, "error", "errorMessage", "error_message"); text != "" {
+			return text, true
 		}
+	}
+	return "", false
+}
+
+// clineToolErrorType names a failed tool call's error for the error.type field.
+//
+// Reads the same keys clineErrorType reads for session errors, which were inconsistent: a session
+// error reported its name while a tool error was always "tool_error", discarding the one detail an
+// investigator would filter on.
+func clineToolErrorType(input map[string]interface{}) string {
+	if errMap := firstMap(input, "error"); errMap != nil {
 		if name := getFirstStr(errMap, "name", "type", "code"); name != "" {
 			return name
 		}
 	}
-	if response := clineToolResponse(input); response != nil {
-		if text := getFirstStr(response, "error", "errorMessage", "error_message"); text != "" {
-			return text
-		}
-	}
-	return ""
+	return "tool_error"
 }
 
 func clineErrorType(input map[string]interface{}) string {
@@ -584,9 +604,11 @@ func clineCommandFields(input, toolInput, toolResponse map[string]interface{}) m
 
 func clineToolAfterEvents(input map[string]interface{}, fields map[string]interface{}) []normalizedEvent {
 	mergeMap(fields, clineToolFields(input, true))
-	if errText := clineToolError(input); errText != "" {
-		fields["error"] = map[string]interface{}{"type": "tool_error"}
-		fields["content"] = retainedContentFields(errText)
+	if errText, failed := clineToolFailure(input); failed {
+		fields["error"] = map[string]interface{}{"type": clineToolErrorType(input)}
+		if errText != "" {
+			fields["content"] = retainedContentFields(errText)
+		}
 		return []normalizedEvent{{
 			action: "tool.failed", category: "tool", severity: "high",
 			message: "Cline tool failed", fields: fields,

--- a/cli/beacon-hooks/cmd/cline_event_test.go
+++ b/cli/beacon-hooks/cmd/cline_event_test.go
@@ -565,6 +565,18 @@ func TestClineWorkspacePathIsHostIndependent(t *testing.T) {
 		{name: "no root leaves the path relative", path: "src/app.ts", root: "", want: "src/app.ts"},
 		{name: "empty path stays empty", path: "", root: "/repo", want: ""},
 		{name: "quoted path is unquoted first", path: `"src/app.ts"`, root: "/repo", want: "/repo/src/app.ts"},
+		// Traversal is the case detection cares about most: stored uncollapsed, "/repo/../../.ssh/id_rsa"
+		// names the same file as "/home/u/.ssh/id_rsa" and matches no rule written against either.
+		{name: "traversal is collapsed", path: "../sibling/a.ts", root: "/repo/pkg", want: "/repo/sibling/a.ts"},
+		{name: "traversal above the root resolves lexically", path: "../../.ssh/id_rsa", root: "/repo", want: "/.ssh/id_rsa"},
+		{name: "dot segments in the middle are collapsed", path: "src/./util/../app.ts", root: "/repo", want: "/repo/src/app.ts"},
+		// A drive prefix cannot go through path.Clean: it treats "C:" as an ordinary segment that
+		// ".." can walk past, which would turn a drive path into a relative one.
+		{name: "traversal under a drive root keeps the drive", path: `..\other\a.ts`, root: `C:\repo\pkg`, want: `C:\repo\other\a.ts`},
+		{name: "traversal above a drive root keeps the drive", path: `..\..\..\x.ts`, root: `C:\repo`, want: `C:\x.ts`},
+		// A leading "//" is a share, not a doubled separator, and path.Clean would collapse it.
+		{name: "unc share survives cleaning", path: `..\b.ts`, root: `\\server\share\repo\pkg`, want: `\\server\share\repo\b.ts`},
+
 		{name: "dotdot segments are collapsed", path: "../../.ssh/id_rsa", root: "/home/u/proj", want: "/home/.ssh/id_rsa"},
 		{name: "single dot segments are collapsed", path: "./src/./app.ts", root: "/repo", want: "/repo/src/app.ts"},
 		{name: "mixed traversal is collapsed", path: "src/../lib/app.ts", root: "/repo", want: "/repo/lib/app.ts"},
@@ -678,5 +690,52 @@ func TestClineEventTaskErrorStaysAnError(t *testing.T) {
 	}
 	if got := nested(t, event, "error")["type"]; got != "provider_timeout" {
 		t.Errorf("error.type = %q, want provider_timeout", got)
+	}
+}
+
+// Cline's two hook surfaces disagree about where the cancel status lives. Missing the nested one
+// labels an abandoned task as cancelled -- a wrong distinction rather than a missing one, which is
+// why it is read from both.
+func TestClineCancelReasonReadsBothShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input map[string]interface{}
+		want  string
+	}{
+		{
+			name:  "top level status",
+			input: map[string]interface{}{"completionStatus": "abandoned"},
+			want:  "abandoned",
+		},
+		{
+			name: "nested under taskCancel.taskMetadata",
+			input: map[string]interface{}{
+				"taskCancel": map[string]interface{}{
+					"taskMetadata": map[string]interface{}{"completionStatus": "abandoned"},
+				},
+			},
+			want: "abandoned",
+		},
+		{
+			name:  "nested under taskMetadata",
+			input: map[string]interface{}{"taskMetadata": map[string]interface{}{"completionStatus": "abandoned"}},
+			want:  "abandoned",
+		},
+		{
+			name:  "top level wins over nested",
+			input: map[string]interface{}{"reason": "cancelled", "taskMetadata": map[string]interface{}{"completionStatus": "abandoned"}},
+			want:  "cancelled",
+		},
+		{
+			name:  "falls back to cancelled",
+			input: map[string]interface{}{},
+			want:  "cancelled",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clineCancelReason(tc.input); got != tc.want {
+				t.Errorf("clineCancelReason() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/cli/beacon-hooks/cmd/cline_event_test.go
+++ b/cli/beacon-hooks/cmd/cline_event_test.go
@@ -487,6 +487,7 @@ func TestClineStageRecognizesSpellingVariants(t *testing.T) {
 		"tool_call_after":  clineStageToolAfter,
 		"afterRun":         clineStageTaskEnd,
 		"session_shutdown": clineStageTaskEnd,
+		"TaskCancel":       clineStageTaskCancel,
 		"stop_error":       clineStageTaskError,
 		"iteration_start":  "",
 		"":                 "",

--- a/cli/beacon-hooks/cmd/cline_event_test.go
+++ b/cli/beacon-hooks/cmd/cline_event_test.go
@@ -172,13 +172,17 @@ func TestClineEventResolvesWorkspaceRelativePaths(t *testing.T) {
 		want  string
 	}{
 		{
+			// A literal expectation, not filepath.Join: the result must be the same on every host,
+			// because the workspace the path belongs to is not necessarily the host's.
 			name:  "relative path is joined to the workspace root",
 			roots: []interface{}{"/tmp/project"},
 			path:  "src/app.ts",
-			want:  filepath.Join("/tmp/project", "src/app.ts"),
+			want:  "/tmp/project/src/app.ts",
 		},
 		{
-			name:  "absolute path is left alone",
+			// filepath.IsAbs says false for this on Windows, so the old implementation joined it and
+			// recorded \tmp\project\etc\hosts -- a file nothing touched.
+			name:  "absolute POSIX path is left alone",
 			roots: []interface{}{"/tmp/project"},
 			path:  "/etc/hosts",
 			want:  "/etc/hosts",
@@ -216,7 +220,9 @@ func TestClineEventWriteToFileRecordsDiff(t *testing.T) {
 
 	event := clineEventWithAction(t, logPath, "file.modified")
 	file := nested(t, event, "file")
-	if got := file["path"]; got != filepath.Join("/Users/example/projects/beacon-demo", "src/health.ts") {
+	// Literal, not filepath.Join: the fixture's workspace is a POSIX one, and the recorded path must
+	// keep that shape whichever host the hook binary runs on.
+	if got := file["path"]; got != "/Users/example/projects/beacon-demo/src/health.ts" {
 		t.Errorf("file.path = %q, want the resolved workspace path", got)
 	}
 	// write_to_file creates a file. diffFields records every diff as a modification, so a create
@@ -523,5 +529,43 @@ func TestClineToolActionDoesNotMatchSubstrings(t *testing.T) {
 		if got, _ := clineToolAction(tool); got != "tool.completed" {
 			t.Errorf("clineToolAction(%q) = %q, want tool.completed", tool, got)
 		}
+	}
+}
+
+// The workspace a Cline path belongs to is not necessarily the host Beacon runs on -- VS Code Remote
+// and WSL are the ordinary cases -- so this resolution answers for the path, not for the host, and
+// every row below holds identically on Linux, macOS, and Windows.
+func TestClineWorkspacePathIsHostIndependent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		root string
+		want string
+	}{
+		{name: "posix relative under posix root", path: "src/app.ts", root: "/repo", want: "/repo/src/app.ts"},
+		{name: "windows relative under windows root", path: `src\app.ts`, root: `C:\repo`, want: `C:\repo\src\app.ts`},
+		// Mixed spellings happen: the payload and the workspace root do not have to agree, and the
+		// recorded path should match the root's shape rather than becoming a mixture.
+		{name: "posix relative under windows root", path: "src/app.ts", root: `C:\repo`, want: `C:\repo\src\app.ts`},
+		{name: "windows relative under posix root", path: `src\app.ts`, root: "/repo", want: "/repo/src/app.ts"},
+		{name: "dot prefix is dropped", path: "./src/app.ts", root: "/repo", want: "/repo/src/app.ts"},
+		{name: "trailing root separator is not doubled", path: "src/app.ts", root: "/repo/", want: "/repo/src/app.ts"},
+		{name: "posix absolute is left alone", path: "/etc/hosts", root: `C:\repo`, want: "/etc/hosts"},
+		{name: "drive absolute is left alone", path: `C:\Windows\hosts`, root: "/repo", want: `C:\Windows\hosts`},
+		{name: "drive absolute with forward slashes is left alone", path: "D:/data/a.ts", root: "/repo", want: "D:/data/a.ts"},
+		{name: "unc path is left alone", path: `\\server\share\a.ts`, root: "/repo", want: `\\server\share\a.ts`},
+		{name: "volume-rooted path is left alone", path: `\Users\x\a.ts`, root: "/repo", want: `\Users\x\a.ts`},
+		// Drive-relative, which names a location only in the context of that drive's working
+		// directory. Not rooted, so it is resolved like any other relative path.
+		{name: "drive relative is treated as relative", path: "C:src/app.ts", root: "/repo", want: "/repo/C:src/app.ts"},
+		{name: "no root leaves the path relative", path: "src/app.ts", root: "", want: "src/app.ts"},
+		{name: "empty path stays empty", path: "", root: "/repo", want: ""},
+		{name: "quoted path is unquoted first", path: `"src/app.ts"`, root: "/repo", want: "/repo/src/app.ts"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clineWorkspacePath(tc.path, tc.root); got != tc.want {
+				t.Errorf("clineWorkspacePath(%q, %q) = %q, want %q", tc.path, tc.root, got, tc.want)
+			}
+		})
 	}
 }

--- a/cli/beacon-hooks/cmd/cline_event_test.go
+++ b/cli/beacon-hooks/cmd/cline_event_test.go
@@ -336,7 +336,7 @@ func TestClineEventSuccessfulToolWithMessageIsNotFailure(t *testing.T) {
 			"name":  "write_to_file",
 			"input": map[string]interface{}{"path": "out.ts", "content": "done"},
 		},
-		"result": map[string]interface{}{"output": "File written", "message": "File written successfully"},
+		"result":         map[string]interface{}{"output": "File written", "message": "File written successfully"},
 		"workspaceRoots": []interface{}{"/tmp/project"},
 	})
 

--- a/cli/beacon-hooks/cmd/cline_event_test.go
+++ b/cli/beacon-hooks/cmd/cline_event_test.go
@@ -106,6 +106,26 @@ func TestClineEventTaskStartRecordsSessionAndPrompt(t *testing.T) {
 	}
 }
 
+// Base fields resolve the workspace through the Cline-specific path (workspaceRoots) regardless of
+// what platformFlag is set to. Without this, the session.working_directory stays empty when the
+// binary is invoked without --platform cline.
+func TestClineEventBaseFieldsResolveWorkspaceWithoutPlatformFlag(t *testing.T) {
+	logPath := clineTestLog(t)
+	platformFlag = "claude" // simulate missing --platform cline
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"type":           "beforeRun",
+		"taskId":         "task-platform",
+		"workspaceRoots": []interface{}{"/tmp/project"},
+		"input":          map[string]interface{}{"text": "hello"},
+	})
+
+	event := clineEventWithAction(t, logPath, "session.started")
+	if got := nested(t, event, "session")["working_directory"]; got != "/tmp/project" {
+		t.Errorf("session.working_directory = %q, want /tmp/project (resolved from workspaceRoots regardless of platformFlag)", got)
+	}
+}
+
 // The file-based hook surface names the hook in `hookName` and sends prompts on their own, so a
 // prompt payload with no run-start context still has to produce a prompt event.
 func TestClineEventPromptOnlyPayload(t *testing.T) {
@@ -301,6 +321,33 @@ func TestClineEventToolFailureIsHighSeverity(t *testing.T) {
 	}
 	if got := nested(t, event, "error")["type"]; got != "tool_error" {
 		t.Errorf("error.type = %q, want tool_error", got)
+	}
+}
+
+// A successful tool result that carries a "message" field (common in Cline for status feedback)
+// must not be treated as a failure. Only explicit error keys indicate a failure.
+func TestClineEventSuccessfulToolWithMessageIsNotFailure(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"type":   "afterTool",
+		"taskId": "task-msg",
+		"toolCall": map[string]interface{}{
+			"name":  "write_to_file",
+			"input": map[string]interface{}{"path": "out.ts", "content": "done"},
+		},
+		"result": map[string]interface{}{"output": "File written", "message": "File written successfully"},
+		"workspaceRoots": []interface{}{"/tmp/project"},
+	})
+
+	actions := clineEventActions(t, logPath)
+	for _, a := range actions {
+		if a == "tool.failed" {
+			t.Fatalf("actions = %v, want no tool.failed for a successful result with a message field", actions)
+		}
+	}
+	if len(actions) == 0 {
+		t.Fatalf("expected at least one event")
 	}
 }
 

--- a/cli/beacon-hooks/cmd/cline_event_test.go
+++ b/cli/beacon-hooks/cmd/cline_event_test.go
@@ -1,0 +1,480 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// clineTestLog puts a Cline hook run in a temp endpoint log and returns its path.
+func clineTestLog(t *testing.T) string {
+	t.Helper()
+	setupHookConfigDirs(t)
+	platformFlag = "cline"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_MODE", "1")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_CONTENT_RETENTION", "full")
+	return logPath
+}
+
+func clineEventActions(t *testing.T, logPath string) []string {
+	t.Helper()
+	var actions []string
+	for _, event := range endpointEvents(t, logPath) {
+		event, _ := event["event"].(map[string]interface{})
+		actions = append(actions, event["action"].(string))
+	}
+	return actions
+}
+
+func clineEventWithAction(t *testing.T, logPath, action string) map[string]interface{} {
+	t.Helper()
+	for _, event := range endpointEvents(t, logPath) {
+		meta, _ := event["event"].(map[string]interface{})
+		if meta["action"] == action {
+			return event
+		}
+	}
+	t.Fatalf("no %s event in log; got %v", action, clineEventActions(t, logPath))
+	return nil
+}
+
+func readClineFixture(t *testing.T, name string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "testdata", "cline", name))
+	if err != nil {
+		t.Fatalf("read cline fixture %s: %v", name, err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("decode cline fixture %s: %v", name, err)
+	}
+	return payload
+}
+
+func nested(t *testing.T, event map[string]interface{}, keys ...string) map[string]interface{} {
+	t.Helper()
+	current := event
+	for _, key := range keys {
+		next, ok := current[key].(map[string]interface{})
+		if !ok {
+			t.Fatalf("event is missing the %s object: %v", strings.Join(keys, "."), event)
+		}
+		current = next
+	}
+	return current
+}
+
+// A task start is both the start of a session and the moment the user's request arrives, so it
+// produces two events. Recording only one would lose either the session boundary or the prompt.
+func TestClineEventTaskStartRecordsSessionAndPrompt(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	out := runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"type":           "beforeRun",
+		"taskId":         "task-1",
+		"workspaceRoots": []interface{}{"/tmp/project"},
+		"apiProvider":    "anthropic",
+		"modelId":        "claude-sonnet-4",
+		"input":          map[string]interface{}{"text": "ship it token=cline-secret"},
+	})
+	if len(out) != 0 {
+		t.Fatalf("response = %#v, want empty object", out)
+	}
+
+	if got := clineEventActions(t, logPath); len(got) != 2 || got[0] != "session.started" || got[1] != "prompt.submitted" {
+		t.Fatalf("actions = %v, want [session.started prompt.submitted]", got)
+	}
+	event := clineEventWithAction(t, logPath, "prompt.submitted")
+	if harness := nested(t, event, "harness")["name"]; harness != "cline" {
+		t.Errorf("harness.name = %q, want cline", harness)
+	}
+	if id := nested(t, event, "session")["id"]; id != "task-1" {
+		t.Errorf("session.id = %q, want task-1", id)
+	}
+	if got := nested(t, event, "prompt")["text"]; got != "ship it token=[REDACTED]" {
+		t.Errorf("prompt.text = %q, want the redacted prompt", got)
+	}
+	if got := event["model"]; got != "anthropic/claude-sonnet-4" {
+		t.Errorf("model = %q, want the provider-qualified model", got)
+	}
+	if got := nested(t, event, "session")["working_directory"]; got != "/tmp/project" {
+		t.Errorf("session.working_directory = %q, want the workspace root", got)
+	}
+}
+
+// The file-based hook surface names the hook in `hookName` and sends prompts on their own, so a
+// prompt payload with no run-start context still has to produce a prompt event.
+func TestClineEventPromptOnlyPayload(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"hookName": "UserPromptSubmit",
+		"taskId":   "task-2",
+		"prompt":   "explain this repo",
+	})
+
+	if got := clineEventActions(t, logPath); len(got) != 1 || got[0] != "prompt.submitted" {
+		t.Fatalf("actions = %v, want [prompt.submitted]", got)
+	}
+}
+
+func TestClineEventBeforeToolRecordsInvocation(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"type":           "beforeTool",
+		"taskId":         "task-3",
+		"workspaceRoots": []interface{}{"/tmp/project"},
+		"toolCall":       map[string]interface{}{"name": "read_file", "input": map[string]interface{}{"path": "src/app.ts"}},
+	})
+
+	event := clineEventWithAction(t, logPath, "tool.invoked")
+	if got := nested(t, event, "tool")["name"]; got != "read_file" {
+		t.Errorf("tool.name = %q, want read_file", got)
+	}
+	if got := nested(t, event, "gen_ai", "tool", "call")["arguments"]; got == nil {
+		t.Errorf("gen_ai.tool.call.arguments is missing: %v", event)
+	}
+}
+
+// Cline addresses files relative to the workspace. Every other runtime reports absolute paths, so
+// the join is what makes a Cline file event comparable with the same file seen through Cursor or
+// Claude Code -- and what lets a threat rule matching an absolute path fire on Cline activity.
+func TestClineEventResolvesWorkspaceRelativePaths(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		roots interface{}
+		path  string
+		want  string
+	}{
+		{
+			name:  "relative path is joined to the workspace root",
+			roots: []interface{}{"/tmp/project"},
+			path:  "src/app.ts",
+			want:  filepath.Join("/tmp/project", "src/app.ts"),
+		},
+		{
+			name:  "absolute path is left alone",
+			roots: []interface{}{"/tmp/project"},
+			path:  "/etc/hosts",
+			want:  "/etc/hosts",
+		},
+		{
+			name:  "relative path stays relative when no root is known",
+			roots: nil,
+			path:  "src/app.ts",
+			want:  "src/app.ts",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logPath := clineTestLog(t)
+			payload := map[string]interface{}{
+				"type":     "afterTool",
+				"taskId":   "task-4",
+				"toolCall": map[string]interface{}{"name": "read_file", "input": map[string]interface{}{"path": tc.path}},
+			}
+			if tc.roots != nil {
+				payload["workspaceRoots"] = tc.roots
+			}
+			runHookWithInput(t, runClineEvent, payload)
+
+			event := clineEventWithAction(t, logPath, "file.read")
+			if got := nested(t, event, "file")["path"]; got != tc.want {
+				t.Errorf("file.path = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClineEventWriteToFileRecordsDiff(t *testing.T) {
+	logPath := clineTestLog(t)
+	runHookWithInput(t, runClineEvent, readClineFixture(t, "tool_after_write.json"))
+
+	event := clineEventWithAction(t, logPath, "file.modified")
+	file := nested(t, event, "file")
+	if got := file["path"]; got != filepath.Join("/Users/example/projects/beacon-demo", "src/health.ts") {
+		t.Errorf("file.path = %q, want the resolved workspace path", got)
+	}
+	// write_to_file creates a file. diffFields records every diff as a modification, so a create
+	// that came back as "modify" would mean the operation was overwritten by the diff builder.
+	if got := file["operation"]; got != "create" {
+		t.Errorf("file.operation = %q, want create", got)
+	}
+	if file["diff_hash"] == nil || file["diff_bytes"] == nil {
+		t.Errorf("file diff metadata is missing: %v", file)
+	}
+	// The content Cline wrote is recorded as an added-lines diff through the shared builder, which
+	// names files by base name for every runtime. The absolute path lives in file.path above.
+	diff, _ := file["diff"].(string)
+	if !strings.Contains(diff, "+++ b/health.ts") || !strings.Contains(diff, "+export const health") {
+		t.Errorf("diff does not describe the written file: %q", diff)
+	}
+	if got := nested(t, event, "tool")["duration_ms"]; got != float64(34) {
+		t.Errorf("tool.duration_ms = %v, want 34", got)
+	}
+}
+
+// replace_in_file's argument is already a diff, so it is passed through rather than reconstructed:
+// what Beacon records should be what Cline applied.
+func TestClineEventReplaceInFilePassesTheDiffThrough(t *testing.T) {
+	logPath := clineTestLog(t)
+	diffText := "------- SEARCH\nold()\n=======\nnew()\n+++++++ REPLACE"
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"type":           "afterTool",
+		"taskId":         "task-5",
+		"workspaceRoots": []interface{}{"/tmp/project"},
+		"toolCall": map[string]interface{}{
+			"name":  "replace_in_file",
+			"input": map[string]interface{}{"path": "src/app.ts", "diff": diffText},
+		},
+	})
+
+	file := nested(t, clineEventWithAction(t, logPath, "file.modified"), "file")
+	if got := file["operation"]; got != "modify" {
+		t.Errorf("file.operation = %q, want modify", got)
+	}
+	if got := file["diff"]; got != diffText {
+		t.Errorf("file.diff = %q, want the diff Cline applied", got)
+	}
+	if got := file["diff_bytes"]; got != float64(len(diffText)) {
+		t.Errorf("file.diff_bytes = %v, want %d", got, len(diffText))
+	}
+}
+
+func TestClineEventExecuteCommandRecordsCommand(t *testing.T) {
+	logPath := clineTestLog(t)
+	runHookWithInput(t, runClineEvent, readClineFixture(t, "tool_after_command.json"))
+
+	event := clineEventWithAction(t, logPath, "command.executed")
+	command := nested(t, event, "command")
+	if got := command["command"]; got != "npm test" {
+		t.Errorf("command.command = %q, want npm test", got)
+	}
+	if got := command["output"]; got != "2 passing" {
+		t.Errorf("command.output = %q, want the captured output", got)
+	}
+	// A zero exit code is a real value, not an absent one: dropping it would report every clean
+	// command as having no result.
+	if got, ok := command["exit_code"]; !ok || got != float64(0) {
+		t.Errorf("command.exit_code = %v (present=%t), want 0", got, ok)
+	}
+	if got := command["duration_ms"]; got != float64(4120) {
+		t.Errorf("command.duration_ms = %v, want 4120", got)
+	}
+}
+
+func TestClineEventMCPToolIsRecordedAsMCP(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"type":   "afterTool",
+		"taskId": "task-6",
+		"toolCall": map[string]interface{}{
+			"name":  "use_mcp_tool",
+			"input": map[string]interface{}{"server_name": "github", "tool_name": "list_issues"},
+		},
+	})
+
+	if got := clineEventActions(t, logPath); len(got) != 1 || got[0] != "mcp.tool_invoked" {
+		t.Fatalf("actions = %v, want [mcp.tool_invoked]", got)
+	}
+}
+
+func TestClineEventToolFailureIsHighSeverity(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"type":     "afterTool",
+		"taskId":   "task-7",
+		"toolCall": map[string]interface{}{"name": "read_file", "input": map[string]interface{}{"path": "missing.ts"}},
+		"error":    map[string]interface{}{"message": "ENOENT: no such file"},
+	})
+
+	event := clineEventWithAction(t, logPath, "tool.failed")
+	if got := event["severity"]; got != "high" {
+		t.Errorf("severity = %q, want high", got)
+	}
+	if got := nested(t, event, "error")["type"]; got != "tool_error" {
+		t.Errorf("error.type = %q, want tool_error", got)
+	}
+}
+
+// A file action with no file is not a file action: Cline's search tools take a pattern rather than
+// a path, and a file.read with no file field matches every file-scoped query and explains none.
+func TestClineEventFileActionWithoutAPathBecomesToolCompleted(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"type":     "afterTool",
+		"taskId":   "task-8",
+		"toolCall": map[string]interface{}{"name": "search_files", "input": map[string]interface{}{"regex": "TODO"}},
+	})
+
+	if got := clineEventActions(t, logPath); len(got) != 1 || got[0] != "tool.completed" {
+		t.Fatalf("actions = %v, want [tool.completed]", got)
+	}
+}
+
+func TestClineEventTaskEndRecordsUsage(t *testing.T) {
+	logPath := clineTestLog(t)
+	runHookWithInput(t, runClineEvent, readClineFixture(t, "run_end_usage.json"))
+
+	event := clineEventWithAction(t, logPath, "session.ended")
+	usage := nested(t, event, "gen_ai", "usage")
+	if got := usage["input_tokens"]; got != float64(1841) {
+		t.Errorf("gen_ai.usage.input_tokens = %v, want 1841", got)
+	}
+	if got := usage["output_tokens"]; got != float64(412) {
+		t.Errorf("gen_ai.usage.output_tokens = %v, want 412", got)
+	}
+	if got := nested(t, event, "gen_ai", "usage", "cache_read")["input_tokens"]; got != float64(1024) {
+		t.Errorf("gen_ai.usage.cache_read.input_tokens = %v, want 1024", got)
+	}
+	if got := usage["cost_usd"]; got != 0.0231 {
+		t.Errorf("gen_ai.usage.cost_usd = %v, want the runtime-reported cost", got)
+	}
+}
+
+// Cost is only ever what the runtime reported. Beacon must not derive it from a local price table,
+// so a usage payload without a cost must produce no cost field at all.
+func TestClineEventDoesNotInventCost(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"type":   "afterRun",
+		"taskId": "task-9",
+		"result": map[string]interface{}{"usage": map[string]interface{}{"inputTokens": 10, "outputTokens": 2}},
+	})
+
+	usage := nested(t, clineEventWithAction(t, logPath, "session.ended"), "gen_ai", "usage")
+	if _, ok := usage["cost_usd"]; ok {
+		t.Errorf("gen_ai.usage.cost_usd = %v, want no cost when the runtime reported none", usage["cost_usd"])
+	}
+}
+
+// Token usage is read at exactly one lifecycle point. Beacon's rollups sum gen_ai.usage across
+// events, so a second stage reporting the same tokens would double every Cline task's token count.
+func TestClineEventReportsUsageOnlyAtTaskEnd(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"type":     "afterModel",
+		"taskId":   "task-10",
+		"usage":    map[string]interface{}{"inputTokens": 10, "outputTokens": 2},
+		"toolCall": map[string]interface{}{"name": "read_file"},
+	})
+
+	if data, err := os.ReadFile(logPath); err == nil && len(strings.TrimSpace(string(data))) != 0 {
+		t.Fatalf("afterModel wrote events, want none: %s", data)
+	}
+}
+
+// An unrecognized stage writes nothing. Cline streams far more runtime events than the lifecycle
+// points Beacon maps, and a generic "something happened" row per event would bury the log.
+func TestClineEventIgnoresUnknownStages(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"type":   "iteration_start",
+		"taskId": "task-11",
+	})
+
+	if data, err := os.ReadFile(logPath); err == nil && len(strings.TrimSpace(string(data))) != 0 {
+		t.Fatalf("unknown stage wrote events, want none: %s", data)
+	}
+}
+
+// A malformed payload must not fail the hook. Cline runs these in-process; an error here would
+// surface in the user's editor, and telemetry is never worth that.
+func TestClineEventSurvivesAnEmptyPayload(t *testing.T) {
+	clineTestLog(t)
+	out := runHookWithInput(t, runClineEvent, map[string]interface{}{})
+	if len(out) != 0 {
+		t.Fatalf("response = %#v, want empty object", out)
+	}
+}
+
+// Every spelling the mapper claims to accept must still produce an event. These strings are the
+// contract between this mapper and the managed plugin, and a typo on either side produces silence
+// rather than an error.
+func TestClineEventSupportedTypesAllProduceEvents(t *testing.T) {
+	for _, eventType := range supportedClineEventTypes() {
+		t.Run(eventType, func(t *testing.T) {
+			logPath := clineTestLog(t)
+			runHookWithInput(t, runClineEvent, map[string]interface{}{
+				"type":           eventType,
+				"taskId":         "task-12",
+				"workspaceRoots": []interface{}{"/tmp/project"},
+				"prompt":         "do the thing",
+				"toolCall":       map[string]interface{}{"name": "read_file", "input": map[string]interface{}{"path": "src/app.ts"}},
+				"usage":          map[string]interface{}{"inputTokens": 4},
+				"error":          map[string]interface{}{"name": "aborted"},
+			})
+			if actions := clineEventActions(t, logPath); len(actions) == 0 {
+				t.Fatalf("type %q produced no events", eventType)
+			}
+		})
+	}
+}
+
+func TestClineStageRecognizesSpellingVariants(t *testing.T) {
+	for input, want := range map[string]string{
+		"beforeRun":        clineStageTaskStart,
+		"run_start":        clineStageTaskStart,
+		"TaskStart":        clineStageTaskStart,
+		"pre_tool_use":     clineStageToolBefore,
+		"PreToolUse":       clineStageToolBefore,
+		"tool_call_before": clineStageToolBefore,
+		"PostToolUse":      clineStageToolAfter,
+		"tool_call_after":  clineStageToolAfter,
+		"afterRun":         clineStageTaskEnd,
+		"session_shutdown": clineStageTaskEnd,
+		"stop_error":       clineStageTaskError,
+		"iteration_start":  "",
+		"":                 "",
+	} {
+		t.Run(input, func(t *testing.T) {
+			if got := clineStage(map[string]interface{}{"type": input}); got != want {
+				t.Errorf("clineStage(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestClineToolActionClassification(t *testing.T) {
+	for tool, want := range map[string]string{
+		"read_file":                  "file.read",
+		"list_files":                 "file.read",
+		"search_files":               "file.read",
+		"list_code_definition_names": "file.read",
+		"write_to_file":              "file.modified",
+		"replace_in_file":            "file.modified",
+		"execute_command":            "command.executed",
+		"run_commands":               "command.executed",
+		"use_mcp_tool":               "mcp.tool_invoked",
+		"access_mcp_resource":        "mcp.tool_invoked",
+		"browser_action":             "tool.completed",
+		"ask_followup_question":      "tool.completed",
+	} {
+		t.Run(tool, func(t *testing.T) {
+			if got, _ := clineToolAction(tool); got != want {
+				t.Errorf("clineToolAction(%q) = %q, want %q", tool, got, want)
+			}
+		})
+	}
+}
+
+// The token rules must not classify a tool by a word that merely appears inside another word --
+// the reason toolNameHasToken splits on boundaries instead of matching substrings.
+func TestClineToolActionDoesNotMatchSubstrings(t *testing.T) {
+	for _, tool := range []string{"spreadsheet_export", "thread_summary"} {
+		if got, _ := clineToolAction(tool); got != "tool.completed" {
+			t.Errorf("clineToolAction(%q) = %q, want tool.completed", tool, got)
+		}
+	}
+}

--- a/cli/beacon-hooks/cmd/cline_event_test.go
+++ b/cli/beacon-hooks/cmd/cline_event_test.go
@@ -565,6 +565,10 @@ func TestClineWorkspacePathIsHostIndependent(t *testing.T) {
 		{name: "no root leaves the path relative", path: "src/app.ts", root: "", want: "src/app.ts"},
 		{name: "empty path stays empty", path: "", root: "/repo", want: ""},
 		{name: "quoted path is unquoted first", path: `"src/app.ts"`, root: "/repo", want: "/repo/src/app.ts"},
+		{name: "dotdot segments are collapsed", path: "../../.ssh/id_rsa", root: "/home/u/proj", want: "/home/.ssh/id_rsa"},
+		{name: "single dot segments are collapsed", path: "./src/./app.ts", root: "/repo", want: "/repo/src/app.ts"},
+		{name: "mixed traversal is collapsed", path: "src/../lib/app.ts", root: "/repo", want: "/repo/lib/app.ts"},
+		{name: "windows dotdot is collapsed", path: `..\..\secret.txt`, root: `C:\Users\dev\project`, want: `C:\Users\secret.txt`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := clineWorkspacePath(tc.path, tc.root); got != tc.want {
@@ -635,6 +639,27 @@ func TestClineEventTaskCancelIsAnEndNotAnError(t *testing.T) {
 	// A cancelled task still reports what it spent.
 	if got := nested(t, event, "gen_ai", "usage")["input_tokens"]; got != float64(40) {
 		t.Errorf("gen_ai.usage.input_tokens = %v, want 40", got)
+	}
+}
+
+// Cline's file-based hook puts completionStatus inside taskCancel.taskMetadata. When only
+// that nested field says "abandoned", the cancel reason must reflect it rather than defaulting.
+func TestClineEventTaskCancelReadsNestedCompletionStatus(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"hookName": "TaskCancel",
+		"taskId":   "task-abandoned",
+		"taskCancel": map[string]interface{}{
+			"taskMetadata": map[string]interface{}{
+				"completionStatus": "abandoned",
+			},
+		},
+	})
+
+	event := clineEventWithAction(t, logPath, "session.ended")
+	if got := nested(t, event, "session")["cancel_reason"]; got != "abandoned" {
+		t.Errorf("session.cancel_reason = %v, want abandoned", got)
 	}
 }
 

--- a/cli/beacon-hooks/cmd/cline_event_test.go
+++ b/cli/beacon-hooks/cmd/cline_event_test.go
@@ -487,10 +487,13 @@ func TestClineStageRecognizesSpellingVariants(t *testing.T) {
 		"tool_call_after":  clineStageToolAfter,
 		"afterRun":         clineStageTaskEnd,
 		"session_shutdown": clineStageTaskEnd,
-		"TaskCancel":       clineStageTaskCancel,
-		"stop_error":       clineStageTaskError,
-		"iteration_start":  "",
-		"":                 "",
+		// A cancel and a failure are different outcomes and must not share a stage.
+		"TaskCancel":      clineStageTaskCancel,
+		"task_cancel":     clineStageTaskCancel,
+		"stop_error":      clineStageTaskError,
+		"error":           clineStageTaskError,
+		"iteration_start": "",
+		"":                "",
 	} {
 		t.Run(input, func(t *testing.T) {
 			if got := clineStage(map[string]interface{}{"type": input}); got != want {
@@ -568,5 +571,87 @@ func TestClineWorkspacePathIsHostIndependent(t *testing.T) {
 				t.Errorf("clineWorkspacePath(%q, %q) = %q, want %q", tc.path, tc.root, got, tc.want)
 			}
 		})
+	}
+}
+
+// An error object with no message-like field is still a failure. Treating its empty text as "no
+// error" recorded a failed tool call as a successful one -- the quietest way to be wrong, because
+// the event still writes and reads as ordinary activity.
+func TestClineEventToolFailureWithoutAMessage(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		errValue interface{}
+		wantType string
+	}{
+		{name: "name only", errValue: map[string]interface{}{"name": "ENOENT"}, wantType: "ENOENT"},
+		{name: "type and code", errValue: map[string]interface{}{"type": "spawn_failed", "code": float64(2)}, wantType: "spawn_failed"},
+		{name: "numeric code only", errValue: map[string]interface{}{"code": float64(2)}, wantType: "tool_error"},
+		{name: "empty object", errValue: map[string]interface{}{}, wantType: "tool_error"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logPath := clineTestLog(t)
+			runHookWithInput(t, runClineEvent, map[string]interface{}{
+				"type":     "afterTool",
+				"taskId":   "task-1",
+				"toolCall": map[string]interface{}{"name": "read_file", "input": map[string]interface{}{"path": "missing.ts"}},
+				"error":    tc.errValue,
+			})
+
+			event := clineEventWithAction(t, logPath, "tool.failed")
+			if got := event["severity"]; got != "high" {
+				t.Errorf("severity = %q, want high", got)
+			}
+			if got := nested(t, event, "error")["type"]; got != tc.wantType {
+				t.Errorf("error.type = %q, want %q", got, tc.wantType)
+			}
+		})
+	}
+}
+
+// A cancel is a person stopping their own task, not an incident. Recorded as session.error at high
+// severity it counted every deliberate stop as a failure, inflating error rollups and tripping
+// alerts on the most ordinary thing anyone does with an agent.
+func TestClineEventTaskCancelIsAnEndNotAnError(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"hookName": "TaskCancel",
+		"taskId":   "task-cancelled",
+		"usage":    map[string]interface{}{"inputTokens": 40, "outputTokens": 5},
+	})
+
+	event := clineEventWithAction(t, logPath, "session.ended")
+	if got := event["severity"]; got != "info" {
+		t.Errorf("severity = %q, want info", got)
+	}
+	if _, ok := event["error"]; ok {
+		t.Errorf("cancel carried an error field: %v", event["error"])
+	}
+	// The reason field is what lets a rollup separate cancels from completions without parsing the
+	// message text.
+	if got := nested(t, event, "session")["cancel_reason"]; got != "cancelled" {
+		t.Errorf("session.cancel_reason = %v, want cancelled", got)
+	}
+	// A cancelled task still reports what it spent.
+	if got := nested(t, event, "gen_ai", "usage")["input_tokens"]; got != float64(40) {
+		t.Errorf("gen_ai.usage.input_tokens = %v, want 40", got)
+	}
+}
+
+func TestClineEventTaskErrorStaysAnError(t *testing.T) {
+	logPath := clineTestLog(t)
+
+	runHookWithInput(t, runClineEvent, map[string]interface{}{
+		"hookName": "stop_error",
+		"taskId":   "task-failed",
+		"error":    map[string]interface{}{"name": "provider_timeout"},
+	})
+
+	event := clineEventWithAction(t, logPath, "session.error")
+	if got := event["severity"]; got != "high" {
+		t.Errorf("severity = %q, want high", got)
+	}
+	if got := nested(t, event, "error")["type"]; got != "provider_timeout" {
+		t.Errorf("error.type = %q, want provider_timeout", got)
 	}
 }

--- a/cli/beacon-hooks/cmd/cline_event_test.go
+++ b/cli/beacon-hooks/cmd/cline_event_test.go
@@ -576,6 +576,15 @@ func TestClineWorkspacePathIsHostIndependent(t *testing.T) {
 		{name: "traversal above a drive root keeps the drive", path: `..\..\..\x.ts`, root: `C:\repo`, want: `C:\x.ts`},
 		// A leading "//" is a share, not a doubled separator, and path.Clean would collapse it.
 		{name: "unc share survives cleaning", path: `..\b.ts`, root: `\\server\share\repo\pkg`, want: `\\server\share\repo\b.ts`},
+		// A bare volume leaves nothing after the prefix, and path.Join drops empty elements -- which
+		// ran the share and the path together as "\\server\sharesrc\app.ts".
+		{name: "bare unc share keeps its separator", path: "src/app.ts", root: `\\server\share`, want: `\\server\share\src\app.ts`},
+		{name: "unc share with trailing separator", path: "src/app.ts", root: `\\server\share\`, want: `\\server\share\src\app.ts`},
+		{name: "bare server keeps its separator", path: "src/app.ts", root: `\\server`, want: `\\server\src\app.ts`},
+		// A workspace root of "C:" means that drive's root, not a path relative to its working
+		// directory, so the result is rooted rather than the drive-relative "C:src\app.ts".
+		{name: "bare drive root is rooted", path: "src/app.ts", root: "C:", want: `C:\src\app.ts`},
+		{name: "forward slash unc share keeps its separator", path: "src/app.ts", root: "//server/share", want: "//server/share/src/app.ts"},
 
 		{name: "dotdot segments are collapsed", path: "../../.ssh/id_rsa", root: "/home/u/proj", want: "/home/.ssh/id_rsa"},
 		{name: "single dot segments are collapsed", path: "./src/./app.ts", root: "/repo", want: "/repo/src/app.ts"},

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -88,7 +88,13 @@ func resolveBranch(input map[string]interface{}, cwd string) string {
 // such as a file edit identified only by its path; it is never used for
 // repository, which must reflect the actual workspace path.
 func applyWorkspaceFields(fields map[string]interface{}, input map[string]interface{}, fallbackDir string) {
-	cwd := resolveCwd(input, platformFlag)
+	applyWorkspaceFieldsForPlatform(fields, input, fallbackDir, platformFlag)
+}
+
+// applyWorkspaceFieldsForPlatform is applyWorkspaceFields for a named runtime. See
+// sessionFieldsForPlatform for why a single-runtime mapper should name its runtime.
+func applyWorkspaceFieldsForPlatform(fields map[string]interface{}, input map[string]interface{}, fallbackDir, platform string) {
+	cwd := resolveCwd(input, platform)
 	if cwd != "" {
 		fields["session"] = mergeNested(fields["session"], map[string]interface{}{"working_directory": cwd})
 		if existing, ok := fields["repository"]; !ok || existing == "" {
@@ -195,12 +201,24 @@ func firstHookEnv(keys ...string) string {
 }
 
 func sessionFields(sessionID string, input map[string]interface{}) map[string]interface{} {
+	return sessionFieldsForPlatform(sessionID, input, platformFlag)
+}
+
+// sessionFieldsForPlatform builds the same fields for a named runtime rather than for whichever
+// --platform the binary happened to be invoked with.
+//
+// A mapper that only ever handles one runtime's payloads should say which one. Reading the flag
+// instead made the workspace resolution depend on the invocation: a Cline payload processed without
+// --platform cline fell through to the default reader, found none of Cline's keys, and produced an
+// event with no working directory, no repository and no branch -- while the file path in the same
+// event resolved correctly, because that path already asked for the Cline shape by name.
+func sessionFieldsForPlatform(sessionID string, input map[string]interface{}, platform string) map[string]interface{} {
 	fields := map[string]interface{}{}
 	session := map[string]interface{}{}
 	if sessionID != "" {
 		session["id"] = sessionID
 	}
-	if cwd := resolveCwd(input, platformFlag); cwd != "" {
+	if cwd := resolveCwd(input, platform); cwd != "" {
 		session["working_directory"] = cwd
 		fields["repository"] = cwd
 	}

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -904,6 +904,7 @@ func setupHookConfigDirs(t *testing.T) {
 	origGrokDir := hookconfig.GrokDir
 	origHermesDir := hookconfig.HermesDir
 	origOpenCodeDir := hookconfig.OpenCodeDir
+	origClineDir := hookconfig.ClineDir
 	origPlatform := platformFlag
 	hookconfig.BeaconDir = tmp
 	hookconfig.ClaudeDir = filepath.Join(tmp, "claude")
@@ -916,6 +917,7 @@ func setupHookConfigDirs(t *testing.T) {
 	hookconfig.GrokDir = filepath.Join(tmp, "grok")
 	hookconfig.HermesDir = filepath.Join(tmp, "hermes")
 	hookconfig.OpenCodeDir = filepath.Join(tmp, "opencode")
+	hookconfig.ClineDir = filepath.Join(tmp, "cline")
 	t.Cleanup(func() {
 		hookconfig.BeaconDir = origBeaconDir
 		hookconfig.ClaudeDir = origClaudeDir
@@ -928,6 +930,7 @@ func setupHookConfigDirs(t *testing.T) {
 		hookconfig.GrokDir = origGrokDir
 		hookconfig.HermesDir = origHermesDir
 		hookconfig.OpenCodeDir = origOpenCodeDir
+		hookconfig.ClineDir = origClineDir
 		platformFlag = origPlatform
 	})
 }

--- a/cli/beacon-hooks/internal/diff/diff.go
+++ b/cli/beacon-hooks/internal/diff/diff.go
@@ -43,7 +43,7 @@ func FromToolResponse(toolName string, toolInput, toolResponse map[string]interf
 		content := GetStringFromMaps("code", toolInput, toolResponse)
 		return fromWriteTool(filePath, content, "")
 
-	case "Write", "Create", "write", "write_file":
+	case "Write", "Create", "write", "write_file", "write_to_file":
 		content := GetStringFromMaps("content", toolInput, toolResponse)
 		originalFile := GetStringFromMaps("originalFile", toolInput, toolResponse)
 		return fromWriteTool(filePath, content, originalFile)

--- a/cli/beacon-hooks/internal/diff/diff_test.go
+++ b/cli/beacon-hooks/internal/diff/diff_test.go
@@ -126,3 +126,22 @@ func TestFromCursorEdits_MultilineEdit(t *testing.T) {
 		t.Error("Missing file header")
 	}
 }
+
+// Cline's write tool is spelled write_to_file. Without it in the Write case, FromToolResponse
+// returns nothing and a created file reaches the log as raw content with no diff metadata.
+func TestFromToolResponse_ClineWriteToFile(t *testing.T) {
+	got := FromToolResponse(
+		"write_to_file",
+		map[string]interface{}{"path": "src/health.ts", "content": "export const health = () => true\n"},
+		nil,
+	)
+	if !strings.Contains(got, "--- a/health.ts") || !strings.Contains(got, "+++ b/health.ts") {
+		t.Fatalf("diff header = %q, want the file named in both halves", got)
+	}
+	if !strings.Contains(got, "@@ -0,0 +1,") {
+		t.Errorf("diff = %q, want a new-file hunk header", got)
+	}
+	if !strings.Contains(got, "+export const health") {
+		t.Errorf("diff = %q, want the written content as added lines", got)
+	}
+}

--- a/cli/beacon-hooks/testdata/cline/README.md
+++ b/cli/beacon-hooks/testdata/cline/README.md
@@ -1,0 +1,25 @@
+# Cline payload fixtures
+
+These payloads are **constructed from Cline's published hook documentation, not captured from a
+running Cline install**. That is a deliberate limitation of this pack and the reason the mapper's
+readers accept several spellings per field: Cline documents the base fields every hook receives
+(`clineVersion`, `hookName`, `timestamp`, `taskId`, `workspaceRoots`, `userId`) and the hook
+handlers a plugin implements (`beforeRun`, `beforeTool`, `afterTool`, `afterRun`), but not the field
+names inside each handler's context object.
+
+What the fixtures do pin is the part Beacon controls: the envelope the Beacon-managed Cline plugin
+sends to `beacon-hooks --platform cline cline-event`. The mapper's job is to turn that envelope into
+endpoint events, and these files are that contract.
+
+Covered payloads:
+
+- `task_start.json` — `beforeRun` carrying the message that started the task
+- `tool_after_write.json` — `afterTool` for `write_to_file`, with a workspace-relative path
+- `tool_after_command.json` — `afterTool` for `execute_command`, with output and an exit code
+- `run_end_usage.json` — `afterRun` with runtime-reported token counts and cost
+
+Replace a fixture with a captured payload whenever one becomes available, and keep the field
+tolerance in the mapper until every fixture here is a real capture.
+
+Keep secrets and real prompt content out of fixtures. Use sanitized payloads that preserve the
+field shape needed by `beacon-hooks --platform cline cline-event`.

--- a/cli/beacon-hooks/testdata/cline/run_end_usage.json
+++ b/cli/beacon-hooks/testdata/cline/run_end_usage.json
@@ -1,0 +1,16 @@
+{
+  "type": "afterRun",
+  "clineVersion": "3.36.0",
+  "hookName": "afterRun",
+  "timestamp": "2026-08-21T10:16:30Z",
+  "taskId": "task-3f9c1d",
+  "workspaceRoots": ["/Users/example/projects/beacon-demo"],
+  "result": {
+    "usage": {
+      "inputTokens": 1841,
+      "outputTokens": 412,
+      "cacheReadTokens": 1024,
+      "totalCost": 0.0231
+    }
+  }
+}

--- a/cli/beacon-hooks/testdata/cline/task_start.json
+++ b/cli/beacon-hooks/testdata/cline/task_start.json
@@ -1,0 +1,14 @@
+{
+  "type": "beforeRun",
+  "clineVersion": "3.36.0",
+  "hookName": "beforeRun",
+  "timestamp": "2026-08-21T10:15:00Z",
+  "taskId": "task-3f9c1d",
+  "userId": "user-local",
+  "workspaceRoots": ["/Users/example/projects/beacon-demo"],
+  "apiProvider": "anthropic",
+  "modelId": "claude-sonnet-4",
+  "input": {
+    "text": "Add a health endpoint, then run the tests"
+  }
+}

--- a/cli/beacon-hooks/testdata/cline/tool_after_command.json
+++ b/cli/beacon-hooks/testdata/cline/tool_after_command.json
@@ -1,0 +1,20 @@
+{
+  "type": "afterTool",
+  "clineVersion": "3.36.0",
+  "hookName": "afterTool",
+  "timestamp": "2026-08-21T10:16:03Z",
+  "taskId": "task-3f9c1d",
+  "workspaceRoots": ["/Users/example/projects/beacon-demo"],
+  "toolCall": {
+    "name": "execute_command",
+    "input": {
+      "command": "npm test",
+      "requires_approval": false
+    }
+  },
+  "durationMs": 4120,
+  "result": {
+    "output": "2 passing",
+    "exitCode": 0
+  }
+}

--- a/cli/beacon-hooks/testdata/cline/tool_after_write.json
+++ b/cli/beacon-hooks/testdata/cline/tool_after_write.json
@@ -1,0 +1,20 @@
+{
+  "type": "afterTool",
+  "clineVersion": "3.36.0",
+  "hookName": "afterTool",
+  "timestamp": "2026-08-21T10:15:42Z",
+  "taskId": "task-3f9c1d",
+  "workspaceRoots": ["/Users/example/projects/beacon-demo"],
+  "toolCall": {
+    "name": "write_to_file",
+    "input": {
+      "path": "src/health.ts",
+      "content": "export const health = () => ({ ok: true })\n"
+    }
+  },
+  "callId": "call-7a2",
+  "durationMs": 34,
+  "result": {
+    "output": "File written"
+  }
+}


### PR DESCRIPTION
Fourth of nine PRs adding [Cline](https://cline.bot/) as a supported runtime surface.
**Stacked on #358.** This is the substantive one — the event semantics live here.

## What changed

`cline-event`: one command that receives a Cline lifecycle payload on stdin and writes the endpoint
events it justifies. Cline delivers hooks through an in-process plugin whose handlers all fire in
the same process, so a single typed envelope fits better than a command per hook — the same shape
opencode uses.

| Lifecycle point | Events |
|---|---|
| Task start | `session.started`, plus `prompt.submitted` when the payload carries the message that started the task |
| Prompt submission | `prompt.submitted` |
| Tool invocation | `tool.invoked` |
| Tool completion | `tool.completed` / `file.read` / `file.modified` / `command.executed` / `mcp.tool_invoked`, or `tool.failed` |
| Task end | `session.ended` with `gen_ai.usage` |
| Task error | `session.error` |

## Why stage names are matched loosely

Cline names the same lifecycle point three ways, and Beacon has to accept all of them because two
different surfaces produce these payloads:

- the plugin SDK exposes **handlers** — `beforeTool`, `afterRun`
- its documented **stage list** spells them differently — `tool_call_before`, `run_end`
- its **file-based hooks** name the script after the hook and pass that name back in the `hookName`
  base field — `PreToolUse`, `TaskStart`

`clineStage` matches on letters and digits only, lowercased, so all three reduce to one comparison
instead of a case list per spelling. That is what lets **one mapper serve both Cline surfaces**
instead of two mappers disagreeing about the same task. An unrecognized stage writes nothing —
Cline streams far more runtime events than the points above, and a generic "something happened" row
per event would bury the log.

## Three decisions worth reviewing

**Token usage is read at exactly one lifecycle point.** Beacon's rollups sum `gen_ai.usage` across
events, so reporting the same tokens at a per-model-call stage *as well* would double every Cline
task's token count. Task end is also the only place Cline documents usage (on the run result), so
it needs no guessed field path. Cost is only ever what Cline reported — nothing is derived from a
local price table. Both are pinned by tests
(`TestClineEventReportsUsageOnlyAtTaskEnd`, `TestClineEventDoesNotInventCost`).

The cost is granularity: per-task totals rather than per-turn. Moving to per-turn means *dropping*
the task-end read in the same change, not adding a second one.

**Workspace-relative paths are resolved against the workspace root.** Cline addresses files
relative to the workspace — `read_file` receives `src/app.ts` — while every other supported runtime
reports absolute paths. Left relative, a Cline file event is not comparable with the same file seen
through Cursor or Claude Code, and a threat rule matching an absolute path never fires on Cline
activity. Skipped when the path is already absolute, and when no root was resolved: a wrong root is
worse than a relative path, because it names a file that was never touched.

**A file action with no file becomes `tool.completed`.** Cline's search tools take a pattern rather
than a path, and a `file.read` carrying no `file` field matches every file-scoped query and explains
none. (This is slightly stricter than the opencode mapper, which guards only `file.modified`.)

## Diffs

`write_to_file` is added to the shared diff builder's write case, so a file Cline created reaches
the log as an added-lines diff with hash and byte count instead of raw content.
`replace_in_file` deliberately bypasses the builder: its `diff` argument is already a diff, so
passing it through records what Cline actually applied rather than an approximation reconstructed
from the pieces.

One thing I got wrong and removed rather than kept: I first substituted the resolved absolute path
into the builder's input so diff headers would match `file.path`. The shared builder names files by
base name in headers for every runtime, so the substitution was a no-op. It is gone.

## Fixtures: constructed, not captured

`testdata/cline/` payloads are built **from Cline's published hook documentation, not captured from
a running install**, and the README there says so plainly. Cline documents the base fields
(`clineVersion`, `hookName`, `timestamp`, `taskId`, `workspaceRoots`, `userId`) and the handlers a
plugin implements, but **not the field names inside each handler's context object**. That is why the
readers accept several spellings per field, and the tolerance should stay until every fixture is a
real capture.

What the fixtures *do* pin is the envelope the Beacon-managed plugin sends — Beacon's own contract,
defined here and produced by the plugin in PR 5.

## Tests

67 passing cases. Both notable behaviours were mutation-tested rather than assumed:

| Mutation | Caught by |
|---|---|
| drop the workspace-root join | `TestClineEventResolvesWorkspaceRelativePaths`, `TestClineEventWriteToFileRecordsDiff` |
| narrow the `file.*` guard to `file.modified` | `TestClineEventFileActionWithoutAPathBecomesToolCompleted` |

Also covered: prompt redaction end-to-end, provider-qualified model, session id from `taskId`,
`exit_code: 0` surviving as a real value, MCP classification, tool failure severity, empty payload
not failing the hook (Cline runs these in-process — an error would surface in the user's editor),
every spelling in `supportedClineEventTypes()` producing at least one event, and token-vs-substring
tool classification (`spreadsheet_export` is not a file read).

`ClineDir` was added to `setupHookConfigDirs` so tests never write to a real `~/.beacon/cline`.

```
cli/beacon-hooks gofmt -l .    (clean)
cli/beacon-hooks go vet ./...  ok
cli/beacon-hooks go test ./... ok
```

## Known gaps, deliberate

- **No approval events.** Cline requires approval for actions by default, but the documented hook
  context does not carry the approval state — `auto_approved` exists only as an OTel analytics
  attribute. Inventing an approval decision from a `beforeTool` firing would be wrong; the raw
  payload is preserved under `raw.cline`, so nothing is lost, and real approval events can be added
  once a capture shows the field.
- **No enforcement.** `beforeTool` can block, which maps onto the existing `BEACON_POLICY_PROVIDER`
  seam, but that is a change to the enforcement surface and belongs in its own PR after the
  observation path is verified.

---
_Generated by [Claude Code](https://claude.ai/code/session_011wJyrxj9Wf7cP23bap1K7E)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Defines Cline telemetry semantics (paths, diffs, prompts, usage, failure vs cancel) that feed detection and rollups. Observation-only; no auth or enforcement changes.
> 
> **Overview**
> Adds a single `cline-event` command that turns Cline plugin/file-hook payloads into Beacon endpoint events (session, prompt, tools, usage). One mapper covers both Cline surfaces by normalizing stage names (`beforeRun` / `run_start` / `TaskStart`, etc.); unknown stages are dropped.
> 
> Task start can emit both `session.started` and `prompt.submitted`. Tool completions classify into file/command/MCP actions (or `tool.failed` when an error object is present). Cancels are `session.ended` with `cancel_reason`, not errors. Token usage and reported cost are attached only at task end so rollups do not double-count.
> 
> Workspace-relative Cline paths are joined to the workspace root with host-independent POSIX/Windows/UNC handling so file events match other runtimes and path-based rules. Shared workspace helpers now take an explicit platform name so Cline cwd resolution does not depend on `--platform`. `write_to_file` is recognized by the shared diff builder; `replace_in_file` keeps Cline’s own diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d726c334849c5ff34a2f03215303455951d3849e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->