### PR TITLE
Cline support 7/9: discover Cline and inventory its managed plugin

### DIFF
--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -55,6 +55,7 @@ func DiscoverAll() []Harness {
 		DiscoverAntigravity(),
 		DiscoverCopilotCLI(),
 		DiscoverOpenCode(),
+		DiscoverCline(),
 		DiscoverPi(),
 		DiscoverHermes(),
 		DiscoverFactory(),
@@ -170,6 +171,38 @@ func DiscoverOpenCode() Harness {
 	} else {
 		h.TelemetryStatus = TelemetryMissing
 		h.Message = "Beacon opencode plugin was not found"
+	}
+	return h
+}
+
+// DiscoverCline reports whether Cline is present and whether Beacon's plugin is installed for it.
+//
+// Unlike every other hook runtime, Cline cannot be found by looking for an executable. It runs as a
+// VS Code extension, a JetBrains plugin, and a CLI over one agent core, and the two IDE hosts ship
+// no `cline` binary at all -- so a binary probe reports "not detected" on the majority of real
+// installs. The ~/.cline directory is what every host shares, and the CLI binary is treated as an
+// extra signal rather than the deciding one.
+func DiscoverCline() Harness {
+	h := Harness{Name: "cline", DisplayName: "Cline", Capability: "plugin"}
+	detectExecutable(&h, "cline")
+	home, _ := os.UserHomeDir()
+	pluginPath := filepath.Join(home, ".cline", "plugins", "beacon.ts")
+	h.ConfigPath = pluginPath
+	if !h.Detected && dirExists(filepath.Join(home, ".cline")) {
+		h.Detected = true
+	}
+	if fileExists(pluginPath) {
+		data, _ := os.ReadFile(pluginPath)
+		if strings.Contains(string(data), "beacon-managed-cline-plugin:v1") {
+			h.TelemetryStatus = TelemetryEnabled
+			h.Message = "Beacon Cline plugin is configured"
+		} else {
+			h.TelemetryStatus = TelemetryDisabled
+			h.Message = "Cline plugin file exists but Beacon endpoint plugin was not found"
+		}
+	} else {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = "Beacon Cline plugin was not found"
 	}
 	return h
 }

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/integrations/cowork"
 	"gopkg.in/yaml.v3"
 )
@@ -185,15 +186,24 @@ func DiscoverOpenCode() Harness {
 func DiscoverCline() Harness {
 	h := Harness{Name: "cline", DisplayName: "Cline", Capability: "plugin"}
 	detectExecutable(&h, "cline")
-	home, err := os.UserHomeDir()
+	// The guard below is the point: Cline's project install is ".cline/plugins/beacon.ts", the user
+	// layout with the home prefix removed, so an unresolved home directory does not merely produce a
+	// useless path -- it produces exactly the path a project install occupies. Discovery would read
+	// a repository's own plugin and report Cline detected with telemetry enabled for the machine, on
+	// the strength of a file in whatever directory the command ran from. DiscoverPi guards the same
+	// way.
+	//
+	// The path comes from the installer rather than being rebuilt here so there is one definition of
+	// where the plugin lives; two copies is how discovery comes to report on a file the installer
+	// does not write.
+	pluginPath, err := hooks.ClinePluginPath(hooks.LevelUser)
 	if err != nil {
 		h.TelemetryStatus = TelemetryMissing
 		h.Message = "Cline plugin directory could not be resolved: " + err.Error()
 		return h
 	}
-	pluginPath := filepath.Join(home, ".cline", "plugins", "beacon.ts")
 	h.ConfigPath = pluginPath
-	if !h.Detected && dirExists(filepath.Join(home, ".cline")) {
+	if !h.Detected && dirExists(filepath.Dir(filepath.Dir(pluginPath))) {
 		h.Detected = true
 	}
 	if fileExists(pluginPath) {

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -185,7 +185,12 @@ func DiscoverOpenCode() Harness {
 func DiscoverCline() Harness {
 	h := Harness{Name: "cline", DisplayName: "Cline", Capability: "plugin"}
 	detectExecutable(&h, "cline")
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = "Cline plugin directory could not be resolved: " + err.Error()
+		return h
+	}
 	pluginPath := filepath.Join(home, ".cline", "plugins", "beacon.ts")
 	h.ConfigPath = pluginPath
 	if !h.Detected && dirExists(filepath.Join(home, ".cline")) {

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -843,3 +843,45 @@ func TestDiscoverAllIncludesCline(t *testing.T) {
 	}
 	t.Fatal("DiscoverAll does not include cline")
 }
+
+// An unresolvable home directory must stop Cline discovery rather than produce a relative path.
+//
+// Cline is the sharpest case for this in the whole harness set: its project install is
+// ".cline/plugins/beacon.ts", which is the user layout with the home prefix removed. A relative
+// path therefore lands exactly where a project install lives, so discovery would read a
+// repository's own plugin and report Cline detected with telemetry enabled for the machine -- on
+// the strength of a file in whatever directory the command happened to run from.
+//
+// An empty HOME is not hypothetical for this binary: system-mode Beacon runs under launchd, and
+// some CI runners leave it unset.
+func TestDiscoverClineDoesNotFallBackToAProjectPluginWhenHomeIsUnresolvable(t *testing.T) {
+	work := t.TempDir()
+	t.Chdir(work)
+	t.Setenv("PATH", t.TempDir())
+	// An empty HOME is what makes os.UserHomeDir fail; USERPROFILE is cleared for the same reason on
+	// Windows.
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+
+	pluginPath := filepath.Join(work, ".cline", "plugins", "beacon.ts")
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0755); err != nil {
+		t.Fatalf("mkdir project plugin dir: %v", err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("// beacon-managed-cline-plugin:v1"), 0644); err != nil {
+		t.Fatalf("write project plugin: %v", err)
+	}
+
+	h := DiscoverCline()
+	if h.TelemetryStatus == TelemetryEnabled {
+		t.Errorf("TelemetryStatus = %q; a project plugin was reported as the user install", h.TelemetryStatus)
+	}
+	if h.ConfigPath != "" {
+		t.Errorf("ConfigPath = %q, want empty when the home directory cannot be resolved", h.ConfigPath)
+	}
+	if h.Detected {
+		t.Errorf("Detected = true from a project directory with no resolvable home")
+	}
+	if !strings.Contains(h.Message, "could not be resolved") {
+		t.Errorf("Message = %q, want it to name the unresolved directory", h.Message)
+	}
+}

--- a/cli/beacon/internal/endpoint/harness/harness_test.go
+++ b/cli/beacon/internal/endpoint/harness/harness_test.go
@@ -765,3 +765,81 @@ func clearCopilotEnv(t *testing.T) {
 		t.Setenv(key, "")
 	}
 }
+
+// Cline is the one hook runtime that cannot be found by looking for an executable: it runs as a VS
+// Code extension, a JetBrains plugin and a CLI over one agent core, and the two IDE hosts ship no
+// `cline` binary. Detecting on the directory alone is deliberate here, and the opposite of what
+// DiscoverCodex and DiscoverGemini do -- a binary probe would report "not detected" on the majority
+// of real Cline installs.
+func TestDiscoverClineDetectsConfigDirectoryWithoutAnExecutable(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	t.Setenv("PATH", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(home, ".cline"), 0755); err != nil {
+		t.Fatalf("mkdir cline config dir: %v", err)
+	}
+
+	h := DiscoverCline()
+	if !h.Detected {
+		t.Fatalf("DiscoverCline did not detect Cline from its config directory: %#v", h)
+	}
+	if h.ExecutablePath != "" {
+		t.Fatalf("ExecutablePath = %q, want empty with no binary on PATH", h.ExecutablePath)
+	}
+	if h.TelemetryStatus != TelemetryMissing {
+		t.Fatalf("TelemetryStatus = %q, want %q", h.TelemetryStatus, TelemetryMissing)
+	}
+	if h.ConfigPath != filepath.Join(home, ".cline", "plugins", "beacon.ts") {
+		t.Fatalf("ConfigPath = %q, want the managed plugin path", h.ConfigPath)
+	}
+}
+
+func TestDiscoverClineTelemetryStatusVariants(t *testing.T) {
+	cases := []struct {
+		name    string
+		plugin  string
+		want    TelemetryStatus
+		message string
+	}{
+		{name: "managed plugin", plugin: "// beacon-managed-cline-plugin:v1\nexport default {}", want: TelemetryEnabled, message: "configured"},
+		// Someone else's plugin at Beacon's path. Reporting that as enabled would claim telemetry
+		// Beacon is not collecting.
+		{name: "unmanaged plugin", plugin: "export default { name: \"someone-else\" }", want: TelemetryDisabled, message: "was not found"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			testenv.SetHome(t, home)
+			t.Setenv("PATH", t.TempDir())
+			pluginPath := filepath.Join(home, ".cline", "plugins", "beacon.ts")
+			if err := os.MkdirAll(filepath.Dir(pluginPath), 0755); err != nil {
+				t.Fatalf("mkdir cline plugin dir: %v", err)
+			}
+			if err := os.WriteFile(pluginPath, []byte(tc.plugin), 0644); err != nil {
+				t.Fatalf("write cline plugin: %v", err)
+			}
+
+			h := DiscoverCline()
+			if h.TelemetryStatus != tc.want {
+				t.Fatalf("TelemetryStatus = %q, want %q", h.TelemetryStatus, tc.want)
+			}
+			if !strings.Contains(h.Message, tc.message) {
+				t.Fatalf("Message = %q, want it to mention %q", h.Message, tc.message)
+			}
+		})
+	}
+}
+
+// A runtime missing from DiscoverAll is invisible to `beacon endpoint discover`, which is where an
+// operator looks to find out whether Beacon can see their agent at all.
+func TestDiscoverAllIncludesCline(t *testing.T) {
+	for _, h := range DiscoverAll() {
+		if h.Name == "cline" {
+			if h.DisplayName != "Cline" || h.Capability != "plugin" {
+				t.Fatalf("cline harness = %#v, want display name Cline and capability plugin", h)
+			}
+			return
+		}
+	}
+	t.Fatal("DiscoverAll does not include cline")
+}

--- a/cli/beacon/internal/endpoint/hooks/cline.go
+++ b/cli/beacon/internal/endpoint/hooks/cline.go
@@ -164,6 +164,15 @@ func isClineInstalledAt(path string) bool {
 // project-scoped ones, and discovers a bare .ts file dropped into either. That is why Beacon writes
 // a file rather than running `cline plugin install`: no CLI has to be present, and an install works
 // the same for the VS Code and JetBrains hosts, which ship no `cline` binary at all.
+// ClinePluginPath is where Beacon installs its managed Cline plugin for the given level.
+//
+// Exported so discovery asks the installer where the plugin lives instead of rebuilding the path
+// itself. Two copies of that path is how discovery comes to report on a file the installer does not
+// write.
+func ClinePluginPath(level Level) (string, error) {
+	return clinePluginPath(level)
+}
+
 func clinePluginPath(level Level) (string, error) {
 	dir, err := clinePluginDir(level)
 	if err != nil {

--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -201,6 +201,7 @@ func candidates(home, wd string) []candidate {
 	items = append(items, factoryCandidates(home, wd)...)
 	items = append(items, copilotCandidates(home)...)
 	items = append(items, opencodeCandidates(home, wd)...)
+	items = append(items, clineCandidates(home, wd)...)
 	items = append(items, hermesCandidates(home)...)
 	items = append(items, devinCandidates(home, wd)...)
 	items = append(items, grokCandidates(home, wd)...)
@@ -280,6 +281,13 @@ func opencodeCandidates(home, wd string) []candidate {
 	return []candidate{
 		{runtime: "opencode", path: filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
 		{runtime: "opencode", path: filepath.Join(wd, ".opencode", "plugins", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
+	}
+}
+
+func clineCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "cline", path: filepath.Join(home, ".cline", "plugins", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
+		{runtime: "cline", path: filepath.Join(wd, ".cline", "plugins", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
 	}
 }
 
@@ -612,6 +620,8 @@ func beaconManaged(item candidate, data []byte) bool {
 		}
 	case "opencode":
 		return strings.Contains(text, "beacon-managed-opencode-plugin:v1")
+	case "cline":
+		return strings.Contains(text, "beacon-managed-cline-plugin:v1")
 	case "grok":
 		return strings.Contains(text, "beacon-managed-grok-hooks:v1")
 	}

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -338,6 +338,8 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 		{runtime: "copilot_cli", path: filepath.Join(home, ".bash_profile"), scope: ScopeUser, format: formatMetadataOnly, kind: KindProfile},
 		{runtime: "opencode", path: filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
 		{runtime: "opencode", path: filepath.Join(work, ".opencode", "plugins", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
+		{runtime: "cline", path: filepath.Join(home, ".cline", "plugins", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
+		{runtime: "cline", path: filepath.Join(work, ".cline", "plugins", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
 		{runtime: "hermes", path: filepath.Join(home, ".hermes", "config.yaml"), scope: ScopeUser, format: formatYAML, kind: KindNativeConfig},
 		{runtime: "devin-cli", path: filepath.Join(home, ".config", "devin", "config.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
 		{runtime: "devin-cli", path: filepath.Join(work, ".devin", "hooks.v1.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
@@ -375,6 +377,7 @@ mcpServers:
       - mcp-server-memory
 `)
 	writeFile(t, filepath.Join(home, ".config", "opencode", "plugins", "beacon.ts"), `// beacon-managed-opencode-plugin:v1`)
+	writeFile(t, filepath.Join(home, ".cline", "plugins", "beacon.ts"), `// beacon-managed-cline-plugin:v1`)
 	writeFile(t, filepath.Join(home, ".zshrc"), `export OTEL_TELEMETRY_ENDPOINT=http://127.0.0.1:4318`)
 
 	result := Scan(Options{
@@ -393,6 +396,19 @@ mcpServers:
 	}
 	if opencode.ParserMode != formatMetadataOnly || opencode.ConfigKind != KindPlugin {
 		t.Fatalf("opencode mode/kind = %s/%s, want %s/%s", opencode.ParserMode, opencode.ConfigKind, formatMetadataOnly, KindPlugin)
+	}
+	// Each plugin runtime needs its own marker case in beaconManaged; a missing one reports an
+	// installed plugin as unmanaged, which is how an inventory comes to show telemetry as absent on
+	// a machine that has it.
+	cline := findConfig(result.Configs, "cline", filepath.Join(home, ".cline", "plugins", "beacon.ts"))
+	if cline == nil {
+		t.Fatal("cline metadata-only config not found")
+	}
+	if cline.ParserStatus != StatusOK || !cline.BeaconManaged {
+		t.Fatalf("cline status = %s managed=%t, want ok/managed", cline.ParserStatus, cline.BeaconManaged)
+	}
+	if cline.ParserMode != formatMetadataOnly || cline.ConfigKind != KindPlugin {
+		t.Fatalf("cline mode/kind = %s/%s, want %s/%s", cline.ParserMode, cline.ConfigKind, formatMetadataOnly, KindPlugin)
 	}
 	factoryProfile := findConfig(result.Configs, "factory", filepath.Join(home, ".zshrc"))
 	if factoryProfile == nil {

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -808,6 +808,8 @@ func configureHarnesses(cfg endpointconfig.Config) ([]string, error) {
 			paths = append(paths, path)
 		case "opencode":
 			return paths, fmt.Errorf("opencode telemetry is installed with `beacon endpoint hooks install --harness opencode`, not endpoint install")
+		case "cline":
+			return paths, fmt.Errorf("Cline telemetry is installed with `beacon endpoint hooks install --harness cline`, not endpoint install")
 		case "copilot", "copilot_cli", "github_copilot":
 			return paths, fmt.Errorf("Copilot CLI telemetry is MDM-managed; set COPILOT_OTEL_ENABLED=true and OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:%d in the Copilot CLI launch environment instead of using --harness %s", cfg.Collector.HTTPPort, name)
 		case "factory", "droid":

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -259,6 +259,17 @@ func TestConfigureHarnessesRejectsOpenCodeAsHookManaged(t *testing.T) {
 	}
 }
 
+// Cline telemetry is a plugin, not an OTLP endpoint setting, so `endpoint install --harness cline`
+// has nothing to configure. Saying so names the command that does work; falling through to
+// "unsupported harness" would suggest Cline is not supported at all.
+func TestConfigureHarnessesRejectsClineAsHookManaged(t *testing.T) {
+	cfg := endpointconfig.Config{Harnesses: []string{"cline"}}
+	_, err := configureHarnesses(cfg)
+	if err == nil || !strings.Contains(err.Error(), "endpoint hooks install --harness cline") {
+		t.Fatalf("configureHarnesses error = %v, want the Cline hook-managed error", err)
+	}
+}
+
 func TestConfigureHarnessesAcceptsGemini(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
Seventh of nine PRs adding [Cline](https://cline.bot/) as a supported runtime surface.
**Stacked on #362.**

## What changed

The three places that answer *"is this runtime here, and is Beacon configured for it"*:

| Surface | Change |
|---|---|
| `beacon endpoint discover` | `DiscoverCline()` + its entry in `DiscoverAll()` |
| `beacon endpoint inventory` | `clineCandidates` for both scopes + the `beaconManaged` marker case |
| `beacon endpoint install --harness cline` | guard naming the command that does work |

## Discovery can't work the way it does elsewhere

Every other hook runtime is found by probing `PATH`. Cline runs as a VS Code extension, a JetBrains
plugin, **and** a CLI over one agent core, and the two IDE hosts ship no `cline` binary at all — so
a binary probe reports "not detected" on the majority of real installs.

`~/.cline` is what the hosts share, so that directory is the detection signal and the CLI binary is
an extra rather than the deciding one. This is **deliberately the opposite** of `DiscoverCodex` and
`DiscoverGemini`, which refuse to detect from a config directory alone —
`TestDiscoverClineDetectsConfigDirectoryWithoutAnExecutable` states the contrast and why, so nobody
"fixes" it later to match its neighbours.

Verified against the built CLI, with only `~/.cline` present and an empty `PATH`:

```
$ beacon endpoint discover
…
Cline: detected, telemetry=missing
```

## Inventory needs its own marker case

`beaconManaged` switches on runtime. Without a `cline` case, an installed plugin is reported as
**unmanaged** — which is how an inventory comes to show telemetry as absent on a machine that has it.
Mutation-checked: deleting the case fails `TestScanYAMLAndMetadataOnlyConfigs` with
`cline status = ok managed=false, want ok/managed`.

The exhaustive candidate table in `TestScanIncludesAllSupportedCurrentUserAndProjectConfigs` (which
asserts an exact count) is what forces both the user and project scopes to be registered.

## The install guard names the working command

Cline telemetry is a plugin, not an OTLP endpoint setting, so `endpoint install --harness cline` has
nothing to configure. It now says so and points at `endpoint hooks install --harness cline`. Falling
through to the default `unsupported harness %q` would suggest Cline is not supported at all —
exactly the wrong signal one PR after making it installable.

## Tests

- `TestDiscoverClineDetectsConfigDirectoryWithoutAnExecutable`
- `TestDiscoverClineTelemetryStatusVariants` — including an unmanaged plugin sitting at Beacon's
  path reporting `disabled`, not `enabled`: claiming telemetry Beacon is not collecting is the
  failure that matters here
- `TestDiscoverAllIncludesCline` — a runtime missing from `DiscoverAll` is invisible to
  `endpoint discover`, which is where an operator looks first
- inventory candidate table + managed-marker case
- `TestConfigureHarnessesRejectsClineAsHookManaged`

```
cli/beacon gofmt -l .    (clean)
cli/beacon go test ./...  ok
cli/beacon go test -race ./internal/endpoint/...  ok
```

---
_Generated by [Claude Code](https://claude.ai/code/session_011wJyrxj9Wf7cP23bap1K7E)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only discovery/inventory plus a clearer error path; no new install, auth, or data-handling behavior.
> 
> **Overview**
> Makes Cline visible to `beacon endpoint discover` and `inventory`, and stops `endpoint install --harness cline` from looking like an unsupported runtime.
> 
> **Discovery** now treats `~/.cline` as the presence signal (IDE hosts ship no `cline` binary) and reports telemetry from the user plugin at `hooks.ClinePluginPath`. Unresolved home is a hard fail so a project `.cline/plugins/beacon.ts` cannot be mistaken for a machine-wide install. Enabled requires the `beacon-managed-cline-plugin:v1` marker.
> 
> **Inventory** registers user and project plugin candidates and the same managed-marker case so an installed plugin is not shown as unmanaged.
> 
> **Install** rejects `--harness cline` with a pointer to `beacon endpoint hooks install --harness cline`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5589d6f43cd2de2834c85fbc8d270934154169a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->