### PR TITLE
DRAFT: feat: streamline onboarding

### DIFF
--- a/ONBOARDING_FEEDBACK.md
+++ b/ONBOARDING_FEEDBACK.md
@@ -1,0 +1,464 @@
+# Beacon Installation and Onboarding Feedback
+
+## Executive summary
+
+Beacon needs a shorter, more guided path from “I heard about Beacon” to “I can see activity from
+my local agents.” The desired experience is:
+
+1. Copy and paste one installation command.
+2. Receive a clear, actionable fix for anything that blocks or limits the installation.
+3. Run a guided getting-started flow that inspects the current machine.
+4. Configure relevant runtimes and hooks with minimal prior knowledge.
+5. Open the dashboard and confirm that real events are arriving.
+
+The current pieces largely exist—installation, discovery, doctor, hook management, status, and the
+dashboard—but the user has to discover and assemble the workflow. The Beacon CLI should connect
+these pieces into one coherent onboarding experience and should never leave the user wondering
+what to do next.
+
+## Revised implementation direction: keep onboarding in Go
+
+An initial approach placed most of the workflow in a downloaded shell installer. Testing exposed
+an important architectural problem: the shell duplicated behavior already owned by Beacon, could
+misinterpret child-process output, and behaved differently depending on which released Beacon
+binary it downloaded. It also made the onboarding logic harder to reuse from repair, packages, and
+direct CLI invocation.
+
+The preferred design is now:
+
+```text
+download release archive → verify archive → extract binaries → run Beacon
+                                                        ↓
+                              Go CLI owns the complete onboarding experience
+```
+
+The documented shell commands should remain deliberately small. They should:
+
+1. Resolve the latest stable release.
+2. Map the host architecture to a published archive.
+3. Download the archive and `checksums.txt`.
+4. Verify the exact archive before extraction.
+5. Place the three binaries on `PATH`.
+6. Invoke `beacon endpoint install` directly in the user's terminal.
+
+Everything involving operating-system state, error interpretation, remediation, runtime
+discovery, hook installation, health validation, and next steps should live in the Go project.
+This provides one behavior whether Beacon came from a tarball, Homebrew, a package, a local build,
+or a future distribution channel.
+
+### Why this matters for the linger failure
+
+The published Beacon v1.2.1 binary successfully installed and ran the collector even though its
+attempt to enable systemd linger emitted the missing-`pkttyagent` message. Direct verification
+showed that:
+
+- The release binary executed normally.
+- The systemd user service was enabled and active.
+- Both OTLP ports were listening.
+- The runtime log contained hundreds of events.
+- Live Codex events continued to arrive.
+
+The failure concerned logout persistence, not Beacon's ability to run during the current login
+session. That distinction belongs in Beacon's lifecycle result and diagnostics. A wrapper script
+should not have to infer it from terminal output—especially because `pkttyagent` can write directly
+to the controlling terminal instead of the stderr stream a wrapper captures.
+
+The Go implementation should therefore report a truthful degraded-success state:
+
+```text
+✓ Collector is installed and running
+! Collection will stop after logout because linger is disabled
+  Fix: sudo loginctl enable-linger <user>
+```
+
+After the fix is applied, Beacon can verify the resulting state with:
+
+```bash
+loginctl show-user "$USER" --property=Linger --value
+```
+
+This is more accurate and useful than either silently declaring complete success or treating the
+entire endpoint installation as failed.
+
+## Feedback from the Linux installation experience
+
+### The primary goal is a dependable copy-and-paste installation
+
+A new user should be able to copy one documented command sequence, paste it into a terminal, and
+get a working Beacon installation. The shell portion should remain narrow: resolve the stable
+release, select the architecture, download and verify the archive, extract the binaries, and invoke
+Beacon. Host inspection, prerequisite handling, remediation, runtime configuration, health checks,
+and guided onboarding belong in the Go CLI, where they can be tested and reused across install,
+repair, doctor, and future packaging paths.
+
+The download instructions should:
+
+- Detect the operating system and architecture.
+- Resolve the latest stable Beacon release.
+- Download the correct release archive.
+- Verify the exact archive before extracting it.
+- Install all required binaries in an appropriate user or system location.
+- Invoke `beacon endpoint install` directly in the user's terminal.
+
+The Go CLI should then check required operating-system capabilities, configure and start the
+endpoint, verify collector health, report precisely what succeeded, and guide the user through any
+remaining work.
+
+### Missing system configuration must produce a solution
+
+The Linux installation encountered a systemd user-service persistence issue. The account did not
+have systemd linger enabled, so the collector would not survive logout. Beacon attempted to enable
+linger through `loginctl`, which tried to launch `/usr/bin/pkttyagent`. That authentication agent
+was not installed, producing this message:
+
+```text
+Failed to execute /usr/bin/pkttyagent: No such file or directory
+```
+
+The endpoint command nevertheless continued and printed successful installation output. From the
+user's perspective, an explicit failure had appeared in the middle of an otherwise successful
+transcript, with no immediate explanation or remedy.
+
+The direct solution on this machine was:
+
+```bash
+sudo loginctl enable-linger "$USER"
+```
+
+The result can be verified with:
+
+```bash
+loginctl show-user "$USER" --property=Linger --value
+```
+
+Expected output:
+
+```text
+yes
+```
+
+Beacon should avoid interactive PolicyKit-agent discovery for this optional configuration. It
+should check the linger state, attempt a noninteractive operation when appropriate, verify the
+result, and then do one of the following:
+
+- Continue quietly when linger is already enabled or was enabled successfully.
+- Present and optionally run the exact `sudo loginctl enable-linger <user>` remediation.
+- Clearly explain the limited operating mode if the user chooses not to enable linger.
+
+The broader principle is that detecting a missing prerequisite is not enough. Every detected gap
+should include a concrete solution. If Beacon can fix it safely, it should offer to do so. If
+administrator approval is required, Beacon should print the exact command and explain why it is
+needed.
+
+### Success output must reflect the actual result
+
+The installer should not print an unconditional message such as:
+
+```text
+beacon-install: installation complete
+```
+
+after an unresolved error. It should distinguish among:
+
+- Fully installed and ready.
+- Installed and running with a clearly described limitation.
+- Partially installed and requiring a specific remediation.
+- Failed, with the failed stage and recovery steps identified.
+
+Warnings written directly to the terminal by a child authentication process may not be captured
+through ordinary stderr redirection. Validation should therefore check resulting system state—not
+only command exit codes or captured output. For linger, the authoritative check is whether
+`loginctl show-user ... --property=Linger --value` returns `yes`.
+
+## Proposed guided onboarding experience
+
+### Add `beacon getting-started`
+
+After installation, Beacon should offer to launch a guided command such as:
+
+```bash
+beacon getting-started
+```
+
+At the end of installation, the prompt could be:
+
+```text
+Beacon is installed. Run guided setup now? [Y/n]
+```
+
+The default should be yes, so pressing Enter starts onboarding. Noninteractive installations
+should skip the prompt and print the command as the next step.
+
+This command should build on `beacon endpoint doctor` but serve a different purpose:
+
+- `doctor` diagnoses the health of an existing configuration.
+- `getting-started` discovers the machine, recommends a setup, helps apply it, and proves that it
+  works.
+
+The command may also expose a short alias:
+
+```bash
+beacon start
+```
+
+Useful automation controls include:
+
+```bash
+beacon getting-started --yes
+beacon getting-started --no-hooks
+beacon getting-started --no-dashboard
+```
+
+Normal package, CI, and other noninteractive installs must never block on these prompts. They
+should print `beacon getting-started` as the next action instead.
+
+### Inspect the current machine
+
+The guided flow should begin by detecting:
+
+- Supported runtimes installed on the machine.
+- Which runtimes already have Beacon telemetry or hooks configured.
+- Which runtimes need hooks, OpenTelemetry configuration, a restart, or another manual action.
+- Collector and service health.
+- User-service persistence requirements such as systemd linger.
+- Whether the local dashboard can be started and opened.
+
+The output should use runtime names familiar to the user and provide runtime-specific guidance.
+For example:
+
+```text
+Detected runtimes
+
+  Claude Code     telemetry configured; restart required
+  Codex CLI       telemetry configured
+  opencode        hooks not installed
+  Devin CLI       hooks not installed
+```
+
+### Offer to configure detected runtimes
+
+For every supported runtime that needs configuration, the flow should explain what Beacon can add
+and ask for confirmation. For example:
+
+```text
+opencode is installed, but Beacon hooks are not configured.
+Install opencode hooks now? [Y/n]
+```
+
+If accepted, Beacon should perform the same supported operation exposed by its existing hook
+commands. If a runtime requires a restart or an action Beacon cannot perform safely, the flow
+should state that explicitly and add it to the final task list.
+
+The user should not need to know in advance:
+
+- Which runtimes use hooks versus OpenTelemetry.
+- Which `--harness` value corresponds to a detected product.
+- Which configuration file is involved.
+- Whether a runtime restart is required.
+
+Those are details Beacon can discover and translate into an actionable setup.
+
+### Prove that collection works
+
+After configuration, the getting-started flow should verify the local chain:
+
+1. The collector service is loaded and running.
+2. The OTLP endpoints are reachable.
+3. Detected runtimes are configured.
+4. The runtime log is writable.
+5. At least an installation or validation event can be observed.
+
+If real runtime activity is still needed, Beacon should say exactly what to do:
+
+```text
+To verify Claude Code telemetry:
+  1. Restart Claude Code.
+  2. Start a session and run a simple command.
+  3. Return here and press Enter to check for the event.
+```
+
+### End with a concise task list
+
+The final output should give the user a clear lay of the land rather than simply ending after the
+last mutation. For example:
+
+```text
+Beacon setup summary
+
+  ✓ Collector is running
+  ✓ Logout persistence is enabled
+  ✓ Codex CLI telemetry is configured
+  ✓ opencode hooks are installed
+  ! Restart Claude Code to load its telemetry settings
+  ! Generate one agent event to complete validation
+
+Next steps:
+  1. Restart Claude Code.
+  2. Use an agent normally.
+  3. Open the dashboard: beacon endpoint dashboard --open
+```
+
+This summary should be safe to rerun. A second `beacon getting-started` invocation should recognize
+completed steps and focus only on remaining work.
+
+## Make the dashboard the destination
+
+The installation and hook setup are means to an end: the user wants to see what Beacon captured.
+Onboarding should therefore conclude by offering to launch the dashboard:
+
+```text
+Open the local Beacon dashboard now? [Y/n]
+```
+
+If accepted, Beacon should start the local dashboard and open the browser using the existing
+dashboard behavior. If a browser cannot be opened, it should print the local URL prominently.
+
+The final output should also preserve commands the user can return to later:
+
+```bash
+beacon endpoint status
+beacon endpoint doctor
+beacon endpoint dashboard --open
+```
+
+## Recommended end-to-end experience
+
+An ideal first run would look like this:
+
+```text
+$ <copy-and-paste install command>
+
+✓ Installer verified
+✓ Beacon release archive verified
+✓ Beacon binaries installed
+✓ Collector service running
+✓ Logout persistence enabled
+
+Beacon is installed. Run guided setup now? [Y/n]
+
+Detected Claude Code, Codex CLI, opencode, and Devin CLI.
+Configure recommended telemetry and hooks? [Y/n]
+
+✓ Claude Code telemetry configured
+✓ Codex CLI telemetry configured
+✓ opencode hooks installed
+✓ Devin CLI hooks installed
+
+Restart required: Claude Code
+Open the local dashboard now? [Y/n]
+```
+
+At every point, Enter should choose the recommended safe default. Advanced users should still be
+able to decline individual steps or run the underlying commands directly.
+
+## Prototype implemented on the feature branch
+
+A Go-native prototype is now implemented on `feature/linux-install-runner` in commit `5df7913`.
+It demonstrates the revised direction rather than putting the workflow in a shell installer.
+
+The prototype includes:
+
+- A root-level `beacon getting-started` command with `beacon start` as an alias.
+- A default-yes offer to launch guided setup after an interactive user endpoint install.
+- Noninteractive detection so package and CI installs remain prompt-free.
+- Collector-service and OTLP receiver health reporting.
+- Existing endpoint diagnostics, including exact remediation actions.
+- Runtime discovery using Beacon's current harness inventory.
+- Detection of missing hook integrations for opencode, Cursor, Devin CLI, Devin Desktop, Hermes,
+  Factory, and Antigravity.
+- A default-yes offer to install recommended hooks.
+- Per-runtime error reporting with an exact manual retry command.
+- A final task list covering runtime restarts, event generation, doctor, the runtime log, and the
+  dashboard.
+- A default-yes offer to start and open the local dashboard.
+- `--yes`, `--no-hooks`, and `--no-dashboard` controls.
+
+Running the prototype against the development machine produced a useful immediate inventory:
+
+```text
+Beacon getting started
+======================
+
+Endpoint health
+  ✓ Collector service is running
+  ✓ OTLP receivers are ready
+  ✓ Runtime log contains events
+
+Detected runtimes
+  Claude Code        telemetry=enabled
+  Codex CLI          telemetry=enabled
+  opencode           telemetry=missing
+  Devin Desktop      telemetry=missing
+```
+
+This is the core experience the product should develop further: start from observed local state,
+perform safe recommended actions, and leave the user with a short list of concrete remaining work.
+
+### Prototype validation
+
+The prototype currently has deterministic tests covering:
+
+- Noninteractive output and recommended commands.
+- Default-yes prompt behavior.
+- Recommended hook installation.
+- Dashboard startup handoff.
+- Hook-install failure reporting and remediation.
+- The post-install offer to run guided setup.
+
+The full CLI test suite and endpoint race suite pass with the prototype. The shell-installer
+prototype and its dedicated CI job were removed; documentation returned to direct, verified
+release-archive installation.
+
+### Follow-up opportunities
+
+The current prototype is a strong integration skeleton. A production pass should consider:
+
+- Persisting guided-setup progress so the summary can distinguish newly completed work from work
+  completed during earlier runs.
+- Waiting for a real event from each newly configured runtime and confirming it interactively.
+- Giving each runtime a richer explanation of what was configured and whether a restart is needed.
+- Detecting an already-running dashboard and opening it instead of attempting a second listener.
+- Adding structured or JSON output for fleet troubleshooting without making the guided mode feel
+  like a diagnostic dump.
+- Ensuring terminal styling remains readable with `NO_COLOR`, redirected output, and narrow
+  terminals.
+- Deciding whether guided setup failures should produce a nonzero exit after still allowing the
+  user to open the dashboard and inspect partial results.
+
+## Suggested acceptance criteria
+
+### Installer
+
+- One documented copy-and-paste flow installs Beacon on supported Linux architectures.
+- The installer itself is verified before execution.
+- The selected release archive is verified before extraction.
+- Unsupported platforms and architectures fail before modifying the machine.
+- Missing prerequisites produce an exact remediation command.
+- Linger handling never emits unexplained `pkttyagent` noise.
+- A success message is printed only after post-install state checks pass.
+- Noninteractive and automated installation remains possible.
+
+### Guided setup
+
+- `beacon getting-started` is safe and useful on both new and existing installations.
+- Installation offers to run it, defaulting to yes on an interactive terminal.
+- It detects supported installed runtimes and their current Beacon configuration.
+- It offers to install or repair recommended runtime integrations.
+- It identifies required restarts and manual actions.
+- It verifies collector, service, configuration, log, and event health.
+- It ends with a prioritized list of incomplete tasks.
+- It offers to open the local dashboard.
+
+### User experience
+
+- No successful-looking transcript contains an unexplained failure.
+- No detected problem is reported without a next action.
+- The user never needs to infer which Beacon subcommand to run next.
+- The user reaches a visible event or dashboard as part of onboarding, not through separate
+  documentation discovery.
+
+## Product principle
+
+Beacon onboarding should optimize for time to first visible event. Installation is not complete
+when binaries exist or a service starts; it is complete when the user understands what was
+configured, knows what remains, and can see evidence that Beacon is working.

--- a/cli/beacon/cmd/endpoint_install.go
+++ b/cli/beacon/cmd/endpoint_install.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/dashboard"
@@ -128,10 +129,11 @@ func runEndpointInstall(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Service definition written to %s\n", result.PlistPath)
 	fmt.Printf("Install manifest written to %s\n", result.ManifestPath)
 	fmt.Printf("Runtime log: %s\n", result.LogPath)
+	printLingerWarning(cmd.ErrOrStderr(), result)
 	if err := installHookTargetsFromEndpointInstall(hookHarnesses); err != nil {
 		return fmt.Errorf("endpoint install completed, but hook installation failed: %w", err)
 	}
-	return nil
+	return maybeOfferGettingStarted(cmd)
 }
 
 func runEndpointStatus(cmd *cobra.Command, args []string) error {
@@ -270,10 +272,24 @@ func runEndpointRepair(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	fmt.Printf("Endpoint repaired. Manifest: %s\n", result.ManifestPath)
+	printLingerWarning(cmd.ErrOrStderr(), result)
 	if err := installHookTargetsFromEndpointInstall(hookHarnesses); err != nil {
 		return fmt.Errorf("endpoint repair completed, but hook installation failed: %w", err)
 	}
 	return nil
+}
+
+func printLingerWarning(out io.Writer, result lifecycle.InstallResult) {
+	if !result.LingerApplicable || result.LingerEnabled {
+		return
+	}
+	fmt.Fprintln(out, "Warning: the collector is running, but collection will stop after logout because systemd linger is disabled.")
+	if result.LingerDetail != "" {
+		fmt.Fprintf(out, "Detail: %s\n", result.LingerDetail)
+	}
+	if result.LingerRemediation != "" {
+		fmt.Fprintf(out, "To keep collection running: %s\n", result.LingerRemediation)
+	}
 }
 
 func installHookTargetsFromEndpointInstall(targets []string) error {

--- a/cli/beacon/cmd/endpoint_install_linger_test.go
+++ b/cli/beacon/cmd/endpoint_install_linger_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
+)
+
+func TestPrintLingerWarningOnlyWhenApplicableAndDisabled(t *testing.T) {
+	for name, result := range map[string]lifecycle.InstallResult{
+		"not applicable": {},
+		"enabled":        {LingerApplicable: true, LingerEnabled: true, LingerDetail: "linger already enabled"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			printLingerWarning(&stderr, result)
+			if stderr.Len() != 0 {
+				t.Fatalf("successful/non-systemd install should be quiet, got %q", stderr.String())
+			}
+		})
+	}
+
+	var stderr bytes.Buffer
+	printLingerWarning(&stderr, lifecycle.InstallResult{
+		LingerApplicable:  true,
+		LingerDetail:      "administrator approval is required",
+		LingerRemediation: "sudo loginctl enable-linger beacon-user",
+	})
+	got := stderr.String()
+	for _, want := range []string{
+		"collection will stop after logout",
+		"administrator approval is required",
+		"sudo loginctl enable-linger beacon-user",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("warning missing %q: %s", want, got)
+		}
+	}
+	if strings.Contains(strings.ToLower(got), "pkttyagent") {
+		t.Fatalf("authentication-agent noise leaked to CLI: %s", got)
+	}
+}

--- a/cli/beacon/cmd/getting_started.go
+++ b/cli/beacon/cmd/getting_started.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/harness"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
+	"github.com/spf13/cobra"
+)
+
+type gettingStartedOptions struct {
+	yes         bool
+	noDashboard bool
+	noHooks     bool
+}
+
+var gettingStartedOpts gettingStartedOptions
+
+var gettingStartedCmd = &cobra.Command{
+	Use:          "getting-started",
+	Aliases:      []string{"start"},
+	Short:        "Discover runtimes and finish setting up Beacon",
+	SilenceUsage: true,
+	RunE:         runGettingStarted,
+}
+
+var (
+	gettingStartedDiscover = harness.DiscoverAll
+	gettingStartedStatus   = lifecycle.GetStatus
+	gettingStartedInstall  = func(target string) error {
+		return installEndpointHookTarget(target, loadOrDefaultConfig())
+	}
+	gettingStartedDashboard = func(cmd *cobra.Command) error {
+		endpointOpts.dashboardOpen = true
+		return runEndpointDashboard(cmd, nil)
+	}
+	gettingStartedIsTTY = func() bool {
+		return isCharDevice(os.Stdin) && isCharDevice(os.Stdout)
+	}
+)
+
+func init() {
+	gettingStartedCmd.Flags().BoolVarP(&gettingStartedOpts.yes, "yes", "y", false, "Accept recommended setup actions")
+	gettingStartedCmd.Flags().BoolVar(&gettingStartedOpts.noDashboard, "no-dashboard", false, "Do not offer to start the local dashboard")
+	gettingStartedCmd.Flags().BoolVar(&gettingStartedOpts.noHooks, "no-hooks", false, "Do not offer to install runtime hooks")
+	gettingStartedCmd.Flags().BoolVar(&endpointOpts.userMode, "user", true, "Use per-user endpoint paths")
+	gettingStartedCmd.Flags().BoolVar(&endpointOpts.systemMode, "system", false, "Use system endpoint paths and the system collector service")
+	gettingStartedCmd.Flags().StringVar(&endpointOpts.logPath, "log-path", "", "Runtime JSONL log path")
+	rootCmd.AddCommand(gettingStartedCmd)
+}
+
+func runGettingStarted(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
+	interactive := gettingStartedOpts.yes || gettingStartedIsTTY()
+	reader := bufio.NewReader(cmd.InOrStdin())
+
+	fmt.Fprintln(out, "Beacon getting started")
+	fmt.Fprintln(out, "======================")
+
+	status := gettingStartedStatus(endpointUserMode(), endpointOpts.logPath)
+	printGettingStartedHealth(out, status)
+
+	discovered := gettingStartedDiscover()
+	hookTargets := printGettingStartedRuntimes(out, discovered)
+	var problems []string
+	if len(hookTargets) > 0 && !gettingStartedOpts.noHooks {
+		if !interactive {
+			fmt.Fprintf(out, "\nRecommended action: beacon endpoint hooks install --harness %s\n", strings.Join(hookTargets, ","))
+		} else if gettingStartedOpts.yes || askYesNo(reader, out, "Install recommended runtime hooks now?", true) {
+			fmt.Fprintln(out)
+			for _, target := range hookTargets {
+				if err := gettingStartedInstall(target); err != nil {
+					problems = append(problems, target+": "+err.Error())
+					fmt.Fprintf(errOut, "Could not install %s hooks: %v\n", target, err)
+					fmt.Fprintf(errOut, "Fix: beacon endpoint hooks install --harness %s\n", target)
+				}
+			}
+		}
+	}
+
+	fmt.Fprintln(out, "\nNext steps")
+	fmt.Fprintln(out, "  1. Restart any detected agent runtimes that were already open.")
+	fmt.Fprintln(out, "  2. Use an agent normally to generate an event.")
+	fmt.Fprintf(out, "  3. Check health: beacon endpoint doctor%s\n", modeFlag())
+	fmt.Fprintf(out, "  4. Watch events: tail -f %s\n", status.LogPath)
+	fmt.Fprintln(out, "  5. Open the dashboard: beacon endpoint dashboard --open")
+
+	if !gettingStartedOpts.noDashboard {
+		if !interactive {
+			fmt.Fprintln(out, "\nRun 'beacon endpoint dashboard --open' when you are ready to explore events.")
+		} else if gettingStartedOpts.yes || askYesNo(reader, out, "Open the local dashboard now?", true) {
+			if err := gettingStartedDashboard(cmd); err != nil {
+				problems = append(problems, "dashboard: "+err.Error())
+				fmt.Fprintf(errOut, "Could not start the dashboard: %v\n", err)
+				fmt.Fprintln(errOut, "Fix: beacon endpoint dashboard --open")
+			}
+		}
+	}
+
+	if len(problems) > 0 {
+		return fmt.Errorf("getting started finished with %d unresolved problem(s)", len(problems))
+	}
+	return nil
+}
+
+func printGettingStartedHealth(out io.Writer, status lifecycle.Status) {
+	fmt.Fprintln(out, "\nEndpoint health")
+	printCheckLine(out, status.Service.Running, "Collector service is running", "Collector service is not running", "beacon endpoint repair"+modeFlag())
+	collectorReady := status.Collector.GRPCReady && status.Collector.HTTPReady
+	printCheckLine(out, collectorReady, "OTLP receivers are ready", "OTLP receivers are not ready", "beacon endpoint doctor"+modeFlag())
+	if status.LastEvent != "" {
+		fmt.Fprintln(out, "  ✓ Runtime log contains events")
+	} else {
+		fmt.Fprintln(out, "  ! No runtime event has been observed yet")
+		fmt.Fprintln(out, "    Next: restart an agent runtime and use it once")
+	}
+	for _, check := range status.Diagnostics {
+		if check.Status == "ok" {
+			continue
+		}
+		fmt.Fprintf(out, "  ! %s: %s\n", check.Name, check.Message)
+		if check.Action != "" {
+			fmt.Fprintf(out, "    Fix: %s\n", check.Action)
+		}
+	}
+}
+
+func printCheckLine(out io.Writer, ok bool, success, failure, action string) {
+	if ok {
+		fmt.Fprintf(out, "  ✓ %s\n", success)
+		return
+	}
+	fmt.Fprintf(out, "  ! %s\n", failure)
+	if action != "" {
+		fmt.Fprintf(out, "    Fix: %s\n", action)
+	}
+}
+
+func printGettingStartedRuntimes(out io.Writer, discovered []harness.Harness) []string {
+	fmt.Fprintln(out, "\nDetected runtimes")
+	var hooks []string
+	seen := map[string]bool{}
+	count := 0
+	for _, runtime := range discovered {
+		if !runtime.Detected {
+			continue
+		}
+		count++
+		fmt.Fprintf(out, "  %-18s telemetry=%s\n", runtime.DisplayName, runtime.TelemetryStatus)
+		if target, ok := gettingStartedHookTarget(runtime); ok && runtime.TelemetryStatus != harness.TelemetryEnabled && !seen[target] {
+			hooks = append(hooks, target)
+			seen[target] = true
+		}
+	}
+	if count == 0 {
+		fmt.Fprintln(out, "  No supported agent runtimes detected yet.")
+	}
+	return hooks
+}
+
+func gettingStartedHookTarget(runtime harness.Harness) (string, bool) {
+	targets := map[string]string{
+		"antigravity_cli": "antigravity",
+		"cursor":          "cursor",
+		"factory":         "factory",
+		"opencode":        "opencode",
+		"hermes":          "hermes",
+		"devin-cli":       "devin-cli",
+		"devin-desktop":   "devin-desktop",
+	}
+	target, ok := targets[runtime.Name]
+	return target, ok
+}
+
+func askYesNo(reader *bufio.Reader, out io.Writer, question string, defaultYes bool) bool {
+	suffix := "[y/N]"
+	if defaultYes {
+		suffix = "[Y/n]"
+	}
+	fmt.Fprintf(out, "\n%s %s ", question, suffix)
+	answer, err := reader.ReadString('\n')
+	if err != nil && len(answer) == 0 {
+		return defaultYes
+	}
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes":
+		return true
+	case "n", "no":
+		return false
+	default:
+		return defaultYes
+	}
+}
+
+func modeFlag() string {
+	if endpointUserMode() {
+		return ""
+	}
+	return " --system"
+}
+
+func maybeOfferGettingStarted(cmd *cobra.Command) error {
+	if !gettingStartedIsTTY() || isCIEnvironment() || !endpointUserMode() || endpointOpts.noStart {
+		fmt.Fprintln(cmd.OutOrStdout(), "Next: beacon getting-started")
+		return nil
+	}
+	reader := bufio.NewReader(cmd.InOrStdin())
+	if !askYesNo(reader, cmd.OutOrStdout(), "Run guided setup now?", true) {
+		fmt.Fprintln(cmd.OutOrStdout(), "Next: beacon getting-started")
+		return nil
+	}
+	return runGettingStarted(cmd, nil)
+}

--- a/cli/beacon/cmd/getting_started_test.go
+++ b/cli/beacon/cmd/getting_started_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	endpointcollector "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/collector"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/diagnostics"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/harness"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/lifecycle"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/service"
+	"github.com/spf13/cobra"
+)
+
+func TestGettingStartedNonInteractivePrintsActionablePlan(t *testing.T) {
+	restore := stubGettingStarted(t)
+	defer restore()
+	gettingStartedIsTTY = func() bool { return false }
+
+	cmd, stdout, stderr := gettingStartedTestCommand("")
+	if err := runGettingStarted(cmd, nil); err != nil {
+		t.Fatalf("runGettingStarted: %v", err)
+	}
+	got := stdout.String()
+	for _, want := range []string{
+		"Collector service is running",
+		"OTLP receivers are ready",
+		"opencode",
+		"beacon endpoint hooks install --harness opencode",
+		"beacon endpoint dashboard --open",
+		"sudo loginctl enable-linger beacon-user",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+func TestMaybeOfferGettingStartedRunsOnDefaultYes(t *testing.T) {
+	restore := stubGettingStarted(t)
+	defer restore()
+	gettingStartedIsTTY = func() bool { return true }
+	gettingStartedOpts.noHooks = true
+	gettingStartedOpts.noDashboard = true
+
+	cmd, stdout, _ := gettingStartedTestCommand("\n")
+	if err := maybeOfferGettingStarted(cmd); err != nil {
+		t.Fatalf("maybeOfferGettingStarted: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Run guided setup now? [Y/n]") || !strings.Contains(got, "Beacon getting started") {
+		t.Fatalf("default yes did not launch guided setup: %s", got)
+	}
+}
+
+func TestGettingStartedAcceptsDefaultsInstallsHooksAndStartsDashboard(t *testing.T) {
+	restore := stubGettingStarted(t)
+	defer restore()
+	gettingStartedIsTTY = func() bool { return true }
+	var installed []string
+	gettingStartedInstall = func(target string) error {
+		installed = append(installed, target)
+		return nil
+	}
+	dashboardStarted := false
+	gettingStartedDashboard = func(cmd *cobra.Command) error {
+		dashboardStarted = true
+		return nil
+	}
+
+	cmd, stdout, _ := gettingStartedTestCommand("\n\n")
+	if err := runGettingStarted(cmd, nil); err != nil {
+		t.Fatalf("runGettingStarted: %v", err)
+	}
+	if len(installed) != 1 || installed[0] != "opencode" {
+		t.Fatalf("installed = %#v, want opencode", installed)
+	}
+	if !dashboardStarted {
+		t.Fatal("dashboard was not started after accepting the default")
+	}
+	if !strings.Contains(stdout.String(), "Install recommended runtime hooks now? [Y/n]") ||
+		!strings.Contains(stdout.String(), "Open the local dashboard now? [Y/n]") {
+		t.Fatalf("interactive prompts missing:\n%s", stdout.String())
+	}
+}
+
+func TestGettingStartedReportsHookFailureWithExactFix(t *testing.T) {
+	restore := stubGettingStarted(t)
+	defer restore()
+	gettingStartedOpts.yes = true
+	gettingStartedOpts.noDashboard = true
+	gettingStartedInstall = func(target string) error { return errors.New("config is read-only") }
+
+	cmd, _, stderr := gettingStartedTestCommand("")
+	err := runGettingStarted(cmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "unresolved problem") {
+		t.Fatalf("error = %v", err)
+	}
+	for _, want := range []string{"config is read-only", "beacon endpoint hooks install --harness opencode"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q: %s", want, stderr.String())
+		}
+	}
+}
+
+func TestMaybeOfferGettingStartedStaysNonInteractiveWithoutTTY(t *testing.T) {
+	restore := stubGettingStarted(t)
+	defer restore()
+	gettingStartedIsTTY = func() bool { return false }
+
+	cmd, stdout, _ := gettingStartedTestCommand("")
+	if err := maybeOfferGettingStarted(cmd); err != nil {
+		t.Fatalf("maybeOfferGettingStarted: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Next: beacon getting-started") || strings.Contains(got, "Run guided setup now?") {
+		t.Fatalf("unexpected noninteractive output: %s", got)
+	}
+}
+
+func stubGettingStarted(t *testing.T) func() {
+	t.Helper()
+	originalDiscover := gettingStartedDiscover
+	originalStatus := gettingStartedStatus
+	originalInstall := gettingStartedInstall
+	originalDashboard := gettingStartedDashboard
+	originalTTY := gettingStartedIsTTY
+	originalOpts := gettingStartedOpts
+	originalEndpointOpts := endpointOpts
+	endpointOpts.userMode = true
+	endpointOpts.systemMode = false
+	gettingStartedOpts = gettingStartedOptions{}
+	gettingStartedDiscover = func() []harness.Harness {
+		return []harness.Harness{
+			{Name: "codex_cli", DisplayName: "Codex CLI", Detected: true, TelemetryStatus: harness.TelemetryEnabled},
+			{Name: "opencode", DisplayName: "opencode", Detected: true, TelemetryStatus: harness.TelemetryMissing},
+		}
+	}
+	gettingStartedStatus = func(bool, string) lifecycle.Status {
+		return lifecycle.Status{
+			LogPath:   "/tmp/runtime.jsonl",
+			LastEvent: "present",
+			Service:   service.Status{Loaded: true, Running: true},
+			Collector: endpointcollector.Status{GRPCReady: true, HTTPReady: true},
+			Diagnostics: []diagnostics.Check{{
+				Name:    "systemd_user_linger",
+				Status:  diagnostics.StatusWarn,
+				Message: "linger is disabled",
+				Action:  "sudo loginctl enable-linger beacon-user",
+			}},
+		}
+	}
+	gettingStartedInstall = func(string) error { return nil }
+	gettingStartedDashboard = func(*cobra.Command) error { return nil }
+	gettingStartedIsTTY = func() bool { return false }
+	return func() {
+		gettingStartedDiscover = originalDiscover
+		gettingStartedStatus = originalStatus
+		gettingStartedInstall = originalInstall
+		gettingStartedDashboard = originalDashboard
+		gettingStartedIsTTY = originalTTY
+		gettingStartedOpts = originalOpts
+		endpointOpts = originalEndpointOpts
+	}
+}
+
+func gettingStartedTestCommand(input string) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	cmd := &cobra.Command{Use: "test"}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	return cmd, stdout, stderr
+}

--- a/cli/beacon/cmd/root.go
+++ b/cli/beacon/cmd/root.go
@@ -45,6 +45,7 @@ func printRootSplash(cmd *cobra.Command) {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Start with:")
 	fmt.Fprintln(out, "  beacon endpoint install")
+	fmt.Fprintln(out, "  beacon getting-started")
 	fmt.Fprintln(out, "  beacon endpoint status")
 	fmt.Fprintln(out, "  beacon endpoint wazuh print-config")
 	fmt.Fprintln(out)

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -66,6 +66,10 @@ type InstallResult struct {
 	LogPath             string   `json:"log_path"`
 	ManifestPath        string   `json:"manifest_path"`
 	HarnessConfigPaths  []string `json:"harness_config_paths,omitempty"`
+	LingerApplicable    bool     `json:"linger_applicable,omitempty"`
+	LingerEnabled       bool     `json:"linger_enabled,omitempty"`
+	LingerDetail        string   `json:"linger_detail,omitempty"`
+	LingerRemediation   string   `json:"linger_remediation,omitempty"`
 }
 
 type Status struct {
@@ -279,6 +283,7 @@ func Install(opts InstallOptions) (InstallResult, error) {
 		tx.Rollback(manifest)
 		return InstallResult{}, err
 	}
+	var lingerOutcome service.LingerOutcome
 	if opts.StartService {
 		// Restart when something is already running, rather than Load.
 		//
@@ -317,9 +322,10 @@ func Install(opts InstallOptions) (InstallResult, error) {
 		// have, and refusing to install over it would be worse than collecting until logout.
 		// The outcome is recorded so status and doctor can report the gap rather than leaving
 		// the user to discover it after their next logout.
-		if ok, detail := manager.EnableLingerIfNeeded(); detail != "" {
-			manifest.LingerEnabled = ok
-			manifest.LingerDetail = detail
+		lingerOutcome = manager.EnableLingerIfNeeded()
+		if lingerOutcome.Applicable {
+			manifest.LingerEnabled = lingerOutcome.Enabled
+			manifest.LingerDetail = lingerOutcome.Detail
 		}
 		if err := endpointcollector.WaitUntilReady(cfg, 10*time.Second); err != nil {
 			tx.Rollback(manifest)
@@ -345,14 +351,23 @@ func Install(opts InstallOptions) (InstallResult, error) {
 		tx.Rollback(manifest)
 		return InstallResult{}, err
 	}
-	return InstallResult{
+	result := InstallResult{
 		ConfigPath:          configPath,
 		CollectorConfigPath: cfg.Collector.ConfigPath,
 		PlistPath:           plistPath,
 		LogPath:             cfg.LogPath,
 		ManifestPath:        manifestPath,
 		HarnessConfigPaths:  harnessPaths,
-	}, nil
+	}
+	applyLingerOutcome(&result, lingerOutcome)
+	return result, nil
+}
+
+func applyLingerOutcome(result *InstallResult, outcome service.LingerOutcome) {
+	result.LingerApplicable = outcome.Applicable
+	result.LingerEnabled = outcome.Enabled
+	result.LingerDetail = outcome.Detail
+	result.LingerRemediation = outcome.Remediation
 }
 
 // Uninstall removes the endpoint and reports what it could not remove.

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -88,6 +88,21 @@ func TestBuildConfigAppliesInstallOptions(t *testing.T) {
 	}
 }
 
+func TestApplyLingerOutcomeCarriesInstallWarningState(t *testing.T) {
+	result := InstallResult{}
+	applyLingerOutcome(&result, service.LingerOutcome{
+		Applicable:  true,
+		Detail:      "administrator approval is required",
+		Remediation: "sudo loginctl enable-linger beacon-user",
+	})
+	if !result.LingerApplicable || result.LingerEnabled {
+		t.Fatalf("linger state = %#v", result)
+	}
+	if result.LingerDetail == "" || result.LingerRemediation != "sudo loginctl enable-linger beacon-user" {
+		t.Fatalf("linger guidance = %#v", result)
+	}
+}
+
 func TestBuildConfigPreservesAutoUpdateMode(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cli/beacon/internal/endpoint/service/service.go
+++ b/cli/beacon/internal/endpoint/service/service.go
@@ -88,25 +88,36 @@ func ParseKind(s string) (Kind, error) {
 	}
 }
 
+// LingerOutcome describes the optional logout-persistence step for a service install.
+type LingerOutcome struct {
+	Applicable  bool
+	Enabled     bool
+	Detail      string
+	Remediation string
+}
+
 // EnableLingerIfNeeded makes a systemd --user unit survive logout, where that applies.
 //
-// The empty detail means exactly one thing: linger does not apply here -- system mode, or any
-// backend but systemd. Every applicable case reports a detail, success included, so a caller can
-// use an empty detail to mean "we did not try" without that also swallowing "we tried and it
-// worked". launchd needs no equivalent: its gui/<uid> domain persists for the login session by
-// itself.
-func (m Manager) EnableLingerIfNeeded() (bool, string) {
+// The outcome says explicitly whether linger applies, so callers do not have to infer that from
+// command output. launchd needs no equivalent: its gui/<uid> domain persists for the login session
+// by itself.
+func (m Manager) EnableLingerIfNeeded() LingerOutcome {
 	if !m.UserMode || m.resolvedKind() != KindSystemd {
-		return false, ""
+		return LingerOutcome{}
 	}
 	u, err := user.Current()
 	if err != nil || u.Username == "" {
-		return false, "could not determine the current user, so logout persistence is unverified"
+		return LingerOutcome{Applicable: true, Detail: "could not determine the current user, so logout persistence is unverified"}
 	}
 	if LingerEnabled(u.Username) {
-		return true, "linger already enabled for " + u.Username
+		return LingerOutcome{Applicable: true, Enabled: true, Detail: "linger already enabled for " + u.Username}
 	}
-	return EnableLinger(u.Username)
+	enabled, detail := EnableLinger(u.Username)
+	outcome := LingerOutcome{Applicable: true, Enabled: enabled, Detail: detail}
+	if !enabled {
+		outcome.Remediation = "sudo loginctl enable-linger " + u.Username
+	}
+	return outcome
 }
 
 // ServiceNoun names what this backend installs, for user-facing messages.

--- a/cli/beacon/internal/endpoint/service/service_test.go
+++ b/cli/beacon/internal/endpoint/service/service_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -572,19 +571,10 @@ func TestEnableLingerIfNeededOnlyAppliesToSystemdUserUnits(t *testing.T) {
 		{UserMode: true, Kind: KindSupervised},
 		{UserMode: false, Kind: KindLaunchd},
 	} {
-		ok, detail := m.EnableLingerIfNeeded()
-		if ok || detail != "" {
-			t.Errorf("%+v should not attempt linger, got ok=%v detail=%q", m, ok, detail)
+		outcome := m.EnableLingerIfNeeded()
+		if outcome.Applicable || outcome.Enabled || outcome.Detail != "" {
+			t.Errorf("%+v should not attempt linger, got %#v", m, outcome)
 		}
-	}
-}
-
-// The applicable case must actually report something, or the manifest and doctor would have
-// nothing to show and the gap would stay invisible.
-func TestEnableLingerIfNeededReportsForSystemdUserUnits(t *testing.T) {
-	_, detail := (Manager{UserMode: true, Kind: KindSystemd}).EnableLingerIfNeeded()
-	if detail == "" {
-		t.Error("a systemd user unit must report a linger outcome, whether or not it succeeded")
 	}
 }
 
@@ -610,35 +600,98 @@ func TestServiceNounNamesEachBackend(t *testing.T) {
 // The success path is the one that used to report nothing. EnableLinger returned an empty detail on
 // success, and the install path reads an empty detail as "linger does not apply" -- so linger
 // actually being enabled was the single outcome the manifest dropped.
-func TestEnableLingerReportsSuccessAndFailureDistinctly(t *testing.T) {
-	if !systemdIsInit() {
-		t.Skip("needs systemd as PID 1; linger does not apply otherwise")
+func TestEnableLingerUsesNoAskPasswordAndReportsSuccess(t *testing.T) {
+	stubLingerSystemd(t)
+	var got []string
+	runLoginctlCommand = func(args ...string) (string, error) {
+		got = append([]string(nil), args...)
+		return "", nil
 	}
-	u, err := user.Current()
-	if err != nil || u.Username == "" {
-		t.Skip("needs a resolvable current user")
+	ok, detail := EnableLinger("beacon-user")
+	if !ok || detail != "linger enabled for beacon-user" {
+		t.Fatalf("EnableLinger = %v, %q", ok, detail)
 	}
-	ok, detail := EnableLinger(u.Username)
-	if detail == "" {
-		t.Fatalf("EnableLinger(%q) = %v with no detail; an empty detail means "+
-			"\"does not apply\" to the caller, so every applicable outcome must say something",
-			u.Username, ok)
+	want := []string{"--no-ask-password", "enable-linger", "beacon-user"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("loginctl args = %#v, want %#v", got, want)
 	}
 }
 
-// The contract the install path depends on: an empty detail means "not applicable", never
-// "succeeded" and never "failed quietly".
-func TestEnableLingerNeverReportsAnEmptyDetailWhenItApplies(t *testing.T) {
-	// The non-applicable cases, which are the only ones allowed to be silent.
-	if _, detail := EnableLinger(""); detail == "" {
-		t.Error("an empty username is a reportable problem, not a silent skip")
+func TestEnableLingerAuthorizationFailureIsCleanAndNonfatal(t *testing.T) {
+	stubLingerSystemd(t)
+	runLoginctlCommand = func(args ...string) (string, error) {
+		return "Error executing command as another user: No such file or directory: pkttyagent", errors.New("exit status 1")
 	}
-	if systemdIsInit() {
-		return
+	ok, detail := EnableLinger("beacon-user")
+	if ok {
+		t.Fatal("authorization denial must not claim linger is enabled")
 	}
-	if _, detail := EnableLinger("anyone"); detail == "" {
-		t.Error("without systemd as PID 1, EnableLinger should still say why it did nothing")
+	if !strings.Contains(detail, "administrator approval") || strings.Contains(strings.ToLower(detail), "pkttyagent") {
+		t.Fatalf("failure detail is not clean and actionable: %q", detail)
 	}
+}
+
+func TestEnableLingerIfNeededAlreadyEnabledDoesNotEnableAgain(t *testing.T) {
+	stubLingerSystemd(t)
+	var calls [][]string
+	runLoginctlCommand = func(args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return "yes\n", nil
+	}
+	outcome := (Manager{UserMode: true, Kind: KindSystemd}).EnableLingerIfNeeded()
+	if !outcome.Applicable || !outcome.Enabled || outcome.Detail == "" {
+		t.Fatalf("outcome = %#v", outcome)
+	}
+	if len(calls) != 1 || calls[0][0] != "show-user" {
+		t.Fatalf("already-enabled linger should only be queried, calls=%#v", calls)
+	}
+}
+
+func TestEnableLingerIfNeededReportsNewlyEnabledWithoutRemediation(t *testing.T) {
+	stubLingerSystemd(t)
+	var calls [][]string
+	runLoginctlCommand = func(args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if args[0] == "show-user" {
+			return "no\n", nil
+		}
+		return "", nil
+	}
+	outcome := (Manager{UserMode: true, Kind: KindSystemd}).EnableLingerIfNeeded()
+	if !outcome.Applicable || !outcome.Enabled || outcome.Remediation != "" {
+		t.Fatalf("outcome = %#v", outcome)
+	}
+	if len(calls) != 2 || calls[1][0] != "--no-ask-password" {
+		t.Fatalf("newly-enabled calls = %#v", calls)
+	}
+}
+
+func TestEnableLingerIfNeededReturnsSudoRemediationOnDenial(t *testing.T) {
+	stubLingerSystemd(t)
+	runLoginctlCommand = func(args ...string) (string, error) {
+		if args[0] == "show-user" {
+			return "no\n", nil
+		}
+		return "pkttyagent: command not found", errors.New("authorization denied")
+	}
+	outcome := (Manager{UserMode: true, Kind: KindSystemd}).EnableLingerIfNeeded()
+	if !outcome.Applicable || outcome.Enabled || !strings.HasPrefix(outcome.Remediation, "sudo loginctl enable-linger ") {
+		t.Fatalf("outcome = %#v", outcome)
+	}
+	if strings.Contains(strings.ToLower(outcome.Detail), "pkttyagent") {
+		t.Fatalf("pkttyagent noise leaked: %q", outcome.Detail)
+	}
+}
+
+func stubLingerSystemd(t *testing.T) {
+	t.Helper()
+	originalInit := lingerSystemdIsInit
+	originalRun := runLoginctlCommand
+	lingerSystemdIsInit = func() bool { return true }
+	t.Cleanup(func() {
+		lingerSystemdIsInit = originalInit
+		runLoginctlCommand = originalRun
+	})
 }
 
 // systemd splits ExecStart on whitespace, so a path containing a space silently becomes two

--- a/cli/beacon/internal/endpoint/service/systemd.go
+++ b/cli/beacon/internal/endpoint/service/systemd.go
@@ -32,6 +32,9 @@ var runLoginctlCommand = func(args ...string) (string, error) {
 	return string(out), err
 }
 
+// Stubbed by linger tests so they never depend on, or alter, the host's real logind state.
+var lingerSystemdIsInit = systemdIsInit
+
 // systemdIsInit reports whether systemd is PID 1.
 //
 // Checked by reading /proc/1/comm rather than by probing for the systemctl binary: many
@@ -202,21 +205,17 @@ func systemctlError(out string, err error, what string) error {
 // Without it a user-mode install silently stops collecting the moment the user logs out.
 // Best-effort, since it needs privileges that a plain user may not have.
 func EnableLinger(username string) (bool, string) {
-	if !systemdIsInit() {
+	if !lingerSystemdIsInit() {
 		return false, "systemd is not PID 1; linger does not apply"
 	}
 	if username == "" {
 		return false, "no username provided"
 	}
-	out, err := runLoginctlCommand("enable-linger", username)
+	_, err := runLoginctlCommand("--no-ask-password", "enable-linger", username)
 	if err != nil {
-		// loginctl does not always print anything on failure, and an empty detail here is
-		// indistinguishable from "linger does not apply" -- which is what the caller uses an empty
-		// detail to mean. The error is folded in so the outcome is always attributable.
-		if detail := strings.TrimSpace(out); detail != "" {
-			return false, detail
-		}
-		return false, "loginctl enable-linger " + username + " failed: " + err.Error()
+		// Do not relay authentication-agent chatter. Older setups can mention a missing
+		// pkttyagent even though linger is optional and the endpoint installed successfully.
+		return false, "linger is disabled for " + username + "; administrator approval is required to keep collection running after logout"
 	}
 	// The success path must say so. It previously returned an empty detail, which the install path
 	// reads as "not applicable" -- so the one outcome worth recording, linger actually being
@@ -226,7 +225,7 @@ func EnableLinger(username string) (bool, string) {
 
 // LingerEnabled reports whether linger is on for a user, so doctor can flag the gap.
 func LingerEnabled(username string) bool {
-	if !systemdIsInit() || username == "" {
+	if !lingerSystemdIsInit() || username == "" {
 		return false
 	}
 	out, err := runLoginctlCommand("show-user", username, "--property=Linger", "--value")

--- a/docs/cli/manual-install.mdx
+++ b/docs/cli/manual-install.mdx
@@ -14,21 +14,41 @@ All three matter. `beacon-hooks` is what supported runtimes invoke to record pro
 and approvals, so an install that keeps only the CLI and the collector captures OpenTelemetry data
 and nothing from the hook path.
 
-```bash title="Download, verify, and extract (Linux amd64)"
-VERSION=1.2.0   # or whichever release you are installing
-BASE=https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}
-curl -fsSLO ${BASE}/beacon_${VERSION}_linux_amd64.tar.gz
-curl -fsSLO ${BASE}/checksums.txt
-sha256sum --check --ignore-missing checksums.txt
+```bash title="Install the latest stable Linux release"
+LATEST_URL="$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/asymptote-labs/agent-beacon/releases/latest)"
+VERSION="${LATEST_URL##*/v}"
 
-tar -xzf beacon_${VERSION}_linux_amd64.tar.gz
+case "$(uname -m)" in
+  x86_64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+ARCHIVE="beacon_${VERSION}_linux_${ARCH}.tar.gz"
+BASE=https://github.com/asymptote-labs/agent-beacon/releases/latest/download
+curl -fsSLO "${BASE}/${ARCHIVE}"
+curl -fsSLO "${BASE}/checksums.txt"
+grep "  ${ARCHIVE}$" checksums.txt | sha256sum --check -
+
+tar -xzf "${ARCHIVE}"
 mkdir -p ~/.local/bin && mv beacon beacon-hooks beacon-otelcol ~/.local/bin/
 beacon version
+beacon endpoint install
 ```
 
-Swap `linux_amd64` for `linux_arm64`, `darwin_arm64`, or `darwin_amd64` as needed; on macOS use
-`shasum -a 256 -c` in place of `sha256sum --check`. The archive layout is identical across
-platforms.
+The commands resolve the latest stable release, map `x86_64` to the published `amd64` archive and
+`aarch64` or `arm64` to `arm64`, and verify the exact downloaded archive using the release's
+`checksums.txt` before extraction. Unsupported architectures stop before downloading.
+
+On an interactive terminal, endpoint installation offers to run the guided setup. It is also
+available directly:
+
+```bash
+beacon getting-started
+```
+
+For macOS archives, use the same latest-release resolution with `darwin_amd64` or
+`darwin_arm64`, and verify with `shasum -a 256 -c`.
 
 For managed endpoint rollouts on Apple Silicon Macs, GitHub Releases also attach
 a signed, notarized, and stapled `BeaconEndpointAgent-<version>-arm64.pkg`. The

--- a/docs/get-started/quickstart-developers.mdx
+++ b/docs/get-started/quickstart-developers.mdx
@@ -17,12 +17,22 @@ beacon endpoint install
 ```
 
 ```bash title="Linux"
-VERSION=1.2.0   # or whichever release you are installing
-curl -fsSLO https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}/beacon_${VERSION}_linux_amd64.tar.gz
-curl -fsSLO https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}/checksums.txt
-sha256sum --check --ignore-missing checksums.txt
+LATEST_URL="$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/asymptote-labs/agent-beacon/releases/latest)"
+VERSION="${LATEST_URL##*/v}"
 
-tar -xzf beacon_${VERSION}_linux_amd64.tar.gz
+case "$(uname -m)" in
+  x86_64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+ARCHIVE="beacon_${VERSION}_linux_${ARCH}.tar.gz"
+BASE=https://github.com/asymptote-labs/agent-beacon/releases/latest/download
+curl -fsSLO "${BASE}/${ARCHIVE}"
+curl -fsSLO "${BASE}/checksums.txt"
+grep "  ${ARCHIVE}$" checksums.txt | sha256sum --check -
+
+tar -xzf "${ARCHIVE}"
 mkdir -p ~/.local/bin && mv beacon beacon-hooks beacon-otelcol ~/.local/bin/
 beacon endpoint install
 ```
@@ -34,6 +44,19 @@ beacon endpoint install
   `/var/log/beacon-agent/runtime.jsonl` instead, so every command below would report on the wrong
   log. If you want the system-mode package, follow [Linux](/platforms/linux) instead of this page.
 </Note>
+
+The commands resolve the latest stable release, select `amd64` or `arm64`, and verify the exact
+downloaded archive against the release's published `checksums.txt` before extracting it. The Go
+CLI owns prerequisite checks, remediation, runtime setup, and guided onboarding.
+
+On an interactive terminal, `beacon endpoint install` offers to run `beacon getting-started` after
+the collector is healthy. The guided flow discovers installed runtimes, offers relevant hook
+integrations, prints unresolved fixes, and offers to open the local dashboard. You can rerun it at
+any time:
+
+```bash
+beacon getting-started
+```
 
 See [Asymptote Open Source](/deployment/open-source) for install details and runtime-specific notes,
 or [macOS](/platforms/macos), [Linux](/platforms/linux), or [Windows](/platforms/windows) for the

--- a/docs/platforms/linux.mdx
+++ b/docs/platforms/linux.mdx
@@ -34,21 +34,37 @@ If you are not an administrator on the machine, or you would rather not touch sy
 tarball and install in user mode:
 
 ```bash title="Tarball install, no root required"
-VERSION=1.2.0   # or whichever release you are installing
-curl -fsSLO https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}/beacon_${VERSION}_linux_amd64.tar.gz
-curl -fsSLO https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}/checksums.txt
+LATEST_URL="$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/asymptote-labs/agent-beacon/releases/latest)"
+VERSION="${LATEST_URL##*/v}"
 
-# Verify before extracting. This is the integrity check for the tarball.
-sha256sum --check --ignore-missing checksums.txt
+case "$(uname -m)" in
+  x86_64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
 
-tar -xzf beacon_${VERSION}_linux_amd64.tar.gz
+ARCHIVE="beacon_${VERSION}_linux_${ARCH}.tar.gz"
+BASE=https://github.com/asymptote-labs/agent-beacon/releases/latest/download
+curl -fsSLO "${BASE}/${ARCHIVE}"
+curl -fsSLO "${BASE}/checksums.txt"
+
+# Verify this exact archive before extracting it.
+grep "  ${ARCHIVE}$" checksums.txt | sha256sum --check -
+
+tar -xzf "${ARCHIVE}"
 mkdir -p ~/.local/bin && mv beacon beacon-hooks beacon-otelcol ~/.local/bin/
-
-# ~/.local/bin is already on PATH on most distributions; if `beacon version` fails, add it:
-#   echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && exec $SHELL
 beacon version
 beacon endpoint install
 ```
+
+The commands resolve the latest stable release, map `x86_64` to `amd64` and
+`aarch64`/`arm64` to `arm64`, and verify the exact downloaded archive against the release's
+`checksums.txt` before extraction. The Go CLI then checks the host, explains remediations, and
+offers guided setup.
+
+Interactive installs offer to launch `beacon getting-started`. It checks endpoint health, detects
+installed agent runtimes, offers relevant hook integrations, and finishes with the dashboard. Run
+it again whenever the machine's runtime setup changes.
 
 The archive contains three binaries — the `beacon` CLI, the `beacon-hooks` adapter that captures
 tool activity, and the `beacon-otelcol` collector. All three are needed, and all three are
@@ -232,8 +248,9 @@ out**, unless linger is enabled for your account. Beacon enables it during insta
 sudo loginctl enable-linger $USER
 ```
 
-Without linger, a user-mode collector works while you are logged in and silently stops collecting
-after you log out.
+Without linger, a user-mode collector works while you are logged in but stops collecting after you
+log out. Install and repair warn when this remains the case and print the exact `sudo loginctl`
+command needed to fix it.
 
 ## Without systemd
 


### PR DESCRIPTION
Much less of a real PR, and more of a draft on how I think you should focus on really getting onboarding dialed in. At a high level, I think the cli needs to immediately get you setup on all your system, it should be a [Y/n] style setup where I just hit enter and it's installed.

I ran into an error on linux that was easy to fix, but agent-beacon should be able to handle those: "This is your error, you can run `this` to fix it - when you're done run `agent-beacon init` to get setup" - something like that.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches endpoint install/repair UX and systemd linger handling, plus optional hook install and dashboard launch from a new interactive command. Noninteractive paths are gated, but a bug here could mislead users about collector persistence or mutate runtime configs.
> 
> **Overview**
> Adds a Go-native **guided onboarding** path so users can go from install to a working collector and dashboard without assembling subcommands themselves.
> 
> `beacon getting-started` (`beacon start`) reports collector/OTLP health, lists detected runtimes, offers default-yes hook install, and can open the dashboard. Interactive `beacon endpoint install` offers to launch it; CI/non-TTY/system installs stay prompt-free and print the next command.
> 
> Linux user-mode linger is now a structured degraded-success: `loginctl` uses `--no-ask-password`, `pkttyagent` noise is not shown, and install/repair print an exact `sudo loginctl enable-linger` fix when logout persistence is still off.
> 
> Docs switch Linux copy-paste install to latest-release + arch detection + checksum of the exact archive, then `beacon endpoint install`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4402bbafd5d678fabbeb47e69cfd25f63cc7ea07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->