### PR TITLE
Add Cline to supported runtimes documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ CI, and cloud surfaces.
 | --- | --- | --- |
 | [Antigravity CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-antigravity-cli) | Native hooks | Prompt, pre-tool, post-tool, stop, invocation, command, and file telemetry where Antigravity exposes hook payloads |
 | [Claude Code](https://docs.asymptotelabs.ai/cli/supported-runtimes-claude-code) | Local OTLP export plus optional hooks | Prompt, command, tool, file, approval, API/model lifecycle, MCP connection, subagent, and session telemetry where emitted through OTLP or hooks |
+| [Cline](https://docs.asymptotelabs.ai/cli/supported-runtimes-cline) | Native hooks | Session, prompt, pre-tool, post-tool, task resume/cancel, command, file, and approval-decision telemetry where Cline's hook payloads expose those fields |
 | [Codex CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-codex-cli) | Local OTLP logs | Session, prompt, approval, and tool-result activity from Codex semantic logs |
 | [Cursor](https://docs.asymptotelabs.ai/cli/supported-runtimes-cursor) | Native hooks | Prompt, tool, shell command, MCP-like, approval, and file edit telemetry |
 | [Devin CLI](https://docs.asymptotelabs.ai/cli/supported-runtimes-devin) | Native hooks | Session, prompt, pre-tool, post-tool, permission request, stop, session-end, approval, and file telemetry |


### PR DESCRIPTION
## Summary

Documents support for Cline as a new supported AI runtime in the Beacon endpoint telemetry agent.

## Changes

- Added Cline to the supported runtimes table in README.md with:
  - Native hooks integration method
  - Telemetry coverage: session, prompt, pre-tool, post-tool, task resume/cancel, command, file, and approval-decision events
  - Documentation link to the Cline runtime guide

This addition reflects Beacon's capability to collect telemetry from Cline through its native hook payloads, consistent with other supported runtimes like Cursor and Claude Code.

https://claude.ai/code/session_01MX2FyXnWJDemc8Hqqu3je1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README table update; no code, auth, or data-handling changes.
> 
> **Overview**
> Documents **Cline** as a supported local coding agent harness in the README runtimes table.
> 
> The new row lists native-hook collection and coverage for session, prompt, pre/post-tool, task resume/cancel, command, file, and approval-decision telemetry, with a link to the Cline runtime docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d124942bdc211b3a05c8881cd1a30b81971c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->