### PR TITLE
docs: sort Cline into alphabetical order in the runtimes nav and index

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -138,6 +138,7 @@
                     "pages": [
                       "runtimes/antigravity-cli",
                       "runtimes/claude-code",
+                      "runtimes/cline",
                       "runtimes/codex-cli",
                       "runtimes/cursor",
                       "runtimes/devin",
@@ -146,7 +147,6 @@
                       "runtimes/gemini-cli",
                       "runtimes/github-copilot-cli",
                       "runtimes/grok-build",
-                      "runtimes/cline",
                       "runtimes/opencode",
                       "runtimes/vscode"
                     ]

--- a/docs/runtimes/index.mdx
+++ b/docs/runtimes/index.mdx
@@ -21,6 +21,7 @@ These integrations are grouped by where the agent runs and how telemetry is coll
 |----------------|-----------------|--------------------|
 | [Antigravity CLI](/runtimes/antigravity-cli) | Native hooks | Prompt, pre-tool, post-tool, stop, invocation, command, and file telemetry where Antigravity exposes hook payloads |
 | [Claude Code](/runtimes/claude-code) | Local OTLP export plus optional hooks | Prompt, command, tool, file, lifecycle, subagent, and permission telemetry where emitted through OTLP or hooks |
+| [Cline](/runtimes/cline) | Managed plugin hooks | Prompts, task lifecycle, tool lifecycle, commands, file reads and edits with diffs, MCP activity, and token usage |
 | [Codex CLI](/runtimes/codex-cli) | Local OTLP logs plus optional inventory hooks | Session, prompt, approval, and tool-result activity from Codex semantic logs; inventory heartbeat triggers from hooks |
 | [Cursor](/runtimes/cursor) | Native hooks | Prompt, tool, shell command, MCP-like, approval, and file edit telemetry |
 | [Devin CLI](/runtimes/devin) | Native hooks | Session, prompt, pre-tool, post-tool, permission request, stop, session-end, approval, and file telemetry |
@@ -30,7 +31,6 @@ These integrations are grouped by where the agent runs and how telemetry is coll
 | [GitHub Copilot CLI](/runtimes/github-copilot-cli) | MDM-managed OTLP HTTP | Prompt, session, tool, and approval-like activity emitted through Copilot CLI spans |
 | [Grok Build](/runtimes/grok-build) | Native hooks | Session, prompt, pre-tool, post-tool, failed tool, stop, session-end, command, and file telemetry |
 | [OpenCode](/runtimes/opencode) | Managed plugin hooks | Chat messages, session events, command execution, permission activity, diffs, and errors |
-| [Cline](/runtimes/cline) | Managed plugin hooks | Prompts, task lifecycle, tool lifecycle, commands, file reads and edits with diffs, MCP activity, and token usage |
 | [VS Code](/runtimes/vscode) | Copilot Chat OTel plus optional preview hooks | Copilot session, prompt, model, and tool activity through OTel; optional hooks for extra lifecycle and cross-agent detail |
 
 ### Local Knowledge Worker Agent Harnesses


### PR DESCRIPTION
Cline was appended to the end of the "Coding" local-agent lists rather than filed by its displayed title, so both lists read out of order:

- The docs sidebar (`docs/docs.json`, Agent Harness Integrations → Local Agents → Coding) showed `... Grok Build, Cline, OpenCode, VS Code`.
- The "Local Coding Agent Harnesses" table on `docs/runtimes/index.mdx` had the Cline row between OpenCode and VS Code.

This moves `runtimes/cline` between Claude Code and Codex CLI in both places (Cla < Cli < Cod), so each list is alphabetical by displayed title again. No page content, titles, or links change — only ordering.

`docs/docs.json` still parses as valid JSON. The prose list of installable harnesses further down `runtimes/index.mdx` already had Cline in the right spot and is untouched, as are the Knowledge Worker, CI Agents, and Cloud Agents groups (already sorted).

---
_Generated by [Claude Code](https://claude.ai/code/session_015UTNjLNn8Kq56fXSZaUTaz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only list reordering with no product, security, or content changes.
> 
> **Overview**
> Moves **Cline** into alphabetical order in the Local Coding agent lists: sidebar nav in `docs/docs.json` and the support-matrix table on `runtimes/index.mdx`. It now sits between Claude Code and Codex CLI. No page content, titles, or links change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27ed4b6348b182397a5c84701ca7d41b88b15bbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->