### PR TITLE
docs: resolve the release and architecture in the copy-paste install commands

### DIFF
--- a/docs/cli/manual-install.mdx
+++ b/docs/cli/manual-install.mdx
@@ -14,21 +14,45 @@ All three matter. `beacon-hooks` is what supported runtimes invoke to record pro
 and approvals, so an install that keeps only the CLI and the collector captures OpenTelemetry data
 and nothing from the hook path.
 
-```bash title="Download, verify, and extract (Linux amd64)"
-VERSION=1.2.0   # or whichever release you are installing
-BASE=https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}
-curl -fsSLO ${BASE}/beacon_${VERSION}_linux_amd64.tar.gz
-curl -fsSLO ${BASE}/checksums.txt
-sha256sum --check --ignore-missing checksums.txt
+```bash title="Download, verify, and extract (macOS or Linux)"
+LATEST_URL="$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/asymptote-labs/agent-beacon/releases/latest)"
+VERSION="${LATEST_URL##*/v}"
 
-tar -xzf beacon_${VERSION}_linux_amd64.tar.gz
+case "$(uname -s)" in
+  Linux) OS=linux ;;
+  Darwin) OS=darwin ;;
+  *) echo "Beacon publishes macOS and Linux archives, not $(uname -s)" >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+  x86_64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "Beacon publishes amd64 and arm64 archives, not $(uname -m)" >&2; exit 1 ;;
+esac
+
+ARCHIVE="beacon_${VERSION}_${OS}_${ARCH}.tar.gz"
+BASE="https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}"
+curl -fsSLO "${BASE}/${ARCHIVE}"
+curl -fsSLO "${BASE}/checksums.txt"
+
+# Verify this exact archive before extracting it. macOS ships shasum rather than sha256sum.
+if [ "$OS" = darwin ]; then
+  grep "  ${ARCHIVE}$" checksums.txt | shasum -a 256 -c -
+else
+  grep "  ${ARCHIVE}$" checksums.txt | sha256sum --check -
+fi
+
+tar -xzf "${ARCHIVE}"
 mkdir -p ~/.local/bin && mv beacon beacon-hooks beacon-otelcol ~/.local/bin/
 beacon version
 ```
 
-Swap `linux_amd64` for `linux_arm64`, `darwin_arm64`, or `darwin_amd64` as needed; on macOS use
-`shasum -a 256 -c` in place of `sha256sum --check`. The archive layout is identical across
-platforms.
+The version comes from the current release rather than a number to keep up to date, and the
+platform and architecture come from `uname`: `x86_64` maps to the published `amd64` archive and
+`aarch64` to `arm64`. A platform or architecture Beacon does not publish stops the run before
+anything is downloaded. The checksum step names the one archive about to be extracted, so it
+verifies that file rather than whatever else the directory happens to hold. The archive layout is
+identical across platforms.
 
 For managed endpoint rollouts on Apple Silicon Macs, GitHub Releases also attach
 a signed, notarized, and stapled `BeaconEndpointAgent-<version>-arm64.pkg`. The

--- a/docs/get-started/quickstart-developers.mdx
+++ b/docs/get-started/quickstart-developers.mdx
@@ -17,12 +17,23 @@ beacon endpoint install
 ```
 
 ```bash title="Linux"
-VERSION=1.2.0   # or whichever release you are installing
-curl -fsSLO https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}/beacon_${VERSION}_linux_amd64.tar.gz
-curl -fsSLO https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}/checksums.txt
-sha256sum --check --ignore-missing checksums.txt
+LATEST_URL="$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/asymptote-labs/agent-beacon/releases/latest)"
+VERSION="${LATEST_URL##*/v}"
 
-tar -xzf beacon_${VERSION}_linux_amd64.tar.gz
+case "$(uname -m)" in
+  x86_64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "Beacon publishes Linux archives for amd64 and arm64, not $(uname -m)" >&2; exit 1 ;;
+esac
+
+ARCHIVE="beacon_${VERSION}_linux_${ARCH}.tar.gz"
+BASE="https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}"
+curl -fsSLO "${BASE}/${ARCHIVE}"
+curl -fsSLO "${BASE}/checksums.txt"
+
+grep "  ${ARCHIVE}$" checksums.txt | sha256sum --check -
+
+tar -xzf "${ARCHIVE}"
 mkdir -p ~/.local/bin && mv beacon beacon-hooks beacon-otelcol ~/.local/bin/
 beacon endpoint install
 ```
@@ -34,6 +45,12 @@ beacon endpoint install
   `/var/log/beacon-agent/runtime.jsonl` instead, so every command below would report on the wrong
   log. If you want the system-mode package, follow [Linux](/platforms/linux) instead of this page.
 </Note>
+
+The Linux commands resolve the current release rather than a version you have to edit in, map
+`x86_64` and `aarch64` to the archive names Beacon actually publishes, and stop before downloading
+anything on an architecture with no published archive. The checksum step names the one archive
+about to be extracted, so it verifies that file rather than whatever else the directory happens to
+hold.
 
 See [Asymptote Open Source](/deployment/open-source) for install details and runtime-specific notes,
 or [macOS](/platforms/macos), [Linux](/platforms/linux), or [Windows](/platforms/windows) for the

--- a/docs/platforms/linux.mdx
+++ b/docs/platforms/linux.mdx
@@ -34,14 +34,24 @@ If you are not an administrator on the machine, or you would rather not touch sy
 tarball and install in user mode:
 
 ```bash title="Tarball install, no root required"
-VERSION=1.2.0   # or whichever release you are installing
-curl -fsSLO https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}/beacon_${VERSION}_linux_amd64.tar.gz
-curl -fsSLO https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}/checksums.txt
+LATEST_URL="$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/asymptote-labs/agent-beacon/releases/latest)"
+VERSION="${LATEST_URL##*/v}"
 
-# Verify before extracting. This is the integrity check for the tarball.
-sha256sum --check --ignore-missing checksums.txt
+case "$(uname -m)" in
+  x86_64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "Beacon publishes Linux archives for amd64 and arm64, not $(uname -m)" >&2; exit 1 ;;
+esac
 
-tar -xzf beacon_${VERSION}_linux_amd64.tar.gz
+ARCHIVE="beacon_${VERSION}_linux_${ARCH}.tar.gz"
+BASE="https://github.com/asymptote-labs/agent-beacon/releases/download/v${VERSION}"
+curl -fsSLO "${BASE}/${ARCHIVE}"
+curl -fsSLO "${BASE}/checksums.txt"
+
+# Verify this exact archive before extracting it, by the name about to be extracted.
+grep "  ${ARCHIVE}$" checksums.txt | sha256sum --check -
+
+tar -xzf "${ARCHIVE}"
 mkdir -p ~/.local/bin && mv beacon beacon-hooks beacon-otelcol ~/.local/bin/
 
 # ~/.local/bin is already on PATH on most distributions; if `beacon version` fails, add it:
@@ -49,6 +59,11 @@ mkdir -p ~/.local/bin && mv beacon beacon-hooks beacon-otelcol ~/.local/bin/
 beacon version
 beacon endpoint install
 ```
+
+The version comes from the current release rather than a number you have to keep up to date, and
+the architecture comes from `uname -m`: `x86_64` maps to the published `amd64` archive and
+`aarch64` to `arm64`. An architecture Beacon does not publish stops the run before anything is
+downloaded.
 
 The archive contains three binaries — the `beacon` CLI, the `beacon-hooks` adapter that captures
 tool activity, and the `beacon-otelcol` collector. All three are needed, and all three are


### PR DESCRIPTION
Second slice out of the onboarding feedback in #367 — docs only, no code, independent of the other slices.

## The problem

The documented Linux install opened with `VERSION=1.2.0   # or whichever release you are installing` and hardcoded `linux_amd64`. Pasted as written it installs a release three tags old, and on an arm64 host it fetches an x86 archive that verifies fine and then will not run. "One documented copy-and-paste flow" was the first acceptance criterion in #367, and an edit-this-line placeholder is not one.

Verification used `sha256sum --check --ignore-missing checksums.txt`, which verifies whatever in the working directory happens to be listed — not the archive the next line extracts. In a directory holding only the release's `.deb`, that reports `beacon_1.2.3_linux_amd64.deb: OK` and exits 0.

## What changed

Three pages — `get-started/quickstart-developers`, `platforms/linux`, `cli/manual-install`:

- The version comes from the current release rather than a number to keep up to date.
- The architecture comes from `uname -m`, mapping `x86_64` → `amd64` and `aarch64`/`arm64` → `arm64`. An unpublished architecture stops the run before anything is downloaded.
- The checksum step names the one archive about to be extracted.
- `manual-install` covers macOS too, so its block now detects the platform and picks `shasum` or `sha256sum`, replacing the prose that told the reader which parts to substitute.

Both `curl` calls now resolve from the same `releases/download/v${VERSION}` base as the version, rather than re-resolving `latest` per request — so a release landing mid-run cannot pair one release's archive with another's checksums.

## Verification

Each block was extracted from the rendered page and run verbatim — download, verification, extraction, `beacon version` — against the live release. All three pass on `linux/amd64`.

Failure modes checked too: a tampered archive fails verification before extraction, and `riscv64` exits non-zero having downloaded nothing.

Not committed as a test: it needs network access, which `CLAUDE.md` rules out for this suite.

**One thing I could not run:** the `darwin` branch of the `manual-install` block, specifically whether `shasum -a 256 -c -` exits non-zero on empty stdin the way GNU `sha256sum` does (verified). The happy path — a matched line piped to `shasum` — is standard and not in doubt. Worth one run on a Mac before merge.

**Considered and kept:** `exit 1` in the architecture guard will close an interactive shell on an unsupported architecture. The alternative is proceeding to a confusing 404, and #367 asks for unsupported architectures to fail before modifying the machine, so stopping wins.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cj2ThWcLKK5hdHq87rXQmY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only install snippets; no product code. Residual risk is users pasting the new shell (including `exit 1` on unsupported arch) and the untested macOS `shasum` empty-stdin failure path.
> 
> **Overview**
> Makes the documented tarball install a true copy-paste: it now follows GitHub `releases/latest` for the version, maps `uname` to `linux`/`darwin` and `amd64`/`arm64`, and bails out before download on unpublished platforms.
> 
> Checksum verification greps the exact archive name instead of `sha256sum --check --ignore-missing`, so it cannot pass on some other file in the working directory. `manual-install` also picks `shasum` vs `sha256sum` instead of asking the reader to swap commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78d0a9db4b45b8bcae2ae2717f0ff4c172dddbcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->