### PR TITLE
Qwen Code support 1/6: pin `qwen_code` as the canonical harness name

### DIFF
--- a/pkg/asymptoteobserve/harness.go
+++ b/pkg/asymptoteobserve/harness.go
@@ -85,6 +85,22 @@ func NormalizeHarnessName(name string) string {
 	case lower == "cline" || lower == "cline_cli" || lower == "cline-cli" || lower == "cline cli" ||
 		lower == "cline.bot":
 		return "cline"
+	// Qwen Code is matched by equality against a closed set, not by a substring rule, and the
+	// reason is specific to this runtime rather than general caution: every Qwen model id begins
+	// with the same four letters the harness does -- qwen3-coder-plus, qwen-max, qwen-turbo. A
+	// Contains rule would therefore report any event whose harness attribute happened to carry a
+	// model string as a Qwen Code session, which is how a model name ends up masquerading as a
+	// runtime in a dashboard grouped by harness.name.
+	//
+	// The canonical spelling is qwen_code rather than qwen_cli because Qwen Code is the product's
+	// name; it follows claude_code, not codex_cli. Both spellings arrive in practice -- the hook
+	// path installs with --platform qwen, while an OTLP resource attribute carries whatever the
+	// runtime calls itself -- and pinning them here is what keeps one session from being recorded
+	// under two names.
+	case lower == "qwen" || lower == "qwen_code" || lower == "qwen-code" || lower == "qwen code" ||
+		lower == "qwencode" || lower == "qwen_cli" || lower == "qwen-cli" || lower == "qwen cli" ||
+		lower == "qwen_coder" || lower == "qwen-coder" || lower == "qwen coder":
+		return "qwen_code"
 	case name != "":
 		// An unrecognized runtime keeps its own name rather than being coerced or dropped. A new
 		// harness should show up in the log as itself, not as "unknown".

--- a/pkg/asymptoteobserve/harness_test.go
+++ b/pkg/asymptoteobserve/harness_test.go
@@ -18,6 +18,7 @@ func TestHookPlatformsConvergeOnCanonicalNames(t *testing.T) {
 		"vscode":      "vscode_copilot",
 		"pi":          "pi_cli",
 		"cline":       "cline",
+		"qwen":        "qwen_code",
 	} {
 		t.Run(platform, func(t *testing.T) {
 			if got := NormalizeHarnessName(platform); got != want {
@@ -36,7 +37,7 @@ func TestCanonicalNamesAreStableUnderRenormalization(t *testing.T) {
 	for _, canonical := range []string{
 		"claude_code", "codex_cli", "gemini_cli", "antigravity_cli", "vscode_copilot",
 		"copilot_cli", "claude_web", "chatgpt_web", "claude_cowork", "claude_agent_sdk",
-		"openclaw_gateway", "pi_cli", "cline",
+		"openclaw_gateway", "pi_cli", "cline", "qwen_code",
 	} {
 		t.Run(canonical, func(t *testing.T) {
 			if got := NormalizeHarnessName(canonical); got != canonical {
@@ -149,6 +150,49 @@ func TestClineIsNotAttributedToClaudeCode(t *testing.T) {
 	for _, in := range []string{"cline", "Cline", "cline_cli", "cline.bot"} {
 		if got := NormalizeHarnessName(in); got == "claude_code" {
 			t.Errorf("NormalizeHarnessName(%q) = %q, want Cline to keep its own harness", in, got)
+		}
+	}
+}
+
+// Qwen Code reaches Beacon under more than one spelling: the hook path installs with
+// --platform qwen, while the OTLP path reports whatever the runtime puts in its resource
+// attributes. Both must land on the same canonical name or one session is recorded as two.
+func TestQwenSpellingsConvergeOnQwenCode(t *testing.T) {
+	for _, in := range []string{
+		"qwen", "Qwen", "QWEN", " qwen ", "qwen_code", "qwen-code", "Qwen Code", "qwencode",
+		"qwen_cli", "qwen-cli", "qwen cli", "qwen-coder", "Qwen Coder",
+	} {
+		t.Run(in, func(t *testing.T) {
+			if got := NormalizeHarnessName(in); got != "qwen_code" {
+				t.Errorf("NormalizeHarnessName(%q) = %q, want %q", in, got, "qwen_code")
+			}
+		})
+	}
+}
+
+// The reason the Qwen case is an equality match rather than a Contains rule. Every Qwen model id
+// starts with the same four letters as the harness, so a substring rule would relabel any name
+// carrying a model string as a Qwen Code session -- turning a model into a runtime in every
+// dashboard grouped by harness.name.
+func TestQwenModelNamesAreNotTreatedAsTheHarness(t *testing.T) {
+	for _, name := range []string{
+		"qwen3-coder-plus", "qwen3-coder", "qwen-max", "qwen-turbo", "qwen2.5-coder-32b-instruct",
+	} {
+		if got := NormalizeHarnessName(name); got != name {
+			t.Errorf("NormalizeHarnessName(%q) = %q, want the model name preserved rather than "+
+				"reported as the Qwen Code harness", name, got)
+		}
+	}
+}
+
+// Qwen Code is a Gemini CLI fork, which is exactly why this needs a test: the generic
+// Contains(lower, "gemini") rule sits above the Qwen case, and Qwen Code keeps some Gemini-derived
+// paths on disk. A Qwen session attributed to gemini_cli would be filed under a runtime the user
+// does not have installed.
+func TestQwenIsNotAttributedToGeminiCLI(t *testing.T) {
+	for _, in := range []string{"qwen", "qwen-code", "qwen_code", "Qwen Code"} {
+		if got := NormalizeHarnessName(in); got != "qwen_code" {
+			t.Errorf("NormalizeHarnessName(%q) = %q, want qwen_code", in, got)
 		}
 	}
 }


### PR DESCRIPTION
First of six stacked PRs adding [Qwen Code](https://qwen.ai/qwencode) as a supported runtime, via its [native hook system](https://qwenlm.github.io/qwen-code-docs/en/users/features/hooks/).

**Stack:** 1/6 ← you are here · [2/6 hook platform] · [3/6 event mapping] · [4/6 installer] · [5/6 CLI wiring] · [6/6 docs]

## What this does

Adds `qwen` → `qwen_code` to `NormalizeHarnessName`.

Two independent writers put a name in `harness.name` for the same session: the hook path takes it from the `--platform` value it was installed with, and the OTLP path derives it from resource attributes. Until both spellings resolve to one canonical name, a single Qwen Code session is recorded twice — once as `qwen`, once as whatever the runtime calls itself — which splits it for every query, dashboard and SIEM detection that groups by that field.

`qwen_code` follows `claude_code` rather than `codex_cli`, because Qwen Code is the product's name.

## Why equality rather than a substring rule

Every Qwen model id begins with the same four letters as the harness — `qwen3-coder-plus`, `qwen-max`, `qwen-turbo`. A `Contains` rule would report any event whose harness attribute carried a model string as a Qwen Code session, which is how a model name comes to masquerade as a runtime. The closed set is what prevents that, and `TestQwenModelNamesAreNotTreatedAsTheHarness` is what holds the line.

Qwen Code is a Gemini CLI fork, so `TestQwenIsNotAttributedToGeminiCLI` pins the other direction: the generic `Contains(lower, "gemini")` rule sits above this case, and a Qwen session filed under `gemini_cli` would be attributed to a runtime the user does not have installed.

## Testing

`go test ./...` in `pkg/asymptoteobserve` passes. Verified the new tests fail without the change (`qwen` returns `qwen` rather than `qwen_code`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjGxqpv6Em1LHdBC9rkBJY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested name-normalization change only. It does not alter auth, ingestion, or event payloads beyond `harness.name` mapping.
> 
> **Overview**
> Pins **Qwen Code** to the canonical harness name `qwen_code` in `NormalizeHarnessName`, so `--platform qwen` and OTLP resource spellings (`qwen_code`, `qwen-cli`, `qwen coder`, etc.) land on one value instead of splitting a session in dashboards and detections.
> 
> Matching is a **closed equality set**, not a substring rule, so Qwen *model* ids (`qwen-max`, `qwen3-coder-plus`, …) stay as themselves rather than being labeled as the runtime. Tests cover spelling convergence, renormalization stability, model-id preservation, and not attributing Qwen to `gemini_cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285dc13a5df9a1760d1034f21bd947b6b8ce17d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->