### PR TITLE
Qwen Code support 2/6: teach the hook adapter the `qwen` platform

### DIFF
--- a/cli/beacon-hooks/cmd/policy.go
+++ b/cli/beacon-hooks/cmd/policy.go
@@ -163,7 +163,14 @@ func policyDenyResponse(reason string) map[string]interface{} {
 		return map[string]interface{}{"decision": "reject"}
 	case platformFlag == "antigravity" || platformFlag == "grok":
 		return map[string]interface{}{"decision": "deny"}
-	case platformFlag == "claude":
+	// Qwen Code shares Claude Code's deny shape exactly: `hookSpecificOutput.permissionDecision`
+	// with a `permissionDecisionReason`, both required by its PreToolUse contract. The
+	// `hookEventName` stays "PreToolUse" in both phases the seam runs in, matching the existing
+	// claude behavior -- Qwen's PermissionRequest event reads a differently shaped
+	// `hookSpecificOutput.decision` object, so a deny raised from that phase is not honored there.
+	// Stated rather than hidden: the seam fails open, so the cost is a deny that does not take
+	// effect on one of two phases, never a tool call blocked for the wrong reason.
+	case platformFlag == "claude" || platformFlag == "qwen":
 		return map[string]interface{}{
 			"hookSpecificOutput": map[string]interface{}{
 				"hookEventName":            "PreToolUse",

--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -49,7 +49,7 @@ func runPreTool(cmd *cobra.Command, args []string) {
 	} else if platformFlag == "antigravity" {
 		emitAntigravityPromptFromTranscript(logger, input, sessionID)
 		emitPreToolObserved(logger, input, sessionID)
-	} else if platformFlag == "claude" || isDevinLikePlatform(platformFlag) || platformFlag == "grok" || platformFlag == "hermes" || platformFlag == "vscode" {
+	} else if platformFlag == "claude" || platformFlag == "qwen" || isDevinLikePlatform(platformFlag) || platformFlag == "grok" || platformFlag == "hermes" || platformFlag == "vscode" {
 		emitPreToolObserved(logger, input, sessionID)
 	} else {
 		emitPreToolDecision(logger, input, sessionID, "approval.allowed", "allow", "Pre-tool observed")
@@ -106,7 +106,15 @@ func preToolResponse() map[string]interface{} {
 	if platformFlag == "antigravity" || platformFlag == "grok" {
 		return map[string]interface{}{"decision": "allow"}
 	}
-	if platformFlag == "claude" || isDevinLikePlatform(platformFlag) || platformFlag == "hermes" || platformFlag == "vscode" {
+	// Qwen Code belongs with claude here, and the reason is a security property rather than a
+	// convention. Qwen's PreToolUse contract reads a decision from
+	// `hookSpecificOutput.permissionDecision`, where "allow" means *run the tool without the usual
+	// approval prompt*. An observing hook that answered "allow" would therefore not be observing:
+	// it would silently disarm the user's own permission prompts for every tool call, on a runtime
+	// where the hook was installed to watch. An empty object carries no decision, so Qwen's normal
+	// permission flow runs untouched -- which is the only correct answer for a telemetry hook, and
+	// what TestQwenPreToolDoesNotApproveOnBehalfOfTheUser holds in place.
+	if platformFlag == "claude" || platformFlag == "qwen" || isDevinLikePlatform(platformFlag) || platformFlag == "hermes" || platformFlag == "vscode" {
 		return emptyResponse
 	}
 	return allowResponse

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -905,6 +905,7 @@ func setupHookConfigDirs(t *testing.T) {
 	origHermesDir := hookconfig.HermesDir
 	origOpenCodeDir := hookconfig.OpenCodeDir
 	origClineDir := hookconfig.ClineDir
+	origQwenDir := hookconfig.QwenDir
 	origPlatform := platformFlag
 	hookconfig.BeaconDir = tmp
 	hookconfig.ClaudeDir = filepath.Join(tmp, "claude")
@@ -918,6 +919,7 @@ func setupHookConfigDirs(t *testing.T) {
 	hookconfig.HermesDir = filepath.Join(tmp, "hermes")
 	hookconfig.OpenCodeDir = filepath.Join(tmp, "opencode")
 	hookconfig.ClineDir = filepath.Join(tmp, "cline")
+	hookconfig.QwenDir = filepath.Join(tmp, "qwen")
 	t.Cleanup(func() {
 		hookconfig.BeaconDir = origBeaconDir
 		hookconfig.ClaudeDir = origClaudeDir
@@ -931,6 +933,7 @@ func setupHookConfigDirs(t *testing.T) {
 		hookconfig.HermesDir = origHermesDir
 		hookconfig.OpenCodeDir = origOpenCodeDir
 		hookconfig.ClineDir = origClineDir
+		hookconfig.QwenDir = origQwenDir
 		platformFlag = origPlatform
 	})
 }

--- a/cli/beacon-hooks/cmd/qwen_hooks_test.go
+++ b/cli/beacon-hooks/cmd/qwen_hooks_test.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	hookconfig "github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/config"
+)
+
+// Qwen Code's hook payloads are the Claude Code shape: snake_case base fields, `tool_name` /
+// `tool_input`, `cwd`. Most of the adapter therefore needs no Qwen-specific reader -- the default
+// branches already do the right thing. These tests exist because that is a fact about Qwen's
+// contract rather than an accident of the code: they pin the default readers to Qwen payloads so a
+// future refactor of the claude branches cannot silently take Qwen's session id, working directory
+// or tool fields with it.
+
+// The base fields Qwen sends on every event: session_id, transcript_path, cwd, hook_event_name.
+// Reading them is what puts session.id, session.working_directory and repository on every Qwen
+// event; without them, a whole runtime's telemetry arrives with no session and no workspace.
+func TestQwenSessionAndWorkspaceComeFromTheBaseFields(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "qwen"
+
+	input := map[string]interface{}{
+		"session_id":      "qwen-session-1",
+		"transcript_path": "/tmp/qwen/transcripts/qwen-session-1.jsonl",
+		"cwd":             "/tmp/qwen-project",
+		"hook_event_name": "PreToolUse",
+	}
+
+	if got := resolveSessionID(input, "qwen"); got != "qwen-session-1" {
+		t.Errorf("resolveSessionID = %q, want qwen-session-1", got)
+	}
+	sessionID, transcriptPath := resolveSessionIDWithTranscript(input, "qwen")
+	if sessionID != "qwen-session-1" {
+		t.Errorf("resolveSessionIDWithTranscript session = %q, want qwen-session-1", sessionID)
+	}
+	if transcriptPath != "/tmp/qwen/transcripts/qwen-session-1.jsonl" {
+		t.Errorf("resolveSessionIDWithTranscript transcript = %q, want Qwen's transcript_path", transcriptPath)
+	}
+	if got := resolveCwd(input, "qwen"); got != "/tmp/qwen-project" {
+		t.Errorf("resolveCwd = %q, want /tmp/qwen-project", got)
+	}
+}
+
+// Qwen gets its own state directory. Sharing Claude's would mix two runtimes' session state and
+// hook logs in one place: a stale-evaluation cleanup for a Qwen session would walk Claude's
+// sessions, and `~/.beacon/claude/hooks.log` would interleave two runtimes.
+func TestQwenHasItsOwnStateDirectory(t *testing.T) {
+	setupHookConfigDirs(t)
+
+	stateDir := hookconfig.GetStateDir("qwen")
+	if stateDir != hookconfig.QwenDir {
+		t.Fatalf("GetStateDir(qwen) = %q, want QwenDir %q", stateDir, hookconfig.QwenDir)
+	}
+	if stateDir == hookconfig.ClaudeDir {
+		t.Fatalf("GetStateDir(qwen) = %q, want a directory distinct from Claude's", stateDir)
+	}
+	if got, want := hookconfig.GetLogFile("qwen"), filepath.Join(hookconfig.QwenDir, "hooks.log"); got != want {
+		t.Fatalf("GetLogFile(qwen) = %q, want %q", got, want)
+	}
+	if got, want := hookconfig.GetSessionLogFile("qwen", "s1"), filepath.Join(hookconfig.QwenDir, "logs", "s1.log"); got != want {
+		t.Fatalf("GetSessionLogFile(qwen) = %q, want %q", got, want)
+	}
+}
+
+// The security property behind routing Qwen through the claude branch of preToolResponse.
+//
+// Qwen reads a PreToolUse decision from `hookSpecificOutput.permissionDecision`, and "allow" there
+// means run the tool *without the usual approval prompt*. A telemetry hook that answered "allow"
+// would silently disarm the user's own permission prompts for every tool call on a runtime where
+// the hook was installed only to watch. The empty object carries no decision, so Qwen's normal
+// permission flow runs untouched.
+func TestQwenPreToolDoesNotApproveOnBehalfOfTheUser(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "qwen"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_MODE", "1")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	out := runHookWithInput(t, runPreTool, map[string]interface{}{
+		"session_id":      "qwen-session-1",
+		"cwd":             "/tmp/qwen-project",
+		"hook_event_name": "PreToolUse",
+		"tool_name":       "run_shell_command",
+		"tool_input":      map[string]interface{}{"command": "rm -rf build"},
+	})
+	if len(out) != 0 {
+		t.Fatalf("pre-tool response = %#v, want an empty object carrying no permission decision", out)
+	}
+	if _, ok := out["hookSpecificOutput"]; ok {
+		t.Fatalf("pre-tool response carried hookSpecificOutput: %#v", out)
+	}
+	if _, ok := out["permission"]; ok {
+		t.Fatalf("pre-tool response carried a Cursor-shaped permission field: %#v", out)
+	}
+
+	// Observed, not approved: the event records the invocation without claiming an approval
+	// decision Beacon did not make.
+	event := lastEndpointEvent(t, logPath)
+	if action := event["event"].(map[string]interface{})["action"]; action != "command.executed" && action != "tool.invoked" {
+		t.Fatalf("event.action = %q, want the tool invocation recorded", action)
+	}
+	if _, ok := event["approval"]; ok {
+		t.Fatalf("pre-tool event claimed an approval decision: %#v", event["approval"])
+	}
+	if got := event["session"].(map[string]interface{})["id"]; got != "qwen-session-1" {
+		t.Fatalf("session.id = %q, want qwen-session-1", got)
+	}
+	if got := event["session"].(map[string]interface{})["working_directory"]; got != "/tmp/qwen-project" {
+		t.Fatalf("working_directory = %q, want /tmp/qwen-project", got)
+	}
+}
+
+// The policy seam is off by default and fails open, but when a provider does deny, the response has
+// to be the shape Qwen actually reads or the deny is silently dropped and the tool runs anyway.
+func TestQwenPolicyDenyUsesQwensPermissionDecisionShape(t *testing.T) {
+	origPlatform := platformFlag
+	t.Cleanup(func() { platformFlag = origPlatform })
+	platformFlag = "qwen"
+
+	deny := policyDenyResponse("Security policy blocks database writes")
+	if deny == nil {
+		t.Fatal("policyDenyResponse(qwen) = nil; a provider deny would be silently dropped and the tool would run")
+	}
+	specific, ok := deny["hookSpecificOutput"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("deny response = %#v, want hookSpecificOutput", deny)
+	}
+	if got := specific["hookEventName"]; got != "PreToolUse" {
+		t.Errorf("hookEventName = %q, want PreToolUse", got)
+	}
+	if got := specific["permissionDecision"]; got != "deny" {
+		t.Errorf("permissionDecision = %q, want deny", got)
+	}
+	// Qwen's contract marks permissionDecisionReason REQUIRED alongside the decision.
+	if got := specific["permissionDecisionReason"]; got != "Security policy blocks database writes" {
+		t.Errorf("permissionDecisionReason = %q, want the provider's reason", got)
+	}
+}
+
+// Beacon's own default platform is claude, and an unknown --platform value falls through to
+// "unknown platform -> allow". Naming qwen explicitly is what keeps it out of that fallback; this
+// guards the pairing between the flag value the installer writes and the branch the adapter takes.
+func TestQwenIsNotTreatedAsAnUnknownPlatform(t *testing.T) {
+	origPlatform := platformFlag
+	t.Cleanup(func() { platformFlag = origPlatform })
+
+	platformFlag = "qwen-code"
+	if deny := policyDenyResponse("blocked"); deny != nil {
+		t.Fatalf("policyDenyResponse(qwen-code) = %#v; only the installed --platform spelling (qwen) is wired", deny)
+	}
+
+	platformFlag = "qwen"
+	if deny := policyDenyResponse("blocked"); deny == nil {
+		t.Fatal("policyDenyResponse(qwen) = nil, want Qwen's deny shape")
+	}
+}

--- a/cli/beacon-hooks/cmd/root.go
+++ b/cli/beacon-hooks/cmd/root.go
@@ -29,8 +29,8 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:   "beacon-hooks",
-	Short: "Beacon hooks for Claude Code, Codex, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Hermes, Antigravity, opencode, and Cline",
-	Long: `Beacon hooks binary for Claude Code, Codex, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Hermes, Antigravity, opencode, and Cline integration.
+	Short: "Beacon hooks for Claude Code, Codex, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Hermes, Antigravity, opencode, Qwen Code, and Cline",
+	Long: `Beacon hooks binary for Claude Code, Codex, GitHub Copilot, Cursor, VS Code, Devin, Factory, Grok, Hermes, Antigravity, opencode, Qwen Code, and Cline integration.
 
 This binary provides hook commands that are called by IDE plugin systems
 to evaluate code changes for security violations.
@@ -39,7 +39,7 @@ Use --platform to specify the calling platform (default: claude).`,
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, cline, codex, antigravity, copilot, cursor, vscode, devin, devin-cli, devin-desktop, factory, grok, hermes, or opencode")
+	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "claude", "Platform context: claude, cline, codex, antigravity, copilot, cursor, vscode, devin, devin-cli, devin-desktop, factory, grok, hermes, opencode, or qwen")
 	rootCmd.PersistentFlags().StringVar(&logFlag, "log", "", "Endpoint runtime log to append to (same value as BEACON_ENDPOINT_LOG)")
 	rootCmd.PersistentFlags().StringVar(&configFlag, "config", "", "Endpoint config to read (same value as BEACON_ENDPOINT_CONFIG)")
 	rootCmd.PersistentFlags().StringVar(&cliFlag, "cli", "", "Path to the beacon CLI for inventory heartbeats (same value as BEACON_ENDPOINT_CLI)")

--- a/cli/beacon-hooks/internal/config/config.go
+++ b/cli/beacon-hooks/internal/config/config.go
@@ -21,6 +21,7 @@ var (
 	GrokDir        = filepath.Join(BeaconDir, "grok")
 	HermesDir      = filepath.Join(BeaconDir, "hermes")
 	OpenCodeDir    = filepath.Join(BeaconDir, "opencode")
+	QwenDir        = filepath.Join(BeaconDir, "qwen")
 	ClineDir       = filepath.Join(BeaconDir, "cline")
 )
 
@@ -100,6 +101,8 @@ func GetStateDir(platform string) string {
 		return HermesDir
 	case "opencode":
 		return OpenCodeDir
+	case "qwen":
+		return QwenDir
 	case "cline":
 		return ClineDir
 	default:


### PR DESCRIPTION
**Stack:** [1/6 #378] ← base · 2/6 you are here · [3/6 event mapping] · [4/6 installer] · [5/6 CLI wiring] · [6/6 docs]

Review only the top commit; the rest is #378.

## What this does

Qwen Code sends Claude Code's payload shape — snake_case base fields (`session_id`, `transcript_path`, `cwd`, `hook_event_name`), plus `tool_name` / `tool_input` / `tool_response` — so most of the adapter needs no Qwen-specific reader at all. What it does need is for `qwen` to be a platform the binary recognizes, and for the branches keyed on the platform to name it. This PR is only that wiring; the tool taxonomy and event mapping follow in 3/6.

## Three things decided here rather than inherited

**`~/.beacon/qwen` is Qwen's own state directory.** Falling through to Claude's default would put two runtimes' session state and hook logs in one place, so a stale-session cleanup run for Qwen would walk Claude's sessions.

**The `PreToolUse` response is an empty object, not an allow.** This is a security property, not a convention: Qwen reads its decision from `hookSpecificOutput.permissionDecision`, where `"allow"` means *run the tool without the usual approval prompt*. A telemetry hook answering `allow` would silently disarm the user's own permission prompts for every tool call on a runtime where the hook was installed to watch. `TestQwenPreToolDoesNotApproveOnBehalfOfTheUser` holds that line, and also checks the event carries no `approval` field — Beacon should not record a decision it did not make.

**The policy seam's deny shape** is Qwen's `permissionDecision` object with a `permissionDecisionReason`, both of which its contract marks required. Without it, `qwen` would land in "unknown platform → allow" and a provider deny would be dropped while the tool ran. The `hookEventName` stays `"PreToolUse"` in both phases the seam runs in, matching the existing `claude` behavior; the comment states the resulting limit rather than hiding it.

## Testing

`go test ./...` in `cli/beacon-hooks` passes. Verified the three behavioral tests fail without the source change (they assert `allow`/`approval` absence and the deny shape). The remaining tests pin Qwen payloads against the *default* readers, so a later refactor of the `claude` branches cannot quietly take Qwen's session id, transcript path and working directory with it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjGxqpv6Em1LHdBC9rkBJY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches policy deny responses and PreToolUse permission semantics for a new runtime. Wrong shapes would either drop denials or silently skip user approval prompts.
> 
> **Overview**
> Recognizes **Qwen Code** as `--platform qwen` in `beacon-hooks`, so it is no longer treated as an unknown platform that always allows.
> 
> State lives under `~/.beacon/qwen` instead of falling through to Claude’s directory, keeping session logs and cleanup isolated.
> 
> Pre-tool observation follows the Claude path: emit `tool.invoked` telemetry and return an **empty** hook response. An `"allow"` `permissionDecision` would skip Qwen’s own approval prompts. Policy denials use Claude’s `hookSpecificOutput.permissionDecision` + required reason so a provider deny is not dropped. Denies still use `hookEventName: PreToolUse` in every seam phase (same fail-open limit as Claude).
> 
> Tests pin session/cwd readers, the empty pre-tool contract, deny shape, and that only the `qwen` spelling is wired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4fbae3f2db414791c8ba515d4110a0fcdaa5ddf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->