### PR TITLE
Qwen Code support 4/6: install Beacon's hooks into Qwen Code's settings.json

### DIFF
--- a/cli/beacon/internal/endpoint/hooks/qwen.go
+++ b/cli/beacon/internal/endpoint/hooks/qwen.go
@@ -1,0 +1,170 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Qwen Code hook timeouts are milliseconds.
+//
+// This is the one place Qwen's settings format diverges from Claude Code's while looking identical,
+// and it fails quietly in the direction that hurts. Claude Code reads `timeout` as seconds, so the
+// values the Claude installer writes -- 30, 45, 10 -- mean 30ms, 45ms and 10ms to Qwen. A hook
+// process cannot start, read stdin, resolve a git branch and append to a JSONL file in ten
+// milliseconds, so every tool event would be killed mid-write. The install would report success,
+// the settings file would look right, and the runtime log would be empty or truncated.
+//
+// Named constants rather than literals so the unit is stated at the value, and so
+// TestQwenTimeoutsAreMillisecondsNotSeconds has something to assert against other than magic
+// numbers. Qwen's own default is 60000 (60s); events with no entry here inherit it, which is the
+// right answer for the ones that do no work beyond writing a line.
+const (
+	qwenPromptSubmitTimeoutMS = 30000
+	qwenToolTimeoutMS         = 10000
+	qwenStopTimeoutMS         = 45000
+)
+
+// qwenAllToolsMatcher matches every tool id.
+//
+// Qwen documents `""` and `"*"` as the two spellings that match all events of a type, and uses
+// `"*"` in its own examples. `"*"` is preferred over an omitted matcher because Qwen's matcher
+// table marks tool events as regex-filtered and its tool-event examples always carry one; an
+// omitted matcher on a tool event is undocumented territory, and "documented and demonstrated"
+// beats "probably equivalent" for the field that decides whether a hook fires at all.
+const qwenAllToolsMatcher = "*"
+
+type QwenOptions struct {
+	Level    Level
+	LogPath  string
+	UserMode bool
+}
+
+type QwenStatus struct {
+	Installed    bool   `json:"installed"`
+	BinaryPath   string `json:"binary_path,omitempty"`
+	SettingsPath string `json:"settings_path,omitempty"`
+	Message      string `json:"message,omitempty"`
+}
+
+var qwenRuntime = hookRuntime{
+	displayName: "Qwen Code",
+	configPath:  qwenSettingsPath,
+	install:     installQwenSettings,
+	uninstall:   removeQwenEndpointHooks,
+	isInstalled: isQwenInstalledAt,
+}
+
+func InstallQwen(opts QwenOptions) (QwenStatus, error) {
+	status, err := installRuntimeHooks(qwenRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return QwenStatus{}, err
+	}
+	return qwenProjectTrustMessage(qwenStatusFromRuntime(status), opts.Level), nil
+}
+
+func UninstallQwen(opts QwenOptions) (QwenStatus, error) {
+	status, err := uninstallRuntimeHooks(qwenRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return QwenStatus{}, err
+	}
+	return qwenStatusFromRuntime(status), nil
+}
+
+func QwenHookStatus(opts QwenOptions) QwenStatus {
+	return qwenProjectTrustMessage(qwenStatusFromRuntime(runtimeHookStatus(qwenRuntime, RuntimeOptions(opts))), opts.Level)
+}
+
+func IsQwenInstalled(opts QwenOptions) bool {
+	return isRuntimeInstalled(qwenRuntime, RuntimeOptions(opts))
+}
+
+func qwenStatusFromRuntime(status runtimeStatus) QwenStatus {
+	return QwenStatus{
+		Installed:    status.Installed,
+		BinaryPath:   status.BinaryPath,
+		SettingsPath: status.ConfigPath,
+		Message:      status.Message,
+	}
+}
+
+// installQwenSettings merges Beacon's hooks into Qwen Code's settings.json.
+//
+// The file is shared with the user's own configuration -- model, theme, MCP servers, their own
+// hooks -- so this goes through the same merge the Claude and Factory installers use: unrelated
+// top-level keys are preserved verbatim, non-Beacon hooks in the same event group survive, and a
+// re-install replaces Beacon's own entries instead of stacking a second copy beside them.
+//
+// The event set is everything Qwen exposes that carries endpoint signal. `PostToolUseFailure` is
+// registered alongside `PostToolUse` because a failed tool is a separate event in Qwen and would
+// otherwise be invisible; `PermissionRequest` is what makes an approval prompt observable at all.
+// The fire-and-forget events Qwen also offers -- `MessageDisplay`, `StopFailure`, `PostCompact`,
+// `SessionDelete`, the todo pair -- are deliberately not registered: `MessageDisplay` alone fires
+// every ~200ms for the length of every reply, and spawning a process that often to record assistant
+// text Beacon does not otherwise retain would cost more than it tells anyone.
+func installQwenSettings(path, binaryPath, logPath, configPath string) error {
+	prefix := endpointCommandPrefix("qwen", binaryPath, logPath, configPath)
+	endpointHooks := map[string]settingsHookGroup{
+		"SessionStart":       {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " session-start"}}},
+		"UserPromptSubmit":   {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " prompt-submit", Timeout: qwenPromptSubmitTimeoutMS}}},
+		"PreToolUse":         {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " pre-tool", Timeout: qwenToolTimeoutMS}}},
+		"PostToolUse":        {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " post-tool", Timeout: qwenToolTimeoutMS}}},
+		"PostToolUseFailure": {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " post-tool", Timeout: qwenToolTimeoutMS}}},
+		"PermissionRequest":  {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " permission-request", Timeout: qwenToolTimeoutMS}}},
+		"Stop":               {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " stop", Timeout: qwenStopTimeoutMS}}},
+		"SubagentStart":      {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " subagent-start"}}},
+		"SubagentStop":       {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " subagent-stop"}}},
+		"SessionEnd":         {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " session-end"}}},
+	}
+	return installSettingsEndpointHooks(path, "qwen", endpointHooks)
+}
+
+func readQwenSettings(path string) (settingsHooksFile, error) {
+	return readSettingsHooks(path)
+}
+
+func removeQwenEndpointHooks(path string) (bool, error) {
+	return removeSettingsEndpointHooks(path, "qwen")
+}
+
+func isQwenInstalledAt(path string) bool {
+	return isSettingsEndpointInstalledAt(path, "qwen")
+}
+
+// qwenSettingsPath returns the settings file Beacon merges into for a given install level.
+//
+// Qwen Code resolves settings from `~/.qwen/settings.json` for the user and `.qwen/settings.json`
+// in the project root, with project settings taking precedence. The user level is the default here
+// for the same reason it is elsewhere: a project-level install only takes effect once the folder is
+// trusted, so it is the one that needs a caveat rather than the one to reach for first.
+func qwenSettingsPath(level Level) (string, error) {
+	switch level {
+	case "", LevelUser:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".qwen", "settings.json"), nil
+	case LevelProject:
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cwd, ".qwen", "settings.json"), nil
+	default:
+		return "", fmt.Errorf("unknown hook level %q", level)
+	}
+}
+
+// qwenProjectTrustMessage says out loud that a project-level install is not yet collecting.
+//
+// Qwen's security model gates project-level hooks behind trusted folder status, so an install that
+// reports plain success into an untrusted folder is reporting something untrue: the file is
+// written, and nothing runs. Grok carries the same caveat for the same reason.
+func qwenProjectTrustMessage(status QwenStatus, level Level) QwenStatus {
+	if level == LevelProject && status.Message != "" && !strings.Contains(status.Message, "trusted") {
+		status.Message += "; Qwen Code runs project hooks only in a trusted folder"
+	}
+	return status
+}

--- a/cli/beacon/internal/endpoint/hooks/qwen.go
+++ b/cli/beacon/internal/endpoint/hooks/qwen.go
@@ -35,6 +35,29 @@ const (
 // beats "probably equivalent" for the field that decides whether a hook fires at all.
 const qwenAllToolsMatcher = "*"
 
+// qwenHookShell tells Qwen which shell to parse Beacon's hook command with.
+//
+// Beacon builds that command with hookCommandQuote, which single-quotes every path on every
+// platform. Single quotes are fully literal in a POSIX shell, which is what a Windows path needs --
+// inside double quotes bash still expands `$` and eats a doubled backslash, so a profile directory
+// containing a `$` would vanish and a UNC path would lose a separator. That function's own comment
+// records the cost of the choice: the same quoting is not valid in cmd.exe, and in PowerShell a
+// quoted string in command position is an expression rather than a command.
+//
+// Qwen is the runtime that comment anticipated. It runs hook commands through a shell of its
+// choosing and documents exactly two values a hook may ask for, `bash` and `powershell`. Left
+// unset on Windows, a Node-hosted runtime lands on the platform default -- cmd.exe -- where
+// Beacon's quotes are literal characters and every hook fails to start while the install still
+// reports success. That is the same silent-failure shape as writing a seconds-valued timeout, and
+// it is worth the same care.
+//
+// `bash` rather than `powershell` because the command is already POSIX-quoted: choosing the other
+// would mean maintaining a second quoting dialect for one runtime. On macOS and Linux this names
+// the shell that would have run anyway. On Windows it requires bash on PATH, which is the same
+// requirement Claude Code already carries there -- and it strictly improves on the alternative,
+// since cmd.exe cannot parse the command at all.
+const qwenHookShell = "bash"
+
 type QwenOptions struct {
 	Level    Level
 	LogPath  string
@@ -106,16 +129,16 @@ func qwenStatusFromRuntime(status runtimeStatus) QwenStatus {
 func installQwenSettings(path, binaryPath, logPath, configPath string) error {
 	prefix := endpointCommandPrefix("qwen", binaryPath, logPath, configPath)
 	endpointHooks := map[string]settingsHookGroup{
-		"SessionStart":       {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " session-start"}}},
-		"UserPromptSubmit":   {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " prompt-submit", Timeout: qwenPromptSubmitTimeoutMS}}},
-		"PreToolUse":         {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " pre-tool", Timeout: qwenToolTimeoutMS}}},
-		"PostToolUse":        {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " post-tool", Timeout: qwenToolTimeoutMS}}},
-		"PostToolUseFailure": {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " post-tool", Timeout: qwenToolTimeoutMS}}},
-		"PermissionRequest":  {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " permission-request", Timeout: qwenToolTimeoutMS}}},
-		"Stop":               {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " stop", Timeout: qwenStopTimeoutMS}}},
-		"SubagentStart":      {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " subagent-start"}}},
-		"SubagentStop":       {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " subagent-stop"}}},
-		"SessionEnd":         {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " session-end"}}},
+		"SessionStart":       {Hooks: []settingsHookRef{{Type: "command", Shell: qwenHookShell, Command: prefix + " session-start"}}},
+		"UserPromptSubmit":   {Hooks: []settingsHookRef{{Type: "command", Shell: qwenHookShell, Command: prefix + " prompt-submit", Timeout: qwenPromptSubmitTimeoutMS}}},
+		"PreToolUse":         {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Shell: qwenHookShell, Command: prefix + " pre-tool", Timeout: qwenToolTimeoutMS}}},
+		"PostToolUse":        {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Shell: qwenHookShell, Command: prefix + " post-tool", Timeout: qwenToolTimeoutMS}}},
+		"PostToolUseFailure": {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Shell: qwenHookShell, Command: prefix + " post-tool", Timeout: qwenToolTimeoutMS}}},
+		"PermissionRequest":  {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Shell: qwenHookShell, Command: prefix + " permission-request", Timeout: qwenToolTimeoutMS}}},
+		"Stop":               {Hooks: []settingsHookRef{{Type: "command", Shell: qwenHookShell, Command: prefix + " stop", Timeout: qwenStopTimeoutMS}}},
+		"SubagentStart":      {Hooks: []settingsHookRef{{Type: "command", Shell: qwenHookShell, Command: prefix + " subagent-start"}}},
+		"SubagentStop":       {Hooks: []settingsHookRef{{Type: "command", Shell: qwenHookShell, Command: prefix + " subagent-stop"}}},
+		"SessionEnd":         {Hooks: []settingsHookRef{{Type: "command", Shell: qwenHookShell, Command: prefix + " session-end"}}},
 	}
 	return installSettingsEndpointHooks(path, "qwen", endpointHooks)
 }

--- a/cli/beacon/internal/endpoint/hooks/qwen.go
+++ b/cli/beacon/internal/endpoint/hooks/qwen.go
@@ -105,17 +105,22 @@ func qwenStatusFromRuntime(status runtimeStatus) QwenStatus {
 // text Beacon does not otherwise retain would cost more than it tells anyone.
 func installQwenSettings(path, binaryPath, logPath, configPath string) error {
 	prefix := endpointCommandPrefix("qwen", binaryPath, logPath, configPath)
+	// Shell is set to "bash" on every hook. The commands use POSIX single-quote quoting
+	// (via hookCommandQuote), which is correct for bash but invalid in cmd.exe and PowerShell.
+	// Unlike Claude Code, which always runs hooks through Git Bash even on Windows, Qwen Code
+	// selects cmd/PowerShell by default and only uses bash when the hook config says so.
+	const shell = "bash"
 	endpointHooks := map[string]settingsHookGroup{
-		"SessionStart":       {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " session-start"}}},
-		"UserPromptSubmit":   {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " prompt-submit", Timeout: qwenPromptSubmitTimeoutMS}}},
-		"PreToolUse":         {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " pre-tool", Timeout: qwenToolTimeoutMS}}},
-		"PostToolUse":        {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " post-tool", Timeout: qwenToolTimeoutMS}}},
-		"PostToolUseFailure": {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " post-tool", Timeout: qwenToolTimeoutMS}}},
-		"PermissionRequest":  {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " permission-request", Timeout: qwenToolTimeoutMS}}},
-		"Stop":               {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " stop", Timeout: qwenStopTimeoutMS}}},
-		"SubagentStart":      {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " subagent-start"}}},
-		"SubagentStop":       {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " subagent-stop"}}},
-		"SessionEnd":         {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " session-end"}}},
+		"SessionStart":       {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " session-start", Shell: shell}}},
+		"UserPromptSubmit":   {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " prompt-submit", Timeout: qwenPromptSubmitTimeoutMS, Shell: shell}}},
+		"PreToolUse":         {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " pre-tool", Timeout: qwenToolTimeoutMS, Shell: shell}}},
+		"PostToolUse":        {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " post-tool", Timeout: qwenToolTimeoutMS, Shell: shell}}},
+		"PostToolUseFailure": {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " post-tool", Timeout: qwenToolTimeoutMS, Shell: shell}}},
+		"PermissionRequest":  {Matcher: qwenAllToolsMatcher, Hooks: []settingsHookRef{{Type: "command", Command: prefix + " permission-request", Timeout: qwenToolTimeoutMS, Shell: shell}}},
+		"Stop":               {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " stop", Timeout: qwenStopTimeoutMS, Shell: shell}}},
+		"SubagentStart":      {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " subagent-start", Shell: shell}}},
+		"SubagentStop":       {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " subagent-stop", Shell: shell}}},
+		"SessionEnd":         {Hooks: []settingsHookRef{{Type: "command", Command: prefix + " session-end", Shell: shell}}},
 	}
 	return installSettingsEndpointHooks(path, "qwen", endpointHooks)
 }

--- a/cli/beacon/internal/endpoint/hooks/qwen_test.go
+++ b/cli/beacon/internal/endpoint/hooks/qwen_test.go
@@ -19,6 +19,7 @@ func decodeQwenHooks(t *testing.T, path string) map[string][]struct {
 		Type    string `json:"type"`
 		Command string `json:"command"`
 		Timeout int    `json:"timeout"`
+		Shell   string `json:"shell"`
 	} `json:"hooks"`
 } {
 	t.Helper()
@@ -33,6 +34,7 @@ func decodeQwenHooks(t *testing.T, path string) map[string][]struct {
 				Type    string `json:"type"`
 				Command string `json:"command"`
 				Timeout int    `json:"timeout"`
+				Shell   string `json:"shell"`
 			} `json:"hooks"`
 		} `json:"hooks"`
 	}
@@ -391,4 +393,57 @@ func readFileString(t *testing.T, path string) string {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(data)
+}
+
+// The second way this installer can look correct and collect nothing.
+//
+// Beacon builds its hook command with hookCommandQuote, which single-quotes every path on every
+// platform. That is POSIX quoting: literal in bash, and *not* valid in cmd.exe, where the quotes
+// are ordinary characters and the command never resolves to an executable. Qwen picks the shell it
+// runs a command hook with, and a Node-hosted runtime left to the Windows default lands on cmd.exe
+// -- so without this field every hook on a Windows host fails to start while `endpoint hooks
+// install` still prints success and the settings file still reads correctly.
+//
+// Same silent-failure shape as a seconds-valued timeout, and it gets the same tripwire. `bash` is
+// the only one of Qwen's two documented values that can parse what Beacon writes; `powershell`
+// would treat a quoted string in command position as an expression.
+func TestQwenHooksDeclareTheShellTheirQuotingRequires(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := installQwenSettings(path, `C:\Program Files\Beacon\beacon-hooks.exe`, "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installQwenSettings returned error: %v", err)
+	}
+
+	hooks := decodeQwenHooks(t, path)
+	if len(hooks) == 0 {
+		t.Fatal("no hooks installed")
+	}
+	for event, groups := range hooks {
+		for _, group := range groups {
+			for _, hook := range group.Hooks {
+				if hook.Shell != qwenHookShell {
+					t.Errorf("%s shell = %q, want %q; Beacon's command is POSIX-quoted and will not "+
+						"run under the Windows default shell", event, hook.Shell, qwenHookShell)
+				}
+				// The pairing this test is really about: the declared shell has to match the
+				// quoting actually emitted. If hookCommandQuote ever stops single-quoting, this
+				// declaration becomes a lie rather than a fix.
+				if !strings.Contains(hook.Command, `'C:\Program Files\Beacon\beacon-hooks.exe'`) {
+					t.Errorf("%s command = %q, want the binary single-quoted for %s", event, hook.Command, qwenHookShell)
+				}
+			}
+		}
+	}
+}
+
+// Declaring a shell must not leak into the runtimes that share this settings writer and do not
+// expose the field. Claude Code has no `shell` key in its hook schema, and emitting one there
+// would put an unrecognized field into a file Beacon does not own.
+func TestOnlyQwenDeclaresAHookShell(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := installClaudeSettings(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installClaudeSettings returned error: %v", err)
+	}
+	if got := readFileString(t, path); strings.Contains(got, `"shell"`) {
+		t.Fatalf("Claude settings carry a shell field:\n%s", got)
+	}
 }

--- a/cli/beacon/internal/endpoint/hooks/qwen_test.go
+++ b/cli/beacon/internal/endpoint/hooks/qwen_test.go
@@ -1,0 +1,394 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
+)
+
+// decodeQwenHooks reads the `hooks` block back out of a settings file as data rather than as text,
+// so assertions can be about values (a timeout of 10000) instead of about substrings that would
+// also match a different number containing the same digits.
+func decodeQwenHooks(t *testing.T, path string) map[string][]struct {
+	Matcher string `json:"matcher"`
+	Hooks   []struct {
+		Type    string `json:"type"`
+		Command string `json:"command"`
+		Timeout int    `json:"timeout"`
+	} `json:"hooks"`
+} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+				Timeout int    `json:"timeout"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("settings are not valid JSON: %v\n%s", err, data)
+	}
+	return settings.Hooks
+}
+
+// The divergence that makes this installer more than a copy of the Claude one.
+//
+// Claude Code reads `timeout` as seconds; Qwen Code reads it as milliseconds. Writing Claude's
+// values into a Qwen settings file gives every tool hook ten *milliseconds* to start a process,
+// read stdin, resolve a git branch and append to a JSONL file. It cannot, so each one is killed
+// mid-write -- while the install reports success and the settings file looks correct. This test is
+// the tripwire for that: any value small enough to be a seconds-shaped number fails it.
+func TestQwenTimeoutsAreMillisecondsNotSeconds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := installQwenSettings(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installQwenSettings returned error: %v", err)
+	}
+
+	hooks := decodeQwenHooks(t, path)
+	for event, wantMS := range map[string]int{
+		"UserPromptSubmit":   qwenPromptSubmitTimeoutMS,
+		"PreToolUse":         qwenToolTimeoutMS,
+		"PostToolUse":        qwenToolTimeoutMS,
+		"PostToolUseFailure": qwenToolTimeoutMS,
+		"PermissionRequest":  qwenToolTimeoutMS,
+		"Stop":               qwenStopTimeoutMS,
+	} {
+		groups, ok := hooks[event]
+		if !ok || len(groups) == 0 || len(groups[0].Hooks) == 0 {
+			t.Fatalf("%s hook was not installed: %#v", event, hooks)
+		}
+		got := groups[0].Hooks[0].Timeout
+		if got != wantMS {
+			t.Errorf("%s timeout = %d, want %d", event, got, wantMS)
+		}
+		// The property, independent of the exact constants: no timeout Beacon writes may be small
+		// enough to be a plausible seconds value, because that is exactly what a copy of the
+		// Claude installer would produce.
+		if got < 1000 {
+			t.Errorf("%s timeout = %d; Qwen reads this field as milliseconds, so anything under "+
+				"1000 kills the hook before it can write", event, got)
+		}
+	}
+
+	// Events with no explicit timeout inherit Qwen's own 60000ms default, which is ample for a
+	// hook that only writes a line. Asserting the absence keeps a future edit from "helpfully"
+	// adding a seconds-shaped value here.
+	for _, event := range []string{"SessionStart", "SessionEnd", "SubagentStart", "SubagentStop"} {
+		groups, ok := hooks[event]
+		if !ok || len(groups) == 0 || len(groups[0].Hooks) == 0 {
+			t.Fatalf("%s hook was not installed: %#v", event, hooks)
+		}
+		if got := groups[0].Hooks[0].Timeout; got != 0 {
+			t.Errorf("%s timeout = %d, want it omitted so Qwen's 60000ms default applies", event, got)
+		}
+	}
+}
+
+// Every Qwen hook event Beacon claims to collect has to actually be registered, wired to the right
+// subcommand, and carry the --platform value the adapter branches on.
+func TestInstallQwenRegistersEveryCollectedEvent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := installQwenSettings(path, "/tmp/beacon hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installQwenSettings returned error: %v", err)
+	}
+
+	hooks := decodeQwenHooks(t, path)
+	for event, wantSubcommand := range map[string]string{
+		"SessionStart":       "session-start",
+		"UserPromptSubmit":   "prompt-submit",
+		"PreToolUse":         "pre-tool",
+		"PostToolUse":        "post-tool",
+		"PostToolUseFailure": "post-tool",
+		"PermissionRequest":  "permission-request",
+		"Stop":               "stop",
+		"SubagentStart":      "subagent-start",
+		"SubagentStop":       "subagent-stop",
+		"SessionEnd":         "session-end",
+	} {
+		groups, ok := hooks[event]
+		if !ok || len(groups) == 0 || len(groups[0].Hooks) == 0 {
+			t.Fatalf("%s hook was not installed: %#v", event, hooks)
+		}
+		hook := groups[0].Hooks[0]
+		if hook.Type != "command" {
+			t.Errorf("%s hook type = %q, want command", event, hook.Type)
+		}
+		if !strings.Contains(hook.Command, "--platform qwen") {
+			t.Errorf("%s command = %q, want --platform qwen", event, hook.Command)
+		}
+		if !strings.HasSuffix(hook.Command, " "+wantSubcommand) {
+			t.Errorf("%s command = %q, want it to end in %q", event, hook.Command, wantSubcommand)
+		}
+		if !strings.Contains(hook.Command, "--log '/tmp/runtime.jsonl'") {
+			t.Errorf("%s command = %q, want the endpoint log flag", event, hook.Command)
+		}
+		if !strings.Contains(hook.Command, "--config '/tmp/config.json'") {
+			t.Errorf("%s command = %q, want the endpoint config flag", event, hook.Command)
+		}
+		// A path with a space in it is the ordinary case on macOS and Windows, and an unquoted one
+		// would run as two arguments.
+		if !strings.Contains(hook.Command, "'/tmp/beacon hooks'") {
+			t.Errorf("%s command = %q, want the binary path quoted", event, hook.Command)
+		}
+	}
+
+	// The fire-and-forget events are deliberately absent. MessageDisplay alone fires roughly every
+	// 200ms for the length of every reply.
+	for _, event := range []string{"MessageDisplay", "StopFailure", "PostCompact", "SessionDelete", "TodoCreated", "TodoCompleted"} {
+		if _, ok := hooks[event]; ok {
+			t.Errorf("%s was registered; it is deliberately not collected", event)
+		}
+	}
+}
+
+// Tool events must carry a matcher Qwen recognizes as "all tools". Qwen documents `""` and `"*"`;
+// anything else is a regex that would silently filter events out.
+func TestQwenToolEventsMatchEveryTool(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := installQwenSettings(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installQwenSettings returned error: %v", err)
+	}
+
+	hooks := decodeQwenHooks(t, path)
+	for _, event := range []string{"PreToolUse", "PostToolUse", "PostToolUseFailure", "PermissionRequest"} {
+		matcher := hooks[event][0].Matcher
+		if matcher != "*" && matcher != "" {
+			t.Errorf("%s matcher = %q; Qwen treats only \"\" and \"*\" as match-all, anything else "+
+				"is a regex that filters tools out", event, matcher)
+		}
+	}
+}
+
+// settings.json is the user's own file: model, theme, MCP servers, their hooks. Installing into it
+// must not cost them any of that.
+func TestInstallQwenPreservesTheUsersOwnSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	existing := `{"theme":"Dracula","selectedAuthType":"qwen-oauth","mcpServers":{"local":{"command":"serve"}},` +
+		`"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo keep"}]}],` +
+		`"PreToolUse":[{"matcher":"^run_shell_command$","hooks":[{"type":"command","command":"my-own-check.sh"}]}]}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installQwenSettings(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installQwenSettings returned error: %v", err)
+	}
+	text := readFileString(t, path)
+	for _, want := range []string{"Dracula", "qwen-oauth", "mcpServers", "echo keep", "my-own-check.sh", "^run_shell_command$"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("install removed the user's own setting %q:\n%s", want, text)
+		}
+	}
+	if !strings.Contains(text, "--platform qwen") {
+		t.Fatalf("Beacon hooks were not installed:\n%s", text)
+	}
+}
+
+// A second install replaces Beacon's own entries rather than stacking a duplicate beside them.
+// Without this, every `endpoint repair` would add another copy and the runtime would write each
+// event twice per repair.
+func TestInstallQwenTwiceDoesNotDuplicateBeaconHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	for i := 0; i < 3; i++ {
+		if err := installQwenSettings(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+			t.Fatalf("installQwenSettings returned error: %v", err)
+		}
+	}
+
+	hooks := decodeQwenHooks(t, path)
+	for event, groups := range hooks {
+		total := 0
+		for _, group := range groups {
+			for _, hook := range group.Hooks {
+				if strings.Contains(hook.Command, "--platform qwen") {
+					total++
+				}
+			}
+		}
+		if total != 1 {
+			t.Errorf("%s carries %d Beacon hooks after three installs, want 1", event, total)
+		}
+	}
+}
+
+// Uninstall removes what Beacon wrote and nothing else, including from a group it shares with a
+// hook the user wrote.
+func TestUninstallQwenRemovesOnlyBeaconHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	existing := `{"theme":"Dracula","hooks":{"PreToolUse":[{"matcher":"*","hooks":[` +
+		`{"type":"command","command":"my-own-check.sh"},` +
+		`{"type":"command","command":"'/tmp/beacon-hooks' --platform qwen --log '/tmp/runtime.jsonl' pre-tool"}]}]}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := removeQwenEndpointHooks(path)
+	if err != nil {
+		t.Fatalf("removeQwenEndpointHooks returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("removeQwenEndpointHooks reported no change, want the Beacon hook removed")
+	}
+	text := readFileString(t, path)
+	if strings.Contains(text, "--platform qwen") {
+		t.Fatalf("Beacon hook was not removed:\n%s", text)
+	}
+	for _, want := range []string{"my-own-check.sh", "Dracula"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("uninstall removed %q, which Beacon did not write:\n%s", want, text)
+		}
+	}
+}
+
+// Detection is scoped by platform in both directions: a Claude hook in a Qwen settings file is not
+// Beacon's Qwen install, and removing Qwen's hooks must not take another runtime's with it. Both
+// spellings of that mistake are silent.
+func TestQwenDetectionDoesNotClaimAnotherRuntimesHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	existing := `{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"'/tmp/beacon-hooks' --platform claude pre-tool"}]}]}}`
+	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if isQwenInstalledAt(path) {
+		t.Fatal("a --platform claude hook was reported as a Qwen install")
+	}
+	changed, err := removeQwenEndpointHooks(path)
+	if err != nil {
+		t.Fatalf("removeQwenEndpointHooks returned error: %v", err)
+	}
+	if changed {
+		t.Fatal("removeQwenEndpointHooks removed a hook belonging to another runtime")
+	}
+	if !strings.Contains(readFileString(t, path), "--platform claude") {
+		t.Fatal("the claude hook was removed from the file")
+	}
+}
+
+func TestQwenSettingsPathUserAndProjectLevels(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+
+	userPath, err := qwenSettingsPath(LevelUser)
+	if err != nil {
+		t.Fatalf("qwenSettingsPath(user) returned error: %v", err)
+	}
+	if want := filepath.Join(home, ".qwen", "settings.json"); userPath != want {
+		t.Errorf("user settings path = %q, want %q", userPath, want)
+	}
+	// An empty level means the user level, which is what an unset --level flag produces.
+	if defaulted, err := qwenSettingsPath(""); err != nil || defaulted != userPath {
+		t.Errorf("qwenSettingsPath(\"\") = %q, %v; want the user path", defaulted, err)
+	}
+
+	project := t.TempDir()
+	t.Chdir(project)
+	projectPath, err := qwenSettingsPath(LevelProject)
+	if err != nil {
+		t.Fatalf("qwenSettingsPath(project) returned error: %v", err)
+	}
+	if want := filepath.Join(project, ".qwen", "settings.json"); projectPath != want {
+		t.Errorf("project settings path = %q, want %q", projectPath, want)
+	}
+
+	if _, err := qwenSettingsPath(Level("nonsense")); err == nil {
+		t.Error("qwenSettingsPath(nonsense) returned no error")
+	}
+}
+
+// A project-level install writes a file that does nothing until the folder is trusted. Reporting
+// plain success there would be reporting something untrue.
+func TestQwenProjectInstallSaysItNeedsATrustedFolder(t *testing.T) {
+	status := qwenProjectTrustMessage(QwenStatus{Message: "Qwen Code endpoint hooks installed"}, LevelProject)
+	if !strings.Contains(status.Message, "trusted") {
+		t.Errorf("project message = %q, want it to mention the trusted-folder requirement", status.Message)
+	}
+
+	user := qwenProjectTrustMessage(QwenStatus{Message: "Qwen Code endpoint hooks installed"}, LevelUser)
+	if strings.Contains(user.Message, "trusted") {
+		t.Errorf("user message = %q, want no project-trust caveat", user.Message)
+	}
+}
+
+func TestQwenHookStatusDetectsAnInstall(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	path := filepath.Join(home, ".qwen", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"'/tmp/beacon-hooks' --platform qwen --log '/tmp/runtime.jsonl' stop"}]}]}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	status := QwenHookStatus(QwenOptions{Level: LevelUser, UserMode: true})
+	if !status.Installed {
+		t.Fatalf("QwenHookStatus installed = false, status=%#v", status)
+	}
+	if status.SettingsPath != path {
+		t.Fatalf("SettingsPath = %q, want %q", status.SettingsPath, path)
+	}
+	if !IsQwenInstalled(QwenOptions{Level: LevelUser, UserMode: true}) {
+		t.Fatal("IsQwenInstalled = false for an installed hook")
+	}
+}
+
+func TestQwenHandlesAnAbsentOrNullHooksBlock(t *testing.T) {
+	for name, existing := range map[string]string{
+		"absent": `{"theme":"Dracula"}`,
+		"null":   `{"hooks":null}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := installQwenSettings(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+				t.Fatalf("installQwenSettings returned error: %v", err)
+			}
+			if !strings.Contains(readFileString(t, path), "--platform qwen") {
+				t.Fatalf("hooks were not installed from %s hooks block:\n%s", name, readFileString(t, path))
+			}
+		})
+	}
+}
+
+// Corrupt JSON must surface as an error rather than being silently overwritten: settings.json holds
+// the user's auth type and MCP servers, and clobbering it to install telemetry is not a trade
+// Beacon gets to make on their behalf.
+func TestQwenRefusesToOverwriteCorruptSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := readQwenSettings(path); err == nil {
+		t.Fatal("readQwenSettings accepted corrupt JSON")
+	}
+	if err := installQwenSettings(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err == nil {
+		t.Fatal("installQwenSettings overwrote a settings file it could not parse")
+	}
+	if got := readFileString(t, path); got != "{not json" {
+		t.Fatalf("settings file was modified: %q", got)
+	}
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/cli/beacon/internal/endpoint/hooks/qwen_test.go
+++ b/cli/beacon/internal/endpoint/hooks/qwen_test.go
@@ -19,6 +19,7 @@ func decodeQwenHooks(t *testing.T, path string) map[string][]struct {
 		Type    string `json:"type"`
 		Command string `json:"command"`
 		Timeout int    `json:"timeout"`
+		Shell   string `json:"shell"`
 	} `json:"hooks"`
 } {
 	t.Helper()
@@ -33,6 +34,7 @@ func decodeQwenHooks(t *testing.T, path string) map[string][]struct {
 				Type    string `json:"type"`
 				Command string `json:"command"`
 				Timeout int    `json:"timeout"`
+				Shell   string `json:"shell"`
 			} `json:"hooks"`
 		} `json:"hooks"`
 	}
@@ -91,6 +93,27 @@ func TestQwenTimeoutsAreMillisecondsNotSeconds(t *testing.T) {
 		}
 		if got := groups[0].Hooks[0].Timeout; got != 0 {
 			t.Errorf("%s timeout = %d, want it omitted so Qwen's 60000ms default applies", event, got)
+		}
+	}
+}
+
+// Qwen Code does not run hooks through Git Bash the way Claude Code does. On Windows it defaults to
+// cmd.exe or PowerShell, where the POSIX single-quote quoting in the command string is invalid. Every
+// hook must set shell to "bash" so Qwen uses a shell that understands the quoting.
+func TestQwenHooksSpecifyBashShell(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := installQwenSettings(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installQwenSettings returned error: %v", err)
+	}
+
+	hooks := decodeQwenHooks(t, path)
+	for event, groups := range hooks {
+		if len(groups) == 0 || len(groups[0].Hooks) == 0 {
+			t.Fatalf("%s hook was not installed", event)
+		}
+		if got := groups[0].Hooks[0].Shell; got != "bash" {
+			t.Errorf("%s shell = %q, want \"bash\"; without it Qwen uses cmd/PowerShell on "+
+				"Windows where the single-quoted command is invalid", event, got)
 		}
 	}
 }

--- a/cli/beacon/internal/endpoint/hooks/settings_hooks.go
+++ b/cli/beacon/internal/endpoint/hooks/settings_hooks.go
@@ -15,6 +15,7 @@ type settingsHookRef struct {
 	Type       string `json:"type,omitempty"`
 	Command    string `json:"command"`
 	Timeout    int    `json:"timeout,omitempty"`
+	Shell      string `json:"shell,omitempty"`
 	ShowOutput *bool  `json:"show_output,omitempty"`
 }
 

--- a/cli/beacon/internal/endpoint/hooks/settings_hooks.go
+++ b/cli/beacon/internal/endpoint/hooks/settings_hooks.go
@@ -12,9 +12,17 @@ type settingsHookGroup struct {
 }
 
 type settingsHookRef struct {
-	Type       string `json:"type,omitempty"`
-	Command    string `json:"command"`
-	Timeout    int    `json:"timeout,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+	// Shell names the interpreter the runtime should parse Command with, for runtimes that let a
+	// hook say. Omitted by default, so the runtimes that do not expose the field are unaffected.
+	//
+	// It exists because Command is quoted for one specific shell -- see hookCommandQuote -- and a
+	// runtime that picks a different one cannot run it at all. Saying which shell the command was
+	// written for is strictly better than emitting a second quoting dialect and hoping the runtime
+	// picks the matching one.
+	Shell      string `json:"shell,omitempty"`
 	ShowOutput *bool  `json:"show_output,omitempty"`
 }
 


### PR DESCRIPTION
**Stack:** [1/6 #378] · [2/6 #379] · [3/6 #380] ← base · 4/6 you are here · [5/6 CLI wiring] · [6/6 docs]

Review only the top commit.

## What this does

Qwen Code's hook configuration is the same `hooks` block Claude Code and Factory use, in `~/.qwen/settings.json` (or `.qwen/settings.json` in a project), so this installer goes through the existing settings merge: unrelated top-level keys are preserved, non-Beacon hooks in the same event group survive, and a re-install replaces Beacon's own entries instead of stacking a second copy beside them.

## The one place the format diverges: `timeout` is milliseconds

This is why this is not a copy of the Claude installer. **Claude Code reads `timeout` as seconds; Qwen Code reads it as milliseconds** (default `60000`). Writing Claude's values — `30`, `45`, `10` — would give every tool hook ten *milliseconds* to start a process, read stdin, resolve a git branch and append to a JSONL file. It cannot, so each hook would be killed mid-write while the install reported success and the settings file looked correct.

`TestQwenTimeoutsAreMillisecondsNotSeconds` asserts the constants and, separately, the property that no timeout Beacon writes may be small enough to be a plausible seconds value — which is exactly what copying the Claude installer would produce.

## Other decisions

**Tool events carry `"*"`**, one of the two spellings Qwen documents as match-all and the one its own examples use. An omitted matcher is undocumented for tool events, and this field decides whether a hook fires at all.

**The registered set** is everything Qwen exposes that carries endpoint signal, including `PostToolUseFailure` (a separate event in Qwen, otherwise invisible) and `PermissionRequest` (what makes an approval prompt observable). The fire-and-forget events are deliberately excluded and the test asserts their absence: `MessageDisplay` alone fires roughly every 200ms for the length of every reply, and spawning a process that often to record assistant text Beacon does not otherwise retain would cost more than it tells anyone.

**A project-level install says out loud** that Qwen runs project hooks only in a trusted folder. Reporting plain success there would be reporting something untrue — the file is written and nothing runs. Grok carries the same caveat.

**Corrupt settings are an error, not an overwrite:** the file holds the user's auth type and MCP servers, and clobbering it to install telemetry is not a trade Beacon gets to make on their behalf.

## Testing

`go test ./...` and `go test -race ./internal/endpoint/...` in `cli/beacon` pass. Verified the tests fail without the source file. Coverage includes the ms/seconds tripwire, every registered event and subcommand, quoting of a binary path containing a space, idempotent re-install, uninstall preserving the user's own hooks in a mixed group, cross-platform detection (a `--platform claude` hook is not claimed as a Qwen install), absent/`null` hooks blocks, and the corrupt-JSON refusal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjGxqpv6Em1LHdBC9rkBJY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes user-owned Qwen settings (auth, MCP, hooks). Merge/uninstall is scoped and tested, but a wrong timeout or shell would silently drop telemetry.
> 
> **Overview**
> Adds install/uninstall/status for **Qwen Code** endpoint hooks, merging Beacon commands into `~/.qwen/settings.json` (or project `.qwen/settings.json`) via the existing settings merge so user keys and non-Beacon hooks are kept.
> 
> Unlike Claude, Qwen treats `timeout` as **milliseconds** and does not default to Git Bash on Windows. The installer writes 10s–45s timeouts (not Claude’s 10/30/45 seconds) and sets `shell: bash` so POSIX-quoted commands run. Tool events use matcher `"*"`. High-frequency events like `MessageDisplay` are omitted. Project-level status notes that Qwen only runs hooks in a trusted folder.
> 
> `settingsHookRef` gains an optional `shell` field (omitted for Claude). Tests cover the ms tripwire, bash pairing, idempotent install, uninstall isolation, and refusing to overwrite corrupt JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0328ec65376bf77deb310f0cc0203e0c54b2e442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->