### PR TITLE
WS3 — Content & payload completeness: promote the text that was already arriving

### DIFF
--- a/cli/beacon-hooks/cmd/agent_thought.go
+++ b/cli/beacon-hooks/cmd/agent_thought.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-
 	"github.com/spf13/cobra"
 
 	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
@@ -56,34 +53,18 @@ func runAgentThought(cmd *cobra.Command, args []string) {
 // output-messages shape (a single assistant message with a reasoning part), so
 // hook-captured reasoning matches what semconv-native OTLP sources emit.
 func reasoningOutputMessages(text string) []interface{} {
-	return []interface{}{
-		map[string]interface{}{
-			"role": "assistant",
-			"parts": []interface{}{
-				map[string]interface{}{"type": "reasoning", "content": text},
-			},
-		},
-	}
+	return asymptoteobserve.ReasoningOutputMessages(text)
 }
 
-// retainedContentFields builds the content marker for an event that retains
-// raw text, computed against the original text so hash and byte count stay
-// stable even after the sink redacts or truncates the stored copy.
+// retainedContentFields builds the content marker for an event that retains raw
+// text, computed against the original text so hash and byte count stay stable
+// even after the sink redacts or truncates the stored copy.
+//
+// The limit passed is the one this writer applies: the hook logger sanitizes the
+// whole event map at DefaultStringLimit, so that is what "truncated" has to mean
+// here. The collector answers the same question with its own limit.
 func retainedContentFields(text string) map[string]interface{} {
-	sum := sha256.Sum256([]byte(text))
-	fields := map[string]interface{}{
-		"retention": asymptoteobserve.ContentRetentionFull,
-		"included":  true,
-		"hash":      hex.EncodeToString(sum[:]),
-		"bytes":     len(text),
-	}
-	if len(text) > asymptoteobserve.DefaultStringLimit {
-		fields["truncated"] = true
-	}
-	if asymptoteobserve.RedactString(text) != text {
-		fields["redacted"] = true
-	}
-	return fields
+	return asymptoteobserve.RetainedContentFields(text, asymptoteobserve.DefaultStringLimit)
 }
 
 // thoughtMetadataFields extracts the non-content afterAgentThought payload

--- a/cli/beacon-hooks/cmd/cline_event.go
+++ b/cli/beacon-hooks/cmd/cline_event.go
@@ -622,8 +622,10 @@ func clineToolFields(input map[string]interface{}, completed bool) map[string]in
 		}
 	}
 
-	if encoded, err := json.Marshal(map[string]interface{}{"input": toolInput, "response": toolResponse}); err == nil && len(encoded) > 0 {
-		fields["content"] = retainedContentFields(string(encoded))
+	if _, hasContent := fields["content"]; !hasContent {
+		if encoded, err := json.Marshal(map[string]interface{}{"input": toolInput, "response": toolResponse}); err == nil && len(encoded) > 0 {
+			fields["content"] = retainedContentFields(string(encoded))
+		}
 	}
 	return fields
 }

--- a/cli/beacon-hooks/cmd/cline_event.go
+++ b/cli/beacon-hooks/cmd/cline_event.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	hookdiff "github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/diff"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 	"github.com/spf13/cobra"
 )
 
@@ -198,14 +199,9 @@ func clineBaseFields(input map[string]interface{}, sessionID string) map[string]
 
 func clinePromptEvent(fields map[string]interface{}, prompt string) normalizedEvent {
 	fields["prompt"] = map[string]interface{}{"text": prompt}
-	fields["gen_ai"] = map[string]interface{}{
-		"input": map[string]interface{}{
-			"messages": []interface{}{map[string]interface{}{
-				"role":  "user",
-				"parts": []interface{}{map[string]interface{}{"type": "text", "content": prompt}},
-			}},
-		},
-	}
+	fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{
+		"input": map[string]interface{}{"messages": asymptoteobserve.TextInputMessages(prompt)},
+	})
 	fields["content"] = retainedContentFields(prompt)
 	return normalizedEvent{
 		action: "prompt.submitted", category: "prompt", severity: "info",

--- a/cli/beacon-hooks/cmd/content_test.go
+++ b/cli/beacon-hooks/cmd/content_test.go
@@ -1,0 +1,202 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+)
+
+// hookFirstPartContent reads the text out of a gen_ai messages value written by a
+// hook, the way a reader of the log would.
+func hookFirstPartContent(t *testing.T, messages interface{}) string {
+	t.Helper()
+	list, ok := messages.([]interface{})
+	if !ok || len(list) == 0 {
+		t.Fatalf("messages = %#v, want a non-empty list", messages)
+	}
+	message, ok := list[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("message = %#v, want a map", list[0])
+	}
+	parts, ok := message["parts"].([]interface{})
+	if !ok || len(parts) == 0 {
+		t.Fatalf("parts = %#v, want a non-empty list", message["parts"])
+	}
+	part, ok := parts[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("part = %#v, want a map", parts[0])
+	}
+	content, _ := part["content"].(string)
+	return content
+}
+
+func TestPromptSubmitRecordsRetainedPromptContent(t *testing.T) {
+	// This path serves Claude Code, Cursor and the rest of the hook runtimes. It
+	// retained the prompt with nothing saying so and without the semconv message
+	// shape the Cline, opencode and Pi mappers already wrote.
+	setupHookConfigDirs(t)
+	platformFlag = "claude"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	prompt := "explain the dedupe key"
+	runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"session_id": "prompt-content-session",
+		"prompt":     prompt,
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if got := event["prompt"].(map[string]interface{})["text"]; got != prompt {
+		t.Fatalf("prompt.text = %q, want %q", got, prompt)
+	}
+	genAI, ok := event["gen_ai"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("gen_ai missing: %#v", event)
+	}
+	input, ok := genAI["input"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("gen_ai.input missing: %#v", genAI)
+	}
+	if got := hookFirstPartContent(t, input["messages"]); got != prompt {
+		t.Fatalf("input message text = %q, want %q", got, prompt)
+	}
+
+	content, ok := event["content"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("content marker missing: %#v", event)
+	}
+	sum := sha256.Sum256([]byte(prompt))
+	if content["hash"] != hex.EncodeToString(sum[:]) {
+		t.Fatalf("content hash = %v, want %s", content["hash"], hex.EncodeToString(sum[:]))
+	}
+	if content["bytes"] != float64(len(prompt)) || content["included"] != true {
+		t.Fatalf("content marker = %#v, want the retained prompt described", content)
+	}
+	if content["retention"] != asymptoteobserve.ContentRetentionFull {
+		t.Fatalf("content retention = %v, want full", content["retention"])
+	}
+}
+
+func TestPromptSubmitWithoutAPromptWritesNoContentMarker(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "claude"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	runHookWithInput(t, runPromptSubmit, map[string]interface{}{
+		"session_id": "no-prompt-session",
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if _, ok := event["content"]; ok {
+		t.Fatalf("no prompt was retained, so no marker belongs on the event: %#v", event["content"])
+	}
+	if _, ok := event["gen_ai"]; ok {
+		t.Fatalf("no prompt was retained, so no input messages belong on the event: %#v", event["gen_ai"])
+	}
+}
+
+func TestCursorShellExecutionRecordsRetainedOutput(t *testing.T) {
+	// command.output has always been written here and was never declared in the
+	// schema, so it reached the log and no reader could see it. It is retained
+	// content, so it takes a marker like every other retained field.
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	output := "PASS\nok  github.com/example/pkg  0.01s\n"
+	runHookWithInput(t, runPostTool, map[string]interface{}{
+		"hook_event_name": "afterShellExecution",
+		"conversation_id": "shell-content-session",
+		"command":         "go test ./...",
+		"output":          output,
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	command, ok := event["command"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("command field missing: %#v", event)
+	}
+	if command["output"] != output {
+		t.Fatalf("command.output = %q, want %q", command["output"], output)
+	}
+	content, ok := event["content"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("content marker missing: %#v", event)
+	}
+	if content["bytes"] != float64(len(output)) || content["included"] != true {
+		t.Fatalf("content marker = %#v, want the retained output described", content)
+	}
+}
+
+func TestCursorShellExecutionWithoutOutputWritesNoContentMarker(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "cursor"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+
+	runHookWithInput(t, runPostTool, map[string]interface{}{
+		"hook_event_name": "afterShellExecution",
+		"conversation_id": "shell-no-output-session",
+		"command":         "true",
+	})
+
+	event := lastEndpointEvent(t, logPath)
+	if _, ok := event["content"]; ok {
+		t.Fatalf("nothing was retained, so no marker belongs on the event: %#v", event["content"])
+	}
+}
+
+func TestDiffFieldsMarkRetainedDiffContent(t *testing.T) {
+	diff := "--- a/main.go\n+++ b/main.go\n@@ -1 +1 @@\n-old\n+new\n"
+	fields := diffFields("/repo/main.go", diff)
+
+	file, ok := fields["file"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("file field missing: %#v", fields)
+	}
+	if file["diff"] != diff {
+		t.Fatalf("file.diff = %v, want the constructed diff", file["diff"])
+	}
+	content, ok := fields["content"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("content marker missing: %#v", fields)
+	}
+	sum := sha256.Sum256([]byte(diff))
+	if content["hash"] != hex.EncodeToString(sum[:]) {
+		t.Fatalf("content hash = %v, want %s", content["hash"], hex.EncodeToString(sum[:]))
+	}
+	// diff_hash and diff_bytes already describe the original diff; the marker must
+	// agree with them rather than restate them differently.
+	if file["diff_hash"] != content["hash"] || file["diff_bytes"] != content["bytes"] {
+		t.Fatalf("diff metadata and content marker disagree: file=%#v content=%#v", file, content)
+	}
+}
+
+func TestDiffFieldsWithoutADiffWriteNoContentMarker(t *testing.T) {
+	fields := diffFields("/repo/main.go", "")
+	if _, ok := fields["content"]; ok {
+		t.Fatalf("no diff was retained, so no marker belongs in the fields: %#v", fields)
+	}
+	if _, ok := fields["file"]; !ok {
+		t.Fatalf("file metadata should still be recorded without a diff: %#v", fields)
+	}
+}
+
+func TestRetainedContentFieldsUseTheHookWritersLimit(t *testing.T) {
+	// The hook logger sanitizes the whole event map at DefaultStringLimit, so that
+	// is the limit "truncated" has to mean on this path.
+	short := strings.Repeat("z", asymptoteobserve.DefaultStringLimit)
+	if fields := retainedContentFields(short); fields["truncated"] != nil {
+		t.Fatalf("text at the limit should not be marked truncated: %#v", fields)
+	}
+	long := strings.Repeat("z", asymptoteobserve.DefaultStringLimit+1)
+	if fields := retainedContentFields(long); fields["truncated"] != true {
+		t.Fatalf("text over the limit should be marked truncated: %#v", fields)
+	}
+}

--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -552,13 +552,18 @@ func diffFields(filePath, diffStr string) map[string]interface{} {
 		"operation": "modify",
 		"language":  strings.TrimPrefix(filepath.Ext(filePath), "."),
 	}
+	fields := map[string]interface{}{"file": file}
 	if diffStr != "" {
 		sum := sha256.Sum256([]byte(diffStr))
 		file["diff_hash"] = hex.EncodeToString(sum[:])
 		file["diff_bytes"] = len(diffStr)
 		file["diff"] = diffStr
+		// diff_hash and diff_bytes already describe the original diff; the marker
+		// adds what they cannot say -- whether the stored copy is the whole diff,
+		// and whether redaction rewrote part of it.
+		fields["content"] = retainedContentFields(diffStr)
 	}
-	return map[string]interface{}{"file": file}
+	return fields
 }
 
 func mergeNested(existing interface{}, values map[string]interface{}) map[string]interface{} {

--- a/cli/beacon-hooks/cmd/grok_hooks_test.go
+++ b/cli/beacon-hooks/cmd/grok_hooks_test.go
@@ -61,8 +61,15 @@ func TestGrokIgnoresLegacyRetentionEnv(t *testing.T) {
 	if _, ok := raw["grok"]; !ok {
 		t.Fatalf("legacy retention env should not omit raw grok payload: %#v", raw)
 	}
-	if _, ok := event["content"]; ok {
-		t.Fatalf("legacy retention env should not emit content marker: %#v", event["content"])
+	// The marker is what proves the env is inert, rather than its absence: it
+	// reports the retention that actually happened, and BEACON_CONTENT_RETENTION
+	// asked for "metadata".
+	content, ok := event["content"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("content marker missing on a retained prompt: %#v", event)
+	}
+	if content["retention"] != "full" || content["included"] != true {
+		t.Fatalf("legacy retention env changed retention: %#v", content)
 	}
 }
 

--- a/cli/beacon-hooks/cmd/opencode_event.go
+++ b/cli/beacon-hooks/cmd/opencode_event.go
@@ -336,8 +336,10 @@ func opencodeToolFields(input map[string]interface{}, completed bool) map[string
 			fields["command"] = commandFields
 		}
 	}
-	if encoded, err := json.Marshal(map[string]interface{}{"input": toolInput, "response": toolResponse}); err == nil && len(encoded) > 0 {
-		fields["content"] = retainedContentFields(string(encoded))
+	if _, hasContent := fields["content"]; !hasContent {
+		if encoded, err := json.Marshal(map[string]interface{}{"input": toolInput, "response": toolResponse}); err == nil && len(encoded) > 0 {
+			fields["content"] = retainedContentFields(string(encoded))
+		}
 	}
 	return fields
 }

--- a/cli/beacon-hooks/cmd/opencode_event.go
+++ b/cli/beacon-hooks/cmd/opencode_event.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	hookdiff "github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/diff"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 	"github.com/spf13/cobra"
 )
 
@@ -58,14 +59,9 @@ func opencodeEndpointEvents(input map[string]interface{}, sessionID string) []no
 	case "chat.message":
 		if prompt := opencodePromptText(input); prompt != "" {
 			fields["prompt"] = map[string]interface{}{"text": prompt}
-			fields["gen_ai"] = map[string]interface{}{
-				"input": map[string]interface{}{
-					"messages": []interface{}{map[string]interface{}{
-						"role":  "user",
-						"parts": []interface{}{map[string]interface{}{"type": "text", "content": prompt}},
-					}},
-				},
-			}
+			fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{
+				"input": map[string]interface{}{"messages": asymptoteobserve.TextInputMessages(prompt)},
+			})
 			fields["content"] = retainedContentFields(prompt)
 		}
 		return one("prompt.submitted", "prompt", "info", "Prompt submitted to opencode", fields)

--- a/cli/beacon-hooks/cmd/pi_event.go
+++ b/cli/beacon-hooks/cmd/pi_event.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 )
 
 // pi-event is the single entry point for every Pi lifecycle payload.
@@ -142,14 +144,9 @@ func piBaseFields(input map[string]interface{}, sessionID string) map[string]int
 
 func piPromptEvent(fields map[string]interface{}, prompt, source string) normalizedEvent {
 	fields["prompt"] = map[string]interface{}{"text": prompt}
-	fields["gen_ai"] = map[string]interface{}{
-		"input": map[string]interface{}{
-			"messages": []interface{}{map[string]interface{}{
-				"role":  "user",
-				"parts": []interface{}{map[string]interface{}{"type": "text", "content": prompt}},
-			}},
-		},
-	}
+	fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{
+		"input": map[string]interface{}{"messages": asymptoteobserve.TextInputMessages(prompt)},
+	})
 	fields["content"] = retainedContentFields(prompt)
 	if source != "" {
 		// Pi distinguishes interactive input from input delivered over its RPC surface or injected

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -395,6 +395,7 @@ func emitCursorPostHookObserved(logger *logging.Logger, input map[string]interfa
 		commandFields := map[string]interface{}{"command": command}
 		if output := getFirstStr(input, "output"); output != "" {
 			commandFields["output"] = output
+			fields["content"] = retainedContentFields(output)
 		}
 		if duration, ok := input["duration"]; ok {
 			commandFields["duration_ms"] = duration

--- a/cli/beacon-hooks/cmd/pre_tool.go
+++ b/cli/beacon-hooks/cmd/pre_tool.go
@@ -155,6 +155,10 @@ func emitAntigravityPromptFromTranscript(logger *logging.Logger, input map[strin
 	}
 	fields := sessionFields(sessionID, input)
 	fields["prompt"] = map[string]interface{}{"text": prompt}
+	fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{
+		"input": map[string]interface{}{"messages": asymptoteobserve.TextInputMessages(prompt)},
+	})
+	fields["content"] = retainedContentFields(prompt)
 	emitHookEvent(logger, "prompt.submitted", "prompt", "info", "Prompt submitted to agent", input, fields)
 	if err := st.SetPromptEmitted(); err != nil {
 		logger.Warn("Failed to persist prompt state", "error", err.Error())

--- a/cli/beacon-hooks/cmd/pre_tool_test.go
+++ b/cli/beacon-hooks/cmd/pre_tool_test.go
@@ -495,8 +495,15 @@ func TestRunPromptSubmitIgnoresLegacyRetentionEnvForDevinDesktop(t *testing.T) {
 	if got := event["prompt"].(map[string]interface{})["text"]; got != "summarize token=[REDACTED]" {
 		t.Fatalf("prompt.text = %q, want redacted prompt", got)
 	}
-	if _, ok := event["content"]; ok {
-		t.Fatalf("legacy retention env should not emit content marker: %#v", event["content"])
+	// The marker is what proves the env is inert, rather than its absence: it
+	// reports the retention that actually happened, and BEACON_CONTENT_RETENTION
+	// asked for "metadata".
+	content, ok := event["content"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("content marker missing on a retained prompt: %#v", event)
+	}
+	if content["retention"] != "full" || content["included"] != true {
+		t.Fatalf("legacy retention env changed retention: %#v", content)
 	}
 }
 
@@ -849,8 +856,15 @@ func TestRunPromptSubmitIgnoresLegacyRetentionEnv(t *testing.T) {
 	if got := event["prompt"].(map[string]interface{})["text"]; got != "summarize this file" {
 		t.Fatalf("prompt.text = %q, want legacy retention env ignored", got)
 	}
-	if _, ok := event["content"]; ok {
-		t.Fatalf("legacy retention env should not emit content marker: %#v", event["content"])
+	// The marker is what proves the env is inert, rather than its absence: it
+	// reports the retention that actually happened, and BEACON_CONTENT_RETENTION
+	// asked for "metadata".
+	content, ok := event["content"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("content marker missing on a retained prompt: %#v", event)
+	}
+	if content["retention"] != "full" || content["included"] != true {
+		t.Fatalf("legacy retention env changed retention: %#v", content)
 	}
 }
 

--- a/cli/beacon-hooks/cmd/prompt_submit.go
+++ b/cli/beacon-hooks/cmd/prompt_submit.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon-hooks/internal/state"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 )
 
 var promptSubmitCmd = &cobra.Command{
@@ -44,6 +45,15 @@ func runPromptSubmit(cmd *cobra.Command, args []string) {
 	hasPrompt := prompt != ""
 	if hasPrompt {
 		fields["prompt"] = map[string]interface{}{"text": prompt}
+		// The same two fields the Cline, opencode and Pi prompt mappers already
+		// write. This path serves Claude Code, Cursor and the rest of the hook
+		// runtimes, and wrote neither -- so a prompt captured here was readable only
+		// as prompt.text, with nothing recording that the text was retained and
+		// nothing in the semconv shape a message-oriented reader looks for.
+		fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{
+			"input": map[string]interface{}{"messages": asymptoteobserve.TextInputMessages(prompt)},
+		})
+		fields["content"] = retainedContentFields(prompt)
 	}
 	emitHookEvent(logger, "prompt.submitted", "prompt", "info", "Prompt submitted to agent", input, fields)
 

--- a/cli/beacon/internal/devincloud/mapper.go
+++ b/cli/beacon/internal/devincloud/mapper.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 )
 
 // Provider is the BEACON_RUN_PROVIDER value for Devin Cloud telemetry. It
@@ -71,16 +72,40 @@ func MapSession(s Session, msgs []Message) []MappedEvent {
 	seen := map[string]bool{}
 	for i, m := range msgs {
 		dedupID := messageDedupID(s.SessionID, m, i, seen)
+		// The marker used to assert full retention with no hash and no byte count,
+		// which is the half of it that carries information: without them a reader
+		// cannot tell a short message from a truncated long one, and has nothing
+		// stable to identify the text by. Both fields hold the message at
+		// DefaultStringLimit, so that is the limit the marker answers against.
+		//
+		// RetainedContent returns nil for an empty message, and the message shapes
+		// are built only alongside it, so a message with no text gets neither a
+		// marker claiming retention nor a message part with empty content.
+		content := asymptoteobserve.RetainedContent(m.Message, asymptoteobserve.DefaultStringLimit)
 		switch strings.ToLower(m.Source) {
 		case "user":
 			ev := baseEvent(s, "prompt.submitted", "prompt", schema.SeverityInfo, m.CreatedAt)
 			ev.Prompt = &schema.PromptInfo{Text: m.Message}
-			ev.Content = &schema.ContentInfo{Retention: schema.ContentRetentionFull, Included: true}
+			if content != nil {
+				ev.GenAI = &schema.GenAIInfo{Input: &schema.GenAIInputInfo{
+					Messages: asymptoteobserve.TextInputMessages(m.Message),
+				}}
+			}
+			ev.Content = content
 			ev.Message = "Devin Cloud user prompt"
 			out = append(out, MappedEvent{DedupID: dedupID, Event: ev})
 		default: // "devin" (assistant) and any future agent-side source
 			ev := baseEvent(s, "agent.message", "session", schema.SeverityInfo, m.CreatedAt)
-			ev.Content = &schema.ContentInfo{Retention: schema.ContentRetentionFull, Included: true}
+			// The assistant's text reached the log only as the event message, which
+			// is a free-text label rather than a payload anything can match on. It
+			// keeps its place there and also lands in the semconv output-messages
+			// shape every other capture path now uses for assistant text.
+			if content != nil {
+				ev.GenAI = &schema.GenAIInfo{Output: &schema.GenAIOutputInfo{
+					Messages: asymptoteobserve.TextOutputMessages(m.Message),
+				}}
+			}
+			ev.Content = content
 			ev.Message = m.Message
 			out = append(out, MappedEvent{DedupID: dedupID, Event: ev})
 		}

--- a/cli/beacon/internal/devincloud/mapper.go
+++ b/cli/beacon/internal/devincloud/mapper.go
@@ -72,18 +72,17 @@ func MapSession(s Session, msgs []Message) []MappedEvent {
 	seen := map[string]bool{}
 	for i, m := range msgs {
 		dedupID := messageDedupID(s.SessionID, m, i, seen)
-		// The marker used to assert full retention with no hash and no byte count,
-		// which is the half of it that carries information: without them a reader
-		// cannot tell a short message from a truncated long one, and has nothing
-		// stable to identify the text by. Both fields hold the message at
-		// DefaultStringLimit, so that is the limit the marker answers against.
-		//
 		// RetainedContent returns nil for an empty message, and the message shapes
 		// are built only alongside it, so a message with no text gets neither a
 		// marker claiming retention nor a message part with empty content.
-		content := asymptoteobserve.RetainedContent(m.Message, asymptoteobserve.DefaultStringLimit)
+		//
+		// The limit passed to RetainedContent must match the limit SanitizeEvent
+		// applies to the field the text actually lives in: prompt.text is sanitized
+		// at DefaultStringLimit, while gen_ai (where assistant text lands) is
+		// sanitized at DefaultRawStringLimit.
 		switch strings.ToLower(m.Source) {
 		case "user":
+			content := asymptoteobserve.RetainedContent(m.Message, asymptoteobserve.DefaultStringLimit)
 			ev := baseEvent(s, "prompt.submitted", "prompt", schema.SeverityInfo, m.CreatedAt)
 			ev.Prompt = &schema.PromptInfo{Text: m.Message}
 			if content != nil {
@@ -95,6 +94,7 @@ func MapSession(s Session, msgs []Message) []MappedEvent {
 			ev.Message = "Devin Cloud user prompt"
 			out = append(out, MappedEvent{DedupID: dedupID, Event: ev})
 		default: // "devin" (assistant) and any future agent-side source
+			content := asymptoteobserve.RetainedContent(m.Message, asymptoteobserve.DefaultRawStringLimit)
 			ev := baseEvent(s, "agent.message", "session", schema.SeverityInfo, m.CreatedAt)
 			// The assistant's text reached the log only as the event message, which
 			// is a free-text label rather than a payload anything can match on. It

--- a/cli/beacon/internal/devincloud/mapper_test.go
+++ b/cli/beacon/internal/devincloud/mapper_test.go
@@ -1,6 +1,10 @@
 package devincloud
 
-import "testing"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
 
 func TestMapSessionProducesLifecycleAndMessages(t *testing.T) {
 	s := Session{
@@ -176,5 +180,47 @@ func TestMappedEventsRecordPollCollectionMethod(t *testing.T) {
 		if got := m.Event.Harness.CollectionMethod; got != "poll" {
 			t.Fatalf("event %d (%s) collection_method = %q, want poll", i, m.Event.Event.Action, got)
 		}
+	}
+}
+
+func TestMapSessionRecordsRetainedMessageContent(t *testing.T) {
+	// Both markers used to claim full retention with no hash and no byte count,
+	// and the assistant's text reached the log only as the event message.
+	prompt := "fix the flaky test"
+	reply := "I disabled the retry and pinned the clock."
+	mapped := MapSession(
+		Session{SessionID: "devin-1", CreatedAt: 100},
+		[]Message{
+			{EventID: "m1", Source: "user", Message: prompt, CreatedAt: 101},
+			{EventID: "m2", Source: "devin", Message: reply, CreatedAt: 102},
+		},
+	)
+	if len(mapped) != 3 {
+		t.Fatalf("mapped = %d events, want 3", len(mapped))
+	}
+
+	promptEvent := mapped[1].Event
+	promptSum := sha256.Sum256([]byte(prompt))
+	if promptEvent.Content == nil || promptEvent.Content.Hash != hex.EncodeToString(promptSum[:]) {
+		t.Fatalf("prompt content marker = %#v, want the prompt hashed", promptEvent.Content)
+	}
+	if promptEvent.Content.Bytes != len(prompt) || !promptEvent.Content.Included {
+		t.Fatalf("prompt content marker = %#v, want the retained prompt described", promptEvent.Content)
+	}
+	if promptEvent.GenAI == nil || promptEvent.GenAI.Input == nil || promptEvent.GenAI.Input.Messages == nil {
+		t.Fatalf("prompt not mirrored into gen_ai.input.messages: %#v", promptEvent.GenAI)
+	}
+
+	agentEvent := mapped[2].Event
+	if agentEvent.GenAI == nil || agentEvent.GenAI.Output == nil || agentEvent.GenAI.Output.Messages == nil {
+		t.Fatalf("assistant text not promoted into gen_ai.output.messages: %#v", agentEvent.GenAI)
+	}
+	replySum := sha256.Sum256([]byte(reply))
+	if agentEvent.Content == nil || agentEvent.Content.Hash != hex.EncodeToString(replySum[:]) {
+		t.Fatalf("agent content marker = %#v, want the reply hashed", agentEvent.Content)
+	}
+	// The message keeps its existing role as the human-readable label.
+	if agentEvent.Message != reply {
+		t.Fatalf("agent message = %q, want the reply text preserved", agentEvent.Message)
 	}
 }

--- a/collector-builder/exporter/beaconjsonexporter/exporter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter_test.go
@@ -49,8 +49,13 @@ func TestNewExporterAcceptsDeprecatedContentRetention(t *testing.T) {
 	record.Attributes().PutStr("beacon.event.action", "prompt.submitted")
 	record.Attributes().PutStr("gen_ai.prompt", "hello")
 	event := exp.eventFromLog(nil, record)
-	if event.Content != nil {
-		t.Fatalf("deprecated content retention should not emit content marker: %#v", event.Content)
+	// The marker is what shows the knob is a no-op: it describes the retention
+	// that actually happened, and the config asked for "metadata".
+	if event.Content == nil {
+		t.Fatalf("content marker missing on a retained prompt: %#v", event)
+	}
+	if event.Content.Retention != asymptoteobserve.ContentRetentionFull || !event.Content.Included {
+		t.Fatalf("deprecated content retention changed retention: %#v", event.Content)
 	}
 }
 
@@ -1904,4 +1909,50 @@ func containsString(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestJSONLWriterCompactsRetainedContentBeforeFailing(t *testing.T) {
+	// The step between "drop raw" and "refuse to write the event" -- survivable
+	// while no OTLP event carried a turn's text, and not once they do.
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	writer := jsonlWriter{
+		path:           path,
+		maxEventBytes:  1024,
+		rotateBytes:    defaultRotateBytes,
+		rotateArchives: defaultRotateArchives,
+		redactSecrets:  true,
+	}
+	long := strings.Repeat("y", 4096)
+	event := newBeaconEvent("command.executed", "command", "info", "cursor", time.Now())
+	event.Session = &sessionInfo{ID: "s-compact"}
+	event.Command = &commandInfo{Command: "make build", Output: long}
+	event.File = &fileInfo{Path: "/repo/main.go", Diff: long}
+	event.Prompt = &promptInfo{Text: long}
+	event.Content = &contentInfo{Retention: asymptoteobserve.ContentRetentionFull, Included: true, Bytes: len(long)}
+
+	if err := writer.append(event); err != nil {
+		t.Fatalf("append returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	var written beaconEvent
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &written); err != nil {
+		t.Fatalf("decode written event: %v", err)
+	}
+	if written.Command.Output != "" || written.File.Diff != "" || written.Prompt.Text != "" {
+		t.Fatalf("retained content survived compaction: %#v", written)
+	}
+	if written.Content == nil || written.Content.Included || !written.Content.Truncated {
+		t.Fatalf("content marker = %#v, want included=false truncated=true", written.Content)
+	}
+	// The event is still identifiable: what it was and what command it described
+	// outlive the content that had to be dropped.
+	if written.Command.Command != "make build" || written.Event.Action != "command.executed" {
+		t.Fatalf("compaction lost the event's identity: %#v", written)
+	}
+	if written.Content.Bytes != len(long) {
+		t.Fatalf("content bytes = %d, want the original %d", written.Content.Bytes, len(long))
+	}
 }

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/content.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/content.go
@@ -1,0 +1,148 @@
+package beaconevent
+
+import (
+	"strings"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+)
+
+// PromptTextKeys are the attribute spellings that carry a user turn's text.
+// Shared with PopulateCommon so the early and late prompt promotions read the
+// same list rather than two copies that can disagree about which runtimes are
+// covered.
+//
+// Bare `prompt` is safe here only because every reader gates on the event being a
+// prompt in the first place.
+var PromptTextKeys = []string{
+	"beacon.prompt.text",
+	"gen_ai.prompt",
+	"prompt",
+	"user_prompt",
+	"input.prompt",
+	"copilot_chat.user_request",
+}
+
+// assistantTextKeys are the spellings that carry an assistant turn's text.
+//
+// Deliberately specific, and with no bare `response`: nothing gates this list on
+// the event being a response, and `response` on its own appears on events that
+// are not a turn at all -- Claude Code's `feedback_survey` carries
+// `response: "positive"`. Every entry is either a semconv-adjacent name or a
+// runtime-namespaced one. The bare spelling is read only on the event whose own
+// name says what it is, in claudeAssistantText.
+var assistantTextKeys = []string{
+	"beacon.gen_ai.output.text",
+	"gen_ai.completion",
+	"gen_ai.response",
+	"gen_ai.output.text",
+	"response.text",
+	"output.text",
+	"completion",
+	"assistant_response",
+}
+
+// claudeAssistantText reads the model's reply off a Claude Code log record.
+//
+// This is where the largest single content gap on the OTLP path was: Claude Code
+// emits the whole reply as `response` on `claude_code.assistant_response` and
+// nothing read it, so the text sat in raw.attributes and the event carried no
+// assistant output at all. The attribute is read only under that event name,
+// which is what keeps a survey answer from being recorded as something the model
+// said.
+func claudeAssistantText(harness, eventName string, attrs map[string]interface{}) string {
+	if harness != "claude_code" || eventName != ClaudeAssistantResponse {
+		return ""
+	}
+	return FirstTextAttr(attrs, "response")
+}
+
+// PromoteRetainedContent fills the fields that carry a turn's text -- prompt.text,
+// gen_ai.input.messages, gen_ai.output.messages -- and stamps the content marker
+// describing what was retained.
+//
+// It runs after the per-harness normalizers rather than inside PopulateCommon,
+// because the normalizers are what decide an event is a prompt: PopulateCommon
+// only promoted prompt text when the category was already "prompt" at the moment
+// it ran, which for a runtime whose classification lands later meant the text was
+// dropped even though the attribute was right there.
+//
+// Nothing here overwrites text a source stated in semconv form. A record that
+// already carries gen_ai.output.messages keeps them; these promotions exist for
+// runtimes that report a turn under their own attribute names.
+func (c Converter) PromoteRetainedContent(event *Event, attrs map[string]interface{}, body string) {
+	if event == nil {
+		return
+	}
+	eventName := ClaudeLogEventName(attrs, body)
+
+	promptText := ""
+	if event.Prompt != nil {
+		promptText = event.Prompt.Text
+	}
+	if promptText == "" && isPromptEvent(event) {
+		promptText = FirstNonEmpty(FirstTextAttr(attrs, PromptTextKeys...), FirstMessageText(event.GenAI))
+		if promptText != "" {
+			event.Prompt = &PromptInfo{Text: promptText}
+		}
+	}
+
+	assistantText := FirstNonEmpty(
+		claudeAssistantText(event.Harness.Name, eventName, attrs),
+		FirstTextAttr(attrs, assistantTextKeys...),
+	)
+	if assistantText != "" && !hasOutputMessages(event) {
+		if event.GenAI == nil {
+			event.GenAI = &GenAIInfo{}
+		}
+		if event.GenAI.Output == nil {
+			event.GenAI.Output = &GenAIOutputInfo{}
+		}
+		event.GenAI.Output.Messages = asymptoteobserve.TextOutputMessages(assistantText)
+	} else {
+		// Cleared, not just unwritten: the marker below describes text this function
+		// retained, and when the source's own messages are what got stored, nothing
+		// here did. Hashing a structured messages payload as if it were one string
+		// would produce a marker that describes neither.
+		assistantText = ""
+	}
+
+	if promptText != "" && !hasInputMessages(event) {
+		if event.GenAI == nil {
+			event.GenAI = &GenAIInfo{}
+		}
+		if event.GenAI.Input == nil {
+			event.GenAI.Input = &GenAIInputInfo{}
+		}
+		event.GenAI.Input.Messages = asymptoteobserve.TextInputMessages(promptText)
+	}
+
+	if event.Content != nil {
+		return
+	}
+	// The marker describes one body of retained text and the limit that will be
+	// applied to where that text is stored, which is why the two cases carry
+	// different limits: gen_ai is sanitized at the raw-attribute limit and
+	// prompt.text at the longer string limit. Assistant text wins when an event
+	// somehow carries both, because it is the larger of the two in every payload
+	// observed.
+	switch {
+	case assistantText != "":
+		event.Content = asymptoteobserve.RetainedContent(assistantText, asymptoteobserve.DefaultRawStringLimit)
+	case promptText != "":
+		event.Content = asymptoteobserve.RetainedContent(promptText, asymptoteobserve.DefaultStringLimit)
+	}
+}
+
+// isPromptEvent reports whether an event describes a user turn, and so whether
+// prompt-shaped attributes on it are that turn's text.
+func isPromptEvent(event *Event) bool {
+	return event.Event.Category == "prompt" || strings.HasPrefix(event.Event.Action, "prompt.")
+}
+
+func hasOutputMessages(event *Event) bool {
+	return event.GenAI != nil && event.GenAI.Output != nil && event.GenAI.Output.Messages != nil
+}
+
+func hasInputMessages(event *Event) bool {
+	return event.GenAI != nil && event.GenAI.Input != nil && event.GenAI.Input.Messages != nil
+}

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/content_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/content_test.go
@@ -1,0 +1,212 @@
+package beaconevent
+
+import (
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// firstPartContent reads the text out of a gen_ai messages value in the semconv
+// shape, so the assertions below read the field the way a consumer would.
+func firstPartContent(t *testing.T, messages interface{}) string {
+	t.Helper()
+	list, ok := messages.([]interface{})
+	if !ok || len(list) == 0 {
+		t.Fatalf("messages = %#v, want a non-empty list", messages)
+	}
+	message, ok := list[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("message = %#v, want a map", list[0])
+	}
+	parts, ok := message["parts"].([]interface{})
+	if !ok || len(parts) == 0 {
+		t.Fatalf("parts = %#v, want a non-empty list", message["parts"])
+	}
+	part, ok := parts[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("part = %#v, want a map", parts[0])
+	}
+	content, _ := part["content"].(string)
+	return content
+}
+
+func claudeLogEvent(t *testing.T, body string, attrs map[string]interface{}) Event {
+	t.Helper()
+	record := plog.NewLogRecord()
+	record.Body().SetStr(body)
+	merged := map[string]interface{}{"service.name": "claude-code"}
+	for key, value := range attrs {
+		merged[key] = value
+	}
+	if err := record.Attributes().FromRaw(merged); err != nil {
+		t.Fatalf("load attributes: %v", err)
+	}
+	return NewConverter(Options{}).EventFromLog(nil, record)
+}
+
+func TestClaudeAssistantResponseCarriesTheAssistantText(t *testing.T) {
+	// The largest content gap on the OTLP path: Claude Code emits the model's whole
+	// reply as `response` and nothing read it, so the text sat in raw.attributes and
+	// the event carried no assistant output at all.
+	event := claudeLogEvent(t, "claude_code.assistant_response", map[string]interface{}{
+		"event.name":      "assistant_response",
+		"response":        "I updated three files.",
+		"response_length": 22,
+		"model":           "claude-opus-5",
+	})
+
+	if event.GenAI == nil || event.GenAI.Output == nil || event.GenAI.Output.Messages == nil {
+		t.Fatalf("assistant text not promoted: %#v", event.GenAI)
+	}
+	if got := firstPartContent(t, event.GenAI.Output.Messages); got != "I updated three files." {
+		t.Fatalf("assistant text = %q, want the response attribute", got)
+	}
+	if event.Content == nil || !event.Content.Included || event.Content.Bytes != len("I updated three files.") {
+		t.Fatalf("content marker = %#v, want the retained response described", event.Content)
+	}
+	// The action stays whatever the classification table says; this change is about
+	// what the event carries, not what it is called.
+	if event.Event.Action != "session.activity" {
+		t.Fatalf("action = %q, want the classification unchanged", event.Event.Action)
+	}
+}
+
+func TestClaudeFeedbackSurveyResponseIsNotAssistantText(t *testing.T) {
+	// `response` means a turn only on the event named for it. feedback_survey uses
+	// the same key for a survey answer, so a blanket alias would record "positive"
+	// as something the model said.
+	event := claudeLogEvent(t, "claude_code.feedback_survey", map[string]interface{}{
+		"event.name":  "feedback_survey",
+		"event_type":  "responded",
+		"response":    "positive",
+		"survey_type": "session",
+	})
+
+	if event.GenAI != nil && event.GenAI.Output != nil && event.GenAI.Output.Messages != nil {
+		t.Fatalf("survey answer promoted as assistant text: %#v", event.GenAI.Output.Messages)
+	}
+	if event.Content != nil {
+		t.Fatalf("survey answer produced a content marker: %#v", event.Content)
+	}
+}
+
+func TestClaudeUserPromptCarriesPromptTextAndInputMessages(t *testing.T) {
+	event := claudeLogEvent(t, "claude_code.user_prompt", map[string]interface{}{
+		"event.name":    "user_prompt",
+		"prompt":        "refactor the writer",
+		"prompt_length": 19,
+	})
+
+	if event.Prompt == nil || event.Prompt.Text != "refactor the writer" {
+		t.Fatalf("prompt = %#v, want the prompt attribute", event.Prompt)
+	}
+	if event.GenAI == nil || event.GenAI.Input == nil || event.GenAI.Input.Messages == nil {
+		t.Fatalf("prompt not mirrored into gen_ai.input.messages: %#v", event.GenAI)
+	}
+	if got := firstPartContent(t, event.GenAI.Input.Messages); got != "refactor the writer" {
+		t.Fatalf("input message text = %q, want the prompt", got)
+	}
+	if event.Content == nil || event.Content.Bytes != len("refactor the writer") {
+		t.Fatalf("content marker = %#v, want the retained prompt described", event.Content)
+	}
+}
+
+func TestSemconvNativeOutputMessagesAreNotOverwritten(t *testing.T) {
+	// A source that already speaks semconv keeps its own messages; the promotions
+	// exist for runtimes that report a turn under their own attribute names.
+	record := plog.NewLogRecord()
+	record.Body().SetStr("chat")
+	attrs := record.Attributes()
+	attrs.PutStr("service.name", "generic-runtime")
+	attrs.PutStr("gen_ai.completion", "promoted text")
+	messages := attrs.PutEmptySlice("gen_ai.output.messages")
+	native := messages.AppendEmpty().SetEmptyMap()
+	native.PutStr("role", "assistant")
+	nativeParts := native.PutEmptySlice("parts")
+	nativePart := nativeParts.AppendEmpty().SetEmptyMap()
+	nativePart.PutStr("type", "text")
+	nativePart.PutStr("content", "native text")
+
+	event := NewConverter(Options{}).EventFromLog(nil, record)
+	if got := firstPartContent(t, event.GenAI.Output.Messages); got != "native text" {
+		t.Fatalf("output messages = %q, want the source's own messages preserved", got)
+	}
+}
+
+func TestGenericAssistantAliasIsPromoted(t *testing.T) {
+	record := plog.NewLogRecord()
+	record.Body().SetStr("chat")
+	attrs := record.Attributes()
+	attrs.PutStr("service.name", "generic-runtime")
+	attrs.PutStr("gen_ai.completion", "the model replied")
+
+	event := NewConverter(Options{}).EventFromLog(nil, record)
+	if event.GenAI == nil || event.GenAI.Output == nil {
+		t.Fatalf("generic assistant alias not promoted: %#v", event.GenAI)
+	}
+	if got := firstPartContent(t, event.GenAI.Output.Messages); got != "the model replied" {
+		t.Fatalf("assistant text = %q, want the completion attribute", got)
+	}
+}
+
+func TestClaudeMCPServerConnectionCarriesItsServer(t *testing.T) {
+	// The event was already actioned mcp.connection with no mcp object on it, so
+	// every rule that gates on e.mcp.server saw nothing.
+	event := claudeLogEvent(t, "claude_code.mcp_server_connection", map[string]interface{}{
+		"event.name":     "mcp_server_connection",
+		"server_name":    "github",
+		"transport_type": "stdio",
+		"status":         "connected",
+	})
+
+	if event.Event.Action != "mcp.connection" {
+		t.Fatalf("action = %q, want mcp.connection", event.Event.Action)
+	}
+	if event.MCP == nil || event.MCP.Server != "github" {
+		t.Fatalf("mcp = %#v, want server github", event.MCP)
+	}
+}
+
+func TestCapturedClaudeLifecycleGainsAssistantTextAndContent(t *testing.T) {
+	// The captured-runtime fixture is the closest thing here to the live log the
+	// content gap was measured in: before this change none of its events carried
+	// assistant text or a content marker.
+	_, events := capturedLogEvents(t, "claude-code-lifecycle-2.1.220.json")
+
+	withAssistantText := 0
+	withContent := 0
+	for _, event := range events {
+		if event.GenAI != nil && event.GenAI.Output != nil && event.GenAI.Output.Messages != nil {
+			withAssistantText++
+		}
+		if event.Content != nil {
+			withContent++
+		}
+	}
+	if withAssistantText != 1 {
+		t.Fatalf("events carrying assistant text = %d, want 1 (the assistant_response record)", withAssistantText)
+	}
+	if withContent != 2 {
+		t.Fatalf("events carrying a content marker = %d, want 2 (the prompt and the response)", withContent)
+	}
+}
+
+func TestPromotedContentIsMarkedTruncatedAtTheCollectorLimit(t *testing.T) {
+	// Assistant text lands in gen_ai, which the collector sanitizes at the
+	// raw-attribute limit, so that is the limit the marker has to answer against.
+	long := make([]byte, asymptoteobserve.DefaultRawStringLimit+1)
+	for i := range long {
+		long[i] = 'x'
+	}
+	event := claudeLogEvent(t, "claude_code.assistant_response", map[string]interface{}{
+		"event.name": "assistant_response",
+		"response":   string(long),
+	})
+	if event.Content == nil || !event.Content.Truncated {
+		t.Fatalf("content marker = %#v, want truncated at the raw limit", event.Content)
+	}
+	if event.Content.Bytes != len(long) {
+		t.Fatalf("content bytes = %d, want the original %d", event.Content.Bytes, len(long))
+	}
+}

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -22,9 +22,16 @@ const (
 	CodexUserPrompt         = "codex.user_prompt"
 	CodexToolDecision       = "codex.tool_decision"
 	CodexToolResult         = "codex.tool_result"
+	ClaudeAssistantResponse = "claude_code.assistant_response"
 	ClaudeAPIRequest        = "claude_code.api_request"
 	ClaudeToolDecision      = "claude_code.tool_decision"
 	ClaudeToolResult        = "claude_code.tool_result"
+	// ClaudeMCPServerConnection is Claude Code's MCP connect/disconnect record. It
+	// is classified mcp.connection by the table below, but it names its server in
+	// `server_name`, which no mcp.* alias read -- so the event arrived actioned as
+	// MCP with no mcp object on it, and every rule that gates on e.mcp.server saw
+	// nothing.
+	ClaudeMCPServerConnection = "claude_code.mcp_server_connection"
 )
 
 type eventClassification struct {
@@ -34,7 +41,7 @@ type eventClassification struct {
 
 var claudeLogEventClassifications = map[string]eventClassification{
 	"claude_code.user_prompt":             {action: "prompt.submitted", category: "prompt"},
-	"claude_code.assistant_response":      {action: "session.activity", category: "session"},
+	ClaudeAssistantResponse:               {action: "session.activity", category: "session"},
 	ClaudeToolResult:                      {},
 	ClaudeAPIRequest:                      {action: "session.activity", category: "session"},
 	"claude_code.api_error":               {action: "session.error", category: "session"},
@@ -320,6 +327,9 @@ func (c Converter) EventFromLog(resourceAttrs map[string]interface{}, record plo
 	})
 	c.NormalizeCodexLogEvent(&event, attrs)
 	c.NormalizeClaudeLogEvent(&event, attrs, body)
+	// Last, so it sees the action and category the normalizers settled on rather
+	// than the ones InferAction guessed.
+	c.PromoteRetainedContent(&event, attrs, body)
 	return event
 }
 
@@ -350,6 +360,7 @@ func (c Converter) EventFromSpan(resourceAttrs map[string]interface{}, span ptra
 		"span_kind":   span.Kind().String(),
 		"status":      span.Status().Code().String(),
 	})
+	c.PromoteRetainedContent(&event, attrs, span.Name())
 	return event
 }
 
@@ -470,6 +481,11 @@ func (c Converter) NormalizeClaudeLogEvent(event *Event, attrs map[string]interf
 	case ClaudeToolResult:
 		event.Event.Fidelity = asymptoteobserve.FidelityObserved
 		NormalizeClaudeToolResult(event, attrs)
+	case ClaudeMCPServerConnection:
+		event.Event.Fidelity = asymptoteobserve.FidelityObserved
+		event.Event.Action = "mcp.connection"
+		event.Event.Category = "mcp"
+		normalizeClaudeMCPConnection(event, attrs)
 	case "":
 		return
 	default:
@@ -578,6 +594,21 @@ func NormalizeClaudeToolResult(event *Event, attrs map[string]interface{}) {
 		normalizeClaudeFileResult(event, toolName, input, "file.read")
 	case "write", "edit", "notebookedit":
 		normalizeClaudeFileResult(event, toolName, input, "file.modified")
+	}
+}
+
+// normalizeClaudeMCPConnection gives an mcp.connection event the mcp payload its
+// action promises, from the attributes Claude Code actually emits.
+func normalizeClaudeMCPConnection(event *Event, attrs map[string]interface{}) {
+	server := FirstString(attrs, "server_name", "mcp.server", "mcp.server.name", "mcp_server_name")
+	if server == "" {
+		return
+	}
+	if event.MCP == nil {
+		event.MCP = &MCPInfo{}
+	}
+	if event.MCP.Server == "" {
+		event.MCP.Server = server
 	}
 }
 
@@ -919,7 +950,7 @@ func (c Converter) PopulateCommon(event *Event, attrs map[string]interface{}) {
 		}
 	}
 	if event.Event.Category == "prompt" {
-		if text := FirstNonEmpty(FirstTextAttr(attrs, "beacon.prompt.text", "gen_ai.prompt", "prompt", "user_prompt", "input.prompt", "copilot_chat.user_request"), FirstMessageText(event.GenAI)); text != "" {
+		if text := FirstNonEmpty(FirstTextAttr(attrs, PromptTextKeys...), FirstMessageText(event.GenAI)); text != "" {
 			event.Prompt = &PromptInfo{Text: text}
 		}
 	}

--- a/collector-builder/exporter/beaconjsonexporter/writer.go
+++ b/collector-builder/exporter/beaconjsonexporter/writer.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/asymptote-labs/agent-beacon/collector-builder/exporter/beaconjsonexporter/internal/beaconevent"
 	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve/filelock"
 )
@@ -30,6 +31,17 @@ func (w jsonlWriter) append(event beaconEvent) error {
 		event.Raw = nil
 		event.Message = asymptoteobserve.TruncateString(event.Message, 1024)
 		event.Truncated = true
+		data, err = json.Marshal(event)
+		if err != nil {
+			return err
+		}
+	}
+	if len(data) > w.maxEventBytes {
+		// Retained content is the next thing to go after raw, mirroring the hook
+		// writer's compactEndpointContent. Before this path existed the only step
+		// past dropping raw was the hard error below, which was survivable while
+		// no OTLP event carried a turn's text and is not now that they do.
+		compactRetainedContent(&event)
 		data, err = json.Marshal(event)
 		if err != nil {
 			return err
@@ -59,6 +71,39 @@ func (w jsonlWriter) append(event beaconEvent) error {
 	return appendJSONL(w.path, append(data, '\n'), w.rotateBytes, w.rotateArchives)
 }
 
+// compactRetainedContent drops an event's retained text and records that it did,
+// so a reader can still tell what the event was about and that its content was
+// held back rather than never captured. The hash and byte count in the content
+// marker describe the original text and stay put.
+func compactRetainedContent(event *beaconEvent) {
+	if event.File != nil {
+		event.File.Diff = ""
+	}
+	if event.Command != nil {
+		event.Command.Output = ""
+	}
+	if event.Prompt != nil {
+		event.Prompt.Text = ""
+	}
+	if event.GenAI != nil {
+		event.GenAI.Input = nil
+		event.GenAI.Output = nil
+		if event.GenAI.Tool != nil && event.GenAI.Tool.Call != nil {
+			event.GenAI.Tool.Call.Arguments = nil
+			event.GenAI.Tool.Call.Result = nil
+		}
+		// An event whose only gen_ai content was the turn text drops the object
+		// rather than writing "gen_ai":{}.
+		if beaconevent.IsZeroJSON(event.GenAI) {
+			event.GenAI = nil
+		}
+	}
+	if event.Content != nil {
+		event.Content.Included = false
+		event.Content.Truncated = true
+	}
+}
+
 func (w jsonlWriter) sanitize(event beaconEvent) beaconEvent {
 	event.Message = w.cleanString(event.Message, asymptoteobserve.DefaultStringLimit)
 	if event.Tool != nil {
@@ -67,6 +112,12 @@ func (w jsonlWriter) sanitize(event beaconEvent) beaconEvent {
 	}
 	if event.Command != nil {
 		event.Command.Command = w.cleanString(event.Command.Command, asymptoteobserve.DefaultStringLimit)
+		event.Command.Output = w.cleanString(event.Command.Output, asymptoteobserve.DefaultStringLimit)
+	}
+	// Mirrors SanitizeEvent: retained bulk content gets the prompt-text limit and
+	// secret redaction, not the shorter raw-attribute limit.
+	if event.File != nil {
+		event.File.Diff = w.cleanString(event.File.Diff, asymptoteobserve.DefaultStringLimit)
 	}
 	if event.Approval != nil {
 		event.Approval.Reason = w.cleanString(event.Approval.Reason, asymptoteobserve.DefaultStringLimit)

--- a/pkg/asymptoteobserve/content.go
+++ b/pkg/asymptoteobserve/content.go
@@ -1,0 +1,124 @@
+package asymptoteobserve
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// Roles and part types Beacon writes into gen_ai.input.messages and
+// gen_ai.output.messages. They are the OpenTelemetry GenAI semconv spellings,
+// not Beacon's own: a consumer that already reads semconv message shapes reads
+// these without a Beacon-specific mapping.
+const (
+	RoleUser      = "user"
+	RoleAssistant = "assistant"
+
+	GenAIPartTypeText      = "text"
+	GenAIPartTypeReasoning = "reasoning"
+)
+
+// GenAIMessages wraps one piece of text in the GenAI messages shape: a single
+// message from role carrying a single part of partType.
+//
+// One helper for every capture path. The hook adapter, the collector exporter
+// and anything else that promotes retained text all reach for this, so
+// hook-captured assistant text and semconv-native OTLP assistant text arrive in
+// the log under the same structure rather than under two shapes a reader has to
+// know about separately.
+func GenAIMessages(role, partType, text string) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"role": role,
+			"parts": []interface{}{
+				map[string]interface{}{"type": partType, "content": text},
+			},
+		},
+	}
+}
+
+// TextOutputMessages is the assistant's own text -- what it said, as opposed to
+// what it thought (ReasoningOutputMessages) -- in the gen_ai.output.messages shape.
+func TextOutputMessages(text string) []interface{} {
+	return GenAIMessages(RoleAssistant, GenAIPartTypeText, text)
+}
+
+// TextInputMessages is the user's text in the gen_ai.input.messages shape.
+func TextInputMessages(text string) []interface{} {
+	return GenAIMessages(RoleUser, GenAIPartTypeText, text)
+}
+
+// ReasoningOutputMessages is a thinking block in the gen_ai.output.messages
+// shape, distinguished from TextOutputMessages only by its part type. Runtimes
+// that expose reasoning separately from the response keep that distinction here.
+func ReasoningOutputMessages(text string) []interface{} {
+	return GenAIMessages(RoleAssistant, GenAIPartTypeReasoning, text)
+}
+
+// RetainedContent builds the content marker for an event that keeps text
+// verbatim -- a prompt, an assistant response, command output, a diff.
+//
+// Hash and Bytes are computed over the original text, before the writer's
+// redaction and truncation touch the stored copy, so an event keeps a stable
+// identifier and a true size even when what is stored is shorter. That is the
+// point of the marker: without it a reader cannot tell a short response from a
+// truncated long one, and cannot tell that two truncated copies of the same
+// response are the same response.
+//
+// storeLimit is the per-string truncation limit the writer emitting this event
+// will apply to the text, and it is a parameter rather than a constant because
+// the two writers do not agree on one: the hook adapter sanitizes a whole event
+// map at DefaultStringLimit, while the collector applies DefaultRawStringLimit
+// to gen_ai and DefaultStringLimit to prompt.text. Truncated has to describe the
+// limit that actually applied, or it is a claim about a copy of the text that
+// nobody stored. Pass 0 to leave Truncated unset.
+//
+// Returns nil for empty text: an event with nothing retained gets no marker
+// rather than one asserting it retained the empty string.
+func RetainedContent(text string, storeLimit int) *ContentInfo {
+	if text == "" {
+		return nil
+	}
+	sum := sha256.Sum256([]byte(text))
+	info := &ContentInfo{
+		Retention: ContentRetentionFull,
+		Included:  true,
+		Hash:      hex.EncodeToString(sum[:]),
+		Bytes:     len(text),
+	}
+	if storeLimit > 0 && len(text) > storeLimit {
+		info.Truncated = true
+	}
+	if RedactString(text) != text {
+		info.Redacted = true
+	}
+	return info
+}
+
+// RetainedContentFields is RetainedContent in the map form used by the hook
+// adapter, which assembles events as maps rather than as the Event struct.
+//
+// The two forms must serialize identically -- a marker written by a hook and one
+// written by the collector are the same object under the same keys -- and
+// TestRetainedContentFieldsMatchesTheTypedMarker is what holds them together.
+// Built field by field rather than round-tripped through JSON so the numbers stay
+// integers: a float64 byte count would serialize the same but sit next to
+// file.diff_bytes, an int, in the same fields map.
+func RetainedContentFields(text string, storeLimit int) map[string]interface{} {
+	info := RetainedContent(text, storeLimit)
+	if info == nil {
+		return nil
+	}
+	fields := map[string]interface{}{
+		"retention": info.Retention,
+		"included":  info.Included,
+		"hash":      info.Hash,
+		"bytes":     info.Bytes,
+	}
+	if info.Truncated {
+		fields["truncated"] = true
+	}
+	if info.Redacted {
+		fields["redacted"] = true
+	}
+	return fields
+}

--- a/pkg/asymptoteobserve/content_test.go
+++ b/pkg/asymptoteobserve/content_test.go
@@ -1,0 +1,177 @@
+package asymptoteobserve
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRetainedContentDescribesTheOriginalText(t *testing.T) {
+	text := "the quick brown fox"
+	sum := sha256.Sum256([]byte(text))
+
+	info := RetainedContent(text, DefaultStringLimit)
+	if info == nil {
+		t.Fatal("RetainedContent returned nil for non-empty text")
+	}
+	if info.Retention != ContentRetentionFull || !info.Included {
+		t.Fatalf("marker = %#v, want full/included", info)
+	}
+	if info.Hash != hex.EncodeToString(sum[:]) {
+		t.Fatalf("hash = %q, want %q", info.Hash, hex.EncodeToString(sum[:]))
+	}
+	if info.Bytes != len(text) {
+		t.Fatalf("bytes = %d, want %d", info.Bytes, len(text))
+	}
+	if info.Truncated || info.Redacted {
+		t.Fatalf("short clean text should be neither truncated nor redacted: %#v", info)
+	}
+}
+
+func TestRetainedContentEmptyTextGetsNoMarker(t *testing.T) {
+	// An event that retained nothing must not claim it retained the empty string.
+	if info := RetainedContent("", DefaultStringLimit); info != nil {
+		t.Fatalf("RetainedContent(\"\") = %#v, want nil", info)
+	}
+}
+
+func TestRetainedContentTruncationFollowsTheWritersLimit(t *testing.T) {
+	// The same text is truncated by one writer and not the other, so the marker
+	// has to answer against the limit it is given rather than a constant.
+	text := strings.Repeat("a", DefaultRawStringLimit+1)
+
+	atRawLimit := RetainedContent(text, DefaultRawStringLimit)
+	if !atRawLimit.Truncated {
+		t.Fatalf("text over the raw limit should be marked truncated: %#v", atRawLimit)
+	}
+	atStringLimit := RetainedContent(text, DefaultStringLimit)
+	if atStringLimit.Truncated {
+		t.Fatalf("text under the string limit should not be marked truncated: %#v", atStringLimit)
+	}
+	if atRawLimit.Bytes != len(text) || atStringLimit.Bytes != len(text) {
+		t.Fatalf("byte count must describe the original text regardless of limit: %#v %#v", atRawLimit, atStringLimit)
+	}
+	if RetainedContent(text, 0).Truncated {
+		t.Fatal("limit 0 means no truncation claim")
+	}
+}
+
+func TestRetainedContentFlagsRedaction(t *testing.T) {
+	info := RetainedContent("deploy with token=hunter2hunter2", DefaultStringLimit)
+	if !info.Redacted {
+		t.Fatalf("text carrying a secret should be marked redacted: %#v", info)
+	}
+}
+
+func TestRetainedContentFieldsMatchesTheTypedMarker(t *testing.T) {
+	// The map form is what the hook adapter writes and the typed form is what the
+	// collector writes. They are the same object or a reader has to know which
+	// writer produced an event before it can read the marker.
+	text := strings.Repeat("b", DefaultStringLimit+1) + " password=abcdefghij"
+	fields := RetainedContentFields(text, DefaultStringLimit)
+
+	data, err := json.Marshal(RetainedContent(text, DefaultStringLimit))
+	if err != nil {
+		t.Fatalf("marshal typed marker: %v", err)
+	}
+	var want map[string]interface{}
+	if err := json.Unmarshal(data, &want); err != nil {
+		t.Fatalf("decode typed marker: %v", err)
+	}
+	gotJSON, _ := json.Marshal(fields)
+	wantJSON, _ := json.Marshal(want)
+	if string(gotJSON) != string(wantJSON) {
+		t.Fatalf("map marker = %s, want %s", gotJSON, wantJSON)
+	}
+	if fields["truncated"] != true || fields["redacted"] != true {
+		t.Fatalf("map marker lost its flags: %#v", fields)
+	}
+	if RetainedContentFields("", DefaultStringLimit) != nil {
+		t.Fatal("empty text should yield no map marker")
+	}
+}
+
+func TestGenAIMessagesUseTheSemconvShape(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		messages []interface{}
+		wantRole string
+		wantType string
+	}{
+		{"output", TextOutputMessages("said"), RoleAssistant, GenAIPartTypeText},
+		{"input", TextInputMessages("asked"), RoleUser, GenAIPartTypeText},
+		{"reasoning", ReasoningOutputMessages("thought"), RoleAssistant, GenAIPartTypeReasoning},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.messages) != 1 {
+				t.Fatalf("messages = %#v, want one message", tc.messages)
+			}
+			message := tc.messages[0].(map[string]interface{})
+			if message["role"] != tc.wantRole {
+				t.Fatalf("role = %v, want %s", message["role"], tc.wantRole)
+			}
+			parts := message["parts"].([]interface{})
+			if len(parts) != 1 {
+				t.Fatalf("parts = %#v, want one part", parts)
+			}
+			part := parts[0].(map[string]interface{})
+			if part["type"] != tc.wantType {
+				t.Fatalf("part type = %v, want %s", part["type"], tc.wantType)
+			}
+			if part["content"] == "" {
+				t.Fatalf("part carries no content: %#v", part)
+			}
+		})
+	}
+}
+
+func TestSanitizeEventCleansRetainedDiffAndCommandOutput(t *testing.T) {
+	// Both fields were written to the log by the hook adapter long before this
+	// struct declared them, which meant SanitizeEvent never saw them: a
+	// credential printed by a command reached the typed path unredacted.
+	longDiff := strings.Repeat("c", DefaultStringLimit+100)
+	event := Event{
+		Vendor:        Vendor,
+		Product:       Product,
+		SchemaVersion: SchemaVersion,
+		Event:         EventInfo{Kind: "agent_runtime", Action: "command.executed"},
+		Severity:      SeverityInfo,
+		Endpoint:      EndpointInfo{OS: "linux"},
+		Harness:       HarnessInfo{Name: "claude_code"},
+		Command:       &CommandInfo{Command: "printenv", Output: "GITHUB_TOKEN=ghp_wJalrXUtnFEMI"},
+		File:          &FileInfo{Path: "/tmp/x.go", Diff: longDiff},
+	}
+
+	out := SanitizeEvent(event, DefaultMaxEventBytes)
+	if strings.Contains(out.Command.Output, "ghp_wJalrXUtnFEMI") {
+		t.Fatalf("command output kept its secret: %q", out.Command.Output)
+	}
+	if len(out.File.Diff) > DefaultStringLimit {
+		t.Fatalf("diff length = %d, want <= %d", len(out.File.Diff), DefaultStringLimit)
+	}
+}
+
+func TestRetainedContentFieldsSurviveTheTypedRoundTrip(t *testing.T) {
+	// The regression these two fields exist to fix: the hook adapter assembles
+	// events as maps, so file.diff and command.output reached the log while every
+	// reader that decodes into Event -- the dashboard, beacon scan, the rules
+	// engine -- dropped them on parse.
+	line := []byte(`{"vendor":"beacon","product":"endpoint-agent","schema_version":"1.0",` +
+		`"event":{"kind":"agent_runtime","action":"file.modified"},"severity":"info",` +
+		`"endpoint":{"os":"darwin"},"harness":{"name":"cursor"},` +
+		`"file":{"path":"/repo/main.go","diff":"@@ -1 +1 @@\n-a\n+b\n"},` +
+		`"command":{"command":"go test","output":"ok\n"}}`)
+
+	var event Event
+	if err := json.Unmarshal(line, &event); err != nil {
+		t.Fatalf("decode endpoint line: %v", err)
+	}
+	if event.File == nil || event.File.Diff == "" {
+		t.Fatalf("file.diff did not survive decoding: %#v", event.File)
+	}
+	if event.Command == nil || event.Command.Output != "ok\n" {
+		t.Fatalf("command.output did not survive decoding: %#v", event.Command)
+	}
+}

--- a/pkg/asymptoteobserve/event.go
+++ b/pkg/asymptoteobserve/event.go
@@ -161,12 +161,27 @@ type FileInfo struct {
 	Language  string `json:"language,omitempty"`
 	DiffHash  string `json:"diff_hash,omitempty"`
 	DiffBytes int    `json:"diff_bytes,omitempty"`
+	// Diff is the retained unified diff for the edit. DiffHash and DiffBytes
+	// describe the original diff, so they stay stable when the stored text is
+	// redacted or truncated; the accompanying Content marker says which happened.
+	//
+	// Declared here because the hook adapter has always written it. It assembles
+	// events as maps, so `file.diff` reached the log while this struct -- what the
+	// dashboard, `beacon scan` and the CEL rules engine read events through --
+	// dropped it on parse. The diff was captured and unreadable at the same time,
+	// and no rule could match on it because the field reference is generated from
+	// this type.
+	Diff string `json:"diff,omitempty"`
 }
 
 type CommandInfo struct {
 	Command    string `json:"command,omitempty"`
 	ExitCode   *int   `json:"exit_code,omitempty"`
 	DurationMS int64  `json:"duration_ms,omitempty"`
+	// Output is the retained combined output of the command, when the runtime
+	// reports it. Same history as FileInfo.Diff: Cursor's afterShellExecution hook
+	// has always written `command.output`, and this struct has always dropped it.
+	Output string `json:"output,omitempty"`
 }
 
 type MCPMethodInfo struct {

--- a/pkg/asymptoteobserve/privacy.go
+++ b/pkg/asymptoteobserve/privacy.go
@@ -121,6 +121,15 @@ func SanitizeEvent(event Event, maxBytes int) Event {
 	}
 	if event.Command != nil {
 		event.Command.Command = CleanString(event.Command.Command, DefaultStringLimit, true)
+		event.Command.Output = CleanString(event.Command.Output, DefaultStringLimit, true)
+	}
+	// Retained content the writers have always emitted but this function never
+	// saw, because the struct did not declare the fields. A diff or a block of
+	// command output is exactly the kind of text that carries a credential, so
+	// these get the same limit and the same secret redaction as prompt.text
+	// rather than a weaker one.
+	if event.File != nil {
+		event.File.Diff = CleanString(event.File.Diff, DefaultStringLimit, true)
 	}
 	if event.Approval != nil {
 		event.Approval.Reason = CleanString(event.Approval.Reason, DefaultStringLimit, true)

--- a/spec/threat-rules/FIELDS.md
+++ b/spec/threat-rules/FIELDS.md
@@ -15,6 +15,7 @@ Regenerate with `beacon rules fields --markdown > spec/threat-rules/FIELDS.md`.
 | `e.command.command` | string |
 | `e.command.duration_ms` | int |
 | `e.command.exit_code` | int |
+| `e.command.output` | string |
 | `e.content.bytes` | int |
 | `e.content.hash` | string |
 | `e.content.included` | bool |
@@ -34,6 +35,7 @@ Regenerate with `beacon rules fields --markdown > spec/threat-rules/FIELDS.md`.
 | `e.event.id` | string |
 | `e.event.kind` | string |
 | `e.field_truncated` | bool |
+| `e.file.diff` | string |
 | `e.file.diff_bytes` | int |
 | `e.file.diff_hash` | string |
 | `e.file.language` | string |


### PR DESCRIPTION
Third workstream of the Beacon foundation revamp, after WS1 (#375, event identity) and WS2 (#376, event ordering).

The measurement behind it: in the 5,595-event snapshot, **0 events carried assistant text, command output, or a `content` object**, while 254 assistant responses sat unpromoted in `raw.attributes.response`. As the doc predicted, most of the fix is promotion and declaration rather than new capture.

Event actions and categories are untouched throughout. What an event is *called* — the `session.activity` bucket — is WS4's question; this is only about what it *carries*.

## What changed

### Shared plumbing — `pkg/asymptoteobserve/content.go`

`RetainedContent` builds the content marker (hash and byte count over the *original* text, plus truncated/redacted flags); `RetainedContentFields` is its map form for the hook adapter, which assembles events as maps rather than as the `Event` struct. `GenAIMessages` and its three wrappers are now the one place the semconv message shape is built, so hook-captured and OTLP-captured text arrive under the same structure. The hook adapter's private copies of both delegate here.

The marker takes **the writer's own truncation limit** rather than a constant, because the two writers do not share one: the hook logger sanitizes a whole event map at `DefaultStringLimit` while the collector applies `DefaultRawStringLimit` to `gen_ai`. A `truncated` flag computed against the wrong limit is a claim about a copy of the text nobody stored. This also fixes the existing reasoning marker, which claimed untruncated text that the collector-side limit would have cut.

### Two fields declared that were already being written

`file.diff` and `command.output` have been written to the log for as long as the hook paths producing them have existed — `diffFields` on every file edit, Cursor's `afterShellExecution` for command output. Because the hook adapter writes maps, they reached the log while `FileInfo`/`CommandInfo` — how the dashboard, `beacon scan`, and the CEL rules engine read events — dropped them on parse. Captured and unreadable at the same time, and unmatchable by any rule, since the field reference is generated from those types.

Declaring them adds `e.file.diff` and `e.command.output` to `FIELDS.md` and routes both through `SanitizeEvent` and the collector's `sanitize` at the prompt-text limit with secret redaction. Neither function saw these fields before, so a credential printed by a command reached the typed path unredacted.

### OTLP path

`PromoteRetainedContent` runs **after** the per-harness normalizers, because those are what decide an event is a prompt: `PopulateCommon` only promoted prompt text when the category was already settled at the moment it ran, so a runtime classified later lost the text even though the attribute was right there. It promotes Claude Code's `response` into `gen_ai.output.messages`, mirrors prompt text into `gen_ai.input.messages`, and stamps the marker. A source that already speaks semconv keeps its own messages.

One thing worth calling out: **`response` is read only under `claude_code.assistant_response`.** `claude_code.feedback_survey` carries `response: "positive"` under the same key, so a blanket alias would have recorded a survey answer as something the model said. The generic alias list is namespaced spellings only (`gen_ai.completion`, `gen_ai.response`, …), with no bare `response`. There's a test pinning the survey case. The prompt alias list is now shared with `PopulateCommon` rather than duplicated, so the early and late promotions can't disagree about which runtimes are covered.

`claude_code.mcp_server_connection` names its server in `server_name`, which no `mcp.*` alias read — so the event arrived actioned `mcp.connection` with no `mcp` object on it, and every rule gating on `e.mcp.server` saw nothing.

The collector writer gains the content-compaction step the hook writer already had (`compactEndpointContent`). Dropping `raw` was previously the only move between sanitize and refusing to write an oversized event, which was survivable while no OTLP event carried a turn's text.

### Devin Cloud mapper

Its markers asserted full retention with no hash and no byte count — the half that carries information — and the assistant's text reached the log only as the free-text event `message`. Both messages now carry the semconv shape and a complete marker; an empty message gets neither, rather than a marker claiming retention of nothing.

## Effect on the fixtures

On the checked-in `claude-code-lifecycle-2.1.220.json` capture, assistant text goes from 0 events to 1 (the `assistant_response` record) and content markers from 0 to 2 (the prompt and the response) — the same shape the 254-event live-log claim takes at fixture scale. A test asserts those counts rather than describing them.

## Deliberately out of scope

- **`api_request_body` / `api_response_body`.** These carry the raw Anthropic request/response JSON in a `body` attribute. Promoting them is a larger retention decision than "promote the turn text" and belongs in its own change.
- **The Stop hook's transcript.** Claude Code's transcript holds the full assistant reply and `extractMessages` already parses it, but nothing calls it. Reading a whole transcript inside a synchronous hook is a latency cost, and the doc's architecture puts session files in a separate read-only post-hoc lane.
- **`error.type` on `api_error` / `internal_error`.** Fillable, but it means deciding whether an HTTP status code is an error type; low value with no rule matching on it today.
- **Dashboard display of the new fields.** Capture-side change only; the dashboard already renders `content` summaries and will now find them populated.

One pre-existing limit I ran into and did not widen: the secret redactor's patterns don't match `AWS_SECRET_ACCESS_KEY=…` (the keyword has to be immediately followed by the separator). Unrelated to this change and affects every redacted field equally, so it isn't touched here — worth its own look.

## Verification

All CI gates run clean locally:

- `go test ./...` in `pkg/asymptoteobserve`, `cli/beacon`, `cli/beacon-hooks`, `collector-builder/exporter/beaconjsonexporter`
- `go test -race ./internal/endpoint/...` in `cli/beacon`
- `sh packaging/macos/test-endpoint-scripts.sh`
- `bun run check && bun test` in all three plugin directories
- `FIELDS.md` regenerated; its drift test passes

New tests cover the marker's arithmetic and limit-sensitivity, map/typed form equivalence, the semconv shapes, sanitization of the two newly declared fields, their survival through a typed decode of a hook-written line, the Claude assistant/prompt promotions, the `feedback_survey` guard, semconv-native messages not being overwritten, the MCP server fill, and the collector's compaction ladder.

Three existing tests asserted the *absence* of a content marker as a proxy for "the legacy `BEACON_CONTENT_RETENTION` env / `content_retention` config knob is inert". Since prompt events now legitimately carry a marker, they assert instead that the marker reports `full`/`included` — which states the same contract more directly: the knob asked for `metadata` and got ignored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5itTjxSEsG8j8Sq6TpSmM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches retained telemetry payloads (prompts, diffs, command output) and sanitization/redaction. Event actions are unchanged, but newly parsed fields can now carry secrets if redaction misses them.
> 
> **Overview**
> Promotes already-captured prompts, assistant replies, diffs, and command output into readable event fields with a shared content marker, instead of leaving them only in maps/`raw`.
> 
> Shared helpers in `pkg/asymptoteobserve` now build GenAI semconv messages and `content` markers (hash/bytes over the original text, truncated/redacted against the *writer's* limit). Hook paths (prompt-submit, Cline/opencode/Pi, Cursor shell, diffs) and Devin Cloud use those helpers; tool events no longer overwrite a more specific marker.
> 
> `file.diff` and `command.output` are declared on the typed event so dashboard/scan/CEL can see what hooks already wrote, and both now go through secret redaction and truncation. The OTLP converter promotes Claude `response` (only on `assistant_response`, not surveys), mirrors prompt text into `gen_ai.input.messages`, fills `mcp.server` on MCP connect, and the JSONL writer can compact retained text when an event is still over size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9813e73b927f77c78f7251c57ff2ffa1c0cdeba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->