### PR TITLE
Import the browser extension into browser-extension/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,113 @@ jobs:
         working-directory: packages/asymptote-sdk-js
         run: npm run pack:smoke
 
+  # Chrome MV3 browser collector. Deliberately a single Node version rather than
+  # the [20, 22, 24] matrix the SDK job uses: the SDK is published and its
+  # consumers pick the Node version, so that matrix tests a real contract. Here
+  # Node is only the build host -- the shipped artifact is browser JavaScript run
+  # by Chrome -- so a matrix would triple the Chromium download and the serial
+  # e2e wall time for no signal.
+  browser-extension:
+    runs-on: ubuntu-latest
+    # The e2e launches a persistent Chromium context against a local HTTPS replay
+    # server. A wedged browser is a plausible failure mode, so bound it rather
+    # than holding a runner for the six-hour GitHub default.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: browser-extension/package-lock.json
+
+      - name: Install extension dependencies
+        working-directory: browser-extension
+        run: npm ci
+
+      - name: Type-check extension
+        working-directory: browser-extension
+        run: npm run check
+
+      - name: Unit-test extension
+        working-directory: browser-extension
+        run: npm run test:unit
+
+      - name: Build extension
+        working-directory: browser-extension
+        run: npm run build
+
+      # esbuild exits 0 on an empty entry point, and a missing static copy would
+      # only surface as a broken extension at load time. Assert the five bundles
+      # and three static files exist before spending a browser on them.
+      - name: Verify the build produced a loadable MV3 extension
+        working-directory: browser-extension
+        shell: bash
+        run: |
+          set -euo pipefail
+          for f in manifest.json sw.js content.js interceptor.js \
+                   popup.html popup.js options.html options.js; do
+            test -s "dist/$f" || { echo "missing or empty dist/$f"; exit 1; }
+          done
+          node -e "
+            const m = require('./dist/manifest.json');
+            if (m.manifest_version !== 3) throw new Error('not MV3');
+            if (m.version !== require('./package.json').version) {
+              throw new Error('manifest.json and package.json versions disagree');
+            }
+          "
+
+      # e2e/helpers/cert.ts shells out to openssl for the throwaway self-signed
+      # cert the replay server uses. Fail here with a clear message rather than
+      # inside a Playwright fixture.
+      - name: Verify openssl is available
+        run: openssl version
+
+      - name: Resolve Playwright version
+        id: pw
+        working-directory: browser-extension
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      # Split from the browser download on purpose: the apt packages live outside
+      # ~/.cache/ms-playwright, so a cache hit must not skip them.
+      - name: Install Playwright system dependencies
+        working-directory: browser-extension
+        run: npx playwright install-deps chromium
+
+      # The full Chromium build, not the headless shell: e2e/fixtures.ts uses
+      # channel: 'chromium', which is what supports MV3 extensions in headless.
+      - name: Install Chromium for Playwright
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        working-directory: browser-extension
+        run: npx playwright install chromium
+
+      # `npx playwright test`, not `npm test`: the pretest hook would rebuild
+      # dist/ and hide a build failure inside the e2e step. GitHub sets CI=true,
+      # which the config already reads for forbidOnly and retries: 1.
+      - name: Replay e2e
+        working-directory: browser-extension
+        run: npx playwright test
+
+      # test-results/ carries the traces, videos and screenshots the config
+      # retains on failure; the HTML report alone is not enough to debug from.
+      - name: Upload Playwright report and traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-extension-playwright-report
+          path: |
+            browser-extension/playwright-report/
+            browser-extension/test-results/
+          if-no-files-found: warn
+          retention-days: 14
+
   go-test:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,0 +1,169 @@
+name: Release Browser Extension
+
+# Publishes the unpacked Chrome MV3 build as a zip on a pushed `ext-v*` tag.
+#
+# Independent of the CLI's `v*` release on purpose: the extension versions on its
+# own cadence and shares no assets with the binary. GitHub tag patterns anchor at
+# the start, so the `v*` filter in release.yml does not match `ext-v0.1.0` and the
+# two never collide.
+#
+# No `environment: release`. That environment exists to gate the Apple signing
+# secrets; this job has none -- it uses github.token only -- so putting it behind
+# the same approval would add friction without protecting anything. Same
+# reasoning as the windows-package job in release.yml.
+#
+# Chrome Web Store publication is deferred. Until then the artifact is a zip you
+# load unpacked, and its .sha256 is the only integrity check it has.
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "ext-v*"
+
+concurrency:
+  group: release-extension-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      REPO: ${{ github.repository }}
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: browser-extension/package-lock.json
+
+      - name: Install extension dependencies
+        working-directory: browser-extension
+        run: npm ci
+
+      # Mirrors the sdk-js tag gate, with one addition: manifest.json carries the
+      # version Chrome actually shows, and package.json is the one humans bump.
+      # Requiring all three to agree makes drift impossible rather than merely
+      # discouraged.
+      - name: Verify tag matches the extension version
+        if: startsWith(github.ref, 'refs/tags/')
+        working-directory: browser-extension
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#ext-v}"
+          manifest_version="$(node -p "require('./src/manifest.json').version")"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$manifest_version" ]; then
+            echo "Tag version ($tag) does not match src/manifest.json version ($manifest_version)"
+            exit 1
+          fi
+          if [ "$pkg_version" != "$manifest_version" ]; then
+            echo "package.json version ($pkg_version) does not match src/manifest.json version ($manifest_version)"
+            exit 1
+          fi
+          echo "version=$tag"
+
+      - name: Type-check extension
+        working-directory: browser-extension
+        run: npm run check
+
+      - name: Unit-test extension
+        working-directory: browser-extension
+        run: npm run test:unit
+
+      - name: Build extension
+        working-directory: browser-extension
+        run: npm run build
+
+      - name: Package the unpacked extension
+        id: pack
+        working-directory: browser-extension
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#ext-v}"
+          name="agent-beacon-browser-extension-${version}-chrome.zip"
+
+          # esbuild emits sourcemaps. Chrome ignores them, they roughly double the
+          # archive, and shipping them publishes unminified sources as a
+          # downloadable asset.
+          find dist -name '*.map' -delete
+
+          # -X drops extra file attributes so the archive is reproducible.
+          ( cd dist && zip -q -r -X "../$name" . )
+          shasum -a 256 "$name" > "$name.sha256"
+
+          unzip -l "$name"
+          cat "$name.sha256"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+
+      # Verify the bytes that are about to be published, not the directory they
+      # came from. Same principle as the MSI job proving its package installs
+      # before attaching it: verification by execution over verification by
+      # assumption.
+      - name: Verify the archive contains a loadable MV3 extension
+        working-directory: browser-extension
+        shell: bash
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          unzip -q "${{ steps.pack.outputs.name }}" -d "$tmp"
+          node -e '
+            const fs = require("fs");
+            const dir = process.argv[1], want = process.argv[2];
+            const m = JSON.parse(fs.readFileSync(dir + "/manifest.json", "utf8"));
+            if (m.manifest_version !== 3) throw new Error("not MV3");
+            if (m.version !== want) throw new Error("manifest version " + m.version + " != " + want);
+            for (const f of ["sw.js", "content.js", "interceptor.js",
+                             "popup.html", "popup.js", "options.html", "options.js"]) {
+              if (!fs.existsSync(dir + "/" + f)) throw new Error("missing " + f);
+            }
+            for (const f of fs.readdirSync(dir)) {
+              if (f.endsWith(".map")) throw new Error("sourcemap leaked into the archive: " + f);
+            }
+            console.log("archive ok: MV3 " + m.version);
+          ' "$tmp" "${GITHUB_REF_NAME#ext-v}"
+
+      - name: Publish the GitHub release
+        working-directory: browser-extension
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${TAG#ext-v}"
+
+          printf '%s\n' \
+            "Unpacked Chrome MV3 build of the Agent Beacon browser collector (\`browser-extension/\`)." \
+            "" \
+            "**Install:** download and unzip, then Chrome -> Extensions -> Developer mode -> Load unpacked -> select the unzipped folder." \
+            "" \
+            "Requires a running Beacon endpoint: the extension POSTs OTLP GenAI logs to \`http://127.0.0.1:4318/v1/logs\`." \
+            "" \
+            "**Retention defaults to \`full\`**, meaning complete prompt and response text from claude.ai and chatgpt.com is written to the local runtime log. Change it in the extension's options page before enabling it on a machine where you use those sites personally." \
+            "" \
+            "The archive is unsigned. Verify it against the \`.sha256\` published beside it:" \
+            "" \
+            '```' \
+            "shasum -a 256 -c agent-beacon-browser-extension-${version}-chrome.zip.sha256" \
+            '```' \
+            > /tmp/ext-release-notes.md
+
+          if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$TAG" --repo "$REPO" \
+              --title "Browser extension $TAG" \
+              --notes-file /tmp/ext-release-notes.md \
+              --verify-tag
+          fi
+
+          gh release upload "$TAG" \
+            "${{ steps.pack.outputs.name }}" \
+            "${{ steps.pack.outputs.name }}.sha256" \
+            --repo "$REPO" --clobber

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -47,28 +47,56 @@ jobs:
         working-directory: browser-extension
         run: npm ci
 
-      # Mirrors the sdk-js tag gate, with one addition: manifest.json carries the
-      # version Chrome actually shows, and package.json is the one humans bump.
-      # Requiring all three to agree makes drift impossible rather than merely
-      # discouraged.
-      - name: Verify tag matches the extension version
-        if: startsWith(github.ref, 'refs/tags/')
+      # Resolves the version once, here, and every later step reads
+      # steps.version.outputs.value. Deriving `${GITHUB_REF_NAME#ext-v}`
+      # separately in each step is what let the packaging and verification steps
+      # disagree with this gate: the gate was skipped on a non-tag run while they
+      # went ahead and used the raw ref.
+      #
+      # The guard is on the shape of the ref, not on the event, because
+      # workflow_dispatch against a *tag* is a legitimate way to re-run a
+      # release. Dispatching from a branch is not: `${ref#ext-v}` leaves the
+      # branch name intact, which would name the archive after a branch (with a
+      # slash in it) and then fail the manifest comparison anyway. Failing here
+      # with an explanation beats failing three steps later with a confusing
+      # version mismatch.
+      #
+      # manifest.json carries the version Chrome actually shows and package.json
+      # is the one humans bump, so all three must agree.
+      - name: Resolve and verify the release version
+        id: version
         working-directory: browser-extension
         shell: bash
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME#ext-v}"
+          case "$GITHUB_REF_NAME" in
+            ext-v*) ;;
+            *)
+              echo "This workflow must run against an 'ext-v*' tag; got '$GITHUB_REF_NAME'."
+              echo "To re-run a release manually, pick the tag (not a branch) as the ref."
+              exit 1
+              ;;
+          esac
+
+          version="${GITHUB_REF_NAME#ext-v}"
+          if [ -z "$version" ]; then
+            echo "Tag '$GITHUB_REF_NAME' has no version after the 'ext-v' prefix."
+            exit 1
+          fi
+
           manifest_version="$(node -p "require('./src/manifest.json').version")"
           pkg_version="$(node -p "require('./package.json').version")"
-          if [ "$tag" != "$manifest_version" ]; then
-            echo "Tag version ($tag) does not match src/manifest.json version ($manifest_version)"
+          if [ "$version" != "$manifest_version" ]; then
+            echo "Tag version ($version) does not match src/manifest.json version ($manifest_version)"
             exit 1
           fi
           if [ "$pkg_version" != "$manifest_version" ]; then
             echo "package.json version ($pkg_version) does not match src/manifest.json version ($manifest_version)"
             exit 1
           fi
-          echo "version=$tag"
+
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+          echo "Releasing extension version $version"
 
       - name: Type-check extension
         working-directory: browser-extension
@@ -86,10 +114,11 @@ jobs:
         id: pack
         working-directory: browser-extension
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#ext-v}"
-          name="agent-beacon-browser-extension-${version}-chrome.zip"
+          name="agent-beacon-browser-extension-${VERSION}-chrome.zip"
 
           # esbuild emits sourcemaps. Chrome ignores them, they roughly double the
           # archive, and shipping them publishes unminified sources as a
@@ -111,6 +140,8 @@ jobs:
       - name: Verify the archive contains a loadable MV3 extension
         working-directory: browser-extension
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
         run: |
           set -euo pipefail
           tmp="$(mktemp -d)"
@@ -129,16 +160,17 @@ jobs:
               if (f.endsWith(".map")) throw new Error("sourcemap leaked into the archive: " + f);
             }
             console.log("archive ok: MV3 " + m.version);
-          ' "$tmp" "${GITHUB_REF_NAME#ext-v}"
+          ' "$tmp" "$VERSION"
 
       - name: Publish the GitHub release
         working-directory: browser-extension
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.value }}
         shell: bash
         run: |
           set -euo pipefail
-          version="${TAG#ext-v}"
+          version="$VERSION"
 
           printf '%s\n' \
             "Unpacked Chrome MV3 build of the Agent Beacon browser collector (\`browser-extension/\`)." \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,18 @@ sh packaging/macos/smoke-endpoint.sh
 
 Each directory above is a separate Go module; run Go commands from inside the module you are
 changing.
+
+The npm and bun subprojects are separate from the Go modules and are not covered by the commands
+above:
+
+```bash
+cd packages/asymptote-sdk-js && npm ci && npm test && npm run check
+cd browser-extension && npm ci && npm run check && npm run test:unit
+cd plugins/opencode-beacon && bun run check && bun test
+cd plugins/cline-beacon && bun run check && bun test
+cd plugins/pi-beacon && bun run check && bun test
+```
+
+The browser extension's Playwright replay e2e (`npm test` in `browser-extension`) needs `openssl`
+on PATH and a one-time `npx playwright install chromium`. It replays recorded SSE through the real
+extension in headless Chromium, so it is deterministic, needs no login, and costs nothing to run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Beacon Endpoint Agent is a local-only endpoint telemetry agent for AI runtimes. 
 - `cli/beacon-hooks`: hook adapter invoked by Cursor and other supported runtimes.
 - `collector-builder`: OpenTelemetry Collector distribution and Beacon JSONL exporter.
 - `packages/asymptote-sdk-js`: TypeScript SDK for cloud agent telemetry that exports Beacon-compatible OpenTelemetry spans.
+- `browser-extension`: optional Chrome MV3 collector that relays Claude.ai and ChatGPT chat telemetry into the local pipeline as OTLP.
 - `packaging`: macOS packaging and deployment assets.
 
 Do not recreate or depend on removed `asymptote` mirror trees. Keep new work focused on the Beacon paths above.
@@ -34,6 +35,7 @@ Supported runtime surfaces today:
 - Cline hook telemetry through a Beacon-managed local plugin (`~/.cline/plugins/beacon.ts`) covering prompts, task lifecycle, tool lifecycle, commands, file reads/edits with diffs, MCP activity, and task token usage. One plugin serves Cline's VS Code, JetBrains, and CLI hosts; Cline's own OTel export and hosted prompt storage are not used. Approval decisions are not exposed by Cline's hook payloads and are not synthesized.
 - Pi hook telemetry through a Beacon-managed local extension (`~/.pi/agent/extensions/beacon.ts`, or `.pi/extensions/beacon.ts` at project level) covering session lifecycle, prompts, tool lifecycle and results, commands including operator `!` commands, file reads/creates/edits with the unified patch, agent reasoning from assistant thinking parts, and token usage/cost. The extension subscribes to seven Pi event types and ignores the streaming and provider internals. Approval decisions are not exposed by Pi's extension API -- its `tool_call` handler can block, but that is an extension deciding rather than an operator being asked -- and are not synthesized, matching the Cline decision.
 - Claude Cowork admin-configured OpenTelemetry setup guidance and local validation.
+- Browser chat telemetry through an optional Chrome MV3 extension (`browser-extension/`) covering claude.ai and chatgpt.com. A main-world interceptor tees the streamed response, a per-site adapter parses it into a normalized turn, and the service worker POSTs OTLP GenAI logs to the local collector on `127.0.0.1:4318`; the extension never writes files and never contacts a remote endpoint. `harness.name` resolves to `claude_web` or `chatgpt_web` (already handled by `NormalizeHarnessName` in `pkg/asymptoteobserve/harness.go`, where the browser cases must stay above the generic `claude` rule) and `harness.collection_method` is `otlp`. Scope is deliberately narrow: only those origins' chat streams, never other tabs or general browsing. Retention defaults to `full`, so prompt and response text is retained by default; this is documented rather than defaulted down, because browser chat telemetry without content has no investigative value. Treat the adapters as experimental, since both sites' stream formats are private and undocumented.
 - `beaconjson` OpenTelemetry Collector exporter that converts OTLP logs, traces, metrics, and resource attributes into Beacon endpoint JSONL.
 - Asymptote Observe TypeScript SDK instrumentation for cloud applications, starting from OpenTelemetry/OpenLLMetry patterns and `observe()` wrappers.
 - Elasticsearch/Filebeat content pack generation for forwarding local Beacon JSONL into customer-managed Elastic deployments or the bundled loopback-only development stack.
@@ -44,7 +46,7 @@ Supported runtime surfaces today:
 
 Current non-goals unless explicitly requested:
 
-- Kernel/process monitoring, EDR replacement, shell history scraping, cloud audit ingestion, browser/SaaS telemetry, credential-use attribution, and MCP configuration inventory.
+- Kernel/process monitoring, EDR replacement, shell history scraping, cloud audit ingestion, general browser or SaaS activity monitoring beyond the supported chat surfaces, credential-use attribution, and MCP configuration inventory.
 - Direct hosted integrations for Datadog, Snowflake, Chronicle, Panther, or other SIEM destinations beyond explicitly supported local/customer-managed forwarding patterns.
 - Dependency vulnerability scanning or package security remediation.
 
@@ -117,6 +119,19 @@ npm test
 npm run check
 npm run build
 npm run pack:dry-run
+```
+
+Run browser extension checks. The e2e replays recorded SSE through the real
+extension in headless Chromium, so it needs `openssl` on PATH and a one-time
+Chromium download, but no login and no network:
+
+```bash
+cd browser-extension
+npm ci
+npm run check
+npm run test:unit
+npx playwright install chromium   # one-time
+npm test                          # builds dist/, runs the replay e2e
 ```
 
 Run the local dashboard during manual testing:
@@ -358,6 +373,42 @@ Use these npm trusted publisher values:
 - Workflow filename: `npm-publish-sdk.yml`
 - Environment: leave unset unless the workflow is updated to declare one
 
+### Browser Extension Release
+
+The browser extension versions independently of the CLI. A pushed `ext-v*` tag
+runs `.github/workflows/release-extension.yml`, which creates its own GitHub
+release carrying the unpacked Chrome build as a zip plus a `.sha256`.
+
+`ext-v*` and the CLI's `v*` trigger cannot collide: GitHub tag patterns anchor at
+the start, so `v*` does not match `ext-v0.1.0`.
+
+Bump the version in **both** `browser-extension/package.json` and
+`browser-extension/src/manifest.json` before tagging. The workflow requires the
+tag and both files to agree and fails otherwise.
+
+```bash
+cd browser-extension
+npm run check && npm run test:unit && npm run build
+cd ../
+git tag -a ext-v<version> -m "ext-v<version>"
+git push origin ext-v<version>
+gh run list --workflow release-extension.yml --limit 5
+```
+
+The zip is unsigned, so its `.sha256` is the only integrity check it has, the
+same posture as the Windows MSI. The workflow proves the artifact works by
+unzipping the published bytes and asserting they are a loadable MV3 extension.
+Verify after the run:
+
+```bash
+gh release download ext-v<version> --repo Asymptote-Labs/agent-beacon \
+  --pattern 'agent-beacon-browser-extension-*-chrome.zip*'
+shasum -a 256 -c agent-beacon-browser-extension-<version>-chrome.zip.sha256
+```
+
+Chrome Web Store publication is not yet wired. Until it is, the zip is loaded
+unpacked through Chrome's developer mode.
+
 ## Implementation Notes
 
 - Prefer deterministic tests that use `t.TempDir()`, `t.Setenv("HOME", ...)`, fake binaries, and free local ports.
@@ -382,6 +433,8 @@ CI runs:
 - `go test ./...` in `collector-builder/exporter/beaconjsonexporter`.
 - `go test ./...` in `pkg/asymptoteobserve` (includes threat-rules pack conformance).
 - `bun run check && bun test` in `plugins/opencode-beacon`, `plugins/cline-beacon`, and `plugins/pi-beacon`.
+- `npm run check`, `npm run test:unit`, and `npm run build` in `browser-extension` on Node 22, plus a check that the build produced a loadable MV3 extension.
+- Playwright replay e2e in `browser-extension` on ubuntu, running the real extension in headless Chromium against a local HTTPS replay server; the HTML report and traces upload on failure.
 - CLI help smoke checks for the public command tree.
 - macOS packaging script validation via `packaging/macos/test-endpoint-scripts.sh`.
 - macOS endpoint smoke validation via `packaging/macos/smoke-endpoint.sh`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,24 @@ Useful contributions include:
 - `cli/beacon`: public `beacon` CLI, endpoint runtime, local dashboard, and
   endpoint integrations.
 - `cli/beacon-hooks`: hook adapter invoked by supported AI agent runtimes.
+- `pkg/asymptoteobserve`: shared endpoint event schema, provenance markers, and
+  the threat-rules engine. Imported by the modules above through a `replace`.
 - `collector-builder`: OpenTelemetry Collector distribution and
   `beaconjson` exporter.
-- `packaging`: macOS package scripts, deployment helpers, and MDM assets.
+- `packages/asymptote-sdk-js`: the `@asymptote/sdk` TypeScript SDK for cloud
+  agent telemetry. npm.
+- `plugins/*-beacon`: managed plugin and extension sources for OpenCode, Cline,
+  and Pi. bun. Each is the root source for a copy embedded in `cli/beacon`, and
+  tests on both sides fail if the two drift.
+- `browser-extension`: optional Chrome MV3 collector for Claude.ai and ChatGPT
+  chat telemetry. npm, with a Playwright replay harness that loads the real
+  extension into headless Chromium.
+- `rules`: the threat-rule corpus, shipped as a release asset rather than
+  embedded in the binary.
+- `spec/threat-rules`: the open Threat Rules format, its JSON schema, and the
+  generated field reference.
+- `packaging`: macOS, Linux, and Windows package scripts, deployment helpers,
+  and MDM assets.
 - `beacon-sandbox`: end-to-end verification tool that runs a real Claude Code
   session in a disposable Linux sandbox and checks what Beacon captured. See
   [Verify Beacon In A Sandbox](https://docs.asymptotelabs.ai/contributing/beacon-sandbox).
@@ -129,10 +144,28 @@ cd cli/beacon && go test ./...
 cd cli/beacon && go test -race ./internal/endpoint/...
 cd cli/beacon-hooks && go test ./...
 cd collector-builder/exporter/beaconjsonexporter && go test ./...
+cd pkg/asymptoteobserve && go test ./...
 cd beacon-sandbox && go test ./...
 sh packaging/macos/test-endpoint-scripts.sh
 sh packaging/macos/smoke-endpoint.sh
 ```
+
+The npm and bun subprojects are separate from the Go modules. Run the ones your
+change touches:
+
+```bash
+cd packages/asymptote-sdk-js && npm ci && npm test && npm run check
+cd browser-extension && npm ci && npm run check && npm run test:unit && npm test
+cd plugins/opencode-beacon && bun run check && bun test
+cd plugins/cline-beacon && bun run check && bun test
+cd plugins/pi-beacon && bun run check && bun test
+```
+
+The browser extension's `npm test` builds the bundle and runs the Playwright
+replay e2e, which needs `openssl` on PATH and a one-time
+`npx playwright install chromium`. After editing a plugin or extension source
+under `plugins/`, run `bun run sync` in its directory so the copy embedded in
+`cli/beacon` matches; a Go test fails if the two drift.
 
 If you cannot run a relevant check locally, mention that in the pull request and
 explain why.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ CI, and cloud surfaces.
 | [Hermes Agent](https://docs.asymptotelabs.ai/cli/supported-runtimes-hermes-agent) | Shell hooks | Prompt, observed tool, command, file, approval request and response, session lifecycle, and subagent stop telemetry |
 | [OpenClaw Gateway](https://docs.asymptotelabs.ai/cli/supported-runtimes-openclaw-gateway) | Gateway-configured OTLP/HTTP | OTLP logs, traces, and metrics from the Gateway diagnostics plugin |
 
+##### Browser Chat Surfaces
+
+| Agent harness | Collection path | Telemetry coverage |
+| --- | --- | --- |
+| [Claude.ai](https://docs.asymptotelabs.ai/runtimes/browser-extension) | Managed browser extension over local OTLP | Prompt, assistant response, tool call, and token usage telemetry from the claude.ai chat stream |
+| [ChatGPT](https://docs.asymptotelabs.ai/runtimes/browser-extension) | Managed browser extension over local OTLP | Prompt, assistant response, and tool call telemetry from the chatgpt.com chat stream |
+
+The optional Chrome MV3 extension in [`browser-extension/`](browser-extension/) posts OTLP GenAI
+logs to the collector already listening on `http://127.0.0.1:4318/v1/logs`, so browser chat lands in
+`runtime.jsonl` beside agent activity and forwards through the same shippers. It reads only the chat
+streams on those two sites and never writes files.
+
+Treat it as experimental: it parses private, undocumented APIs, so a change on either site can
+interrupt capture until the adapter is updated. **Retention defaults to `full`**, meaning complete
+prompt and response text is retained locally unless you change it in the extension's options page.
+
 #### CI Agents
 
 | Harness | Collection path | Telemetry coverage |

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ paths under customer control.
   <img src="images/beacon-architecture.png" alt="Beacon endpoint architecture" width="860">
 </p>
 
-- **Agent runtime layer:** Hooks, OpenTelemetry sources, CI wrappers, and SDKs
-  capture supported activity from AI agent harnesses wherever they run.
+- **Agent runtime layer:** Hooks, OpenTelemetry sources, CI wrappers, SDKs, and an
+  optional browser extension capture supported activity from AI agent harnesses
+  wherever they run, including chat on Claude.ai and ChatGPT.
 - **Beacon endpoint layer:** Local processing normalizes events, applies
   retention and redaction settings, and writes durable endpoint telemetry.
 - **Output layer:** Teams inspect events in the local dashboard, retain JSONL,
@@ -106,8 +107,8 @@ CI, and cloud surfaces.
 
 | Agent harness | Collection path | Telemetry coverage |
 | --- | --- | --- |
-| [Claude.ai](https://docs.asymptotelabs.ai/runtimes/browser-extension) | Managed browser extension over local OTLP | Prompt, assistant response, tool call, and token usage telemetry from the claude.ai chat stream |
-| [ChatGPT](https://docs.asymptotelabs.ai/runtimes/browser-extension) | Managed browser extension over local OTLP | Prompt, assistant response, and tool call telemetry from the chatgpt.com chat stream |
+| [Claude.ai](https://docs.asymptotelabs.ai/runtimes/browser-extension) (beta) | Managed browser extension over local OTLP | Prompt, assistant response, tool call, and token usage telemetry from the claude.ai chat stream |
+| [ChatGPT](https://docs.asymptotelabs.ai/runtimes/browser-extension) (beta) | Managed browser extension over local OTLP | Prompt, assistant response, and tool call telemetry from the chatgpt.com chat stream |
 
 The optional Chrome MV3 extension in [`browser-extension/`](browser-extension/) posts OTLP GenAI
 logs to the collector already listening on `http://127.0.0.1:4318/v1/logs`, so browser chat lands in
@@ -331,6 +332,21 @@ go run ./cmd/beacon-sandbox run --scenario s02-bash-command
 
 See [Verify Beacon In A Sandbox](https://docs.asymptotelabs.ai/contributing/beacon-sandbox)
 for setup, what it can verify, and its limitations.
+
+The browser extension is a separate, optional component that builds on its own. It
+needs a running Beacon endpoint to post to, and its test suite replays recorded
+chat streams through the real extension in headless Chromium, so it needs no login
+and no network:
+
+```bash
+cd browser-extension
+npm ci
+npm run build          # load dist/ unpacked in Chrome
+npm test               # replay e2e
+```
+
+See [`browser-extension/README.md`](browser-extension/) for what it captures and
+what it retains.
 
 For setup, deployment, integrations, and command details, see the
 [Beacon CLI docs](https://docs.asymptotelabs.ai).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ For the full enterprise review package, see the
 
 | Area | Default behavior |
 | --- | --- |
-| Collection | Local OpenTelemetry receivers on `127.0.0.1` or local `beacon-hooks` adapter execution |
+| Collection | Local OpenTelemetry receivers on `127.0.0.1`, local `beacon-hooks` adapter execution, or the optional browser extension posting to the same loopback receiver |
 | Content handling | Retained local telemetry is subject to secret redaction, sanitization, truncation, and event-size limits |
 | Forwarding | Optional and customer configured |
 | Hosted dependency | None required for normal endpoint collection or hook execution |
@@ -36,6 +36,15 @@ telemetry through a configured local surface. Required event fields identify the
 event, endpoint, and harness; optional entities add session, tool, command,
 file, approval, MCP-like, prompt, destination, and health context when
 available.
+
+The optional browser extension is a distinct surface. It observes only the chat
+request and response streams on `claude.ai`, `chatgpt.com`, and
+`chat.openai.com`, and posts them as OTLP logs to the same loopback receiver as
+every other source. It has no access to other tabs, browsing history, or page
+content elsewhere, and it never writes files. Its retention setting defaults to
+`full`, so complete prompt and assistant response text is retained in the local
+runtime log unless an operator changes it in the extension's options page.
+Retention is enforced in the browser before anything is sent.
 
 Review the full
 [data inventory](https://docs.asymptotelabs.ai/cli/security-review-data-inventory).

--- a/browser-extension/.gitignore
+++ b/browser-extension/.gitignore
@@ -32,6 +32,12 @@ fixtures/**/diag-*.sse
 *.log
 .DS_Store
 
+# Release archives. Built by .github/workflows/release-extension.yml, but the
+# same `zip` step is runnable locally, and a committed binary here would be a
+# stale copy of a published asset.
+*.zip
+*.zip.sha256
+
 # Note for future work: the repo-root .gitignore ignores `*.jsonl` everywhere,
 # with per-destination `!` negations. If a future integration test needs a
 # committed golden runtime.jsonl under this directory, add the negation HERE --

--- a/browser-extension/.gitignore
+++ b/browser-extension/.gitignore
@@ -12,5 +12,6 @@ blob-report/
 fixtures/**/*.page.html
 fixtures/**/*.meta.json
 fixtures/**/real-*.sse
+fixtures/**/diag-*.sse
 *.log
 .DS_Store

--- a/browser-extension/.gitignore
+++ b/browser-extension/.gitignore
@@ -1,17 +1,38 @@
+# Dependencies and build output. `node_modules/` and `dist/` are also matched by
+# the repo-root .gitignore (both are bare patterns there, so they apply at any
+# depth). Kept here so this directory stays self-contained if it is ever
+# extracted back into its own repository.
 node_modules/
 dist/
+
+# Playwright artifacts. NOT covered by the repo-root .gitignore -- these four
+# lines are the only thing keeping them out of the repository.
 test-results/
 playwright-report/
 blob-report/
 .playwright/
+
 # Persistent authed browser profiles used for live smoke / fixture recording.
-# Contains real session cookies — must never be committed.
+# Contains real session cookies -- must never be committed.
 .auth-profiles/
+
 # Raw fixture-recorder output may contain personal chat/account data. Only
 # hand-sanitized *.sse fixtures are committed.
+#
+# PRIVACY-CRITICAL: do not delete, narrow, or move these four patterns. They are
+# the sole mechanism preventing an unsanitized capture from being committed, and
+# a mistake here fails silently -- the first bad capture just gets committed.
+# `npm run record:fixtures` writes files matching every one of them. See the
+# "Recording fixtures" section of README.md.
 fixtures/**/*.page.html
 fixtures/**/*.meta.json
 fixtures/**/real-*.sse
 fixtures/**/diag-*.sse
+
 *.log
 .DS_Store
+
+# Note for future work: the repo-root .gitignore ignores `*.jsonl` everywhere,
+# with per-destination `!` negations. If a future integration test needs a
+# committed golden runtime.jsonl under this directory, add the negation HERE --
+# a deeper .gitignore wins on a per-file basis -- rather than editing the root.

--- a/browser-extension/.gitignore
+++ b/browser-extension/.gitignore
@@ -1,0 +1,16 @@
+node_modules/
+dist/
+test-results/
+playwright-report/
+blob-report/
+.playwright/
+# Persistent authed browser profiles used for live smoke / fixture recording.
+# Contains real session cookies — must never be committed.
+.auth-profiles/
+# Raw fixture-recorder output may contain personal chat/account data. Only
+# hand-sanitized *.sse fixtures are committed.
+fixtures/**/*.page.html
+fixtures/**/*.meta.json
+fixtures/**/real-*.sse
+*.log
+.DS_Store

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -1,0 +1,2 @@
+# agent-beacon-browser-extension
+Chrome extension to relay AI telemetry from the browser (i.e. ChatGPT, Claude) to Agent Beacon

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -1,2 +1,117 @@
 # agent-beacon-browser-extension
-Chrome extension to relay AI telemetry from the browser (i.e. ChatGPT, Claude) to Agent Beacon
+
+Chrome (MV3) extension that relays LLM chat telemetry from the browser — Claude.ai and
+ChatGPT — into the **same local Agent Beacon pipeline** as the endpoint agent, normalized into
+the same schema. Browser chat activity (prompts, responses, tool calls) ends up in
+`runtime.jsonl` next to agent activity, and forwards onward via the same Vector shippers.
+
+It ships with a **fully automated, self-verifying build/test loop**: recorded chat streams are
+replayed through the real, loaded extension in headless Chromium and asserted against — no login,
+no API cost, deterministic.
+
+## How it reaches Beacon
+
+The extension never writes files (it can't — extensions are sandboxed). Instead its service
+worker POSTs **OTLP GenAI logs** to the beacon collector already listening on
+`http://127.0.0.1:4318/v1/logs`, which normalizes, redacts, rotates, and forwards them exactly
+like every other source.
+
+```
+claude.ai / chatgpt.com page
+  │  interceptor.js (MAIN world) — tees the streamed SSE via response.clone()
+  ▼
+content.js (ISOLATED world) — relays raw events to the service worker
+  ▼
+service worker — per-site adapter parses SSE → ChatTurn → normalize() → OTLP → batched POST
+  ▼
+http://127.0.0.1:4318/v1/logs  →  beacon-otelcol  →  runtime.jsonl  →  Vector → GCS/S3
+```
+
+## Setup
+
+```bash
+npm install
+npx playwright install chromium   # one-time, for the e2e harness
+```
+
+## Commands
+
+```bash
+npm run build         # bundle src/ → dist/ (esbuild)
+npm run build:watch   # rebuild on change
+npm run typecheck     # tsc --noEmit
+npm run test:unit     # pure adapter + normalization tests (vitest, no browser)
+npm test              # builds dist/, runs the Playwright replay e2e (THE autonomous loop)
+npm run test:headed   # watch it drive a browser
+npm run test:integration   # opt-in: route through the real beacon-otelcol binary (Phase 4)
+npm run test:live          # opt-in: headed smoke vs the real sites in an authed profile (Phase 4)
+npm run report        # open the last HTML report
+```
+
+## Loading the extension in your own browser
+
+`npm run build`, then in Chrome → Extensions → Developer mode → **Load unpacked** → select `dist/`.
+Make sure the beacon endpoint agent is running (it provides the `127.0.0.1:4318` collector).
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `src/shared/` | Site-agnostic core. `normalize.ts` (pure `ChatTurn → OTLP`), `otlp.ts`, `vocab.ts`, `types.ts`, `ids.ts`. |
+| `src/adapters/` | The only site-specific code. `claude.ts` (done), `chatgpt.ts` (next). `sse.ts` shared SSE framing. |
+| `src/interceptor/` | MAIN-world `fetch`/stream tee. |
+| `src/content/` | ISOLATED-world relay + (future) DOM fallback. |
+| `src/background/` | Service worker: `assembler.ts`, `delivery.ts` (durable queue + backoff), `settings.ts`, `sw.ts`. |
+| `src/popup/`, `src/options/` | On/off, retention toggle, endpoint + per-site config. |
+| `e2e/` | Playwright fixtures + helpers (`mock-collector`, `sse-replay-server`, `otlp-assertions`) + specs. |
+| `test/unit/` | vitest unit tests. |
+| `fixtures/<site>/*.sse` | Recorded chat streams (currently **synthetic**, pending real capture). |
+
+## Testing model (layered by fidelity/cost)
+
+- **(a) unit** — recorded `.sse` → `ChatTurn` → golden OTLP. Milliseconds, no browser.
+- **(b) e2e replay** — a local HTTPS server impersonates the chat site (via `--host-resolver-rules`
+  mapping the real hostname to it + a throwaway self-signed cert), the real extension loads, and a
+  **mock collector** captures what it POSTs. Fully autonomous — **this is the loop run every iteration.**
+- **(c) integration** (opt-in) — route through the real `beacon-otelcol` binary into a temp
+  `runtime.jsonl`; assert the actual `Event` schema. *(Phase 4)*
+- **(d) live smoke** (opt-in, headed) — drive the real sites in a persistent authed profile; a
+  drift alarm that flags when recorded fixtures go stale. *(Phase 4)*
+
+## Status
+
+This is a **V0 MVP**: Claude.ai capture proven end-to-end against the real site and the real
+Beacon collector (prompt → response → tool calls → `runtime.jsonl` → S3 → dashboard).
+
+- ✅ Shared core + normalization (unit-tested)
+- ✅ Claude capture end-to-end + autonomous replay e2e
+- ✅ Resilience: multi-tab correlation + aborted/partial stream (e2e)
+- ✅ Content-script context-invalidation guard (survives extension reloads)
+- ⬜ ChatGPT adapter
+- ⬜ DOM-fallback capture, XHR transport
+- ⬜ Real-collector integration test + live-smoke/fixture-recorder as CI layers
+
+### Known limitations (V0 — intentionally deferred)
+
+- **Service-worker suspension mid-stream.** In-flight turn assembly lives in memory in the SW.
+  Active streaming keeps the SW alive (each chunk is activity), so normal turns are safe; a >30s
+  stall between chunks could drop a turn. The durable delivery queue (in `chrome.storage`) protects
+  everything *after* a turn is assembled, not during. Persisting partial assembler state is a
+  future item.
+- **Delivery retry cadence.** Retries use `chrome.alarms`, which MV3 clamps to a ~30s minimum, so
+  the first retry lands at ~30s rather than the computed sub-second backoff. Fine for a
+  local-loopback collector that is almost always reachable; the queue guarantees eventual delivery.
+- **Capture depends on `window.fetch`.** Confirmed correct for claude.ai. Sites using XHR or a page
+  service worker for streaming would need additional interception (deferred).
+- **Single capture path.** No DOM-scraping fallback yet; if a site changes its SSE wire format, the
+  adapter needs updating (the live-smoke drift alarm is designed to catch this).
+
+> **Fixtures.** `fixtures/claude/simple-turn.sse` is a **real, sanitized** claude.ai capture
+> (via `npm run record:fixtures`); the adapter is verified against it. `with-tool-call.sse` is
+> still synthetic (written to the documented Anthropic tool-use shape) pending a real tool-call
+> capture. Raw recorder output (`*.page.html`, `*.meta.json`, `real-*.sse`) is git-ignored because
+> it can contain personal chat/account data — only hand-sanitized `*.sse` fixtures are committed.
+>
+> Notable real-format findings: claude.ai emits a leading `conversation_ready` event, nests the
+> model in `message_start.message.model`, and does **not** stream token usage (so `gen_ai.usage.*`
+> is absent for `claude_web`).

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -1,4 +1,6 @@
-# agent-beacon-browser-extension
+# Agent Beacon browser extension
+
+Part of the [agent-beacon](../README.md) monorepo. MIT, under the repository root `LICENSE`.
 
 Chrome (MV3) extension that relays LLM chat telemetry from the browser — Claude.ai and
 ChatGPT — into the **same local Agent Beacon pipeline** as the endpoint agent, normalized into
@@ -62,8 +64,13 @@ Each captured turn emits one `prompt.submitted` + one `agent.response.completed`
 
 ## Setup
 
+Requires Node 22 or newer (`npm run record:fixtures` uses `--experimental-strip-types`,
+which landed in Node 22.6). The e2e harness also needs `openssl` on `PATH` — it
+generates a throwaway self-signed cert for the local replay server.
+
 ```bash
-npm install
+cd browser-extension
+npm ci
 npx playwright install chromium   # one-time, for the e2e harness
 ```
 
@@ -72,13 +79,11 @@ npx playwright install chromium   # one-time, for the e2e harness
 ```bash
 npm run build         # bundle src/ → dist/ (esbuild)
 npm run build:watch   # rebuild on change
-npm run typecheck     # tsc --noEmit
+npm run check         # tsc --noEmit
 npm run test:unit     # pure adapter + normalization tests (vitest, no browser)
 npm test              # builds dist/, runs the Playwright replay e2e (THE autonomous loop)
 npm run test:headed   # watch it drive a browser
 npm run record:fixtures -- --site claude|chatgpt --name <n>   # capture a fixture (headed, authed)
-npm run test:integration   # opt-in, NOT YET WIRED (no spec): route through the real beacon-otelcol
-npm run test:live          # opt-in, NOT YET WIRED (no spec): headed smoke vs the real sites
 npm run report        # open the last HTML report
 ```
 
@@ -86,6 +91,50 @@ npm run report        # open the last HTML report
 
 `npm run build`, then in Chrome → Extensions → Developer mode → **Load unpacked** → select `dist/`.
 Make sure the beacon endpoint agent is running (it provides the `127.0.0.1:4318` collector).
+
+## Retained content
+
+**The default is `retention: 'full'`.** With the extension enabled, the *complete text* of your
+prompts and of the model's responses on claude.ai and chatgpt.com is sent to the local Beacon
+collector and written to `runtime.jsonl` — and forwarded onward by whatever shippers you have
+configured. This is deliberate: browser chat telemetry is worthless for investigation without
+content. It is also the most sensitive default in the product.
+
+Turn it down in the extension's options page before enabling it on a machine where you use these
+sites personally:
+
+| Mode | What is retained |
+|---|---|
+| `full` (default) | Complete prompt text, full assistant response, tool call arguments and results |
+| `redacted` | The same text with emails and API-key-shaped tokens scrubbed client-side |
+| `metadata` | No chat text at all. Actions, models, token counts, and tool names only |
+
+Retention is enforced in the browser, before anything is sent — under `metadata` the text never
+leaves the page. Beacon's endpoint-side redaction, sanitization, truncation, and event-size limits
+apply to whatever the extension does send, but they are a safety net, not a content filter.
+
+Note that retained prompt text also appears verbatim under `raw.attributes` in the written event,
+which is consistent with how every other OTLP source is recorded.
+
+The extension reads only the chat streams on `claude.ai`, `chatgpt.com`, and `chat.openai.com`.
+It has no access to other tabs, browsing history, or page content elsewhere, and it never writes
+files.
+
+## Recording fixtures
+
+`npm run record:fixtures` drives a **real, logged-in Chrome** against your actual Claude.ai or
+ChatGPT account to capture new `.sse` fixtures when a site changes its stream format. Two
+consequences worth understanding before running it:
+
+- It persists a browser profile under `.auth-profiles/<site>/`, which contains **real session
+  cookies**.
+- Its raw output (`*.page.html`, `*.meta.json`, `real-*.sse`, `diag-*.sse`) can contain personal
+  chat and account data.
+
+None of that is committable: the four `fixtures/**` patterns plus `.auth-profiles/` in
+[`.gitignore`](.gitignore) are what enforce it, and they are marked PRIVACY-CRITICAL there for the
+same reason. **Only hand-sanitized `*.sse` files are ever committed** — check the diff before
+staging one. Prefer a throwaway account where practical.
 
 ## Layout
 
@@ -107,10 +156,13 @@ Make sure the beacon endpoint agent is running (it provides the `127.0.0.1:4318`
 - **(b) e2e replay** — a local HTTPS server impersonates the chat site (via `--host-resolver-rules`
   mapping the real hostname to it + a throwaway self-signed cert), the real extension loads, and a
   **mock collector** captures what it POSTs. Fully autonomous — **this is the loop run every iteration.**
-- **(c) integration** (opt-in) — route through the real `beacon-otelcol` binary into a temp
-  `runtime.jsonl`; assert the actual `Event` schema. *(Phase 4)*
+- **(c) collector conformance** *(planned)* — now that this lives in the agent-beacon monorepo,
+  the consumer of these envelopes is in-tree at `collector-builder/exporter/beaconjsonexporter`.
+  The plan is a Go test that feeds committed golden envelopes straight through the real exporter
+  and asserts the resulting `Event` — no binary, no ports, no network — rather than the
+  out-of-tree `/opt/beacon/bin/beacon-otelcol` approach sketched in `tools/integration-otelcol/`.
 - **(d) live smoke** (opt-in, headed) — drive the real sites in a persistent authed profile; a
-  drift alarm that flags when recorded fixtures go stale. *(Phase 4)*
+  drift alarm that flags when recorded fixtures go stale. *(not yet implemented)*
 
 ## Status
 

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -89,8 +89,28 @@ npm run report        # open the last HTML report
 
 ## Loading the extension in your own browser
 
-`npm run build`, then in Chrome → Extensions → Developer mode → **Load unpacked** → select `dist/`.
-Make sure the beacon endpoint agent is running (it provides the `127.0.0.1:4318` collector).
+**Beta, and not on the Chrome Web Store.** It installs unpacked, so Chrome will not
+auto-update it: to move to a new version, rebuild or re-download and reload.
+
+Build it, or download `agent-beacon-browser-extension-<version>-chrome.zip` from an
+[`ext-v*` release](https://github.com/Asymptote-Labs/agent-beacon/releases) and unzip it:
+
+```bash
+npm ci
+npm run build      # produces dist/
+```
+
+Then:
+
+1. Make sure the Beacon endpoint agent is running. It provides the `127.0.0.1:4318` collector.
+2. Open `chrome://extensions`.
+3. Turn on **Developer mode**, top right.
+4. Choose **Load unpacked**, and select `dist/` (or the unzipped release folder).
+5. Send a message on claude.ai or chatgpt.com, then check for `claude_web` / `chatgpt_web`
+   events in `runtime.jsonl` or `beacon endpoint dashboard`.
+
+Read [Retained content](#retained-content) before enabling it on a browser profile you
+also use personally.
 
 ## Retained content
 

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -16,49 +16,49 @@ POSTs **OTLP GenAI logs** to the Beacon collector already listening on `http://1
 which normalizes, redacts, rotates, and forwards them exactly like every other source.
 
 ```mermaid
-flowchart TB
-    subgraph PAGE["Chat page — claude.ai / chatgpt.com"]
+flowchart LR
+    subgraph PAGE["Chat page · claude.ai / chatgpt.com"]
         direction TB
-        FETCH["site's streamed SSE response (window.fetch)"]
-        MAIN["interceptor.js · MAIN world<br/>monkeypatch fetch → response.clone() tee"]
-        ISO["content.js · ISOLATED world<br/>validate + relay"]
-        FETCH -->|clone stream| MAIN
-        MAIN -->|window.postMessage| ISO
+        MAIN["interceptor.js<br/>MAIN world · tee fetch SSE"]
+        ISO["content.js<br/>ISOLATED world · relay"]
+        MAIN -->|postMessage| ISO
     end
 
-    subgraph SW["Extension service worker (background)"]
+    subgraph SW["Extension service worker"]
         direction TB
-        ASM["assembler.ts<br/>accumulate per (tab, request)"]
-        ADP["per-site adapter · claude.ts / chatgpt.ts<br/>parse SSE → ChatTurn"]
-        NRM["normalize.ts — pure, site-agnostic<br/>ChatTurn → OTLP GenAI logs<br/>prompt.submitted · agent.response.completed · tool.invoked"]
-        DLV["delivery.ts<br/>durable queue (chrome.storage) + retry (chrome.alarms)"]
+        ASM["assembler.ts<br/>accumulate per tab/request"]
+        ADP["adapters<br/>claude.ts · chatgpt.ts<br/>SSE → ChatTurn"]
+        NRM["normalize.ts · pure<br/>ChatTurn → OTLP"]
+        DLV["delivery.ts<br/>queue + retry"]
         ASM --> ADP --> NRM --> DLV
     end
 
-    subgraph BEACON["Local Beacon agent (already running)"]
+    subgraph BEACON["Local Beacon agent"]
         direction TB
-        COL["beacon-otelcol<br/>OTLP receiver · 127.0.0.1:4318"]
-        JSONL["runtime.jsonl<br/>normalize · redact · rotate"]
-        VEC["Vector forwarders"]
-        COL --> JSONL --> VEC
+        COL["beacon-otelcol<br/>OTLP · 127.0.0.1:4318"]
+        JSONL["runtime.jsonl"]
+        COL --> JSONL
     end
 
     subgraph DOWN["Downstream"]
         direction TB
+        VEC["Vector"]
         OBJ["S3 / GCS"]
-        DASH["ClickHouse → telemetry dashboard"]
-        OBJ --> DASH
+        DASH["ClickHouse → dashboard"]
+        VEC --> OBJ --> DASH
     end
 
-    ISO -->|"chrome.runtime.sendMessage (BEACON_RAW)"| ASM
-    DLV -->|"OTLP/HTTP POST /v1/logs"| COL
-    VEC --> OBJ
+    ISO -->|BEACON_RAW| ASM
+    DLV -->|OTLP POST| COL
+    JSONL --> VEC
 ```
 
 **Two capture surfaces per page:** the **MAIN-world** `interceptor.js` runs in the page's own JS
 context so it can tee `window.fetch`'s streamed SSE via `response.clone()`; the **ISOLATED-world**
 `content.js` holds the privileged `chrome.runtime` channel to the service worker. Everything from
 `ChatTurn` onward is **site-agnostic** — only the per-site adapters know each site's wire format.
+Each captured turn emits one `prompt.submitted` + one `agent.response.completed` OTLP log (plus a
+`tool.invoked` per tool call).
 
 ## Setup
 

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -43,8 +43,9 @@ npm run typecheck     # tsc --noEmit
 npm run test:unit     # pure adapter + normalization tests (vitest, no browser)
 npm test              # builds dist/, runs the Playwright replay e2e (THE autonomous loop)
 npm run test:headed   # watch it drive a browser
-npm run test:integration   # opt-in: route through the real beacon-otelcol binary (Phase 4)
-npm run test:live          # opt-in: headed smoke vs the real sites in an authed profile (Phase 4)
+npm run record:fixtures -- --site claude|chatgpt --name <n>   # capture a fixture (headed, authed)
+npm run test:integration   # opt-in, NOT YET WIRED (no spec): route through the real beacon-otelcol
+npm run test:live          # opt-in, NOT YET WIRED (no spec): headed smoke vs the real sites
 npm run report        # open the last HTML report
 ```
 
@@ -65,7 +66,7 @@ Make sure the beacon endpoint agent is running (it provides the `127.0.0.1:4318`
 | `src/popup/`, `src/options/` | On/off, retention toggle, endpoint + per-site config. |
 | `e2e/` | Playwright fixtures + helpers (`mock-collector`, `sse-replay-server`, `otlp-assertions`) + specs. |
 | `test/unit/` | vitest unit tests. |
-| `fixtures/<site>/*.sse` | Recorded chat streams (currently **synthetic**, pending real capture). |
+| `fixtures/<site>/*.sse` | Recorded, sanitized chat streams — real captures for `claude/` and `chatgpt/`. |
 
 ## Testing model (layered by fidelity/cost)
 
@@ -80,8 +81,9 @@ Make sure the beacon endpoint agent is running (it provides the `127.0.0.1:4318`
 
 ## Status
 
-This is a **V0 MVP**: Claude.ai capture proven end-to-end against the real site and the real
-Beacon collector (prompt → response → tool calls → `runtime.jsonl` → S3 → dashboard).
+This is a **V0 MVP**: both **Claude.ai** and **ChatGPT** capture are proven end-to-end against the
+real sites and the real Beacon collector (prompt → response → tool calls → `runtime.jsonl` → S3 →
+dashboard), including interleaved sessions with no cross-contamination.
 
 - ✅ Shared core + normalization (unit-tested)
 - ✅ Claude capture end-to-end + autonomous replay e2e
@@ -118,12 +120,15 @@ Beacon collector (prompt → response → tool calls → `runtime.jsonl` → S3 
   telemetry *integrity* only (no credential/code exposure). A proper fix is service-worker-driven
   MAIN injection (`chrome.scripting`) with a per-tab nonce the page can't read; deferred for V0.
 
-> **Fixtures.** `fixtures/claude/simple-turn.sse` is a **real, sanitized** claude.ai capture
-> (via `npm run record:fixtures`); the adapter is verified against it. `with-tool-call.sse` is
-> still synthetic (written to the documented Anthropic tool-use shape) pending a real tool-call
-> capture. Raw recorder output (`*.page.html`, `*.meta.json`, `real-*.sse`) is git-ignored because
-> it can contain personal chat/account data — only hand-sanitized `*.sse` fixtures are committed.
+> **Fixtures.** The committed `*.sse` files are **real, sanitized** captures (via
+> `npm run record:fixtures`): `fixtures/claude/simple-turn.sse` (claude.ai) and
+> `fixtures/chatgpt/simple-turn.sse` (ChatGPT). `claude/with-tool-call.sse` is synthetic (documented
+> Anthropic tool-use shape) pending a real tool-call capture. Raw recorder output (`*.page.html`,
+> `*.meta.json`, `real-*.sse`, `diag-*.sse`) is git-ignored — it can contain personal chat/account
+> data, so only hand-sanitized `*.sse` fixtures are committed.
 >
-> Notable real-format findings: claude.ai emits a leading `conversation_ready` event, nests the
-> model in `message_start.message.model`, and does **not** stream token usage (so `gen_ai.usage.*`
-> is absent for `claude_web`).
+> Real-format notes: **claude.ai** emits a leading `conversation_ready` event and nests the model in
+> `message_start.message.model` (typed Anthropic events). **ChatGPT** posts to
+> `/backend-api/f/conversation` and streams OpenAI `delta_encoding: v1` JSON-patch ops (add/append/patch
+> with bare-value path inheritance), model in `metadata.model_slug`. Neither site streams token usage,
+> so `gen_ai.usage.*` is absent for both.

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -9,23 +9,56 @@ It ships with a **fully automated, self-verifying build/test loop**: recorded ch
 replayed through the real, loaded extension in headless Chromium and asserted against — no login,
 no API cost, deterministic.
 
-## How it reaches Beacon
+## Architecture
 
-The extension never writes files (it can't — extensions are sandboxed). Instead its service
-worker POSTs **OTLP GenAI logs** to the beacon collector already listening on
-`http://127.0.0.1:4318/v1/logs`, which normalizes, redacts, rotates, and forwards them exactly
-like every other source.
+The extension never writes files (it can't — extensions are sandboxed). Instead its service worker
+POSTs **OTLP GenAI logs** to the Beacon collector already listening on `http://127.0.0.1:4318/v1/logs`,
+which normalizes, redacts, rotates, and forwards them exactly like every other source.
 
+```mermaid
+flowchart TB
+    subgraph PAGE["Chat page — claude.ai / chatgpt.com"]
+        direction TB
+        FETCH["site's streamed SSE response (window.fetch)"]
+        MAIN["interceptor.js · MAIN world<br/>monkeypatch fetch → response.clone() tee"]
+        ISO["content.js · ISOLATED world<br/>validate + relay"]
+        FETCH -->|clone stream| MAIN
+        MAIN -->|window.postMessage| ISO
+    end
+
+    subgraph SW["Extension service worker (background)"]
+        direction TB
+        ASM["assembler.ts<br/>accumulate per (tab, request)"]
+        ADP["per-site adapter · claude.ts / chatgpt.ts<br/>parse SSE → ChatTurn"]
+        NRM["normalize.ts — pure, site-agnostic<br/>ChatTurn → OTLP GenAI logs<br/>prompt.submitted · agent.response.completed · tool.invoked"]
+        DLV["delivery.ts<br/>durable queue (chrome.storage) + retry (chrome.alarms)"]
+        ASM --> ADP --> NRM --> DLV
+    end
+
+    subgraph BEACON["Local Beacon agent (already running)"]
+        direction TB
+        COL["beacon-otelcol<br/>OTLP receiver · 127.0.0.1:4318"]
+        JSONL["runtime.jsonl<br/>normalize · redact · rotate"]
+        VEC["Vector forwarders"]
+        COL --> JSONL --> VEC
+    end
+
+    subgraph DOWN["Downstream"]
+        direction TB
+        OBJ["S3 / GCS"]
+        DASH["ClickHouse → telemetry dashboard"]
+        OBJ --> DASH
+    end
+
+    ISO -->|"chrome.runtime.sendMessage (BEACON_RAW)"| ASM
+    DLV -->|"OTLP/HTTP POST /v1/logs"| COL
+    VEC --> OBJ
 ```
-claude.ai / chatgpt.com page
-  │  interceptor.js (MAIN world) — tees the streamed SSE via response.clone()
-  ▼
-content.js (ISOLATED world) — relays raw events to the service worker
-  ▼
-service worker — per-site adapter parses SSE → ChatTurn → normalize() → OTLP → batched POST
-  ▼
-http://127.0.0.1:4318/v1/logs  →  beacon-otelcol  →  runtime.jsonl  →  Vector → GCS/S3
-```
+
+**Two capture surfaces per page:** the **MAIN-world** `interceptor.js` runs in the page's own JS
+context so it can tee `window.fetch`'s streamed SSE via `response.clone()`; the **ISOLATED-world**
+`content.js` holds the privileged `chrome.runtime` channel to the service worker. Everything from
+`ChatTurn` onward is **site-agnostic** — only the per-site adapters know each site's wire format.
 
 ## Setup
 

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -105,6 +105,12 @@ Beacon collector (prompt → response → tool calls → `runtime.jsonl` → S3 
   service worker for streaming would need additional interception (deferred).
 - **Single capture path.** No DOM-scraping fallback yet; if a site changes its SSE wire format, the
   adapter needs updating (the live-smoke drift alarm is designed to catch this).
+- **Telemetry integrity on the injected page.** The MAIN-world interceptor and any other page script
+  share the same JS world, so the ISOLATED content script cannot cryptographically distinguish the
+  extension's own `postMessage` events from forged ones. A malicious script already running on
+  claude.ai could therefore inject fabricated chat records into the local collector. Impact is
+  telemetry *integrity* only (no credential/code exposure). A proper fix is service-worker-driven
+  MAIN injection (`chrome.scripting`) with a per-tab nonce the page can't read; deferred for V0.
 
 > **Fixtures.** `fixtures/claude/simple-turn.sse` is a **real, sanitized** claude.ai capture
 > (via `npm run record:fixtures`); the adapter is verified against it. `with-tool-call.sse` is

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -58,7 +58,7 @@ Make sure the beacon endpoint agent is running (it provides the `127.0.0.1:4318`
 | Path | Purpose |
 |---|---|
 | `src/shared/` | Site-agnostic core. `normalize.ts` (pure `ChatTurn → OTLP`), `otlp.ts`, `vocab.ts`, `types.ts`, `ids.ts`. |
-| `src/adapters/` | The only site-specific code. `claude.ts` (done), `chatgpt.ts` (next). `sse.ts` shared SSE framing. |
+| `src/adapters/` | The only site-specific code. `claude.ts` + `chatgpt.ts` (both done). `sse.ts` shared SSE framing. |
 | `src/interceptor/` | MAIN-world `fetch`/stream tee. |
 | `src/content/` | ISOLATED-world relay + (future) DOM fallback. |
 | `src/background/` | Service worker: `assembler.ts`, `delivery.ts` (durable queue + backoff), `settings.ts`, `sw.ts`. |
@@ -87,8 +87,8 @@ Beacon collector (prompt → response → tool calls → `runtime.jsonl` → S3 
 - ✅ Claude capture end-to-end + autonomous replay e2e
 - ✅ Resilience: multi-tab correlation + aborted/partial stream (e2e)
 - ✅ Content-script context-invalidation guard (survives extension reloads)
-- ⬜ ChatGPT adapter
-- ⬜ DOM-fallback capture, XHR transport
+- ✅ ChatGPT capture (`delta_encoding: v1` parser) + autonomous replay e2e
+- ⬜ ChatGPT stream-handoff/resume case (see limitations); DOM-fallback capture, XHR transport
 - ⬜ Real-collector integration test + live-smoke/fixture-recorder as CI layers
 
 ### Known limitations (V0 — intentionally deferred)
@@ -105,6 +105,12 @@ Beacon collector (prompt → response → tool calls → `runtime.jsonl` → S3 
   service worker for streaming would need additional interception (deferred).
 - **Single capture path.** No DOM-scraping fallback yet; if a site changes its SSE wire format, the
   adapter needs updating (the live-smoke drift alarm is designed to catch this).
+- **ChatGPT stream-handoff turns.** ChatGPT streams the answer as `delta_encoding: v1` SSE, usually
+  *inline* on the `POST /backend-api/f/conversation` response (which we tee). Occasionally it instead
+  returns a `stream_handoff` and streams the tokens on a **resume-SSE endpoint** — those turns are
+  currently missed. That resume stream is also SSE-over-fetch (no WebSocket needed for tokens; the
+  `wss://ws.chatgpt.com` socket only carries control messages), so teeing the resume GET is a
+  follow-up, not a rearchitecture. ChatGPT web (like Claude web) doesn't stream token usage.
 - **Telemetry integrity on the injected page.** The MAIN-world interceptor and any other page script
   share the same JS world, so the ISOLATED content script cannot cryptographically distinguish the
   extension's own `postMessage` events from forged ones. A malicious script already running on

--- a/browser-extension/e2e/chatgpt.replay.spec.ts
+++ b/browser-extension/e2e/chatgpt.replay.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect, seedSettings } from './fixtures.js';
+import { flatAttrs, recordByAction, resourceAttrs } from './helpers/otlp-assertions.js';
+
+// conversation id embedded in the fixture's resume_conversation_token
+const CONV = '6a73b75a-18d8-83ea-bbcf-984208806963';
+const COMPLETION_PATH = '/backend-api/f/conversation';
+
+test.beforeEach(async ({ mockCollector }) => {
+  mockCollector.reset();
+});
+
+test('captures a simple ChatGPT turn end-to-end into normalized OTLP', async ({
+  context,
+  serviceWorker,
+  replay,
+  mockCollector,
+}) => {
+  replay.setCase({
+    site: 'chatgpt',
+    name: 'simple-turn',
+    conversationId: CONV,
+    prompt: 'good evening',
+    completionPath: COMPLETION_PATH,
+  });
+  await seedSettings(serviceWorker, {
+    enabled: true,
+    retention: 'full',
+    endpoint: mockCollector.url,
+    sites: { claude_web: true, chatgpt_web: true },
+  });
+
+  const page = await context.newPage();
+  await page.goto('https://chatgpt.com/');
+  await expect(page.locator('[data-testid="assistant-message"]')).toHaveAttribute(
+    'data-complete',
+    '1',
+  );
+
+  await expect.poll(() => mockCollector.received.length, { timeout: 10_000 }).toBeGreaterThan(0);
+
+  const res = resourceAttrs(mockCollector.received[0]);
+  expect(res['beacon.harness.name']).toBe('chatgpt_web');
+  expect(res['gen_ai.provider.name']).toBe('openai');
+
+  // Prompt lands on its own prompt.submitted record with the conv id from the stream.
+  const promptRec = recordByAction(mockCollector.received, 'prompt.submitted');
+  expect(promptRec, 'a prompt.submitted record should have been delivered').toBeTruthy();
+  const promptAttrs = flatAttrs(promptRec!.attributes);
+  expect(promptAttrs['beacon.prompt.text']).toBe('good evening');
+  expect(promptAttrs['beacon.session.id']).toBe(CONV);
+
+  // Response lands on the agent.response.completed record.
+  const rec = recordByAction(mockCollector.received, 'agent.response.completed');
+  expect(rec, 'a completed-response record should have been delivered').toBeTruthy();
+  const attrs = flatAttrs(rec!.attributes);
+  expect(attrs['gen_ai.conversation.id']).toBe(CONV);
+  expect(attrs['gen_ai.response.model']).toBe('gpt-5-6-thinking');
+  expect(String(attrs['gen_ai.output.messages'])).toContain('Good evening');
+});

--- a/browser-extension/e2e/claude.replay.spec.ts
+++ b/browser-extension/e2e/claude.replay.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, seedSettings } from './fixtures.js';
+import { flatAttrs, recordByAction, resourceAttrs } from './helpers/otlp-assertions.js';
+
+const CONV = '11111111-2222-3333-4444-555555555555';
+const COMPLETION_PATH = '/api/organizations/org-test/chat_conversations/{conv}/completion';
+
+test.beforeEach(async ({ mockCollector }) => {
+  mockCollector.reset();
+});
+
+test('captures a simple Claude turn end-to-end into normalized OTLP', async ({
+  context,
+  serviceWorker,
+  replay,
+  mockCollector,
+}) => {
+  replay.setCase({
+    site: 'claude',
+    name: 'simple-turn',
+    conversationId: CONV,
+    prompt: 'What is the capital of France?',
+    completionPath: COMPLETION_PATH,
+  });
+  await seedSettings(serviceWorker, {
+    enabled: true,
+    retention: 'full',
+    endpoint: mockCollector.url,
+    sites: { claude_web: true, chatgpt_web: true },
+  });
+
+  const page = await context.newPage();
+  await page.goto('https://claude.ai/chat');
+  // Wait until the page finished consuming the stream.
+  await expect(page.locator('[data-testid="assistant-message"]')).toHaveAttribute(
+    'data-complete',
+    '1',
+  );
+
+  await expect.poll(() => mockCollector.received.length, { timeout: 10_000 }).toBeGreaterThan(0);
+
+  const res = resourceAttrs(mockCollector.received[0]);
+  expect(res['beacon.harness.name']).toBe('claude_web');
+  expect(res['gen_ai.provider.name']).toBe('anthropic');
+
+  // The prompt lands on its own prompt.submitted record (category "prompt") so
+  // the collector lifts it into the queryable Event.prompt.text field.
+  const promptRec = recordByAction(mockCollector.received, 'prompt.submitted');
+  expect(promptRec, 'a prompt.submitted record should have been delivered').toBeTruthy();
+  const promptAttrs = flatAttrs(promptRec!.attributes);
+  expect(promptAttrs['beacon.event.category']).toBe('prompt');
+  expect(promptAttrs['beacon.prompt.text']).toBe('What is the capital of France?');
+  expect(promptAttrs['beacon.session.id']).toBe(CONV);
+
+  // The response lands on the agent.response.completed record.
+  const rec = recordByAction(mockCollector.received, 'agent.response.completed');
+  expect(rec, 'a completed-response record should have been delivered').toBeTruthy();
+  const attrs = flatAttrs(rec!.attributes);
+  expect(attrs['gen_ai.conversation.id']).toBe(CONV);
+  expect(attrs['gen_ai.response.model']).toBe('claude-opus-4-8');
+  expect(String(attrs['gen_ai.output.messages'])).toContain('Paris');
+});
+
+test('captures a Claude tool call as a tool.invoked record', async ({
+  context,
+  serviceWorker,
+  replay,
+  mockCollector,
+}) => {
+  replay.setCase({
+    site: 'claude',
+    name: 'with-tool-call',
+    conversationId: CONV,
+    prompt: 'What is the weather today?',
+    completionPath: COMPLETION_PATH,
+  });
+  await seedSettings(serviceWorker, {
+    enabled: true,
+    retention: 'full',
+    endpoint: mockCollector.url,
+    sites: { claude_web: true, chatgpt_web: true },
+  });
+
+  const page = await context.newPage();
+  await page.goto('https://claude.ai/chat');
+  await expect(page.locator('[data-testid="assistant-message"]')).toHaveAttribute(
+    'data-complete',
+    '1',
+  );
+
+  await expect
+    .poll(() => recordByAction(mockCollector.received, 'tool.invoked'), { timeout: 10_000 })
+    .toBeTruthy();
+
+  const tool = flatAttrs(recordByAction(mockCollector.received, 'tool.invoked')!.attributes);
+  expect(tool['tool.name']).toBe('web_search');
+  expect(tool['gen_ai.tool.call.id']).toBe('toolu_abc');
+  expect(String(tool['gen_ai.tool.call.arguments'])).toContain('weather today');
+});
+
+test('respects the disabled toggle (no delivery)', async ({
+  context,
+  serviceWorker,
+  replay,
+  mockCollector,
+}) => {
+  replay.setCase({
+    site: 'claude',
+    name: 'simple-turn',
+    conversationId: CONV,
+    prompt: 'What is the capital of France?',
+    completionPath: COMPLETION_PATH,
+  });
+  await seedSettings(serviceWorker, {
+    enabled: false,
+    retention: 'full',
+    endpoint: mockCollector.url,
+    sites: { claude_web: true, chatgpt_web: true },
+  });
+
+  const page = await context.newPage();
+  await page.goto('https://claude.ai/chat');
+  await expect(page.locator('[data-testid="assistant-message"]')).toHaveAttribute(
+    'data-complete',
+    '1',
+  );
+  // Give any (erroneous) delivery a chance to arrive, then assert none did.
+  await page.waitForTimeout(1000);
+  expect(mockCollector.received).toHaveLength(0);
+});

--- a/browser-extension/e2e/claude.replay.spec.ts
+++ b/browser-extension/e2e/claude.replay.spec.ts
@@ -60,6 +60,41 @@ test('captures a simple Claude turn end-to-end into normalized OTLP', async ({
   expect(String(attrs['gen_ai.output.messages'])).toContain('Paris');
 });
 
+test('captures the prompt when the page uses fetch(new Request(...))', async ({
+  context,
+  serviceWorker,
+  replay,
+  mockCollector,
+}) => {
+  replay.setCase({
+    site: 'claude',
+    name: 'simple-turn',
+    conversationId: CONV,
+    prompt: 'What is the capital of France?',
+    completionPath: COMPLETION_PATH,
+    requestStyle: 'request', // body lives on the Request object, not init.body
+  });
+  await seedSettings(serviceWorker, {
+    enabled: true,
+    retention: 'full',
+    endpoint: mockCollector.url,
+    sites: { claude_web: true, chatgpt_web: true },
+  });
+
+  const page = await context.newPage();
+  await page.goto('https://claude.ai/chat');
+  await expect(page.locator('[data-testid="assistant-message"]')).toHaveAttribute(
+    'data-complete',
+    '1',
+  );
+
+  await expect
+    .poll(() => recordByAction(mockCollector.received, 'prompt.submitted'), { timeout: 10_000 })
+    .toBeTruthy();
+  const p = flatAttrs(recordByAction(mockCollector.received, 'prompt.submitted')!.attributes);
+  expect(p['beacon.prompt.text']).toBe('What is the capital of France?');
+});
+
 test('captures a Claude tool call as a tool.invoked record', async ({
   context,
   serviceWorker,

--- a/browser-extension/e2e/fixtures.ts
+++ b/browser-extension/e2e/fixtures.ts
@@ -1,0 +1,91 @@
+import { test as base, chromium, type BrowserContext, type Worker } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startMockCollector, type MockCollector } from './helpers/mock-collector.js';
+import { startReplayServer, type ReplayServer } from './helpers/sse-replay-server.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Load the built extension from dist/ (npm's pretest builds it). Overridable.
+const pathToExtension = process.env.EXTENSION_PATH ?? path.join(__dirname, '..', 'dist');
+const headless = process.env.HEADED !== '1';
+
+interface Fixtures {
+  mockCollector: MockCollector;
+  replay: ReplayServer;
+  context: BrowserContext;
+  serviceWorker: Worker;
+  extensionId: string;
+}
+
+export const test = base.extend<Fixtures>({
+  // Stand-in beacon collector. Fresh per test (received reset in beforeEach via reset()).
+  mockCollector: async ({}, use) => {
+    const c = await startMockCollector();
+    await use(c);
+    await c.close();
+  },
+
+  // HTTPS server impersonating the chat sites; started before the browser so its
+  // port can feed --host-resolver-rules.
+  replay: async ({}, use) => {
+    const r = await startReplayServer();
+    await use(r);
+    await r.close();
+  },
+
+  context: async ({ replay }, use) => {
+    // Map the real chat hostnames (:443) to the local replay server so the
+    // extension's content-script matches fire on the genuine origins.
+    const map = [
+      `MAP claude.ai:443 127.0.0.1:${replay.port}`,
+      `MAP chatgpt.com:443 127.0.0.1:${replay.port}`,
+      `MAP chat.openai.com:443 127.0.0.1:${replay.port}`,
+    ].join(', ');
+
+    const context = await chromium.launchPersistentContext('', {
+      channel: 'chromium',
+      headless,
+      ignoreHTTPSErrors: true,
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+        `--host-resolver-rules=${map}`,
+        '--ignore-certificate-errors',
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+
+  serviceWorker: async ({ context }, use) => {
+    let [worker] = context.serviceWorkers();
+    if (!worker) worker = await context.waitForEvent('serviceworker');
+    await use(worker);
+  },
+
+  extensionId: async ({ serviceWorker }, use) => {
+    await use(new URL(serviceWorker.url()).host);
+  },
+});
+
+export const expect = test.expect;
+
+/** Seed the extension's settings through the service worker. Waits for the
+ *  SW's onInstalled default-write to land first so it can't clobber our seed. */
+export async function seedSettings(
+  worker: Worker,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  await worker.evaluate(async (p) => {
+    for (let i = 0; i < 100; i++) {
+      const cur = (await chrome.storage.local.get('settings')).settings;
+      if (cur) {
+        await chrome.storage.local.set({ settings: { ...cur, ...p } });
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await chrome.storage.local.set({ settings: p });
+  }, patch);
+}

--- a/browser-extension/e2e/helpers/cert.ts
+++ b/browser-extension/e2e/helpers/cert.ts
@@ -1,0 +1,29 @@
+// Generates a throwaway self-signed cert (via openssl) covering the chat-site
+// hostnames, so the replay server can answer https://claude.ai / https://chatgpt.com
+// after --host-resolver-rules maps those hosts to it. Test-only; never trusted
+// beyond the automation Chromium launched with --ignore-certificate-errors.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let cached: { key: string; cert: string } | undefined;
+
+export function getTestCert(): { key: string; cert: string } {
+  if (cached) return cached;
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'beacon-cert-'));
+  const keyPath = path.join(dir, 'key.pem');
+  const certPath = path.join(dir, 'cert.pem');
+  execFileSync('openssl', [
+    'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+    '-keyout', keyPath,
+    '-out', certPath,
+    '-days', '3',
+    '-subj', '/CN=claude.ai',
+    '-addext',
+    'subjectAltName=DNS:claude.ai,DNS:chatgpt.com,DNS:chat.openai.com,DNS:localhost,IP:127.0.0.1',
+  ]);
+  cached = { key: readFileSync(keyPath, 'utf8'), cert: readFileSync(certPath, 'utf8') };
+  return cached;
+}

--- a/browser-extension/e2e/helpers/mock-collector.ts
+++ b/browser-extension/e2e/helpers/mock-collector.ts
@@ -1,0 +1,61 @@
+// A stand-in for the beacon OTLP collector. Listens on an ephemeral loopback
+// port, records every POST to /v1/logs (decoded OTLP JSON), and satisfies CORS
+// preflight so the extension service worker can post to it cross-origin.
+
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { LogsEnvelope } from '../../src/shared/otlp.js';
+
+export interface MockCollector {
+  url: string;
+  received: LogsEnvelope[];
+  reset(): void;
+  close(): Promise<void>;
+}
+
+export async function startMockCollector(): Promise<MockCollector> {
+  const received: LogsEnvelope[] = [];
+
+  const server = http.createServer((req, res) => {
+    // CORS preflight from the extension SW (content-type: application/json).
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, corsHeaders());
+      res.end();
+      return;
+    }
+    if (req.method === 'POST' && req.url === '/v1/logs') {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        try {
+          received.push(JSON.parse(body) as LogsEnvelope);
+        } catch {
+          /* ignore malformed */
+        }
+        res.writeHead(200, { 'content-type': 'application/json', ...corsHeaders() });
+        res.end('{}');
+      });
+      return;
+    }
+    res.writeHead(404, corsHeaders());
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}/v1/logs`,
+    received,
+    reset: () => (received.length = 0),
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function corsHeaders(): http.OutgoingHttpHeaders {
+  return {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'POST, OPTIONS',
+    'access-control-allow-headers': 'content-type',
+  };
+}

--- a/browser-extension/e2e/helpers/otlp-assertions.ts
+++ b/browser-extension/e2e/helpers/otlp-assertions.ts
@@ -1,0 +1,27 @@
+// Helpers to read OTLP log envelopes captured by the mock collector.
+
+import type { KeyValue, LogRecord, LogsEnvelope } from '../../src/shared/otlp.js';
+import { attrValue } from '../../src/shared/otlp.js';
+
+export function flatAttrs(attrs: KeyValue[]): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {};
+  for (const a of attrs) {
+    const v = attrValue(attrs, a.key);
+    if (v !== undefined) out[a.key] = v;
+  }
+  return out;
+}
+
+export function resourceAttrs(env: LogsEnvelope): Record<string, string | number | boolean> {
+  return flatAttrs(env.resourceLogs[0]?.resource.attributes ?? []);
+}
+
+/** All log records across all captured envelopes. */
+export function allRecords(envs: LogsEnvelope[]): LogRecord[] {
+  return envs.flatMap((e) => e.resourceLogs.flatMap((rl) => rl.scopeLogs.flatMap((sl) => sl.logRecords)));
+}
+
+/** Find the first record whose beacon.event.action matches. */
+export function recordByAction(envs: LogsEnvelope[], action: string): LogRecord | undefined {
+  return allRecords(envs).find((r) => flatAttrs(r.attributes)['beacon.event.action'] === action);
+}

--- a/browser-extension/e2e/helpers/sse-replay-server.ts
+++ b/browser-extension/e2e/helpers/sse-replay-server.ts
@@ -1,0 +1,163 @@
+// HTTPS server that impersonates claude.ai / chatgpt.com for tests. It serves a
+// minimal chat page (whose DOM mirrors the real message list) that fires the
+// same completion fetch the real site would, and it streams a recorded .sse
+// fixture back with realistic chunking. Combined with --host-resolver-rules,
+// this lets the real extension content scripts (matched on the real hostnames)
+// run against deterministic recorded data — no login, no cost.
+//
+// Multiple cases can be registered (keyed by conversationId) so tests can drive
+// two concurrent tabs; a page selects its case via ?conv=<id> (defaulting to the
+// first-registered case for single-case tests).
+
+import https from 'node:https';
+import type { AddressInfo } from 'node:net';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getTestCert } from './cert.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, '..', '..', 'fixtures');
+
+export interface ReplayCase {
+  /** e.g. 'claude' */
+  site: string;
+  /** e.g. 'simple-turn' */
+  name: string;
+  /** conversation id embedded in the completion URL */
+  conversationId: string;
+  /** prompt the page will submit */
+  prompt: string;
+  /** completion path (must match the adapter's request matcher) */
+  completionPath: string;
+  /** optional CSP header to prove injection survives it */
+  csp?: string;
+}
+
+export interface ReplayServer {
+  port: number;
+  /** Register (or replace) a case, keyed by its conversationId. */
+  setCase(c: ReplayCase): void;
+  close(): Promise<void>;
+}
+
+export async function startReplayServer(): Promise<ReplayServer> {
+  const { key, cert } = getTestCert();
+  const cases = new Map<string, ReplayCase>();
+  let defaultConv: string | undefined;
+
+  const server = https.createServer({ key, cert }, (req, res) => {
+    const url = new URL(req.url ?? '/', 'https://claude.ai');
+
+    // The completion endpoint: stream the recorded SSE for that conversation.
+    if (req.method === 'POST' && url.pathname.includes('/chat_conversations/')) {
+      const convId = url.pathname.match(/chat_conversations\/([^/]+)\//)?.[1] ?? '';
+      const c = cases.get(convId);
+      if (!c) {
+        res.writeHead(404).end('no case for conversation');
+        return;
+      }
+      streamFixture(res, c);
+      return;
+    }
+
+    // Anything else → the chat page for the requested (or default) conversation.
+    const convId = url.searchParams.get('conv') ?? defaultConv;
+    const c = convId ? cases.get(convId) : undefined;
+    if (!c) {
+      res.writeHead(503).end('no case set');
+      return;
+    }
+    const headers: Record<string, string> = { 'content-type': 'text/html; charset=utf-8' };
+    if (c.csp) headers['content-security-policy'] = c.csp;
+    res.writeHead(200, headers).end(pageHtml(c));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    port,
+    setCase: (c) => {
+      cases.set(c.conversationId, c);
+      defaultConv ??= c.conversationId;
+    },
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function readFixture(site: string, name: string): string {
+  return readFileSync(path.join(fixturesDir, site, `${name}.sse`), 'utf8');
+}
+
+function streamFixture(res: import('node:http').ServerResponse, c: ReplayCase): void {
+  res.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
+  });
+  const body = readFixture(c.site, c.name);
+  // Chunk on a coarse boundary that does NOT respect SSE frame boundaries, to
+  // exercise the parser's buffering; write with small delays to simulate streaming.
+  const pieces = chunkify(body);
+  let i = 0;
+  const tick = () => {
+    if (i >= pieces.length) {
+      res.end();
+      return;
+    }
+    res.write(pieces[i++]);
+    setTimeout(tick, 5);
+  };
+  tick();
+}
+
+/** Split into byte-ish pieces that don't respect SSE frame boundaries. */
+function chunkify(body: string): string[] {
+  const size = 24;
+  const out: string[] = [];
+  for (let i = 0; i < body.length; i += size) out.push(body.slice(i, i + size));
+  return out;
+}
+
+/** Minimal page that mirrors a chat message list and fires the completion fetch. */
+function pageHtml(c: ReplayCase): string {
+  const completionUrl = c.completionPath.replace('{conv}', c.conversationId);
+  return `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>${c.site} (replay)</title></head>
+  <body>
+    <main>
+      <div class="message-list" data-testid="message-list">
+        <div class="user-message">${escapeHtml(c.prompt)}</div>
+        <div class="assistant-message" data-testid="assistant-message"></div>
+      </div>
+    </main>
+    <script>
+      (async () => {
+        const res = await fetch(${JSON.stringify(completionUrl)}, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ prompt: ${JSON.stringify(c.prompt)}, conversation_id: ${JSON.stringify(
+            c.conversationId,
+          )} }),
+        });
+        // Consume the stream like the real site does.
+        const reader = res.body.getReader();
+        const dec = new TextDecoder();
+        const el = document.querySelector('[data-testid="assistant-message"]');
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          el.textContent += dec.decode(value, { stream: true });
+        }
+        el.setAttribute('data-complete', '1');
+      })();
+    </script>
+  </body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"]/g, (ch) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[ch]!));
+}

--- a/browser-extension/e2e/helpers/sse-replay-server.ts
+++ b/browser-extension/e2e/helpers/sse-replay-server.ts
@@ -32,6 +32,8 @@ export interface ReplayCase {
   completionPath: string;
   /** optional CSP header to prove injection survives it */
   csp?: string;
+  /** how the page issues the completion fetch: 'init' (default) or a Request object */
+  requestStyle?: 'init' | 'request';
 }
 
 export interface ReplayServer {
@@ -135,13 +137,17 @@ function pageHtml(c: ReplayCase): string {
     </main>
     <script>
       (async () => {
-        const res = await fetch(${JSON.stringify(completionUrl)}, {
+        const url = ${JSON.stringify(completionUrl)};
+        const init = {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({ prompt: ${JSON.stringify(c.prompt)}, conversation_id: ${JSON.stringify(
             c.conversationId,
           )} }),
-        });
+        };
+        const res = await ${
+          c.requestStyle === 'request' ? 'fetch(new Request(url, init))' : 'fetch(url, init)'
+        };
         // Consume the stream like the real site does.
         const reader = res.body.getReader();
         const dec = new TextDecoder();

--- a/browser-extension/e2e/helpers/sse-replay-server.ts
+++ b/browser-extension/e2e/helpers/sse-replay-server.ts
@@ -51,16 +51,16 @@ export async function startReplayServer(): Promise<ReplayServer> {
   const server = https.createServer({ key, cert }, (req, res) => {
     const url = new URL(req.url ?? '/', 'https://claude.ai');
 
-    // The completion endpoint: stream the recorded SSE for that conversation.
-    if (req.method === 'POST' && url.pathname.includes('/chat_conversations/')) {
-      const convId = url.pathname.match(/chat_conversations\/([^/]+)\//)?.[1] ?? '';
-      const c = cases.get(convId);
-      if (!c) {
-        res.writeHead(404).end('no case for conversation');
-        return;
+    // The completion endpoint: match the POST path against a registered case's
+    // completion path (site-agnostic — Claude embeds the conv id in the path;
+    // ChatGPT posts to a fixed /backend-api/f/conversation).
+    if (req.method === 'POST') {
+      for (const c of cases.values()) {
+        if (url.pathname === c.completionPath.replace('{conv}', c.conversationId)) {
+          streamFixture(res, c);
+          return;
+        }
       }
-      streamFixture(res, c);
-      return;
     }
 
     // Anything else → the chat page for the requested (or default) conversation.
@@ -125,6 +125,19 @@ function chunkify(body: string): string[] {
 /** Minimal page that mirrors a chat message list and fires the completion fetch. */
 function pageHtml(c: ReplayCase): string {
   const completionUrl = c.completionPath.replace('{conv}', c.conversationId);
+  // Per-site request body: ChatGPT posts messages[].content.parts (conv id comes
+  // back in the stream); Claude posts {prompt, conversation_id}.
+  const bodyStr =
+    c.site === 'chatgpt'
+      ? JSON.stringify({
+          action: 'next',
+          conversation_id: null,
+          model: 'gpt-5-6-thinking',
+          messages: [
+            { author: { role: 'user' }, content: { content_type: 'text', parts: [c.prompt] } },
+          ],
+        })
+      : JSON.stringify({ prompt: c.prompt, conversation_id: c.conversationId });
   return `<!doctype html>
 <html>
   <head><meta charset="utf-8" /><title>${c.site} (replay)</title></head>
@@ -141,9 +154,7 @@ function pageHtml(c: ReplayCase): string {
         const init = {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ prompt: ${JSON.stringify(c.prompt)}, conversation_id: ${JSON.stringify(
-            c.conversationId,
-          )} }),
+          body: ${JSON.stringify(bodyStr)},
         };
         const res = await ${
           c.requestStyle === 'request' ? 'fetch(new Request(url, init))' : 'fetch(url, init)'

--- a/browser-extension/e2e/resilience.spec.ts
+++ b/browser-extension/e2e/resilience.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, seedSettings } from './fixtures.js';
+import { allRecords, flatAttrs, recordByAction } from './helpers/otlp-assertions.js';
+
+const COMPLETION = '/api/organizations/org-test/chat_conversations/{conv}/completion';
+
+const FULL_SETTINGS = (endpoint: string) => ({
+  enabled: true,
+  retention: 'full' as const,
+  endpoint,
+  sites: { claude_web: true, chatgpt_web: true },
+});
+
+test.beforeEach(async ({ mockCollector }) => {
+  mockCollector.reset();
+});
+
+test('two concurrent tabs stay correlated to their own conversations', async ({
+  context,
+  serviceWorker,
+  replay,
+  mockCollector,
+}) => {
+  const A = 'aaaaaaaa-1111-2222-3333-444444444444';
+  const B = 'bbbbbbbb-5555-6666-7777-888888888888';
+  replay.setCase({ site: 'claude', name: 'simple-turn', conversationId: A, prompt: 'capital of France?', completionPath: COMPLETION });
+  replay.setCase({ site: 'claude', name: 'with-tool-call', conversationId: B, prompt: 'weather in NYC?', completionPath: COMPLETION });
+  await seedSettings(serviceWorker, FULL_SETTINGS(mockCollector.url));
+
+  const [p1, p2] = [await context.newPage(), await context.newPage()];
+  await Promise.all([
+    p1.goto(`https://claude.ai/chat?conv=${A}`),
+    p2.goto(`https://claude.ai/chat?conv=${B}`),
+  ]);
+  await Promise.all([
+    expect(p1.locator('[data-testid="assistant-message"]')).toHaveAttribute('data-complete', '1'),
+    expect(p2.locator('[data-testid="assistant-message"]')).toHaveAttribute('data-complete', '1'),
+  ]);
+
+  // Wait until B's tool call (the last-arriving signal) has been delivered.
+  await expect
+    .poll(() => recordByAction(mockCollector.received, 'tool.invoked'), { timeout: 10_000 })
+    .toBeTruthy();
+
+  const recs = allRecords(mockCollector.received).map((r) => flatAttrs(r.attributes));
+  const promptFor = (sid: string) =>
+    recs.find((a) => a['beacon.session.id'] === sid && a['beacon.event.action'] === 'prompt.submitted');
+
+  // Prompts are attributed to the correct conversation (no cross-contamination).
+  expect(promptFor(A)?.['beacon.prompt.text']).toBe('capital of France?');
+  expect(promptFor(B)?.['beacon.prompt.text']).toBe('weather in NYC?');
+
+  // The tool call belongs only to conversation B (its fixture had one); A had none.
+  const toolSessions = recs
+    .filter((a) => a['beacon.event.action'] === 'tool.invoked')
+    .map((a) => a['beacon.session.id']);
+  expect(toolSessions).toContain(B);
+  expect(toolSessions).not.toContain(A);
+});
+
+test('aborted stream still delivers a best-effort agent.response (not completed)', async ({
+  context,
+  serviceWorker,
+  replay,
+  mockCollector,
+}) => {
+  const C = 'cccccccc-9999-0000-1111-222222222222';
+  replay.setCase({ site: 'claude', name: 'aborted', conversationId: C, prompt: 'tell me a story', completionPath: COMPLETION });
+  await seedSettings(serviceWorker, FULL_SETTINGS(mockCollector.url));
+
+  const page = await context.newPage();
+  await page.goto(`https://claude.ai/chat?conv=${C}`);
+  await expect(page.locator('[data-testid="assistant-message"]')).toHaveAttribute('data-complete', '1');
+
+  // A partial turn is emitted as agent.response (NOT agent.response.completed).
+  await expect
+    .poll(() => recordByAction(mockCollector.received, 'agent.response'), { timeout: 10_000 })
+    .toBeTruthy();
+  expect(recordByAction(mockCollector.received, 'agent.response.completed')).toBeFalsy();
+
+  const resp = flatAttrs(recordByAction(mockCollector.received, 'agent.response')!.attributes);
+  expect(resp['beacon.session.id']).toBe(C);
+  // The prompt was still captured for the aborted turn.
+  expect(recordByAction(mockCollector.received, 'prompt.submitted')).toBeTruthy();
+});

--- a/browser-extension/esbuild.config.mjs
+++ b/browser-extension/esbuild.config.mjs
@@ -1,0 +1,63 @@
+import * as esbuild from 'esbuild';
+import { cp, mkdir, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const src = path.join(__dirname, 'src');
+const dist = path.join(__dirname, 'dist');
+const watch = process.argv.includes('--watch');
+
+// Each extension surface is its own bundle. Content scripts and the MAIN-world
+// interceptor must be classic scripts (no ESM import in those worlds), so we
+// bundle everything into a single IIFE per entry.
+const entries = {
+  'sw': 'background/sw.ts',
+  'content': 'content/content.ts',
+  'interceptor': 'interceptor/interceptor.ts',
+  'popup': 'popup/popup.ts',
+  'options': 'options/options.ts',
+};
+
+/** Copy static assets (manifest, html, icons) into dist/. */
+async function copyStatic() {
+  await cp(path.join(src, 'manifest.json'), path.join(dist, 'manifest.json'));
+  for (const surface of ['popup', 'options']) {
+    await cp(path.join(src, surface, `${surface}.html`), path.join(dist, `${surface}.html`));
+  }
+  // icons/ is optional; copy if present.
+  await cp(path.join(src, 'icons'), path.join(dist, 'icons'), { recursive: true }).catch(() => {});
+}
+
+const buildOptions = {
+  entryPoints: Object.fromEntries(
+    Object.entries(entries).map(([out, rel]) => [out, path.join(src, rel)]),
+  ),
+  outdir: dist,
+  bundle: true,
+  format: 'iife',
+  target: ['chrome120'],
+  sourcemap: true,
+  logLevel: 'info',
+};
+
+async function run() {
+  await rm(dist, { recursive: true, force: true });
+  await mkdir(dist, { recursive: true });
+
+  if (watch) {
+    const ctx = await esbuild.context(buildOptions);
+    await copyStatic();
+    await ctx.watch();
+    console.log('[esbuild] watching…');
+  } else {
+    await esbuild.build(buildOptions);
+    await copyStatic();
+    console.log('[esbuild] build complete → dist/');
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/browser-extension/fixtures/chatgpt/simple-turn.sse
+++ b/browser-extension/fixtures/chatgpt/simple-turn.sse
@@ -1,0 +1,24 @@
+event: delta_encoding
+data: "v1"
+
+data: {"type": "resume_conversation_token", "kind": "topic", "token": "REDACTED", "conversation_id": "6a73b75a-18d8-83ea-bbcf-984208806963"}
+
+event: delta
+data: {"p": "", "o": "add", "v": {"message": {"id": "seed-system", "author": {"role": "system", "name": null, "metadata": {}}, "content": {"content_type": "text", "parts": [""]}, "status": "finished_successfully", "recipient": "all", "metadata": {}}}}
+
+event: delta
+data: {"v": {"message": {"id": "asst-0001", "author": {"role": "assistant", "name": null, "metadata": {}}, "content": {"content_type": "text", "parts": [""]}, "status": "in_progress", "recipient": "all", "metadata": {"model_slug": "gpt-5-6-thinking"}}}}
+
+event: delta
+data: {"p": "/message/content/parts/0", "o": "append", "v": "Good evening"}
+
+event: delta
+data: {"v": "! Hello to you as well."}
+
+event: delta
+data: {"o": "patch", "p": "", "v": [{"p": "/message/content/parts/0", "o": "append", "v": " Hope your day is going well."}, {"p": "/message/status", "o": "replace", "v": "finished_successfully"}, {"p": "/message/end_turn", "o": "replace", "v": true}, {"p": "/message/metadata", "o": "append", "v": {"search_result_groups": []}}]}
+
+data: {"type": "message_stream_complete", "conversation_id": "6a73b75a-18d8-83ea-bbcf-984208806963"}
+
+data: [DONE]
+

--- a/browser-extension/fixtures/claude/aborted.sse
+++ b/browser-extension/fixtures/claude/aborted.sse
@@ -1,0 +1,12 @@
+event: conversation_ready
+data: {"type":"conversation_ready"}
+
+event: message_start
+data: {"type":"message_start","message":{"id":"chatcompl_REDACTED","type":"message","role":"assistant","model":"claude-opus-4-8","content":[],"stop_reason":null}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"","citations":[]}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Once upon a time"}}
+

--- a/browser-extension/fixtures/claude/simple-turn.sse
+++ b/browser-extension/fixtures/claude/simple-turn.sse
@@ -1,0 +1,21 @@
+event: conversation_ready
+data: {"type":"conversation_ready"}
+
+event: message_start
+data: {"type":"message_start","message":{"id":"chatcompl_REDACTED","type":"message","role":"assistant","model":"claude-opus-4-8","content":[],"stop_reason":null,"stop_sequence":null}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"","citations":[]}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Paris."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/browser-extension/fixtures/claude/with-tool-call.sse
+++ b/browser-extension/fixtures/claude/with-tool-call.sse
@@ -1,0 +1,33 @@
+event: conversation_ready
+data: {"type":"conversation_ready"}
+
+event: message_start
+data: {"type":"message_start","message":{"id":"chatcompl_REDACTED","type":"message","role":"assistant","model":"claude-opus-4-8","content":[],"stop_reason":null}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_abc","name":"web_search","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"weather"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" today\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":"","citations":[]}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Let me check the weather."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/browser-extension/package-lock.json
+++ b/browser-extension/package-lock.json
@@ -14,12 +14,15 @@
         "esbuild": "^0.24.0",
         "typescript": "^5.6.0",
         "vitest": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -385,9 +388,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
       "cpu": [
         "arm64"
       ],
@@ -742,6 +745,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -1720,9 +1757,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1737,9 +1774,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
       "cpu": [
         "arm"
       ],
@@ -1754,9 +1791,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
       "cpu": [
         "arm64"
       ],
@@ -1771,9 +1808,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
       "cpu": [
         "x64"
       ],
@@ -1788,9 +1825,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
       "cpu": [
         "arm64"
       ],
@@ -1805,9 +1842,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
       "cpu": [
         "x64"
       ],
@@ -1822,9 +1859,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
       "cpu": [
         "arm64"
       ],
@@ -1839,9 +1876,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
       "cpu": [
         "x64"
       ],
@@ -1856,9 +1893,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
       "cpu": [
         "arm"
       ],
@@ -1873,9 +1910,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
       "cpu": [
         "arm64"
       ],
@@ -1890,9 +1927,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
       "cpu": [
         "ia32"
       ],
@@ -1907,9 +1944,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
       "cpu": [
         "loong64"
       ],
@@ -1924,9 +1961,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
       "cpu": [
         "mips64el"
       ],
@@ -1941,9 +1978,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1958,9 +1995,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
       "cpu": [
         "riscv64"
       ],
@@ -1975,9 +2012,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
       "cpu": [
         "s390x"
       ],
@@ -1992,9 +2029,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
       "cpu": [
         "x64"
       ],
@@ -2009,9 +2046,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
       "cpu": [
         "arm64"
       ],
@@ -2026,9 +2063,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
       "cpu": [
         "x64"
       ],
@@ -2043,9 +2080,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
       "cpu": [
         "arm64"
       ],
@@ -2060,9 +2097,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
       "cpu": [
         "x64"
       ],
@@ -2077,9 +2114,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
       "cpu": [
         "x64"
       ],
@@ -2094,9 +2131,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
       "cpu": [
         "arm64"
       ],
@@ -2111,9 +2148,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
       "cpu": [
         "ia32"
       ],
@@ -2128,9 +2165,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
       "cpu": [
         "x64"
       ],

--- a/browser-extension/package-lock.json
+++ b/browser-extension/package-lock.json
@@ -1,0 +1,2286 @@
+{
+  "name": "agent-beacon-browser-extension",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-beacon-browser-extension",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.55.0",
+        "@types/chrome": "^0.0.270",
+        "@types/node": "^22.0.0",
+        "esbuild": "^0.24.0",
+        "typescript": "^5.6.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.0.270",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.270.tgz",
+      "integrity": "sha512-ADvkowV7YnJfycZZxL2brluZ6STGW+9oKG37B422UePf2PCXuFA/XdERI0T18wtuWPx0tmFeZqq6MOXVk1IC+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/browser-extension/package-lock.json
+++ b/browser-extension/package-lock.json
@@ -19,17 +19,6 @@
         "node": ">=22"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
-      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.24.2",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
@@ -479,29 +468,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -509,25 +479,42 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
       "cpu": [
         "arm64"
       ],
@@ -542,9 +529,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
       "cpu": [
         "arm64"
       ],
@@ -559,9 +546,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
       "cpu": [
         "x64"
       ],
@@ -576,9 +563,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
       "cpu": [
         "x64"
       ],
@@ -593,9 +580,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
       "cpu": [
         "arm"
       ],
@@ -610,9 +597,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
       "cpu": [
         "arm64"
       ],
@@ -627,9 +614,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
       "cpu": [
         "arm64"
       ],
@@ -644,9 +631,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
       "cpu": [
         "ppc64"
       ],
@@ -661,9 +648,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
       "cpu": [
         "s390x"
       ],
@@ -678,9 +665,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
       "cpu": [
         "x64"
       ],
@@ -695,9 +682,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
       "cpu": [
         "x64"
       ],
@@ -712,9 +699,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
       "cpu": [
         "arm64"
       ],
@@ -728,63 +715,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
       "cpu": [
         "arm64"
       ],
@@ -799,9 +733,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
       "cpu": [
         "x64"
       ],
@@ -828,17 +762,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -912,16 +835,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -930,9 +853,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -943,13 +866,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -957,14 +880,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -973,9 +896,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -983,13 +906,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1035,9 +958,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1407,9 +1330,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1454,9 +1377,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1468,41 +1391,41 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1520,7 +1443,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1529,13 +1452,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.139.0",
+        "@oxc-project/types": "=0.146.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -1545,21 +1468,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.5",
-        "@rolldown/binding-darwin-arm64": "1.1.5",
-        "@rolldown/binding-darwin-x64": "1.1.5",
-        "@rolldown/binding-freebsd-x64": "1.1.5",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-        "@rolldown/binding-linux-arm64-musl": "1.1.5",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-musl": "1.1.5",
-        "@rolldown/binding-openharmony-arm64": "1.1.5",
-        "@rolldown/binding-wasm32-wasi": "1.1.5",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
     },
     "node_modules/siginfo": {
@@ -1601,9 +1524,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1628,22 +1551,14 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -1667,19 +1582,19 @@
       "license": "MIT"
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -1707,12 +1622,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -2182,13 +2097,13 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2208,6 +2123,50 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/vitest/node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2224,17 +2183,17 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "lightningcss": "^1.32.0",
+        "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.17",
-        "rolldown": "~1.1.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -2251,7 +2210,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -7,17 +7,18 @@
   "scripts": {
     "build": "node esbuild.config.mjs",
     "build:watch": "node esbuild.config.mjs --watch",
-    "typecheck": "tsc --noEmit",
+    "check": "tsc --noEmit",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
     "pretest": "npm run build",
     "test": "playwright test",
     "test:headed": "HEADED=1 playwright test --headed",
     "test:ui": "playwright test --ui",
-    "test:integration": "RUN_INTEGRATION=1 playwright test integration",
-    "test:live": "RUN_LIVE=1 HEADED=1 playwright test smoke.live",
     "record:fixtures": "node --experimental-strip-types tools/record-fixtures.ts",
     "report": "playwright show-report"
+  },
+  "engines": {
+    "node": ">=22"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "agent-beacon-browser-extension",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Chrome extension that relays LLM chat telemetry (ChatGPT, Claude) into the local Agent Beacon pipeline, with a fully automated self-verifying build/test loop.",
+  "scripts": {
+    "build": "node esbuild.config.mjs",
+    "build:watch": "node esbuild.config.mjs --watch",
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
+    "pretest": "npm run build",
+    "test": "playwright test",
+    "test:headed": "HEADED=1 playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "test:integration": "RUN_INTEGRATION=1 playwright test integration",
+    "test:live": "RUN_LIVE=1 HEADED=1 playwright test smoke.live",
+    "record:fixtures": "node --experimental-strip-types tools/record-fixtures.ts",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0",
+    "@types/chrome": "^0.0.270",
+    "@types/node": "^22.0.0",
+    "esbuild": "^0.24.0",
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.0"
+  }
+}

--- a/browser-extension/playwright.config.ts
+++ b/browser-extension/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Playwright config tuned for Manifest V3 extension testing.
+ *
+ * - No `projects` with the usual `devices` — extensions require a persistent
+ *   context that we build by hand in e2e/fixtures.ts, so the browser launch
+ *   lives there, not here.
+ * - `trace`/`video` on failure give me artifacts to self-diagnose without a human.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false, // one persistent Chromium profile at a time keeps state clean
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+});

--- a/browser-extension/src/adapters/adapter.ts
+++ b/browser-extension/src/adapters/adapter.ts
@@ -1,0 +1,42 @@
+// SiteAdapter interface + registry. This is the ONLY place site-specific
+// knowledge lives. Everything downstream consumes the canonical ChatTurn.
+
+import type { ChatTurn, SiteName } from '../shared/types.js';
+
+/** Stateful, per-request parser that turns raw SSE/request data into a ChatTurn. */
+export interface TurnParser {
+  /** Called once with the outbound request (prompt lives in the body). */
+  onRequest(url: string, method: string, body: string | null): void;
+  /** Called for each raw SSE chunk from the response stream. */
+  onChunk(chunk: string): void;
+  /** Called when the stream ends (cleanly or aborted). */
+  onDone(): void;
+  /** Best-effort snapshot of the turn so far (null if nothing captured yet). */
+  getTurn(): ChatTurn | null;
+}
+
+export interface SiteAdapter {
+  name: SiteName;
+  matchesHost(host: string): boolean;
+  /** Whether this request is a chat completion worth capturing. */
+  matchesRequest(url: string, method: string): boolean;
+  createParser(): TurnParser;
+}
+
+const registry: SiteAdapter[] = [];
+
+export function registerAdapter(a: SiteAdapter): void {
+  registry.push(a);
+}
+
+export function adapterForHost(host: string): SiteAdapter | undefined {
+  return registry.find((a) => a.matchesHost(host));
+}
+
+/** Permissive request predicate for the MAIN-world interceptor (which is
+ *  site-agnostic). The SW's adapter makes the authoritative decision. */
+export function looksLikeChatRequest(url: string): boolean {
+  return /(\/backend-api\/conversation|\/backend-anon\/conversation|chat_conversations\/.+\/(completion|retry_completion)|\/completion\b)/.test(
+    url,
+  );
+}

--- a/browser-extension/src/adapters/adapter.ts
+++ b/browser-extension/src/adapters/adapter.ts
@@ -37,7 +37,9 @@ export function adapterForHost(host: string): SiteAdapter | undefined {
 /** Permissive request predicate for the MAIN-world interceptor (which is
  *  site-agnostic). The SW's adapter makes the authoritative decision. */
 export function looksLikeChatRequest(url: string): boolean {
-  return /(\/backend-api\/conversation|\/backend-anon\/conversation|chat_conversations\/.+\/(completion|retry_completion)|\/completion\b)/.test(
+  // Over-matches on purpose (the SW's adapter.matchesRequest makes the precise
+  // call); must include ChatGPT's /f/conversation variant so it gets teed.
+  return /(\/backend-(api|anon)\/(f\/)?conversation|chat_conversations\/.+\/(completion|retry_completion)|\/completion\b)/.test(
     url,
   );
 }

--- a/browser-extension/src/adapters/adapter.ts
+++ b/browser-extension/src/adapters/adapter.ts
@@ -20,7 +20,8 @@ export interface SiteAdapter {
   matchesHost(host: string): boolean;
   /** Whether this request is a chat completion worth capturing. */
   matchesRequest(url: string, method: string): boolean;
-  createParser(): TurnParser;
+  /** @param reqId the interceptor's per-page request id (from the InterceptEvent). */
+  createParser(reqId: number): TurnParser;
 }
 
 const registry: SiteAdapter[] = [];

--- a/browser-extension/src/adapters/chatgpt.ts
+++ b/browser-extension/src/adapters/chatgpt.ts
@@ -26,8 +26,6 @@ import { registerAdapter, type SiteAdapter, type TurnParser } from './adapter.js
 import { SSEParser, type SSEEvent } from './sse.js';
 import { turnId } from '../shared/ids.js';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 class ChatGptParser implements TurnParser {
   private sse = new SSEParser();
   private reqId: number;

--- a/browser-extension/src/adapters/chatgpt.ts
+++ b/browser-extension/src/adapters/chatgpt.ts
@@ -1,0 +1,256 @@
+// ChatGPT (chatgpt.com / chat.openai.com) adapter.
+//
+// ChatGPT streams the assistant turn as Server-Sent Events over `fetch` from
+// POST /backend-api/f/conversation, using OpenAI's `delta_encoding: v1` format:
+//   event: delta_encoding   data: "v1"
+//   data: {"type":"resume_conversation_token", "conversation_id":"..."}
+//   event: delta  data: {"p":"","o":"add","v":{"message":{...}}}      ← seed a message
+//   event: delta  data: {"v":{"message":{...}}}                        ← bare: inherits o/p (add @ "")
+//   event: delta  data: {"p":"/message/content/parts/0","o":"append","v":"tok"}
+//   event: delta  data: {"v":"more"}                                   ← bare: inherits append @ path
+//   event: delta  data: {"o":"patch","p":"","v":[{op},{op},...]}       ← batched ops
+//   data: {"type":"message_stream_complete", ...}
+//   data: [DONE]
+//
+// A frame carrying only `v` inherits the previous frame's `o` (op) and `p`
+// (path). We maintain a single "root" object and apply add/append/replace/patch
+// to it, tracking the visible assistant message (author.role === 'assistant',
+// recipient 'all') and accumulating its content/parts text.
+//
+// NOTE: ChatGPT sometimes hands the stream off to a resume endpoint instead of
+// streaming inline on this POST (a `stream_handoff` event). That resume stream
+// is also SSE-over-fetch; capturing it is a documented follow-up.
+
+import type { ChatTurn, Msg, ToolCall } from '../shared/types.js';
+import { registerAdapter, type SiteAdapter, type TurnParser } from './adapter.js';
+import { SSEParser, type SSEEvent } from './sse.js';
+import { turnId } from '../shared/ids.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+class ChatGptParser implements TurnParser {
+  private sse = new SSEParser();
+  private reqId: number;
+  private sessionId = '';
+  private requestModel?: string;
+  private promptText = '';
+  private inputMessages: Msg[] = [];
+  private startedAt = Date.now();
+  private completedAt?: number;
+
+  // delta_encoding v1 cursor + document state
+  private lastOp = '';
+  private lastPath = '';
+  private root: any = null;
+  /** Reference to the visible assistant message object (mutated in place by ops). */
+  private assistantMsg: any = null;
+
+  constructor(reqId: number) {
+    this.reqId = reqId;
+  }
+
+  onRequest(_url: string, _method: string, body: string | null): void {
+    if (!body) return;
+    try {
+      const parsed = JSON.parse(body);
+      if (typeof parsed?.conversation_id === 'string') this.sessionId = parsed.conversation_id;
+      if (typeof parsed?.model === 'string') this.requestModel = parsed.model;
+      const { text, messages } = extractPrompt(parsed);
+      this.promptText = text;
+      this.inputMessages = messages;
+    } catch {
+      /* non-JSON body — prompt stays empty */
+    }
+  }
+
+  onChunk(chunk: string): void {
+    for (const evt of this.sse.push(chunk)) this.handle(evt);
+  }
+
+  onDone(): void {
+    for (const evt of this.sse.flush()) this.handle(evt);
+  }
+
+  private handle(evt: SSEEvent): void {
+    const data = evt.data;
+    if (!data) return;
+    if (data === '[DONE]') {
+      this.completedAt ??= Date.now();
+      return;
+    }
+    if (evt.event === 'delta_encoding') return; // just declares "v1"
+
+    let obj: any;
+    try {
+      obj = JSON.parse(data);
+    } catch {
+      return;
+    }
+    if (obj == null || typeof obj !== 'object') return;
+
+    // Typed control events carry a `type` and are not delta ops.
+    if (typeof obj.type === 'string' && !('v' in obj && (('o' in obj) || ('p' in obj)))) {
+      switch (obj.type) {
+        case 'resume_conversation_token':
+          if (!this.sessionId && typeof obj.conversation_id === 'string')
+            this.sessionId = obj.conversation_id;
+          break;
+        case 'message_stream_complete':
+          this.completedAt ??= Date.now();
+          break;
+        // input_message / message_marker / title_generation / *_metadata → ignore
+      }
+      return;
+    }
+
+    // Delta op: resolve op/path with bare-value inheritance.
+    if ('o' in obj) this.lastOp = obj.o;
+    if ('p' in obj) this.lastPath = obj.p;
+    this.apply(this.lastOp, this.lastPath, obj.v);
+  }
+
+  private apply(op: string, path: string, v: any): void {
+    switch (op) {
+      case 'add':
+        if (path === '' || path === '/') {
+          this.root = v;
+          this.trackAssistant();
+        } else {
+          setAt(this.root, path, v);
+        }
+        break;
+      case 'append':
+        appendAt(this.root, path, v);
+        break;
+      case 'replace':
+        setAt(this.root, path, v);
+        break;
+      case 'patch':
+        if (Array.isArray(v)) for (const s of v) this.apply(s.o, s.p ?? '', s.v);
+        break;
+    }
+  }
+
+  /** After an add at root, record the visible assistant message reference. */
+  private trackAssistant(): void {
+    const m = this.root?.message;
+    if (!m || m.author?.role !== 'assistant') return;
+    if (m.recipient != null && m.recipient !== 'all') return; // tool/aside message
+    if (!m.content || !Array.isArray(m.content.parts)) m.content = { parts: [''] };
+    this.assistantMsg = m; // subsequent ops mutate this in place
+  }
+
+  getTurn(): ChatTurn | null {
+    const m = this.assistantMsg;
+    const responseText = m?.content?.parts?.filter((p: any) => typeof p === 'string').join('') ?? '';
+    if (!responseText && !this.promptText) return null;
+
+    const responseModel = m?.metadata?.model_slug ?? this.requestModel;
+    const messageId: string = m?.id ?? '';
+    const sessionId = this.sessionId || `chatgpt-unknown-${this.reqId}`;
+    const turnKey = messageId || `r${this.reqId}`;
+
+    return {
+      site: 'chatgpt_web',
+      sessionId,
+      turnId: turnId(sessionId, turnKey),
+      requestModel: this.requestModel,
+      responseModel,
+      promptText: this.promptText,
+      inputMessages: this.inputMessages,
+      outputMessages: [{ role: 'assistant', text: responseText }],
+      responseText,
+      toolCalls: extractToolCalls(m, messageId),
+      usage: {}, // ChatGPT web does not stream token usage
+      startedAt: this.startedAt,
+      completedAt: this.completedAt,
+      captureMode: 'sse',
+    };
+  }
+}
+
+/** Best-effort web-search/tool capture from the assistant message metadata. */
+function extractToolCalls(m: any, messageId: string): ToolCall[] {
+  const groups = m?.metadata?.search_result_groups;
+  if (Array.isArray(groups) && groups.length > 0) {
+    return [{ id: `${messageId}:search`, name: 'web_search', arguments: { search_result_groups: groups } }];
+  }
+  return [];
+}
+
+/** Navigate to the parent of `path` and return [container, key]. */
+function locate(root: any, path: string): [any, string | number] | null {
+  const segs = path.split('/').filter(Boolean);
+  if (segs.length === 0) return null;
+  let obj = root;
+  for (let i = 0; i < segs.length - 1; i++) {
+    if (obj == null) return null;
+    const k = segs[i];
+    obj = Array.isArray(obj) ? obj[Number(k)] : obj[k];
+  }
+  if (obj == null) return null;
+  const last = segs[segs.length - 1];
+  return [obj, Array.isArray(obj) ? Number(last) : last];
+}
+
+function appendAt(root: any, path: string, v: any): void {
+  const loc = locate(root, path);
+  if (!loc) return;
+  const [obj, key] = loc;
+  const cur = (obj as any)[key];
+  if (typeof v === 'string') {
+    (obj as any)[key] = (typeof cur === 'string' ? cur : '') + v;
+  } else if (v && typeof v === 'object' && !Array.isArray(v) && cur && typeof cur === 'object') {
+    (obj as any)[key] = { ...cur, ...v }; // merge (e.g. metadata) — preserves model_slug
+  } else {
+    (obj as any)[key] = v;
+  }
+}
+
+function setAt(root: any, path: string, v: any): void {
+  const loc = locate(root, path);
+  if (!loc) return;
+  const [obj, key] = loc;
+  (obj as any)[key] = v;
+}
+
+function extractPrompt(body: any): { text: string; messages: Msg[] } {
+  const messages: Msg[] = [];
+  let text = '';
+  for (const m of Array.isArray(body?.messages) ? body.messages : []) {
+    const role = normalizeRole(m?.author?.role ?? m?.role);
+    const t = coerceParts(m?.content);
+    messages.push({ role, text: t });
+    if (role === 'user') text = t;
+  }
+  return { text, messages };
+}
+
+function coerceParts(content: any): string {
+  if (typeof content === 'string') return content;
+  const parts = content?.parts;
+  if (Array.isArray(parts)) {
+    return parts.map((p: any) => (typeof p === 'string' ? p : typeof p?.text === 'string' ? p.text : '')).join('');
+  }
+  return '';
+}
+
+function normalizeRole(role: unknown): Msg['role'] {
+  return role === 'assistant' || role === 'system' || role === 'tool' ? role : 'user';
+}
+
+export const chatgptAdapter: SiteAdapter = {
+  name: 'chatgpt_web',
+  matchesHost: (host) =>
+    host === 'chatgpt.com' ||
+    host.endsWith('.chatgpt.com') ||
+    host === 'chat.openai.com' ||
+    host.endsWith('.chat.openai.com'),
+  // The message-send endpoint is a POST to /backend-(api|anon)/(f/)?conversation
+  // exactly — NOT sub-resources like /conversation/init or /conversation/{id}.
+  matchesRequest: (url, method) =>
+    /\/backend-(api|anon)\/(f\/)?conversation(?:\?|$)/.test(url) && method.toUpperCase() === 'POST',
+  createParser: (reqId) => new ChatGptParser(reqId),
+};
+
+registerAdapter(chatgptAdapter);

--- a/browser-extension/src/adapters/claude.ts
+++ b/browser-extension/src/adapters/claude.ts
@@ -31,6 +31,9 @@ class ClaudeParser implements TurnParser {
   private startedAt = Date.now();
   private completedAt?: number;
   private reqId: number;
+  /** Stable per-turn id from message_start; used for turnId so ids don't collide
+   *  across service-worker restarts (which reset the reqId counter). */
+  private messageId = '';
   // tool_use blocks keyed by content-block index.
   private blocks = new Map<number, { type: string; tool?: ToolCall; argBuf: string }>();
 
@@ -83,6 +86,8 @@ class ClaudeParser implements TurnParser {
       case 'message_start': {
         const m = obj.message ?? {};
         if (typeof m.model === 'string') this.model = m.model;
+        if (typeof m.uuid === 'string') this.messageId = m.uuid;
+        else if (typeof m.id === 'string') this.messageId = m.id;
         if (typeof m.id === 'string' && !this.sessionId) this.sessionId = m.id;
         if (typeof m.usage?.input_tokens === 'number') this.inputTokens = m.usage.input_tokens;
         break;
@@ -135,11 +140,14 @@ class ClaudeParser implements TurnParser {
         toolCalls.push({ ...entry.tool, arguments: args });
       }
     }
-    const sessionId = this.sessionId || `claude-${this.reqId}`;
+    const sessionId = this.sessionId || `claude-${this.messageId || this.reqId}`;
+    // Prefer the stable assistant message id; fall back to the interceptor's
+    // per-page reqId only when message_start was never seen (degenerate case).
+    const turnKey = this.messageId || `r${this.reqId}`;
     return {
       site: 'claude_web',
       sessionId,
-      turnId: turnId(sessionId, this.reqId),
+      turnId: turnId(sessionId, turnKey),
       requestModel: this.model,
       responseModel: this.model,
       promptText: this.promptText,
@@ -197,12 +205,7 @@ export const claudeAdapter: SiteAdapter = {
   matchesRequest: (url, method) =>
     /chat_conversations\/.+\/(completion|retry_completion)/.test(url) &&
     method.toUpperCase() === 'POST',
-  createParser: () => new ClaudeParser(nextReqId()),
+  createParser: (reqId) => new ClaudeParser(reqId),
 };
-
-let reqCounter = 0;
-function nextReqId(): number {
-  return ++reqCounter;
-}
 
 registerAdapter(claudeAdapter);

--- a/browser-extension/src/adapters/claude.ts
+++ b/browser-extension/src/adapters/claude.ts
@@ -86,9 +86,11 @@ class ClaudeParser implements TurnParser {
       case 'message_start': {
         const m = obj.message ?? {};
         if (typeof m.model === 'string') this.model = m.model;
+        // The completion/message id is a per-turn id — capture it for turnId,
+        // but never use it as the conversation/session id (that comes only from
+        // the URL/request body; using message.id would mis-correlate turns).
         if (typeof m.uuid === 'string') this.messageId = m.uuid;
         else if (typeof m.id === 'string') this.messageId = m.id;
-        if (typeof m.id === 'string' && !this.sessionId) this.sessionId = m.id;
         if (typeof m.usage?.input_tokens === 'number') this.inputTokens = m.usage.input_tokens;
         break;
       }
@@ -140,9 +142,11 @@ class ClaudeParser implements TurnParser {
         toolCalls.push({ ...entry.tool, arguments: args });
       }
     }
-    const sessionId = this.sessionId || `claude-${this.messageId || this.reqId}`;
-    // Prefer the stable assistant message id; fall back to the interceptor's
-    // per-page reqId only when message_start was never seen (degenerate case).
+    // Session id comes only from the conversation id (URL/body). If truly
+    // absent, use a clearly-synthetic per-stream id — never the message id.
+    const sessionId = this.sessionId || `claude-unknown-${this.reqId}`;
+    // Turn key prefers the stable assistant message id; falls back to the
+    // interceptor's per-page reqId only when message_start was never seen.
     const turnKey = this.messageId || `r${this.reqId}`;
     return {
       site: 'claude_web',

--- a/browser-extension/src/adapters/claude.ts
+++ b/browser-extension/src/adapters/claude.ts
@@ -1,0 +1,208 @@
+// Claude (claude.ai) adapter. Parses the streamed response into a ChatTurn.
+//
+// claude.ai streams Server-Sent Events whose `data:` payloads are Anthropic
+// streaming objects keyed by `type`:
+//   message_start { message: { model, usage:{input_tokens} } }
+//   content_block_start { index, content_block:{ type:'text'|'tool_use', id?, name? } }
+//   content_block_delta { index, delta:{ type:'text_delta', text } | { type:'input_json_delta', partial_json } }
+//   content_block_stop { index }
+//   message_delta { delta:{ stop_reason }, usage:{ output_tokens } }
+//   message_stop
+// A legacy shape ({ completion: "…delta" }) is also tolerated.
+//
+// The exact claude.ai envelope must be confirmed against recorded live traffic
+// (the live-smoke drift alarm exists for exactly this); the parser is written
+// defensively so minor wrapping differences degrade gracefully.
+
+import type { ChatTurn, Msg, ToolCall } from '../shared/types.js';
+import { registerAdapter, type SiteAdapter, type TurnParser } from './adapter.js';
+import { SSEParser } from './sse.js';
+import { turnId } from '../shared/ids.js';
+
+class ClaudeParser implements TurnParser {
+  private sse = new SSEParser();
+  private sessionId = '';
+  private model?: string;
+  private promptText = '';
+  private inputMessages: Msg[] = [];
+  private responseText = '';
+  private inputTokens?: number;
+  private outputTokens?: number;
+  private startedAt = Date.now();
+  private completedAt?: number;
+  private reqId: number;
+  // tool_use blocks keyed by content-block index.
+  private blocks = new Map<number, { type: string; tool?: ToolCall; argBuf: string }>();
+
+  constructor(reqId: number) {
+    this.reqId = reqId;
+  }
+
+  onRequest(url: string, _method: string, body: string | null): void {
+    this.sessionId = conversationIdFromUrl(url) ?? this.sessionId;
+    if (!body) return;
+    try {
+      const parsed = JSON.parse(body);
+      const { text, messages } = extractPrompt(parsed);
+      this.promptText = text;
+      this.inputMessages = messages;
+      if (typeof parsed?.model === 'string') this.model = parsed.model;
+      if (typeof parsed?.conversation_id === 'string' && !this.sessionId)
+        this.sessionId = parsed.conversation_id;
+    } catch {
+      // Non-JSON body — leave prompt empty; DOM fallback may fill it later.
+    }
+  }
+
+  onChunk(chunk: string): void {
+    for (const evt of this.sse.push(chunk)) this.handle(evt.data);
+  }
+
+  onDone(): void {
+    for (const evt of this.sse.flush()) this.handle(evt.data);
+    if (this.completedAt == null) this.completedAt = undefined; // stayed partial
+  }
+
+  private handle(data: string): void {
+    if (!data || data === '[DONE]') return;
+    let obj: any;
+    try {
+      obj = JSON.parse(data);
+    } catch {
+      return;
+    }
+
+    // Legacy delta shape.
+    if (typeof obj.completion === 'string' && obj.type == null) {
+      this.responseText += obj.completion;
+      if (obj.stop_reason) this.completedAt = Date.now();
+      return;
+    }
+
+    switch (obj.type) {
+      case 'message_start': {
+        const m = obj.message ?? {};
+        if (typeof m.model === 'string') this.model = m.model;
+        if (typeof m.id === 'string' && !this.sessionId) this.sessionId = m.id;
+        if (typeof m.usage?.input_tokens === 'number') this.inputTokens = m.usage.input_tokens;
+        break;
+      }
+      case 'content_block_start': {
+        const cb = obj.content_block ?? {};
+        const entry = { type: cb.type ?? 'text', argBuf: '' } as {
+          type: string;
+          tool?: ToolCall;
+          argBuf: string;
+        };
+        if (cb.type === 'tool_use') {
+          entry.tool = { id: String(cb.id ?? ''), name: String(cb.name ?? '') };
+        }
+        this.blocks.set(obj.index ?? this.blocks.size, entry);
+        break;
+      }
+      case 'content_block_delta': {
+        const d = obj.delta ?? {};
+        if (d.type === 'text_delta' && typeof d.text === 'string') {
+          this.responseText += d.text;
+        } else if (d.type === 'input_json_delta' && typeof d.partial_json === 'string') {
+          const entry = this.blocks.get(obj.index);
+          if (entry) entry.argBuf += d.partial_json;
+        }
+        break;
+      }
+      case 'message_delta': {
+        if (typeof obj.usage?.output_tokens === 'number') this.outputTokens = obj.usage.output_tokens;
+        break;
+      }
+      case 'message_stop': {
+        this.completedAt = Date.now();
+        break;
+      }
+    }
+  }
+
+  getTurn(): ChatTurn | null {
+    if (!this.responseText && this.blocks.size === 0 && !this.promptText) return null;
+    const toolCalls: ToolCall[] = [];
+    for (const entry of this.blocks.values()) {
+      if (entry.tool) {
+        let args: unknown = entry.argBuf;
+        try {
+          args = entry.argBuf ? JSON.parse(entry.argBuf) : undefined;
+        } catch {
+          /* keep raw string */
+        }
+        toolCalls.push({ ...entry.tool, arguments: args });
+      }
+    }
+    const sessionId = this.sessionId || `claude-${this.reqId}`;
+    return {
+      site: 'claude_web',
+      sessionId,
+      turnId: turnId(sessionId, this.reqId),
+      requestModel: this.model,
+      responseModel: this.model,
+      promptText: this.promptText,
+      inputMessages: this.inputMessages,
+      outputMessages: [{ role: 'assistant', text: this.responseText }],
+      responseText: this.responseText,
+      toolCalls,
+      usage: { inputTokens: this.inputTokens, outputTokens: this.outputTokens },
+      startedAt: this.startedAt,
+      completedAt: this.completedAt,
+      captureMode: 'sse',
+    };
+  }
+}
+
+function conversationIdFromUrl(url: string): string | undefined {
+  const m = url.match(/chat_conversations\/([0-9a-f-]{16,})/i);
+  return m?.[1];
+}
+
+/** Pull prompt text + input messages from a variety of request-body shapes. */
+function extractPrompt(body: any): { text: string; messages: Msg[] } {
+  const messages: Msg[] = [];
+  let text = '';
+  if (typeof body?.prompt === 'string') {
+    text = body.prompt;
+    messages.push({ role: 'user', text });
+  } else if (Array.isArray(body?.messages)) {
+    for (const m of body.messages) {
+      const t = coerceContent(m?.content);
+      messages.push({ role: normalizeRole(m?.role), text: t });
+      if (m?.role === 'user') text = t;
+    }
+  }
+  return { text, messages };
+}
+
+function coerceContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((p: any) => (typeof p === 'string' ? p : typeof p?.text === 'string' ? p.text : ''))
+      .join('');
+  }
+  return '';
+}
+
+function normalizeRole(role: unknown): Msg['role'] {
+  return role === 'assistant' || role === 'system' || role === 'tool' ? role : 'user';
+}
+
+export const claudeAdapter: SiteAdapter = {
+  name: 'claude_web',
+  matchesHost: (host) => host === 'claude.ai' || host.endsWith('.claude.ai'),
+  matchesRequest: (url, method) =>
+    /chat_conversations\/.+\/(completion|retry_completion)/.test(url) &&
+    method.toUpperCase() === 'POST',
+  createParser: () => new ClaudeParser(nextReqId()),
+};
+
+let reqCounter = 0;
+function nextReqId(): number {
+  return ++reqCounter;
+}
+
+registerAdapter(claudeAdapter);

--- a/browser-extension/src/adapters/sse.ts
+++ b/browser-extension/src/adapters/sse.ts
@@ -1,0 +1,56 @@
+// Minimal, robust SSE frame parser. Handles chunks that split mid-line or
+// mid-event (the common source of streaming bugs), multi-line `data:` fields,
+// and CRLF. Site adapters feed raw chunks in; they get whole events out.
+
+export interface SSEEvent {
+  event: string; // the `event:` field, or 'message' if absent
+  data: string; // concatenated `data:` lines (newline-joined)
+}
+
+export class SSEParser {
+  private buffer = '';
+
+  /** Push a raw chunk; returns any complete events it produced. */
+  push(chunk: string): SSEEvent[] {
+    this.buffer += chunk;
+    const out: SSEEvent[] = [];
+    // Events are separated by a blank line. Normalize CRLF first.
+    const normalized = this.buffer.replace(/\r\n/g, '\n');
+    const frames = normalized.split('\n\n');
+    // The last element may be a partial frame — keep it buffered.
+    this.buffer = frames.pop() ?? '';
+    for (const frame of frames) {
+      const evt = parseFrame(frame);
+      if (evt) out.push(evt);
+    }
+    return out;
+  }
+
+  /** Flush any trailing buffered frame (call on stream end). */
+  flush(): SSEEvent[] {
+    if (!this.buffer.trim()) {
+      this.buffer = '';
+      return [];
+    }
+    const evt = parseFrame(this.buffer.replace(/\r\n/g, '\n'));
+    this.buffer = '';
+    return evt ? [evt] : [];
+  }
+}
+
+function parseFrame(frame: string): SSEEvent | null {
+  let event = 'message';
+  const dataLines: string[] = [];
+  for (const line of frame.split('\n')) {
+    if (line === '' || line.startsWith(':')) continue; // blank or comment
+    const idx = line.indexOf(':');
+    const field = idx === -1 ? line : line.slice(0, idx);
+    // Spec: strip one leading space after the colon.
+    let value = idx === -1 ? '' : line.slice(idx + 1);
+    if (value.startsWith(' ')) value = value.slice(1);
+    if (field === 'event') event = value;
+    else if (field === 'data') dataLines.push(value);
+  }
+  if (dataLines.length === 0 && event === 'message') return null;
+  return { event, data: dataLines.join('\n') };
+}

--- a/browser-extension/src/background/assembler.ts
+++ b/browser-extension/src/background/assembler.ts
@@ -26,7 +26,7 @@ export class Assembler {
     if (event.kind === 'request') {
       const adapter = adapterForHost(host);
       if (!adapter || !adapter.matchesRequest(event.url, event.method)) return null;
-      const parser = adapter.createParser();
+      const parser = adapter.createParser(event.reqId);
       parser.onRequest(event.url, event.method, event.body);
       this.entries.set(k, { adapter, parser });
       return null;

--- a/browser-extension/src/background/assembler.ts
+++ b/browser-extension/src/background/assembler.ts
@@ -1,0 +1,57 @@
+// Accumulates raw intercept events into completed ChatTurns, one parser per
+// (tabId, reqId). No chrome.* — unit-testable. State is intentionally in-memory:
+// a stream lasts seconds and the SW is kept awake while one is active; the
+// DURABLE state (the delivery queue) lives in storage, not here.
+
+import type { ChatTurn } from '../shared/types.js';
+import type { InterceptEvent } from '../shared/types.js';
+import { adapterForHost, type SiteAdapter, type TurnParser } from '../adapters/adapter.js';
+
+interface Entry {
+  adapter: SiteAdapter;
+  parser: TurnParser;
+}
+
+export class Assembler {
+  private entries = new Map<string, Entry>();
+
+  private key(tabId: number | undefined, reqId: number): string {
+    return `${tabId ?? -1}:${reqId}`;
+  }
+
+  /** Feed one intercept event. Returns a finalized ChatTurn on 'done'/'error'. */
+  handle(host: string, tabId: number | undefined, event: InterceptEvent): ChatTurn | null {
+    const k = this.key(tabId, event.reqId);
+
+    if (event.kind === 'request') {
+      const adapter = adapterForHost(host);
+      if (!adapter || !adapter.matchesRequest(event.url, event.method)) return null;
+      const parser = adapter.createParser();
+      parser.onRequest(event.url, event.method, event.body);
+      this.entries.set(k, { adapter, parser });
+      return null;
+    }
+
+    const entry = this.entries.get(k);
+    if (!entry) return null;
+
+    switch (event.kind) {
+      case 'chunk':
+        entry.parser.onChunk(event.chunk);
+        return null;
+      case 'done':
+      case 'error': {
+        entry.parser.onDone();
+        const turn = entry.parser.getTurn();
+        this.entries.delete(k);
+        return turn;
+      }
+    }
+    return null;
+  }
+
+  /** Number of in-flight streams (used to decide SW keepalive). */
+  get active(): number {
+    return this.entries.size;
+  }
+}

--- a/browser-extension/src/background/delivery.ts
+++ b/browser-extension/src/background/delivery.ts
@@ -1,0 +1,98 @@
+// Durable delivery queue. Normalized OTLP envelopes are persisted to
+// chrome.storage.local so nothing is lost if the SW is suspended, then POSTed
+// to the local beacon collector. Failed sends retry with exponential backoff
+// driven by chrome.alarms (which survives suspension, unlike setTimeout).
+
+import type { ChatTurn, Settings } from '../shared/types.js';
+import { turnToEnvelope } from '../shared/normalize.js';
+import type { LogsEnvelope } from '../shared/otlp.js';
+
+const QUEUE_KEY = 'delivery_queue';
+const ALARM = 'beacon_flush';
+const MAX_ATTEMPTS = 6;
+
+interface QueueItem {
+  id: string;
+  endpoint: string;
+  envelope: LogsEnvelope;
+  attempts: number;
+}
+
+async function readQueue(): Promise<QueueItem[]> {
+  const got = await chrome.storage.local.get(QUEUE_KEY);
+  return (got[QUEUE_KEY] as QueueItem[]) ?? [];
+}
+
+async function writeQueue(items: QueueItem[]): Promise<void> {
+  await chrome.storage.local.set({ [QUEUE_KEY]: items });
+}
+
+/** Normalize a turn and enqueue it for delivery, then kick a flush. */
+export async function enqueueTurn(turn: ChatTurn, settings: Settings): Promise<void> {
+  const envelope = turnToEnvelope(turn, settings.retention);
+  const item: QueueItem = {
+    id: turn.turnId,
+    endpoint: settings.endpoint,
+    envelope,
+    attempts: 0,
+  };
+  const queue = await readQueue();
+  queue.push(item);
+  await writeQueue(queue);
+  await flush();
+}
+
+/** Attempt to POST everything queued; requeue failures with backoff. */
+export async function flush(): Promise<void> {
+  const queue = await readQueue();
+  if (queue.length === 0) return;
+
+  const remaining: QueueItem[] = [];
+  let anyFailed = false;
+
+  for (const item of queue) {
+    const ok = await post(item);
+    if (!ok) {
+      item.attempts += 1;
+      if (item.attempts < MAX_ATTEMPTS) {
+        remaining.push(item);
+        anyFailed = true;
+      } // else: give up, drop it (avoid an unbounded queue)
+    }
+  }
+
+  await writeQueue(remaining);
+  if (anyFailed) scheduleRetry(remaining);
+}
+
+async function post(item: QueueItem): Promise<boolean> {
+  try {
+    const res = await fetch(item.endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(item.envelope),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function scheduleRetry(queue: QueueItem[]): void {
+  const minAttempts = Math.min(...queue.map((i) => i.attempts));
+  // We compute an exponential backoff, but note MV3 clamps chrome.alarms to a
+  // ~30s minimum — so in practice the first retry lands at ~30s regardless of
+  // this value. That's acceptable here: the collector is a local loopback
+  // endpoint that is almost always reachable, so retries are the rare path and
+  // the durable queue (chrome.storage) guarantees eventual delivery. We use
+  // alarms rather than setTimeout because they survive service-worker suspension.
+  const backoffMs = Math.min(250 * 2 ** minAttempts, 60_000);
+  chrome.alarms.create(ALARM, { when: Date.now() + backoffMs });
+}
+
+/** Wire the alarm listener (called once from the SW entry). */
+export function installFlushAlarm(): void {
+  chrome.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === ALARM) void flush();
+  });
+}

--- a/browser-extension/src/background/delivery.ts
+++ b/browser-extension/src/background/delivery.ts
@@ -27,6 +27,20 @@ async function writeQueue(items: QueueItem[]): Promise<void> {
   await chrome.storage.local.set({ [QUEUE_KEY]: items });
 }
 
+// Serialize every read-modify-write on the queue. The service worker is a single
+// JS context, but async interleaving of enqueue/flush would otherwise let two
+// read→write cycles clobber each other's writes (dropping queued telemetry).
+// Only this SW writes QUEUE_KEY, so an in-memory promise-chain mutex suffices.
+let queueLock: Promise<unknown> = Promise.resolve();
+function withQueueLock<T>(fn: () => Promise<T>): Promise<T> {
+  const result = queueLock.then(fn, fn);
+  queueLock = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
 /** Normalize a turn and enqueue it for delivery, then kick a flush. */
 export async function enqueueTurn(turn: ChatTurn, settings: Settings): Promise<void> {
   const envelope = turnToEnvelope(turn, settings.retention);
@@ -36,33 +50,37 @@ export async function enqueueTurn(turn: ChatTurn, settings: Settings): Promise<v
     envelope,
     attempts: 0,
   };
-  const queue = await readQueue();
-  queue.push(item);
-  await writeQueue(queue);
+  await withQueueLock(async () => {
+    const queue = await readQueue();
+    queue.push(item);
+    await writeQueue(queue);
+  });
   await flush();
 }
 
 /** Attempt to POST everything queued; requeue failures with backoff. */
 export async function flush(): Promise<void> {
-  const queue = await readQueue();
-  if (queue.length === 0) return;
+  await withQueueLock(async () => {
+    const queue = await readQueue();
+    if (queue.length === 0) return;
 
-  const remaining: QueueItem[] = [];
-  let anyFailed = false;
+    const remaining: QueueItem[] = [];
+    let anyFailed = false;
 
-  for (const item of queue) {
-    const ok = await post(item);
-    if (!ok) {
-      item.attempts += 1;
-      if (item.attempts < MAX_ATTEMPTS) {
-        remaining.push(item);
-        anyFailed = true;
-      } // else: give up, drop it (avoid an unbounded queue)
+    for (const item of queue) {
+      const ok = await post(item);
+      if (!ok) {
+        item.attempts += 1;
+        if (item.attempts < MAX_ATTEMPTS) {
+          remaining.push(item);
+          anyFailed = true;
+        } // else: give up, drop it (avoid an unbounded queue)
+      }
     }
-  }
 
-  await writeQueue(remaining);
-  if (anyFailed) scheduleRetry(remaining);
+    await writeQueue(remaining);
+    if (anyFailed) scheduleRetry(remaining);
+  });
 }
 
 async function post(item: QueueItem): Promise<boolean> {

--- a/browser-extension/src/background/settings.ts
+++ b/browser-extension/src/background/settings.ts
@@ -1,0 +1,31 @@
+// Storage-backed settings with defaults. Lives in chrome.storage.local so it
+// survives service-worker suspension.
+
+import { DEFAULT_SETTINGS, type Settings, type SiteName } from '../shared/types.js';
+
+const KEY = 'settings';
+
+export async function getSettings(): Promise<Settings> {
+  const got = await chrome.storage.local.get(KEY);
+  const stored = (got[KEY] ?? {}) as Partial<Settings>;
+  return {
+    ...DEFAULT_SETTINGS,
+    ...stored,
+    sites: { ...DEFAULT_SETTINGS.sites, ...(stored.sites ?? {}) },
+  };
+}
+
+export async function saveSettings(patch: Partial<Settings>): Promise<Settings> {
+  const current = await getSettings();
+  const next: Settings = {
+    ...current,
+    ...patch,
+    sites: { ...current.sites, ...(patch.sites ?? {}) },
+  };
+  await chrome.storage.local.set({ [KEY]: next });
+  return next;
+}
+
+export function siteEnabled(settings: Settings, site: SiteName): boolean {
+  return settings.enabled && settings.sites[site] !== false;
+}

--- a/browser-extension/src/background/sw.ts
+++ b/browser-extension/src/background/sw.ts
@@ -2,6 +2,7 @@
 // completed turns to the durable delivery queue.
 
 import '../adapters/claude.js'; // registers the Claude adapter (side effect)
+import '../adapters/chatgpt.js'; // registers the ChatGPT adapter (side effect)
 import type { ChatTurn, RelayMessage, Settings } from '../shared/types.js';
 import { getSettings, saveSettings, siteEnabled } from './settings.js';
 import { Assembler } from './assembler.js';

--- a/browser-extension/src/background/sw.ts
+++ b/browser-extension/src/background/sw.ts
@@ -1,0 +1,78 @@
+// Service-worker entry. Wires message handling, assembles turns, and hands
+// completed turns to the durable delivery queue.
+
+import '../adapters/claude.js'; // registers the Claude adapter (side effect)
+import type { RelayMessage, Settings } from '../shared/types.js';
+import { getSettings, saveSettings, siteEnabled } from './settings.js';
+import { Assembler } from './assembler.js';
+import { enqueueTurn, flush, installFlushAlarm } from './delivery.js';
+
+const assembler = new Assembler();
+
+// Keep the SW awake while any stream is active, so mid-stream suspension is
+// rare. Correctness never depends on this — durable state covers the rest.
+let keepAliveTimer: ReturnType<typeof setInterval> | undefined;
+function updateKeepAlive(): void {
+  if (assembler.active > 0 && keepAliveTimer == null) {
+    keepAliveTimer = setInterval(() => chrome.runtime.getPlatformInfo(() => {}), 20_000);
+  } else if (assembler.active === 0 && keepAliveTimer != null) {
+    clearInterval(keepAliveTimer);
+    keepAliveTimer = undefined;
+  }
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  void saveSettings({}); // materialize defaults
+});
+
+installFlushAlarm();
+
+chrome.runtime.onMessage.addListener((msg: RelayMessage | ControlMessage, sender, sendResponse) => {
+  if (isControl(msg)) {
+    handleControl(msg).then(sendResponse);
+    return true; // async response
+  }
+  if (msg?.type === 'BEACON_RAW') {
+    handleRaw(msg, sender.tab?.id);
+    return false;
+  }
+  return false;
+});
+
+async function handleRaw(msg: RelayMessage, tabId: number | undefined): Promise<void> {
+  const settings = await getSettings();
+  if (!settings.enabled) return;
+
+  const turn = assembler.handle(msg.host, tabId, msg.event);
+  updateKeepAlive();
+  if (!turn) return;
+  if (!siteEnabled(settings, turn.site)) return;
+
+  await enqueueTurn(turn, settings);
+}
+
+// ---- Control messages from popup/options ----
+
+type ControlMessage =
+  | { type: 'GET_STATUS' }
+  | { type: 'SET_SETTINGS'; patch: Partial<Settings> }
+  | { type: 'FLUSH_NOW' };
+
+function isControl(msg: any): msg is ControlMessage {
+  return msg?.type === 'GET_STATUS' || msg?.type === 'SET_SETTINGS' || msg?.type === 'FLUSH_NOW';
+}
+
+async function handleControl(msg: ControlMessage): Promise<unknown> {
+  switch (msg.type) {
+    case 'GET_STATUS': {
+      const settings = await getSettings();
+      const q = await chrome.storage.local.get('delivery_queue');
+      return { settings, queueDepth: (q.delivery_queue ?? []).length, active: assembler.active };
+    }
+    case 'SET_SETTINGS':
+      return { settings: await saveSettings(msg.patch) };
+    case 'FLUSH_NOW':
+      await flush();
+      return { ok: true };
+  }
+}

--- a/browser-extension/src/background/sw.ts
+++ b/browser-extension/src/background/sw.ts
@@ -2,7 +2,7 @@
 // completed turns to the durable delivery queue.
 
 import '../adapters/claude.js'; // registers the Claude adapter (side effect)
-import type { RelayMessage, Settings } from '../shared/types.js';
+import type { ChatTurn, RelayMessage, Settings } from '../shared/types.js';
 import { getSettings, saveSettings, siteEnabled } from './settings.js';
 import { Assembler } from './assembler.js';
 import { enqueueTurn, flush, installFlushAlarm } from './delivery.js';
@@ -33,21 +33,23 @@ chrome.runtime.onMessage.addListener((msg: RelayMessage | ControlMessage, sender
     return true; // async response
   }
   if (msg?.type === 'BEACON_RAW') {
-    handleRaw(msg, sender.tab?.id);
+    // Feed the assembler SYNCHRONOUSLY, in message-arrival order. Stream events
+    // arrive ordered (request → chunk → … → done); an `await` before this call
+    // could let a chunk be processed before its `request` registered a parser,
+    // dropping early SSE (e.g. message_start). Async work (settings, delivery)
+    // happens only after a turn is finalized.
+    const turn = assembler.handle(msg.host, sender.tab?.id, msg.event);
+    updateKeepAlive();
+    if (turn) void finalizeTurn(turn);
     return false;
   }
   return false;
 });
 
-async function handleRaw(msg: RelayMessage, tabId: number | undefined): Promise<void> {
+async function finalizeTurn(turn: ChatTurn): Promise<void> {
   const settings = await getSettings();
-  if (!settings.enabled) return;
-
-  const turn = assembler.handle(msg.host, tabId, msg.event);
-  updateKeepAlive();
-  if (!turn) return;
+  // siteEnabled covers both the global toggle and the per-site toggle.
   if (!siteEnabled(settings, turn.site)) return;
-
   await enqueueTurn(turn, settings);
 }
 

--- a/browser-extension/src/content/content.ts
+++ b/browser-extension/src/content/content.ts
@@ -31,7 +31,6 @@ window.addEventListener('message', (event: MessageEvent) => {
   if (!extensionAlive()) {
     if (!warnedInvalidated) {
       warnedInvalidated = true;
-      // eslint-disable-next-line no-console
       console.debug('[agent-beacon] extension context invalidated; refresh this tab to resume capture.');
     }
     return;

--- a/browser-extension/src/content/content.ts
+++ b/browser-extension/src/content/content.ts
@@ -1,0 +1,54 @@
+// ISOLATED-world content script. The bridge between the page (MAIN interceptor)
+// and the extension service worker. Deliberately thin: validate the message
+// origin, then forward raw intercept events to the SW. All parsing/normalizing
+// happens in the SW so this script stays resistant to page interference.
+
+import { BEACON_MSG, type BeaconWindowMessage, type RelayMessage } from '../shared/types.js';
+
+/**
+ * True only when the extension context this content script belongs to is still
+ * alive. After the extension is reloaded/updated, previously-injected content
+ * scripts in already-open tabs are orphaned: `chrome.runtime` is torn down and
+ * touching `.sendMessage` throws. Guarding here degrades gracefully (a tab
+ * refresh re-injects a fresh, connected content script).
+ */
+function extensionAlive(): boolean {
+  try {
+    return typeof chrome !== 'undefined' && !!chrome.runtime && !!chrome.runtime.id;
+  } catch {
+    return false;
+  }
+}
+
+let warnedInvalidated = false;
+
+window.addEventListener('message', (event: MessageEvent) => {
+  // Only trust messages from this same window/frame.
+  if (event.source !== window) return;
+  const data = event.data as BeaconWindowMessage | undefined;
+  if (!data || data.source !== BEACON_MSG) return;
+
+  if (!extensionAlive()) {
+    if (!warnedInvalidated) {
+      warnedInvalidated = true;
+      // eslint-disable-next-line no-console
+      console.debug('[agent-beacon] extension context invalidated; refresh this tab to resume capture.');
+    }
+    return;
+  }
+
+  const relay: RelayMessage = {
+    type: 'BEACON_RAW',
+    host: window.location.host,
+    event: data.event,
+  };
+  // Fire-and-forget; the SW may be asleep and will wake to handle it. Wrap in
+  // try/catch in case the context is invalidated between the check and the call.
+  try {
+    void chrome.runtime.sendMessage(relay).catch(() => {
+      /* SW not ready / extension reloading — safe to drop a single event */
+    });
+  } catch {
+    /* context invalidated mid-flight */
+  }
+});

--- a/browser-extension/src/interceptor/interceptor.ts
+++ b/browser-extension/src/interceptor/interceptor.ts
@@ -37,13 +37,27 @@ declare global {
     const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
 
     const matched = looksLikeChatRequest(url);
+
+    // Capture the request body BEFORE fetch consumes it. Prefer a string
+    // init.body; otherwise read a clone of the Request (fetch(new Request(...))),
+    // whose body would otherwise never be seen and the prompt would be lost.
+    let body: string | null = null;
+    if (matched) {
+      if (typeof init?.body === 'string') {
+        body = init.body;
+      } else if (input instanceof Request) {
+        try {
+          body = await input.clone().text();
+        } catch {
+          body = null;
+        }
+      }
+    }
+
     const response = await originalFetch(input as RequestInfo, init);
 
     if (matched && response.body) {
       const reqId = ++reqSeq;
-      // Capture request body if it is a simple string (claude.ai/ChatGPT both
-      // send JSON string bodies for completions).
-      const body = typeof init?.body === 'string' ? init.body : null;
       post({ kind: 'request', reqId, url, method, body });
 
       // Tee the stream via a clone so the page's own reader is untouched.

--- a/browser-extension/src/interceptor/interceptor.ts
+++ b/browser-extension/src/interceptor/interceptor.ts
@@ -1,0 +1,80 @@
+// MAIN-world interceptor. Runs in the page's own JS context (injected as a file
+// via a world:"MAIN" content script, which satisfies ChatGPT's CSP since it is
+// not inline). It monkeypatches window.fetch, clones matched streaming
+// responses so the page is completely unaffected, and posts raw SSE chunks to
+// the ISOLATED content script over window.postMessage.
+//
+// This layer is deliberately site-agnostic: it does NOT understand SSE
+// semantics. It only decides "is this a chat request worth teeing?" and relays
+// bytes. All parsing happens in the service worker via the site adapter.
+
+import { BEACON_MSG, type InterceptEvent } from '../shared/types.js';
+import { looksLikeChatRequest } from '../adapters/adapter.js';
+
+declare global {
+  interface Window {
+    __beaconInterceptorInstalled?: boolean;
+  }
+}
+
+(function install() {
+  if (window.__beaconInterceptorInstalled) return;
+  window.__beaconInterceptorInstalled = true;
+
+  let reqSeq = 0;
+  const originalFetch = window.fetch.bind(window);
+
+  function post(event: InterceptEvent): void {
+    window.postMessage({ source: BEACON_MSG, event }, window.location.origin);
+  }
+
+  window.fetch = async function beaconFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
+
+    const matched = looksLikeChatRequest(url);
+    const response = await originalFetch(input as RequestInfo, init);
+
+    if (matched && response.body) {
+      const reqId = ++reqSeq;
+      // Capture request body if it is a simple string (claude.ai/ChatGPT both
+      // send JSON string bodies for completions).
+      const body = typeof init?.body === 'string' ? init.body : null;
+      post({ kind: 'request', reqId, url, method, body });
+
+      // Tee the stream via a clone so the page's own reader is untouched.
+      const clone = response.clone();
+      teeStream(clone, reqId, post).catch((err) =>
+        post({ kind: 'error', reqId, message: String(err) }),
+      );
+    }
+
+    return response;
+  } as typeof window.fetch;
+})();
+
+async function teeStream(
+  response: Response,
+  reqId: number,
+  post: (e: InterceptEvent) => void,
+): Promise<void> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = decoder.decode(value, { stream: true });
+      if (chunk) post({ kind: 'chunk', reqId, chunk });
+    }
+    const tail = decoder.decode();
+    if (tail) post({ kind: 'chunk', reqId, chunk: tail });
+    post({ kind: 'done', reqId });
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -8,8 +8,8 @@
     "*://claude.ai/*",
     "*://chatgpt.com/*",
     "*://chat.openai.com/*",
-    "http://127.0.0.1:4318/*",
-    "http://localhost:4318/*"
+    "http://127.0.0.1/*",
+    "http://localhost/*"
   ],
   "background": {
     "service_worker": "sw.js"

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,0 +1,42 @@
+{
+  "manifest_version": 3,
+  "name": "Agent Beacon — Browser Collector",
+  "version": "0.1.0",
+  "description": "Relays LLM chat telemetry (Claude, ChatGPT) into the local Agent Beacon pipeline.",
+  "permissions": ["storage", "alarms", "scripting"],
+  "host_permissions": [
+    "*://claude.ai/*",
+    "*://chatgpt.com/*",
+    "*://chat.openai.com/*",
+    "http://127.0.0.1:4318/*",
+    "http://localhost:4318/*"
+  ],
+  "background": {
+    "service_worker": "sw.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Agent Beacon Collector"
+  },
+  "options_page": "options.html",
+  "content_scripts": [
+    {
+      "matches": ["*://claude.ai/*", "*://chatgpt.com/*", "*://chat.openai.com/*"],
+      "js": ["interceptor.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["*://claude.ai/*", "*://chatgpt.com/*", "*://chat.openai.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_start",
+      "world": "ISOLATED"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["interceptor.js"],
+      "matches": ["*://claude.ai/*", "*://chatgpt.com/*", "*://chat.openai.com/*"]
+    }
+  ]
+}

--- a/browser-extension/src/options/options.html
+++ b/browser-extension/src/options/options.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { max-width: 520px; margin: 24px auto; padding: 0 16px; font: 14px system-ui, sans-serif; color: #111; }
+      h1 { font-size: 18px; }
+      label { display: block; margin: 14px 0 4px; font-weight: 600; }
+      input[type="text"] { width: 100%; padding: 6px 8px; font: inherit; box-sizing: border-box; }
+      .site { display: flex; align-items: center; gap: 8px; font-weight: 400; margin: 6px 0; }
+      button { margin-top: 16px; padding: 8px 14px; font: inherit; }
+      .saved { color: #2a7; margin-left: 10px; }
+    </style>
+  </head>
+  <body>
+    <h1>Agent Beacon — Browser Collector</h1>
+
+    <label for="endpoint">OTLP logs endpoint</label>
+    <input type="text" id="endpoint" data-testid="endpoint" />
+
+    <label>Sites</label>
+    <div class="site"><input type="checkbox" id="site_claude_web" /><span>claude.ai</span></div>
+    <div class="site"><input type="checkbox" id="site_chatgpt_web" /><span>chatgpt.com</span></div>
+
+    <div>
+      <button id="save">Save</button>
+      <span class="saved" id="saved" hidden>Saved ✓</span>
+    </div>
+
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/browser-extension/src/options/options.ts
+++ b/browser-extension/src/options/options.ts
@@ -1,0 +1,29 @@
+// Options UI: endpoint override + per-site enable.
+import type { Settings } from '../shared/types.js';
+
+const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
+
+async function load(): Promise<void> {
+  const { settings } = (await chrome.runtime.sendMessage({ type: 'GET_STATUS' })) as {
+    settings: Settings;
+  };
+  ($('endpoint') as HTMLInputElement).value = settings.endpoint;
+  ($('site_claude_web') as HTMLInputElement).checked = settings.sites.claude_web !== false;
+  ($('site_chatgpt_web') as HTMLInputElement).checked = settings.sites.chatgpt_web !== false;
+}
+
+$('save').addEventListener('click', async () => {
+  const patch: Partial<Settings> = {
+    endpoint: ($('endpoint') as HTMLInputElement).value.trim(),
+    sites: {
+      claude_web: ($('site_claude_web') as HTMLInputElement).checked,
+      chatgpt_web: ($('site_chatgpt_web') as HTMLInputElement).checked,
+    },
+  };
+  await chrome.runtime.sendMessage({ type: 'SET_SETTINGS', patch });
+  const saved = $('saved');
+  saved.hidden = false;
+  setTimeout(() => (saved.hidden = true), 1500);
+});
+
+void load();

--- a/browser-extension/src/popup/popup.html
+++ b/browser-extension/src/popup/popup.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { width: 260px; margin: 0; padding: 14px; font: 13px system-ui, sans-serif; color: #111; }
+      h1 { font-size: 14px; margin: 0 0 10px; }
+      .row { display: flex; align-items: center; justify-content: space-between; margin: 8px 0; }
+      .muted { color: #666; font-size: 12px; }
+      select, button { font: inherit; }
+      .status { margin-top: 10px; padding-top: 10px; border-top: 1px solid #eee; }
+    </style>
+  </head>
+  <body>
+    <h1>Agent Beacon — Browser Collector</h1>
+    <div class="row">
+      <label for="enabled">Capture enabled</label>
+      <input type="checkbox" id="enabled" />
+    </div>
+    <div class="row">
+      <label for="retention">Content retention</label>
+      <select id="retention">
+        <option value="full">Full</option>
+        <option value="redacted">Redacted</option>
+        <option value="metadata">Metadata only</option>
+      </select>
+    </div>
+    <div class="status muted">
+      <div>Endpoint: <span id="endpoint" data-testid="endpoint">…</span></div>
+      <div>Queue depth: <span id="queue" data-testid="queue">…</span></div>
+      <div>Active streams: <span id="active" data-testid="active">…</span></div>
+    </div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/browser-extension/src/popup/popup.ts
+++ b/browser-extension/src/popup/popup.ts
@@ -1,0 +1,37 @@
+// Popup UI: toggle capture, choose retention, show live status.
+import type { Settings } from '../shared/types.js';
+
+interface Status {
+  settings: Settings;
+  queueDepth: number;
+  active: number;
+}
+
+const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
+
+async function refresh(): Promise<void> {
+  const status = (await chrome.runtime.sendMessage({ type: 'GET_STATUS' })) as Status;
+  ($('enabled') as HTMLInputElement).checked = status.settings.enabled;
+  ($('retention') as HTMLSelectElement).value = status.settings.retention;
+  $('endpoint').textContent = status.settings.endpoint;
+  $('queue').textContent = String(status.queueDepth);
+  $('active').textContent = String(status.active);
+}
+
+$('enabled').addEventListener('change', async (e) => {
+  await chrome.runtime.sendMessage({
+    type: 'SET_SETTINGS',
+    patch: { enabled: (e.target as HTMLInputElement).checked },
+  });
+  await refresh();
+});
+
+$('retention').addEventListener('change', async (e) => {
+  await chrome.runtime.sendMessage({
+    type: 'SET_SETTINGS',
+    patch: { retention: (e.target as HTMLSelectElement).value as Settings['retention'] },
+  });
+  await refresh();
+});
+
+void refresh();

--- a/browser-extension/src/shared/ids.ts
+++ b/browser-extension/src/shared/ids.ts
@@ -1,0 +1,15 @@
+// Correlation id helpers. Kept deterministic and dependency-free so both the
+// service worker and unit tests can use them without a DOM/crypto polyfill.
+
+/**
+ * Derive a stable turn id from a conversation id and the request sequence.
+ * Deterministic so retried/duplicate deliveries can be de-duped downstream.
+ */
+export function turnId(sessionId: string, reqId: number): string {
+  return `${sessionId}:${reqId}`;
+}
+
+/** A per-record idempotency key for dedupe across delivery retries. */
+export function recordId(turnId: string, action: string, index = 0): string {
+  return `${turnId}#${action}#${index}`;
+}

--- a/browser-extension/src/shared/ids.ts
+++ b/browser-extension/src/shared/ids.ts
@@ -5,8 +5,8 @@
  * Derive a stable turn id from a conversation id and the request sequence.
  * Deterministic so retried/duplicate deliveries can be de-duped downstream.
  */
-export function turnId(sessionId: string, reqId: number): string {
-  return `${sessionId}:${reqId}`;
+export function turnId(sessionId: string, key: string | number): string {
+  return `${sessionId}:${key}`;
 }
 
 /** A per-record idempotency key for dedupe across delivery retries. */

--- a/browser-extension/src/shared/normalize.ts
+++ b/browser-extension/src/shared/normalize.ts
@@ -1,0 +1,211 @@
+// PURE: ChatTurn -> normalized OTLP log records for the beacon collector.
+// No I/O, no globals, no chrome.* — this is the primary unit-tested seam.
+//
+// The collector's beaconjson exporter fills vendor/product/schema_version/
+// endpoint/user/timestamp itself, so we MUST NOT emit those. We emit the
+// beacon.* + gen_ai.* attributes that converter.go maps into the Event schema.
+
+import type { ChatTurn, Retention, ToolCall } from './types.js';
+import {
+  type KeyValue,
+  type LogRecord,
+  buildLogsEnvelope,
+  bool,
+  int,
+  msToUnixNano,
+  str,
+} from './otlp.js';
+import {
+  type EventAction,
+  MAX_FIELD_BYTES,
+  ORIGIN,
+  SERVICE_NAME,
+  categoryFor,
+  providerFor,
+  severityNumber,
+} from './vocab.js';
+import { recordId, turnId } from './ids.js';
+
+export interface NormalizedTurn {
+  resourceAttributes: KeyValue[];
+  logRecords: LogRecord[];
+}
+
+const encoder = new TextEncoder();
+
+/** Truncate a string to a UTF-8 byte budget; returns [text, wasTruncated]. */
+function capBytes(text: string, max = MAX_FIELD_BYTES): [string, boolean] {
+  if (encoder.encode(text).length <= max) return [text, false];
+  // Binary-search the largest prefix that fits (chars ≠ bytes for multibyte).
+  let lo = 0;
+  let hi = text.length;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (encoder.encode(text.slice(0, mid)).length <= max) lo = mid;
+    else hi = mid - 1;
+  }
+  return [text.slice(0, lo), true];
+}
+
+/** Light client-side scrubber for retention=redacted (defense in depth; the
+ *  collector also redacts). Masks emails and long token-like strings. */
+function scrub(text: string): string {
+  return text
+    .replace(/[\w.+-]+@[\w-]+\.[\w.-]+/g, '[email]')
+    .replace(/\b(sk|pk|ghp|xox[baprs]|AKIA)[A-Za-z0-9_-]{12,}\b/g, '[token]');
+}
+
+interface Shaped {
+  text: string;
+  truncated: boolean;
+}
+
+/** Apply retention + size cap to a text field. Returns null when the field
+ *  must be dropped entirely (metadata retention). */
+function shapeText(text: string, retention: Retention): Shaped | null {
+  if (retention === 'metadata') return null;
+  const shown = retention === 'redacted' ? scrub(text) : text;
+  const [capped, truncated] = capBytes(shown);
+  return { text: capped, truncated };
+}
+
+/**
+ * Normalize a chat turn into 1..N OTLP log records:
+ *  - one response record (agent.response.completed, or agent.response if partial)
+ *  - one tool.invoked record per captured tool call
+ */
+export function normalizeTurn(turn: ChatTurn, retention: Retention): NormalizedTurn {
+  const resourceAttributes: KeyValue[] = [
+    str('beacon.origin', ORIGIN),
+    str('beacon.harness.name', turn.site),
+    str('service.name', SERVICE_NAME),
+    str('gen_ai.provider.name', providerFor(turn.site)),
+  ];
+
+  const tid = turn.turnId || turnId(turn.sessionId, 0);
+  const startNano = msToUnixNano(turn.startedAt);
+  const endNano = msToUnixNano(turn.completedAt ?? turn.startedAt);
+  const logRecords: LogRecord[] = [];
+
+  // Correlation attrs shared by every record in the turn.
+  const base = (action: EventAction, index = 0): KeyValue[] => [
+    str('beacon.event.action', action),
+    str('beacon.event.category', categoryFor(action)),
+    str('beacon.session.id', turn.sessionId),
+    str('gen_ai.conversation.id', turn.sessionId),
+    str('beacon.content.retention', retention),
+    str('beacon.record.id', recordId(tid, action, index)),
+    str('beacon.capture.mode', turn.captureMode),
+  ];
+
+  // ---- prompt.submitted ----
+  // Emitted as its own event with category "prompt" so the collector's
+  // converter lifts the text into the top-level Event.prompt.text field (it
+  // only does so for prompt-category events). Without this, the prompt stays
+  // buried in raw.attributes and never reaches the queryable prompt.text column.
+  const prompt = shapeText(turn.promptText, retention);
+  const inputMsgs = shapeText(JSON.stringify(turn.inputMessages), retention);
+  if (prompt || inputMsgs) {
+    const attrs = base('prompt.submitted');
+    if (turn.requestModel) attrs.push(str('gen_ai.request.model', turn.requestModel));
+    let truncated = false;
+    if (prompt) {
+      attrs.push(str('beacon.prompt.text', prompt.text));
+      truncated ||= prompt.truncated;
+    }
+    if (inputMsgs) {
+      attrs.push(str('gen_ai.input.messages', inputMsgs.text));
+      truncated ||= inputMsgs.truncated;
+    }
+    if (truncated) attrs.push(bool('beacon.field_truncated', true));
+    logRecords.push({
+      timeUnixNano: startNano,
+      severityNumber: severityNumber('info'),
+      severityText: 'INFO',
+      body: { stringValue: `${turn.site} prompt.submitted` },
+      attributes: attrs,
+    });
+  }
+
+  // ---- agent.response(.completed) ----
+  const completed = turn.completedAt != null;
+  const respAction: EventAction = completed ? 'agent.response.completed' : 'agent.response';
+  const respAttrs = base(respAction);
+  if (turn.requestModel) respAttrs.push(str('gen_ai.request.model', turn.requestModel));
+  if (turn.responseModel) respAttrs.push(str('gen_ai.response.model', turn.responseModel));
+  if (turn.usage?.inputTokens != null)
+    respAttrs.push(int('gen_ai.usage.input_tokens', turn.usage.inputTokens));
+  if (turn.usage?.outputTokens != null)
+    respAttrs.push(int('gen_ai.usage.output_tokens', turn.usage.outputTokens));
+
+  let respTrunc = false;
+  const outputMsgs = shapeText(JSON.stringify(turn.outputMessages), retention);
+  if (outputMsgs) {
+    respAttrs.push(str('gen_ai.output.messages', outputMsgs.text));
+    respTrunc ||= outputMsgs.truncated;
+  }
+  // Always-available metadata (survives metadata retention).
+  respAttrs.push(int('beacon.response.chars', turn.responseText.length));
+  respAttrs.push(int('beacon.tool_calls.count', turn.toolCalls.length));
+  if (respTrunc) respAttrs.push(bool('beacon.field_truncated', true));
+
+  logRecords.push({
+    timeUnixNano: endNano,
+    severityNumber: severityNumber('info'),
+    severityText: 'INFO',
+    body: { stringValue: `${turn.site} ${respAction}` },
+    attributes: respAttrs,
+  });
+
+  // ---- tool.invoked ----
+  turn.toolCalls.forEach((tool, i) => {
+    logRecords.push(toolRecord(turn, tool, i, retention, endNano));
+  });
+
+  return { resourceAttributes, logRecords };
+}
+
+function toolRecord(
+  turn: ChatTurn,
+  tool: ToolCall,
+  index: number,
+  retention: Retention,
+  when: string,
+): LogRecord {
+  const tid = turn.turnId || turnId(turn.sessionId, 0);
+  const action: EventAction = 'tool.invoked';
+  const attrs: KeyValue[] = [
+    str('beacon.event.action', action),
+    str('beacon.event.category', categoryFor(action)),
+    str('beacon.session.id', turn.sessionId),
+    str('gen_ai.conversation.id', turn.sessionId),
+    str('beacon.content.retention', retention),
+    str('beacon.record.id', recordId(tid, action, index)),
+    str('tool.name', tool.name),
+    str('gen_ai.tool.call.id', tool.id),
+    str('gen_ai.tool.call.name', tool.name),
+  ];
+  const args = shapeText(stringify(tool.arguments), retention);
+  if (args) attrs.push(str('gen_ai.tool.call.arguments', args.text));
+  if (tool.result !== undefined) {
+    const res = shapeText(stringify(tool.result), retention);
+    if (res) attrs.push(str('gen_ai.tool.call.result', res.text));
+  }
+  return {
+    timeUnixNano: when,
+    severityNumber: severityNumber('info'),
+    severityText: 'INFO',
+    body: { stringValue: `${turn.site} ${action} ${tool.name}` },
+    attributes: attrs,
+  };
+}
+
+function stringify(v: unknown): string {
+  return typeof v === 'string' ? v : JSON.stringify(v ?? null);
+}
+
+/** Convenience: normalize straight into a single OTLP logs envelope. */
+export function turnToEnvelope(turn: ChatTurn, retention: Retention) {
+  const { resourceAttributes, logRecords } = normalizeTurn(turn, retention);
+  return buildLogsEnvelope(resourceAttributes, logRecords, SERVICE_NAME);
+}

--- a/browser-extension/src/shared/otlp.ts
+++ b/browser-extension/src/shared/otlp.ts
@@ -1,0 +1,78 @@
+// OTLP/HTTP JSON (logs) envelope builders + attribute coercion.
+// Reference: OpenTelemetry OTLP/JSON encoding. int64 values are encoded as
+// strings ("intValue": "42") per the proto3 JSON mapping — the collector and
+// our tests both rely on this.
+
+export type AnyValue =
+  | { stringValue: string }
+  | { intValue: string }
+  | { doubleValue: number }
+  | { boolValue: boolean };
+
+export interface KeyValue {
+  key: string;
+  value: AnyValue;
+}
+
+export interface LogRecord {
+  timeUnixNano: string;
+  severityNumber: number;
+  severityText: string;
+  body: AnyValue;
+  attributes: KeyValue[];
+}
+
+export interface LogsEnvelope {
+  resourceLogs: Array<{
+    resource: { attributes: KeyValue[] };
+    scopeLogs: Array<{
+      scope: { name: string };
+      logRecords: LogRecord[];
+    }>;
+  }>;
+}
+
+export function str(key: string, value: string): KeyValue {
+  return { key, value: { stringValue: value } };
+}
+
+/** int64 attribute — encoded as a string per OTLP/JSON. */
+export function int(key: string, value: number): KeyValue {
+  return { key, value: { intValue: String(Math.trunc(value)) } };
+}
+
+export function bool(key: string, value: boolean): KeyValue {
+  return { key, value: { boolValue: value } };
+}
+
+/** epoch milliseconds → OTLP nanosecond timestamp string. */
+export function msToUnixNano(ms: number): string {
+  return String(Math.trunc(ms)) + '000000';
+}
+
+/** Look up a single attribute's primitive value (used by tests/delivery). */
+export function attrValue(attrs: KeyValue[], key: string): string | number | boolean | undefined {
+  const kv = attrs.find((a) => a.key === key);
+  if (!kv) return undefined;
+  const v = kv.value;
+  if ('stringValue' in v) return v.stringValue;
+  if ('intValue' in v) return Number(v.intValue);
+  if ('doubleValue' in v) return v.doubleValue;
+  if ('boolValue' in v) return v.boolValue;
+  return undefined;
+}
+
+export function buildLogsEnvelope(
+  resourceAttributes: KeyValue[],
+  logRecords: LogRecord[],
+  scopeName: string,
+): LogsEnvelope {
+  return {
+    resourceLogs: [
+      {
+        resource: { attributes: resourceAttributes },
+        scopeLogs: [{ scope: { name: scopeName }, logRecords }],
+      },
+    ],
+  };
+}

--- a/browser-extension/src/shared/types.ts
+++ b/browser-extension/src/shared/types.ts
@@ -1,0 +1,94 @@
+// Shared, site-agnostic types. Everything downstream of `ChatTurn` is generic;
+// only the per-site adapters know how ChatGPT vs Claude wire formats look.
+
+export type SiteName = 'claude_web' | 'chatgpt_web';
+
+export type Retention = 'metadata' | 'redacted' | 'full';
+
+/** A single chat message (user or assistant), provider-neutral. */
+export interface Msg {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  text: string;
+}
+
+export interface ToolCall {
+  id: string;
+  name: string;
+  /** Raw arguments as sent by the model (JSON string or object). */
+  arguments?: unknown;
+  /** Tool result, if the turn captured one. */
+  result?: unknown;
+}
+
+export interface Usage {
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+/**
+ * The canonical representation of one completed (or best-effort partial) chat
+ * turn. Produced by a SiteAdapter, consumed by the pure `normalizeTurn`.
+ */
+export interface ChatTurn {
+  site: SiteName;
+  /** Conversation id — becomes both beacon.session.id and gen_ai.conversation.id. */
+  sessionId: string;
+  /** Stable id for this request/response pair within the conversation. */
+  turnId: string;
+  requestModel?: string;
+  responseModel?: string;
+  promptText: string;
+  inputMessages: Msg[];
+  outputMessages: Msg[];
+  responseText: string;
+  toolCalls: ToolCall[];
+  usage?: Usage;
+  /** epoch ms */
+  startedAt: number;
+  /** epoch ms; undefined => stream never completed (aborted/partial). */
+  completedAt?: number;
+  captureMode: 'sse' | 'dom';
+  /** Trimmed raw payload for debugging; subject to the size cap. */
+  raw?: unknown;
+}
+
+export interface Settings {
+  enabled: boolean;
+  retention: Retention;
+  /** OTLP logs endpoint; defaults to the local beacon collector. */
+  endpoint: string;
+  /** Per-site enable toggles. */
+  sites: Record<SiteName, boolean>;
+}
+
+export const DEFAULT_SETTINGS: Settings = {
+  enabled: true,
+  retention: 'full',
+  endpoint: 'http://127.0.0.1:4318/v1/logs',
+  sites: { claude_web: true, chatgpt_web: true },
+};
+
+// ---- Messaging between MAIN interceptor → ISOLATED content → service worker ----
+
+/** Emitted by the MAIN-world interceptor via window.postMessage. */
+export type InterceptEvent =
+  | { kind: 'request'; reqId: number; url: string; method: string; body: string | null }
+  | { kind: 'chunk'; reqId: number; chunk: string }
+  | { kind: 'done'; reqId: number }
+  | { kind: 'error'; reqId: number; message: string };
+
+export const BEACON_MSG = '__beacon_intercept__' as const;
+
+/** Envelope posted on window by the interceptor. */
+export interface BeaconWindowMessage {
+  source: typeof BEACON_MSG;
+  event: InterceptEvent;
+}
+
+/** Sent from the content script to the service worker. */
+export interface RelayMessage {
+  type: 'BEACON_RAW';
+  host: string;
+  tabId?: number;
+  event: InterceptEvent;
+}

--- a/browser-extension/src/shared/vocab.ts
+++ b/browser-extension/src/shared/vocab.ts
@@ -1,0 +1,58 @@
+// The normalized event vocabulary, mirroring the beacon endpoint schema
+// (pkg/asymptoteobserve/event.go) and the actions the collector's converter.go
+// recognizes.
+
+import type { SiteName } from './types.js';
+
+export type EventAction =
+  | 'prompt.submitted'
+  | 'agent.response'
+  | 'agent.response.completed'
+  | 'tool.invoked'
+  | 'tool.completed';
+
+export type Severity = 'info' | 'low' | 'medium' | 'high' | 'critical';
+
+/** Map an action to its event.category (matches the collector's inference). */
+export function categoryFor(action: EventAction): string {
+  if (action.startsWith('prompt.')) return 'prompt';
+  if (action.startsWith('tool.')) return 'tool';
+  if (action.startsWith('agent.')) return 'agent';
+  return 'trace';
+}
+
+/** OTLP severity number for a severity text (INFO=9 per OTel spec). */
+export function severityNumber(sev: Severity): number {
+  switch (sev) {
+    case 'info':
+      return 9;
+    case 'low':
+      return 5;
+    case 'medium':
+      return 13;
+    case 'high':
+      return 17;
+    case 'critical':
+      return 21;
+  }
+}
+
+/** gen_ai.provider.name for a site. */
+export function providerFor(site: SiteName): string {
+  return site === 'claude_web' ? 'anthropic' : 'openai';
+}
+
+/** service.name reported to the collector. */
+export const SERVICE_NAME = 'agent-beacon-browser-collector';
+
+/** beacon.origin value identifying browser-sourced telemetry. */
+export const ORIGIN = 'browser-extension';
+
+/**
+ * Per-event byte cap matching the collector's max_event_bytes (64 KiB). We
+ * truncate oversized string fields client-side and flag it, mirroring the
+ * exporter's field_truncated contract.
+ */
+export const MAX_EVENT_BYTES = 65536;
+/** Leave headroom for envelope/attribute overhead when capping field text. */
+export const MAX_FIELD_BYTES = 48000;

--- a/browser-extension/test/unit/chatgpt.adapter.test.ts
+++ b/browser-extension/test/unit/chatgpt.adapter.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chatgptAdapter } from '../../src/adapters/chatgpt.js';
+import type { TurnParser } from '../../src/adapters/adapter.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixture = (name: string) =>
+  readFileSync(path.join(__dirname, '..', '..', 'fixtures', 'chatgpt', `${name}.sse`), 'utf8');
+
+const CONV = '6a73b75a-18d8-83ea-bbcf-984208806963';
+
+/** ChatGPT request body shape (messages[].content.parts). */
+function reqBody(prompt: string, conversationId: string | null): string {
+  return JSON.stringify({
+    action: 'next',
+    conversation_id: conversationId,
+    model: 'gpt-5-6-thinking',
+    messages: [
+      { id: 'u1', author: { role: 'user' }, content: { content_type: 'text', parts: [prompt] } },
+    ],
+  });
+}
+
+function run(name: string, prompt: string, conversationId: string | null, chunkSize = 7): TurnParser {
+  const parser = chatgptAdapter.createParser(1);
+  parser.onRequest('https://chatgpt.com/backend-api/f/conversation', 'POST', reqBody(prompt, conversationId));
+  const body = fixture(name);
+  for (let i = 0; i < body.length; i += chunkSize) parser.onChunk(body.slice(i, i + chunkSize));
+  parser.onDone();
+  return parser;
+}
+
+describe('chatgpt adapter — simple turn (delta_encoding v1)', () => {
+  const turn = run('simple-turn', 'good evening', null)!.getTurn()!;
+
+  it('reconstructs the response across add/append/bare/patch ops', () => {
+    expect(turn.responseText).toBe('Good evening! Hello to you as well. Hope your day is going well.');
+  });
+  it('captures the prompt from the request body', () => {
+    expect(turn.promptText).toBe('good evening');
+  });
+  it('takes the conversation id from the stream (not the message id)', () => {
+    expect(turn.sessionId).toBe(CONV);
+  });
+  it('captures the response model from metadata.model_slug', () => {
+    expect(turn.responseModel).toBe('gpt-5-6-thinking');
+  });
+  it('selects the assistant message id for the turn key', () => {
+    expect(turn.turnId).toBe(`${CONV}:asst-0001`);
+  });
+  it('marks the turn completed and has no tool calls (empty search groups)', () => {
+    expect(turn.completedAt).toBeTypeOf('number');
+    expect(turn.toolCalls).toHaveLength(0);
+  });
+});
+
+describe('chatgpt adapter — chunk-size invariance', () => {
+  it('produces the same response text regardless of chunk boundaries', () => {
+    const texts = [1, 3, 13, 100, 9999].map((n) => run('simple-turn', 'x', null, n).getTurn()!.responseText);
+    for (const t of texts)
+      expect(t).toBe('Good evening! Hello to you as well. Hope your day is going well.');
+  });
+});
+
+describe('chatgpt adapter — existing conversation', () => {
+  it('uses the request-body conversation_id when present', () => {
+    const turn = run('simple-turn', 'hi', 'body-conv-123')!.getTurn()!;
+    expect(turn.sessionId).toBe('body-conv-123');
+  });
+});

--- a/browser-extension/test/unit/claude.adapter.test.ts
+++ b/browser-extension/test/unit/claude.adapter.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { claudeAdapter } from '../../src/adapters/claude.js';
+import type { TurnParser } from '../../src/adapters/adapter.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixture = (name: string) =>
+  readFileSync(path.join(__dirname, '..', '..', 'fixtures', 'claude', `${name}.sse`), 'utf8');
+
+const CONV = '11111111-2222-3333-4444-555555555555';
+const URL = `/api/organizations/org-x/chat_conversations/${CONV}/completion`;
+
+/** Feed a body through a fresh parser in tiny, boundary-crossing chunks. */
+function run(name: string, prompt: string, chunkSize = 7): TurnParser {
+  const parser = claudeAdapter.createParser();
+  parser.onRequest(URL, 'POST', JSON.stringify({ prompt, conversation_id: CONV }));
+  const body = fixture(name);
+  for (let i = 0; i < body.length; i += chunkSize) parser.onChunk(body.slice(i, i + chunkSize));
+  parser.onDone();
+  return parser;
+}
+
+describe('claude adapter — simple turn', () => {
+  const turn = run('simple-turn', 'What is the capital of France?')!.getTurn()!;
+
+  it('reconstructs the streamed response text across split chunks', () => {
+    expect(turn.responseText).toBe('Paris.');
+  });
+  it('captures the prompt from the request body', () => {
+    expect(turn.promptText).toBe('What is the capital of France?');
+  });
+  it('captures the conversation id from the URL', () => {
+    expect(turn.sessionId).toBe(CONV);
+  });
+  it('captures the model', () => {
+    expect(turn.responseModel).toBe('claude-opus-4-8');
+  });
+  it('leaves usage tokens undefined (claude.ai does not stream them)', () => {
+    expect(turn.usage?.inputTokens).toBeUndefined();
+    expect(turn.usage?.outputTokens).toBeUndefined();
+  });
+  it('marks the turn completed', () => {
+    expect(turn.completedAt).toBeTypeOf('number');
+    expect(turn.toolCalls).toHaveLength(0);
+  });
+});
+
+describe('claude adapter — tool call', () => {
+  const turn = run('with-tool-call', 'What is the weather today?')!.getTurn()!;
+
+  it('captures the tool call with assembled JSON arguments', () => {
+    expect(turn.toolCalls).toHaveLength(1);
+    expect(turn.toolCalls[0].name).toBe('web_search');
+    expect(turn.toolCalls[0].id).toBe('toolu_abc');
+    expect(turn.toolCalls[0].arguments).toEqual({ query: 'weather today' });
+  });
+  it('still captures the accompanying text', () => {
+    expect(turn.responseText).toBe('Let me check the weather.');
+  });
+});
+
+describe('claude adapter — chunk-size invariance', () => {
+  it('produces the same response text regardless of chunk boundaries', () => {
+    const texts = [1, 3, 13, 100, 5000].map(
+      (n) => run('simple-turn', 'x', n).getTurn()!.responseText,
+    );
+    for (const t of texts) expect(t).toBe('Paris.');
+  });
+});

--- a/browser-extension/test/unit/claude.adapter.test.ts
+++ b/browser-extension/test/unit/claude.adapter.test.ts
@@ -14,7 +14,7 @@ const URL = `/api/organizations/org-x/chat_conversations/${CONV}/completion`;
 
 /** Feed a body through a fresh parser in tiny, boundary-crossing chunks. */
 function run(name: string, prompt: string, chunkSize = 7): TurnParser {
-  const parser = claudeAdapter.createParser();
+  const parser = claudeAdapter.createParser(1);
   parser.onRequest(URL, 'POST', JSON.stringify({ prompt, conversation_id: CONV }));
   const body = fixture(name);
   for (let i = 0; i < body.length; i += chunkSize) parser.onChunk(body.slice(i, i + chunkSize));

--- a/browser-extension/test/unit/normalize.test.ts
+++ b/browser-extension/test/unit/normalize.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeTurn } from '../../src/shared/normalize.js';
+import { attrValue, type KeyValue, type LogRecord } from '../../src/shared/otlp.js';
+import type { ChatTurn, Retention } from '../../src/shared/types.js';
+
+function baseTurn(over: Partial<ChatTurn> = {}): ChatTurn {
+  return {
+    site: 'claude_web',
+    sessionId: 'conv-123',
+    turnId: 'conv-123:1',
+    requestModel: 'claude-opus-4-8',
+    responseModel: 'claude-opus-4-8',
+    promptText: 'What is 2+2?',
+    inputMessages: [{ role: 'user', text: 'What is 2+2?' }],
+    outputMessages: [{ role: 'assistant', text: '4' }],
+    responseText: '4',
+    toolCalls: [],
+    usage: { inputTokens: 10, outputTokens: 2 },
+    startedAt: 1_700_000_000_000,
+    completedAt: 1_700_000_002_000,
+    captureMode: 'sse',
+    ...over,
+  };
+}
+
+function flat(attrs: KeyValue[]): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {};
+  for (const a of attrs) {
+    const v = attrValue(attrs, a.key);
+    if (v !== undefined) out[a.key] = v;
+  }
+  return out;
+}
+
+/** Find the record for a given beacon.event.action. */
+function byAction(recs: LogRecord[], action: string): LogRecord | undefined {
+  return recs.find((r) => flat(r.attributes)['beacon.event.action'] === action);
+}
+
+function normalize(turn: ChatTurn, retention: Retention = 'full') {
+  return normalizeTurn(turn, retention);
+}
+
+describe('normalizeTurn — full retention, simple completed turn', () => {
+  const { resourceAttributes, logRecords } = normalize(baseTurn());
+  const res = flat(resourceAttributes);
+  const promptRec = byAction(logRecords, 'prompt.submitted')!;
+  const respRec = byAction(logRecords, 'agent.response.completed')!;
+
+  it('emits a prompt.submitted AND an agent.response.completed record', () => {
+    expect(logRecords).toHaveLength(2);
+    expect(promptRec).toBeTruthy();
+    expect(respRec).toBeTruthy();
+  });
+
+  it('sets resource attrs identifying the browser source', () => {
+    expect(res['beacon.harness.name']).toBe('claude_web');
+    expect(res['beacon.origin']).toBe('browser-extension');
+    expect(res['gen_ai.provider.name']).toBe('anthropic');
+    expect(res['service.name']).toBe('agent-beacon-browser-collector');
+  });
+
+  it('puts prompt text on the prompt.submitted record (category prompt)', () => {
+    const p = flat(promptRec.attributes);
+    expect(p['beacon.event.category']).toBe('prompt');
+    expect(p['beacon.prompt.text']).toBe('What is 2+2?');
+  });
+
+  it('keeps the response record focused on the response (no prompt.text)', () => {
+    const r = flat(respRec.attributes);
+    expect(r['beacon.event.category']).toBe('agent');
+    expect(r['beacon.prompt.text']).toBeUndefined();
+    expect(String(r['gen_ai.output.messages'])).toContain('4');
+  });
+
+  it('uses the conversation id for both session and gen_ai.conversation', () => {
+    const r = flat(respRec.attributes);
+    expect(r['beacon.session.id']).toBe('conv-123');
+    expect(r['gen_ai.conversation.id']).toBe('conv-123');
+  });
+
+  it('encodes usage tokens as integers on the response', () => {
+    const r = flat(respRec.attributes);
+    expect(r['gen_ai.usage.input_tokens']).toBe(10);
+    expect(r['gen_ai.usage.output_tokens']).toBe(2);
+  });
+
+  it('does NOT set fields the exporter fills', () => {
+    for (const rec of logRecords) {
+      const a = flat(rec.attributes);
+      for (const forbidden of ['vendor', 'product', 'schema_version', 'timestamp']) {
+        expect(a[forbidden]).toBeUndefined();
+        expect(res[forbidden]).toBeUndefined();
+      }
+    }
+  });
+
+  it('timestamps prompt from startedAt and response from completedAt', () => {
+    expect(promptRec.timeUnixNano).toBe('1700000000000000000');
+    expect(respRec.timeUnixNano).toBe('1700000002000000000');
+  });
+});
+
+describe('normalizeTurn — retention modes', () => {
+  it('metadata retention drops the prompt.submitted record and all text', () => {
+    const { logRecords } = normalize(baseTurn(), 'metadata');
+    expect(byAction(logRecords, 'prompt.submitted')).toBeUndefined();
+    const r = flat(byAction(logRecords, 'agent.response.completed')!.attributes);
+    expect(r['beacon.prompt.text']).toBeUndefined();
+    expect(r['gen_ai.output.messages']).toBeUndefined();
+    expect(r['beacon.content.retention']).toBe('metadata');
+    // Metadata still present:
+    expect(r['gen_ai.request.model']).toBe('claude-opus-4-8');
+    expect(r['gen_ai.usage.output_tokens']).toBe(2);
+    expect(r['beacon.response.chars']).toBe(1);
+  });
+
+  it('redacted retention scrubs emails from the prompt.submitted text', () => {
+    const turn = baseTurn({ promptText: 'email me at alice@example.com please' });
+    const p = flat(byAction(normalize(turn, 'redacted').logRecords, 'prompt.submitted')!.attributes);
+    expect(p['beacon.prompt.text']).toBe('email me at [email] please');
+    expect(p['beacon.content.retention']).toBe('redacted');
+  });
+});
+
+describe('normalizeTurn — tool calls', () => {
+  const turn = baseTurn({
+    toolCalls: [
+      { id: 'toolu_1', name: 'web_search', arguments: { q: 'weather' }, result: 'sunny' },
+    ],
+  });
+  const { logRecords } = normalize(turn);
+
+  it('emits prompt.submitted + agent.response.completed + tool.invoked', () => {
+    expect(logRecords).toHaveLength(3);
+    const tool = flat(byAction(logRecords, 'tool.invoked')!.attributes);
+    expect(tool['beacon.event.category']).toBe('tool');
+    expect(tool['tool.name']).toBe('web_search');
+    expect(tool['gen_ai.tool.call.name']).toBe('web_search');
+    expect(tool['gen_ai.tool.call.id']).toBe('toolu_1');
+    expect(tool['gen_ai.tool.call.arguments']).toBe('{"q":"weather"}');
+    expect(tool['gen_ai.tool.call.result']).toBe('sunny');
+  });
+});
+
+describe('normalizeTurn — partial/aborted stream', () => {
+  it('marks an incomplete response as agent.response (not completed)', () => {
+    const turn = baseTurn({ completedAt: undefined });
+    const { logRecords } = normalize(turn);
+    expect(byAction(logRecords, 'agent.response')).toBeTruthy();
+    expect(byAction(logRecords, 'agent.response.completed')).toBeUndefined();
+    // Prompt still captured.
+    expect(byAction(logRecords, 'prompt.submitted')).toBeTruthy();
+  });
+});
+
+describe('normalizeTurn — size cap', () => {
+  it('truncates oversized prompt text and flags it', () => {
+    const huge = 'x'.repeat(200_000);
+    const p = flat(byAction(normalize(baseTurn({ promptText: huge })).logRecords, 'prompt.submitted')!.attributes);
+    expect((p['beacon.prompt.text'] as string).length).toBeLessThan(huge.length);
+    expect(p['beacon.field_truncated']).toBe(true);
+  });
+});

--- a/browser-extension/tools/integration-otelcol/README.md
+++ b/browser-extension/tools/integration-otelcol/README.md
@@ -1,0 +1,14 @@
+# Integration collector (opt-in)
+
+`e2e/integration.beacon.spec.ts` (run via `npm run test:integration`, gated on `RUN_INTEGRATION=1`)
+spawns the **real** `/opt/beacon/bin/beacon-otelcol` with a generated test config that:
+
+- listens on isolated OTLP ports (so it never touches the live `127.0.0.1:4318` collector), and
+- writes via the `beaconjson` exporter to a **temp** `runtime.jsonl` (never `/var/log`).
+
+It then POSTs the exact OTLP envelope our `turnToEnvelope()` produces and asserts the written line
+deserializes to a valid beacon `Event` (schema_version, event.action, harness.name, session.id,
+gen_ai.*, prompt.text) with vendor/product/timestamp filled by the exporter.
+
+This is the only layer that proves our OTLP → real `converter.go` → `Event` contract. It is
+advisory (kept out of the default unattended loop) because it depends on the installed binary.

--- a/browser-extension/tools/record-fixtures.ts
+++ b/browser-extension/tools/record-fixtures.ts
@@ -1,0 +1,133 @@
+// Fixture recorder. Opens a HEADED browser with a PERSISTENT profile you log
+// into once (the session is saved locally under .auth-profiles/, git-ignored —
+// no credentials are ever seen by the tooling). It watches for the chat
+// completion request via the Chrome DevTools Protocol, captures the raw SSE
+// response body + the request (prompt) + a DOM snapshot, and writes them to
+// fixtures/<site>/<name>.{sse,meta.json,page.html}.
+//
+// Usage:
+//   npm run record:fixtures -- --site claude --name simple-turn
+//
+// Then: log in if prompted, send ONE message, and wait for the full reply.
+// The first captured completion is saved and the tool exits.
+
+import { chromium } from '@playwright/test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+
+interface SiteConfig {
+  startUrl: string;
+  /** matches the completion request URL */
+  isCompletion: (url: string) => boolean;
+}
+
+const SITES: Record<string, SiteConfig> = {
+  claude: {
+    startUrl: 'https://claude.ai/',
+    isCompletion: (u) => /chat_conversations\/.+\/(completion|retry_completion)/.test(u),
+  },
+  chatgpt: {
+    startUrl: 'https://chatgpt.com/',
+    isCompletion: (u) => /\/backend-api\/(conversation|f\/conversation)\b/.test(u),
+  },
+};
+
+function arg(name: string, fallback?: string): string {
+  const i = process.argv.indexOf(`--${name}`);
+  const v = i >= 0 ? process.argv[i + 1] : undefined;
+  if (v == null && fallback == null) throw new Error(`missing --${name}`);
+  return v ?? fallback!;
+}
+
+async function main() {
+  const site = arg('site', 'claude');
+  const name = arg('name', 'live-capture');
+  const cfg = SITES[site];
+  if (!cfg) throw new Error(`unknown site: ${site} (known: ${Object.keys(SITES).join(', ')})`);
+
+  const profileDir = path.join(ROOT, '.auth-profiles', site);
+  mkdirSync(profileDir, { recursive: true });
+  const outDir = path.join(ROOT, 'fixtures', site);
+  mkdirSync(outDir, { recursive: true });
+
+  console.log(`\n▶ Opening ${cfg.startUrl} with profile ${profileDir}`);
+  console.log('  Log in if needed, then send ONE message and wait for the full reply.\n');
+
+  // Use the real installed Chrome and strip the automation fingerprint so
+  // bot-detection (Cloudflare et al.) treats it like a normal browser:
+  //  - channel:'chrome' → genuine Chrome branding/UA, not "Chrome for Testing"
+  //  - drop --enable-automation and the automation extension
+  //  - --disable-blink-features=AutomationControlled → navigator.webdriver=false
+  const context = await chromium.launchPersistentContext(profileDir, {
+    channel: 'chrome',
+    headless: false,
+    viewport: null,
+    ignoreDefaultArgs: ['--enable-automation'],
+    args: ['--disable-blink-features=AutomationControlled', '--start-maximized'],
+  });
+  const page = context.pages()[0] ?? (await context.newPage());
+  const client = await context.newCDPSession(page);
+  await client.send('Network.enable');
+
+  const pending = new Map<string, { url: string; postData?: string }>();
+
+  client.on('Network.requestWillBeSent', (e: any) => {
+    if (cfg.isCompletion(e.request.url)) {
+      pending.set(e.requestId, { url: e.request.url, postData: e.request.postData });
+    }
+  });
+
+  let done = false;
+  client.on('Network.loadingFinished', async (e: any) => {
+    if (done) return;
+    const meta = pending.get(e.requestId);
+    if (!meta) return;
+    done = true;
+    try {
+      const { body, base64Encoded } = await client.send('Network.getResponseBody', {
+        requestId: e.requestId,
+      });
+      const sse = base64Encoded ? Buffer.from(body, 'base64').toString('utf8') : body;
+      const html = await page.content();
+
+      writeFileSync(path.join(outDir, `${name}.sse`), sse);
+      writeFileSync(path.join(outDir, `${name}.page.html`), html);
+      writeFileSync(
+        path.join(outDir, `${name}.meta.json`),
+        JSON.stringify({ url: meta.url, requestBody: safeJson(meta.postData) }, null, 2),
+      );
+
+      console.log(`\n✅ Captured ${site}/${name}:`);
+      console.log(`   • ${name}.sse        (${sse.length} bytes of SSE)`);
+      console.log(`   • ${name}.meta.json  (request URL + prompt body)`);
+      console.log(`   • ${name}.page.html  (DOM snapshot)`);
+      console.log('\n⚠ Review these for personal content before committing.\n');
+    } catch (err) {
+      console.error('capture failed:', err);
+    } finally {
+      await context.close();
+      process.exit(0);
+    }
+  });
+
+  await page.goto(cfg.startUrl);
+  // Stay open until a completion is captured (loadingFinished handler exits).
+}
+
+function safeJson(s?: string): unknown {
+  if (!s) return null;
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/browser-extension/tools/record-fixtures.ts
+++ b/browser-extension/tools/record-fixtures.ts
@@ -32,7 +32,10 @@ const SITES: Record<string, SiteConfig> = {
   },
   chatgpt: {
     startUrl: 'https://chatgpt.com/',
-    isCompletion: (u) => /\/backend-api\/(conversation|f\/conversation)\b/.test(u),
+    // The message-send endpoint is a POST to /backend-api/conversation (or the
+    // /f/conversation variant), NOT sub-resources like /conversation/init,
+    // /conversation/{id}, or /conversation/gen_title — hence the end/query anchor.
+    isCompletion: (u) => /\/backend-(api|anon)\/(f\/)?conversation(?:\?|$)/.test(u),
   },
 };
 
@@ -76,7 +79,7 @@ async function main() {
   const pending = new Map<string, { url: string; postData?: string }>();
 
   client.on('Network.requestWillBeSent', (e: any) => {
-    if (cfg.isCompletion(e.request.url)) {
+    if ((e.request.method || '').toUpperCase() === 'POST' && cfg.isCompletion(e.request.url)) {
       pending.set(e.requestId, { url: e.request.url, postData: e.request.postData });
     }
   });

--- a/browser-extension/tsconfig.json
+++ b/browser-extension/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node", "chrome"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts", "e2e/**/*.ts", "test/**/*.ts", "tools/**/*.ts", "playwright.config.ts", "vitest.config.ts", "esbuild.config.mjs"]
+}

--- a/browser-extension/vitest.config.ts
+++ b/browser-extension/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+// Pure unit tests for the browser-free core (adapters + normalization).
+// Node environment: no DOM, no chrome.* — these tests exercise pure functions.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/unit/**/*.test.ts'],
+    watch: false,
+  },
+});

--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -11,6 +11,34 @@ Stay up to date with the latest changes to the Agent Beacon CLI.
 
 ## August 2026
 
+### Browser extension · August 24, 2026
+
+- **Browser chat is a supported surface** · An optional Chrome MV3 extension
+  relays Claude.ai and ChatGPT conversations into the same local pipeline as
+  agent activity, normalized into the same schema. Its service worker posts OTLP
+  GenAI logs to the collector already listening on `127.0.0.1:4318`, so browser
+  chats land in `runtime.jsonl` beside agent activity and forward through the
+  same shippers. Build it from `browser-extension/`, or download the zip from an
+  `ext-v*` release, then load it unpacked in Chrome.
+- **Narrow by construction** · The extension reads the chat streams on
+  `claude.ai`, `chatgpt.com`, and `chat.openai.com`, and nothing else. It has no
+  access to other tabs, browsing history, or page content elsewhere, and it never
+  writes files. Activity is attributed to the `claude_web` and `chatgpt_web`
+  harnesses, so browser chat stays distinguishable from CLI agents.
+- **Retention defaults to full** · Complete prompt and assistant response text is
+  retained locally. Browser chat telemetry without content has little
+  investigative value, so the default keeps it. Change it to `redacted` or
+  `metadata` in the extension's options page before enabling it on a machine
+  where the same browser profile is used for personal conversations. Retention is
+  enforced in the browser, so under `metadata` the text never leaves the page.
+- **Released on its own tags** · An `ext-v*` tag publishes the unpacked build as a
+  zip with a `.sha256`, independent of the CLI's `v*` releases. The archive is
+  unsigned, and Chrome Web Store publication is not yet available.
+- **Documented boundaries updated** · The security overview, threat model, and FAQ
+  previously listed browser telemetry as out of scope. They now scope that
+  statement to general browser activity, which the extension still does not
+  collect.
+
 ### Documentation · August 23, 2026
 
 - **One house style across the docs** · Rewrote the pages that had drifted into

--- a/docs/concepts/faq.mdx
+++ b/docs/concepts/faq.mdx
@@ -47,8 +47,10 @@ Beacon can help investigate this when the data appears in emitted prompts, tool
 results, command output, file activity, or retained content. That can make it
 possible to spot data from an unexpected source in a session timeline.
 
-Beacon is not a browser monitor, email collector, SaaS audit log collector,
-kernel monitor, or universal data-origin tracker. If a runtime does not expose
+Beacon is not a general browser monitor, email collector, SaaS audit log
+collector, kernel monitor, or universal data-origin tracker. The optional
+browser extension is narrow: it reads the chat streams on claude.ai and
+chatgpt.com and nothing else you browse. If a runtime does not expose
 the source content or action, Beacon cannot reconstruct it from outside the
 runtime.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -160,6 +160,12 @@
                       "runtimes/hermes-agent",
                       "runtimes/openclaw-gateway"
                     ]
+                  },
+                  {
+                    "group": "Browser Chat",
+                    "pages": [
+                      "runtimes/browser-extension"
+                    ]
                   }
                 ]
               },

--- a/docs/runtimes/browser-extension.mdx
+++ b/docs/runtimes/browser-extension.mdx
@@ -1,0 +1,68 @@
+---
+title: "Browser Extension"
+description: "Asymptote support details for Claude.ai and ChatGPT browser chat telemetry"
+---
+
+## Runtime overview
+
+Asymptote supports browser chat on Claude.ai and ChatGPT through an optional Chrome MV3 extension that relays conversation telemetry into the same local pipeline as agent activity.
+
+The extension is experimental. It reads the chat streams of two sites whose APIs are private and undocumented, so a change on either site can interrupt capture until the adapter is updated.
+
+Browser chat resolves to two harness names, `claude_web` and `chatgpt_web`, so browser activity is attributed separately from CLI agents in the runtime log and the dashboard.
+
+## Prerequisites
+
+Before enabling browser chat telemetry, make sure:
+
+- The Beacon endpoint is installed and running, because the extension posts to the local collector on `http://127.0.0.1:4318/v1/logs`.
+- You have reviewed what the extension retains. It captures full prompt and response text by default.
+- The people whose browsers it runs in know it is there, since it reads their Claude.ai and ChatGPT conversations.
+
+## Collection path
+
+A content script running in the page's main world tees the streamed chat response, a per-site adapter parses it into a normalized turn, and the extension's service worker posts OTLP GenAI logs to the local collector. The `beaconjson` exporter converts those into endpoint events and writes them to the runtime JSONL log, alongside every other source.
+
+The extension never writes files and never contacts a remote endpoint. Delivery is queued in local extension storage and retried with backoff, so a turn survives the service worker being suspended mid-stream.
+
+Events collected this way carry `harness.collection_method` of `otlp`.
+
+## Discovery and status
+
+Asymptote treats the browser extension as a user-installed source. It is not configured by `beacon endpoint install` and has no hook or plugin file on disk.
+
+To confirm it is working, generate a chat turn on either site and look for `claude_web` or `chatgpt_web` events in the runtime log or the local dashboard.
+
+## Install or configuration support
+
+Build the extension from `browser-extension/` in the agent-beacon repository, or download the zip from an `ext-v*` release, then load it unpacked through Chrome's developer mode.
+
+Capture is configured in the extension's own options page: on/off, retention mode, the collector endpoint, and per-site toggles. There is no `beacon` command that configures it.
+
+## Retained content
+
+Retention defaults to `full`. Browser chat telemetry has little investigative value without content, so the default keeps it, and the tradeoff is documented rather than defaulted away.
+
+| Mode | What is retained |
+|------|------------------|
+| `full` (default) | Complete prompt text, full assistant response, tool call arguments and results |
+| `redacted` | The same text with emails and API-key-shaped tokens scrubbed in the browser |
+| `metadata` | No chat text. Actions, models, token counts, and tool names only |
+
+Retention is enforced in the browser before anything is sent, so under `metadata` the text never leaves the page. Endpoint-side redaction, sanitization, truncation, and event-size limits apply to whatever is sent.
+
+Change the mode in the extension's options page before enabling it on a machine where the same browser profile is used for personal conversations.
+
+## Telemetry coverage
+
+| Area | Support |
+|------|---------|
+| Prompt telemetry | Supported, with full prompt text under `full` and `redacted` retention |
+| Assistant response telemetry | Supported, including the response text and model |
+| Tool telemetry | Supported where the chat stream exposes tool calls, including call id, arguments, and results |
+| Token usage | Supported for Claude.ai. ChatGPT web does not report usage in its stream |
+| Command and file telemetry | Not applicable. Browser chat performs no local commands or file edits |
+| Approval telemetry | Not available. Neither site exposes approval decisions to a page script |
+| Session lifecycle | Partial. Turns are correlated by conversation id; there is no session start or stop signal |
+| Local JSONL and dashboard | Supported after events reach the collector |
+| MDM deployment | Not covered by Beacon's MDM assets. Distribute through browser policy instead |

--- a/docs/runtimes/browser-extension.mdx
+++ b/docs/runtimes/browser-extension.mdx
@@ -7,7 +7,7 @@ description: "Asymptote support details for Claude.ai and ChatGPT browser chat t
 
 Asymptote supports browser chat on Claude.ai and ChatGPT through an optional Chrome MV3 extension that relays conversation telemetry into the same local pipeline as agent activity.
 
-The extension is experimental. It reads the chat streams of two sites whose APIs are private and undocumented, so a change on either site can interrupt capture until the adapter is updated.
+The extension is in beta. It is not published on the Chrome Web Store and installs unpacked. It also reads the chat streams of two sites whose APIs are private and undocumented, so a change on either site can interrupt capture until the adapter is updated.
 
 Browser chat resolves to two harness names, `claude_web` and `chatgpt_web`, so browser activity is attributed separately from CLI agents in the runtime log and the dashboard.
 
@@ -35,9 +35,47 @@ To confirm it is working, generate a chat turn on either site and look for `clau
 
 ## Install or configuration support
 
-Build the extension from `browser-extension/` in the agent-beacon repository, or download the zip from an `ext-v*` release, then load it unpacked through Chrome's developer mode.
+<Note>
+The browser extension is in beta and is not published on the Chrome Web Store. It installs unpacked through Chrome's developer mode, so Chrome will not auto-update it: to move to a new version, download it again and reload. The published archive is unsigned, and its `.sha256` is the only integrity check it has.
+</Note>
+
+Install it one of two ways.
+
+### From a release
+
+1. Download `agent-beacon-browser-extension-<version>-chrome.zip` and its `.sha256` from the [`ext-v*` releases](https://github.com/Asymptote-Labs/agent-beacon/releases).
+2. Verify the archive, then unzip it:
+
+```bash
+shasum -a 256 -c agent-beacon-browser-extension-<version>-chrome.zip.sha256
+unzip agent-beacon-browser-extension-<version>-chrome.zip -d agent-beacon-extension
+```
+
+### From source
+
+```bash
+cd browser-extension
+npm ci
+npm run build
+```
+
+The loadable extension is the `dist/` directory.
+
+### Load it in Chrome
+
+1. Make sure the Beacon endpoint is running, since the extension posts to the local collector on `127.0.0.1:4318`.
+2. Open `chrome://extensions`.
+3. Turn on **Developer mode**, top right.
+4. Choose **Load unpacked**, and select the unzipped folder or `browser-extension/dist`.
+5. Open claude.ai or chatgpt.com and send a message, then confirm `claude_web` or `chatgpt_web` events appear in the runtime log or the local dashboard.
+
+Chrome disables unpacked extensions when it restarts in some managed configurations. If capture stops, check that the extension is still enabled in `chrome://extensions`.
+
+### Configuration
 
 Capture is configured in the extension's own options page: on/off, retention mode, the collector endpoint, and per-site toggles. There is no `beacon` command that configures it.
+
+Review the retention mode before enabling it on a machine where the same browser profile is used for personal conversations. The default retains full chat text.
 
 ## Retained content
 

--- a/docs/runtimes/index.mdx
+++ b/docs/runtimes/index.mdx
@@ -43,6 +43,15 @@ These integrations are grouped by where the agent runs and how telemetry is coll
 | [Hermes Agent](/runtimes/hermes-agent) | Shell hooks | Prompt, observed tool, command, file, approval request and response, session lifecycle, and subagent stop telemetry |
 | [OpenClaw Gateway](/runtimes/openclaw-gateway) | Gateway-configured OTLP/HTTP | OTLP logs, traces, and metrics from the Gateway diagnostics plugin |
 
+### Local browser chat surfaces
+
+| Agent harness | Collection path | Telemetry coverage |
+|----------------|-----------------|--------------------|
+| [Claude.ai](/runtimes/browser-extension) (beta) | Managed browser extension over local OTLP | Prompt, assistant response, tool call, and token usage telemetry from the claude.ai chat stream |
+| [ChatGPT](/runtimes/browser-extension) (beta) | Managed browser extension over local OTLP | Prompt, assistant response, and tool call telemetry from the chatgpt.com chat stream |
+
+Browser chat resolves to the `claude_web` and `chatgpt_web` harness names, so it stays distinguishable from CLI agents. The extension retains full prompt and response text by default. See [Browser Extension](/runtimes/browser-extension) for the retention modes.
+
 ### CI harnesses
 
 | Harness | Collection path | Telemetry coverage |

--- a/docs/runtimes/integration-model.mdx
+++ b/docs/runtimes/integration-model.mdx
@@ -67,6 +67,7 @@ During install, Beacon configures the runtime surfaces it can safely manage:
 | [Cursor](/runtimes/cursor) | Native hook payloads through `beacon-hooks` | Hooks emit session, prompt, tool, command, MCP-like, approval, and file edit telemetry where Cursor exposes payloads. |
 | [Claude Cowork](/runtimes/claude-cowork) | Admin-configured OTLP from Anthropic's service | Production Cowork telemetry should use a durable customer-managed HTTPS collector endpoint. |
 | [OpenClaw Gateway](/runtimes/openclaw-gateway) | Gateway-configured OTLP/HTTP export | Beacon prints Gateway diagnostics settings and validates OpenClaw-derived events in the runtime log. |
+| [Browser Extension](/runtimes/browser-extension) | Managed browser extension over local OTLP | A Chrome MV3 extension parses the claude.ai and chatgpt.com chat streams and posts OTLP GenAI logs to the local collector. Beta, installed unpacked rather than from the Chrome Web Store, and configured in the extension's own options page rather than by `beacon`. |
 
 ## Hook telemetry
 

--- a/docs/security/data-flow-threat-model.mdx
+++ b/docs/security/data-flow-threat-model.mdx
@@ -42,7 +42,9 @@ flowchart LR
 
 ## Current boundaries
 
-Beacon focuses on supported agent harness telemetry and local endpoint configuration context. It does not provide kernel or process monitoring, shell history collection, cloud audit ingestion, browser or SaaS telemetry, credential-use attribution, Datadog API export from Beacon, Sumo Logic API export from Beacon, Rapid7 API export from Beacon, or automatic mutation of Factory Droid shell profiles.
+Beacon focuses on supported agent harness telemetry and local endpoint configuration context. It does not provide kernel or process monitoring, shell history collection, cloud audit ingestion, general browser or SaaS activity monitoring outside the supported chat surfaces, credential-use attribution, Datadog API export from Beacon, Sumo Logic API export from Beacon, Rapid7 API export from Beacon, or automatic mutation of Factory Droid shell profiles.
+
+Browser chat telemetry is limited to the Claude.ai and ChatGPT conversation streams captured by the optional [Agent Beacon browser extension](/runtimes/browser-extension). Beacon does not observe other tabs, browsing history, or page content elsewhere. That extension retains full prompt and response text by default, which is the most sensitive default in the product; see [its retention modes](/runtimes/browser-extension).
 
 Provider-managed cloud agents use a separate ephemeral boundary from the local
 endpoint. Their hook adapter writes sandbox-local JSONL and can send compressed

--- a/docs/security/data-inventory.mdx
+++ b/docs/security/data-inventory.mdx
@@ -24,6 +24,21 @@ Beacon writes normalized endpoint events only when supported runtimes provide te
 | Cursor | Native hooks | Prompt, tool, shell command, MCP-like, approval, and file edit telemetry |
 | Claude Cowork | Admin-configured OTLP | Prompt, command, tool, and file telemetry when emitted through Claude Cowork OTLP |
 | OpenClaw Gateway | Gateway-configured OTLP/HTTP | OTLP logs, traces, and metrics from the Gateway diagnostics plugin |
+| Claude.ai (`claude_web`) | Managed browser extension over local OTLP | Prompt text, assistant response text, request and response model, tool call id/name/arguments/results, token usage, and conversation id from the claude.ai chat stream |
+| ChatGPT (`chatgpt_web`) | Managed browser extension over local OTLP | Prompt text, assistant response text, model, tool call activity, and conversation id from the chatgpt.com chat stream. ChatGPT web does not report token usage in its stream |
+
+The browser extension is the only surface that reads content from a site the
+person is signed into personally, so its boundaries are worth stating explicitly.
+It observes the chat request and response streams on `claude.ai`, `chatgpt.com`,
+and `chat.openai.com`, and nothing else. It has no access to other tabs, browsing
+history, or page content elsewhere, and it never writes files.
+
+Its retention setting defaults to `full`, so complete prompt and assistant
+response text is retained in the local runtime log unless an operator changes it
+in the extension's options page. `redacted` scrubs emails and API-key-shaped
+tokens; `metadata` retains no chat text at all. Retention is applied in the
+browser before anything is sent, so under `metadata` the text never leaves the
+page.
 
 ## Local inventory metadata
 

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -88,4 +88,6 @@ For dedicated infrastructure, stricter data boundaries, or residency requirement
 
 ## Boundaries
 
-Beacon currently focuses on endpoint telemetry for supported agent harnesses and local endpoint configuration context. It does not provide kernel or process monitoring, shell history collection, cloud audit ingestion, browser or SaaS telemetry, credential-use attribution, or automatic mutation of Factory Droid shell profiles. Use [Log Forwarding](/log-forwarding) for supported SIEM, observability, object-storage, local JSONL, and customer-managed destinations.
+Beacon currently focuses on endpoint telemetry for supported agent harnesses and local endpoint configuration context. It does not provide kernel or process monitoring, shell history collection, cloud audit ingestion, general browser or SaaS activity monitoring outside the supported chat surfaces, credential-use attribution, or automatic mutation of Factory Droid shell profiles. Use [Log Forwarding](/log-forwarding) for supported SIEM, observability, object-storage, local JSONL, and customer-managed destinations.
+
+Browser chat telemetry is limited to the Claude.ai and ChatGPT conversation streams captured by the optional [Agent Beacon browser extension](/runtimes/browser-extension). Beacon does not observe other tabs, browsing history, or page content elsewhere.


### PR DESCRIPTION
## ⚠️ MERGE WITH "CREATE A MERGE COMMIT" — SQUASH DESTROYS THE IMPORTED HISTORY.

Squash and rebase are both enabled on this repo and no ruleset prevents either. This PR carries 11 rewritten commits from the extension repo; squashing collapses them into one and throws away the history the import was designed to preserve.

---

Brings `Asymptote-Labs/agent-beacon-browser-extension` in at `browser-extension/`, additively. Nothing else moves.

## Why

The two repos already share a contract that nothing tests. `src/shared/vocab.ts` hand-copies `MAX_EVENT_BYTES = 65536` to match the collector's `max_event_bytes` and cites `pkg/asymptoteobserve/event.go` and `converter.go` by path in a comment, neither of which was checkable from that repo. Meanwhile `NormalizeHarnessName` has resolved `claude_web` and `chatgpt_web` since v1.0.5, and `docs/changelog/cli.mdx` announced it. agent-beacon shipped support *for* this extension; the extension targets agent-beacon's schema; nothing proved they agree.

`tools/integration-otelcol/` is a README for a test that was never written because it needed a collector binary from the other repo. That test becomes writable now. It is deliberately **not** in this PR.

## This PR does not touch the CLI or the binary

- No `.go`, `go.mod`, `go.sum`, `.goreleaser.yaml`, `packaging/`, `rules/`, or `spec/` file is modified. Verified by `git diff --name-only origin/main..HEAD | grep -E '\.go$|go\.mod$|...'` returning empty.
- The extension is **not** embedded in the binary the way `plugins/*-beacon` are.
- `ext-v*` does not match the `v*` release trigger, so the CLI release path is unchanged.
- The new CI job has no `needs:`, matching all ten existing jobs.

58 files: 45 imported, 13 docs/CI.

## Commits

| Commit | What |
|---|---|
| `chore: import…` | The merge. Byte-identical mirror of remote `main`. |
| `chore(browser-extension): adapt…` | Dead scripts, `typecheck`→`check`, `engines`, lockfile, privacy docs. |
| `ci: add the browser-extension job` | Type-check, unit, build, MV3 assertion, replay e2e. |
| `ci: add the ext-v* … release workflow` | Zip + `.sha256`, three-way version gate. |
| `docs: document the browser extension…` | Runtime page, nav, README rows, changelog, posture retractions. |
| `docs(contributing): complete the project layout…` | Fixes a list that omitted five existing paths. |

## Verification run locally

- **Tree-hash equality**: `HEAD:browser-extension` == remote `origin/main^{tree}` (`70a4a5a4…`). A path rewrite re-parents entries without touching blobs, so this proves the import is byte-identical to the source.
- **History preserved**: `git log --follow -- browser-extension/README.md` walks all 7 original commits back to `Initial commit`; `git blame` attributes correctly. This is what `git subtree add` would have lost.
- **Privacy rules**: all 10 ignore patterns re-verified with `git check-ignore -v --no-index`, including the four PRIVACY-CRITICAL `fixtures/**` rules that keep unsanitized captures out of git. Inverse checked too: the 4 committed sanitized fixtures remain trackable.
- **Tests**: `tsc --noEmit` clean, 30/30 unit, 7/7 Playwright e2e (~8s).
- **Release packaging dry-run**: built the zip locally — 8 files, 36 KB, no sourcemaps, archive verification script reported `archive ok: MV3 0.1.0`.
- **Docs**: `docs.json` parses; all 171 referenced pages exist.
- Working tree clean after a full build, proving nothing escaped `.gitignore`.

## Posture change worth a reviewer's attention

Four places listed browser telemetry as an explicit non-goal while the code already contradicted them. The retraction **narrows rather than deletes** — Beacon still is not a general browser monitor, and the extension reads only two origins' chat streams.

Separately: **retention defaults to `full`**, so complete prompt and response text from personal chat sessions is retained locally. That default is kept deliberately and is now documented in the extension README, the runtime page, `SECURITY.md`, and the changelog.

## Known follow-ups (not in this PR)

Designing the conformance test surfaced three pre-existing defects:

1. `beacon.origin: "browser-extension"` produces nothing — `Event.Origin`'s value space is `local|cloud|ci`.
2. `RetainedContent` hardcodes `Retention: ContentRetentionFull`, so a `redacted` capture is stamped `"full"` — a false privacy label.
3. `MAX_EVENT_BYTES` has four copies across the repo.

Also unaddressed: `npm audit` reports 3 advisories in dev-only transitive deps (via vitest). They never reach the extension bundle, which esbuild builds from `src/` alone. Left out to keep this diff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New user-facing collection path with sensitive default retention (`full` prompt/response text) and telemetry-integrity limits documented for MAIN-world injection; CI/release changes are additive and do not modify the CLI binary or `v*` releases.
> 
> **Overview**
> Adds **`browser-extension/`**, an optional Chrome MV3 extension that tees chat SSE on **claude.ai** and **chatgpt.com**, normalizes turns to Beacon OTLP logs, and POSTs them to the loopback collector (`127.0.0.1:4318`). Capture is **fetch interception → content relay → service worker** with site adapters, a durable delivery queue, and retention options defaulting to **`full`**.
> 
> **CI and release:** `ci.yml` gains a **`browser-extension`** job (type-check, vitest, esbuild build, MV3 artifact checks, Playwright replay e2e with Chromium caching and failure artifacts). New **`release-extension.yml`** publishes an unsigned zip plus **`.sha256`** on **`ext-v*`** tags, with a three-way version gate (`tag`, `package.json`, `manifest.json`).
> 
> **Docs:** README, SECURITY, CONTRIBUTING, and agent guides now describe the extension, dev/test commands, and independent **`ext-v*`** release flow; product posture is updated from “no browser telemetry” to **narrow chat-surface collection only** (not general browsing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c5a96cdc1b037f312c6891e1ce9c6110ddd491a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->