### PR TITLE
Add browser coverage to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ## What is Agent Beacon
 
-Agent Beacon is the world's first [open-source telemetry layer](https://justindsouza.substack.com/p/introducing-beacon-endpoint-telemetry) for AI agents wherever they run: locally, in CI, or in the cloud.
+Agent Beacon is the world's first [open-source telemetry layer](https://justindsouza.substack.com/p/introducing-beacon-endpoint-telemetry) for AI agents wherever they run: locally, in CI, in the browser, or in the cloud.
 
 The problem is that AI agent activity is fragmented across runtimes, leaving teams without a consistent way to get visibility into what agents are doing. Agent Beacon solves this by extending the OpenTelemetry GenAI standard and normalizing runtime events into a unified data model.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no code or configuration impact.
> 
> **Overview**
> Updates the **What is Agent Beacon** intro so supported runtimes explicitly include **in the browser**, alongside local, CI, and cloud—aligning the opening pitch with browser chat coverage documented elsewhere in the README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de1d9dce5e6c7fdcf598cf2359911574897de6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->