### PR TITLE
feat(harness): map fx spellings to the canonical vercel_fx name

### DIFF
--- a/pkg/asymptoteobserve/harness.go
+++ b/pkg/asymptoteobserve/harness.go
@@ -101,6 +101,20 @@ func NormalizeHarnessName(name string) string {
 		lower == "qwencode" || lower == "qwen_cli" || lower == "qwen-cli" || lower == "qwen cli" ||
 		lower == "qwen_coder" || lower == "qwen-coder" || lower == "qwen coder":
 		return "qwen_code"
+	// fx (vercel-labs/fx) is matched by equality against a closed set for the same reason Pi is,
+	// only more so: "fx" is two characters and appears inside ordinary words a harness attribute
+	// can plausibly carry -- "sfx", "fx-runner", "effects" does not contain it but "fxagent" does
+	// -- so a Contains rule would claim sessions that are not fx's. There is no prefix rule here
+	// either: a future runtime named "fxr" is not this one.
+	//
+	// The canonical name is vercel_fx rather than fx because harness.name is what a SIEM query
+	// groups by, and a two-letter value there says nothing about which product produced the row.
+	// The vendor prefix follows what the product is called in practice ("Vercel fx") and keeps the
+	// name self-describing for a reader who has never seen it before.
+	case lower == "fx" || lower == "fx_cli" || lower == "fx-cli" || lower == "fx cli" ||
+		lower == "fx.sh" || lower == "vercel_fx" || lower == "vercel-fx" || lower == "vercel fx" ||
+		lower == "vercel fx cli" || lower == "fx_agent" || lower == "fx-agent":
+		return "vercel_fx"
 	case name != "":
 		// An unrecognized runtime keeps its own name rather than being coerced or dropped. A new
 		// harness should show up in the log as itself, not as "unknown".

--- a/pkg/asymptoteobserve/harness_test.go
+++ b/pkg/asymptoteobserve/harness_test.go
@@ -37,7 +37,7 @@ func TestCanonicalNamesAreStableUnderRenormalization(t *testing.T) {
 	for _, canonical := range []string{
 		"claude_code", "codex_cli", "gemini_cli", "antigravity_cli", "vscode_copilot",
 		"copilot_cli", "claude_web", "chatgpt_web", "claude_cowork", "claude_agent_sdk",
-		"openclaw_gateway", "pi_cli", "cline", "qwen_code",
+		"openclaw_gateway", "pi_cli", "cline", "qwen_code", "vercel_fx",
 	} {
 		t.Run(canonical, func(t *testing.T) {
 			if got := NormalizeHarnessName(canonical); got != canonical {
@@ -212,5 +212,57 @@ func TestEmptyNameStaysEmpty(t *testing.T) {
 		if got := NormalizeHarnessName(in); got != "" {
 			t.Errorf("NormalizeHarnessName(%q) = %q, want empty", in, got)
 		}
+	}
+}
+
+// fx (vercel-labs/fx) reaches Beacon under the spellings a reader is likely to type and the ones
+// the session collector records, and all of them must land on one canonical name. fx has no hook
+// or OTLP surface, so the collector is currently the only writer -- but harness names also arrive
+// from `--harness` flags and hand-written queries, and one session recorded as both "fx" and
+// "vercel_fx" splits it for anything grouping by harness.name.
+func TestFxSpellingsConvergeOnVercelFx(t *testing.T) {
+	for _, in := range []string{
+		"fx", "FX", " fx ", "fx_cli", "fx-cli", "fx cli", "fx.sh", "vercel_fx", "vercel-fx",
+		"Vercel FX", "vercel fx cli", "fx_agent", "fx-agent",
+	} {
+		t.Run(in, func(t *testing.T) {
+			if got := NormalizeHarnessName(in); got != "vercel_fx" {
+				t.Errorf("NormalizeHarnessName(%q) = %q, want %q", in, got, "vercel_fx")
+			}
+		})
+	}
+}
+
+// The reason the fx case is an equality match rather than a Contains rule. "fx" is two characters
+// and sits inside ordinary words, so a substring rule would relabel unrelated runtimes -- and
+// unlike a wrong name on a known runtime, this failure invents fx activity on a machine that has
+// never run fx.
+func TestFxDoesNotSwallowNamesContainingFx(t *testing.T) {
+	for _, name := range []string{"fxagent", "sfx", "soundfx", "fxr", "myfx-cli", "fx-runner"} {
+		if got := NormalizeHarnessName(name); got != name {
+			t.Errorf("NormalizeHarnessName(%q) = %q, want it preserved -- a substring rule for fx "+
+				"would report this runtime's sessions as fx activity", name, got)
+		}
+	}
+}
+
+// fx runs on Vercel AI Gateway and can authenticate against ChatGPT and Grok subscriptions, so its
+// events carry provider and model strings from three vendors. None of those makes the harness
+// something other than fx, and none of the harness rules above may claim an fx session because a
+// provider name happens to appear beside it.
+func TestFxIsNotAttributedToItsModelProviders(t *testing.T) {
+	if got := NormalizeHarnessName("fx"); got != "vercel_fx" {
+		t.Errorf("NormalizeHarnessName(%q) = %q, want vercel_fx", "fx", got)
+	}
+	for _, provider := range []string{"gateway", "grok", "xai"} {
+		if got := NormalizeHarnessName(provider); got != provider {
+			t.Errorf("NormalizeHarnessName(%q) = %q, want it preserved", provider, got)
+		}
+	}
+	// "codex" is the one provider spelling fx uses that an existing rule already claims for the
+	// Codex CLI. That rule stays as it is: an event whose harness is literally "codex" is the
+	// Codex CLI, and fx's own events say "fx".
+	if got := NormalizeHarnessName("codex"); got != "codex_cli" {
+		t.Errorf("NormalizeHarnessName(%q) = %q, want codex_cli", "codex", got)
 	}
 }


### PR DESCRIPTION
**Stack 1/8 — fx (vercel-labs/fx) support.** Base: `main`.

Pins the harness name before anything writes it. fx is a coding agent whose telemetry the rest of this stack collects.

### Why equality and not substring

Matched against a closed set of spellings rather than by `Contains`, for the reason the Pi and Cline cases already are — only sharper. "fx" is two characters and appears inside ordinary names (`fxagent`, `sfx`, `myfx-cli`), so a substring rule would not merely mislabel a known runtime: it would invent fx activity on a machine that has never run fx.

### Why `vercel_fx` and not `fx`

`harness.name` is what a SIEM query groups by, and a two-letter value there identifies nothing. The vendor prefix follows what the product is called in practice and keeps the name self-describing.

### Tests

- every spelling converges on `vercel_fx` (`fx`, `fx_cli`, `vercel-fx`, `fx.sh`, …)
- names merely *containing* "fx" keep their own name — the blast radius of getting this wrong
- `vercel_fx` survives re-normalization, so nothing that re-reads and re-writes an event renames it
- fx's model providers (`gateway`, `grok`, `codex`) are not mistaken for the harness

`go test ./...` green in `pkg/asymptoteobserve` and `cli/beacon`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhLzasbgAsNZWN35ZxKZGE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to harness name normalization in asymptoteobserve with extensive regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Adds **Vercel fx** to `NormalizeHarnessName` so common spellings (`fx`, `fx_cli`, `vercel-fx`, `fx.sh`, `fx_agent`, etc.) all write **`vercel_fx`** to `harness.name`, keeping one session from splitting across SIEM/dashboard groupings.
> 
> Matching uses a **closed equality list** (not substring), because `fx` is short and would falsely relabel names like `sfx` or `fxagent`. **`vercel_fx`** is chosen over bare `fx` so grouped telemetry stays self-describing.
> 
> Tests cover spelling convergence, non-swallowing of unrelated names, re-normalization stability, and that gateway/grok/codex provider strings are not mistaken for the harness (while `codex` still maps to `codex_cli`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 967b021d5c809e121718232948c03878157208d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->