### PR TITLE
feat(fx): report fx in endpoint discovery

### DIFF
--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -1291,6 +1291,11 @@ func harnessAction(h harness.Harness, effectiveUserMode bool) string {
 		return doctorRepairCommand(effectiveUserMode)
 	case "admin_otel":
 		return "beacon endpoint integrations claude-cowork setup"
+	// fx has nothing to install into, so the remedy is to run a collection sweep rather than to
+	// configure the runtime. Pointing at `hooks install` here would name a command that cannot
+	// succeed for this harness.
+	case "session_log":
+		return "beacon endpoint fx sync"
 	}
 	return ""
 }

--- a/cli/beacon/cmd/endpoint_fx.go
+++ b/cli/beacon/cmd/endpoint_fx.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -246,16 +245,11 @@ func runEndpointFxStatus(cmd *cobra.Command, args []string) error {
 // resolveFxStatePath always returns a path so the cursor survives between runs. Without one, every
 // scheduled sweep would re-append every session's whole history.
 //
-// It prefers the endpoint state directory next to the runtime log, and falls back to the OS temp
-// directory when there is no home to put it in -- some cron and service environments have none, and
-// a sweep with no cursor is worse than a cursor in a volatile place.
+// A system-mode sweep keeps its cursor beside the system runtime log; everything else uses the
+// per-user default in fxsession.DefaultStatePath.
 func resolveFxStatePath(override string, userMode bool) string {
 	if strings.TrimSpace(override) != "" {
 		return override
-	}
-	base := filepath.Join(os.TempDir(), "beacon")
-	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
-		base = filepath.Join(home, ".beacon")
 	}
 	if !userMode {
 		// A system-mode sweep collects on behalf of the machine, so its cursor belongs beside the
@@ -264,5 +258,5 @@ func resolveFxStatePath(override string, userMode bool) string {
 			return filepath.Join(dir, "fx-state.json")
 		}
 	}
-	return filepath.Join(base, "endpoint", "state", "fx.json")
+	return fxsession.DefaultStatePath()
 }

--- a/cli/beacon/internal/endpoint/harness/fx.go
+++ b/cli/beacon/internal/endpoint/harness/fx.go
@@ -1,0 +1,104 @@
+package harness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/fxsession"
+)
+
+// FxName is the canonical harness name for fx (vercel-labs/fx), matching what
+// asymptoteobserve.NormalizeHarnessName resolves every fx spelling to.
+const FxName = fxsession.Harness
+
+// DiscoverFx reports whether fx is present and how much of its session history Beacon has read.
+//
+// Its capability is "session_log", which no other runtime here has. The existing four all describe
+// something Beacon writes into the runtime -- a hooks file, a plugin, an OTel environment, an
+// admin-managed config -- and then the runtime calls Beacon. fx offers none of those: its lifecycle
+// hooks are compiled into the binary, it has no OpenTelemetry export, and MCP describes the tools
+// it calls rather than what it did. So Beacon reads the session records fx commits, and there is
+// nothing on disk to install or to check for a marker.
+//
+// That changes what "telemetry enabled" can honestly mean here. For a hook runtime the config file
+// answers it: the hook is installed or it is not. For fx the only evidence that telemetry is
+// flowing is that a sweep has actually run and knows about the sessions on this machine, so that is
+// what this reports -- not the mere presence of fx, which would claim coverage nobody has collected.
+func DiscoverFx() Harness {
+	h := Harness{Name: FxName, DisplayName: "fx (Vercel Labs)", Capability: "session_log"}
+	detectExecutable(&h, "fx")
+
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = "fx session directory could not be resolved: no home directory"
+		return h
+	}
+	sessionsDir := filepath.Join(home, ".fx", "sessions")
+	h.ConfigPath = sessionsDir
+
+	// fx installed through its setup script may not be on the PATH this process inherited -- a
+	// shell alias, a per-user bin directory, a version manager -- while its profile directory is
+	// still there. Treating that directory as evidence keeps discovery from reporting "not
+	// detected" for a runtime the user is actively running, the same fallback the opencode,
+	// Cursor, Hermes and Pi probes make for the same reason.
+	if !h.Detected && dirExists(filepath.Join(home, ".fx")) {
+		h.Detected = true
+	}
+
+	h.TelemetryStatus, h.Message = fxCollectionStatus(sessionsDir)
+	return h
+}
+
+// fxCollectionStatus classifies what Beacon has collected from fx's session store.
+//
+// The four cases are deliberately distinct, because the remedy differs and a single "not
+// configured" would send someone to fix the wrong thing:
+//
+//   - no session directory: fx has not run here, and there is nothing to collect yet.
+//   - sessions present, no cursor: fx has been used and `beacon endpoint fx sync` has not run.
+//   - cursor behind the sessions: collection is set up but stale; sweep again.
+//   - cursor level with every session: everything fx has committed has been read.
+func fxCollectionStatus(sessionsDir string) (TelemetryStatus, string) {
+	store := &fxsession.Store{Dir: sessionsDir}
+	if !store.Exists() {
+		return TelemetryMissing, "fx has written no sessions on this machine"
+	}
+	refs, err := store.List()
+	if err != nil {
+		return TelemetryMissing, "fx sessions could not be read: " + err.Error()
+	}
+	if len(refs) == 0 {
+		return TelemetryMissing, "fx has written no sessions on this machine"
+	}
+
+	state, err := fxsession.LoadState(fxsession.DefaultStatePath())
+	if err != nil {
+		return TelemetryMisconfigured, "fx collector state could not be read: " + err.Error()
+	}
+
+	collected := 0
+	for _, ref := range refs {
+		cursor := state.Sessions[ref.ID]
+		if cursor == nil || cursor.LastSeq == 0 {
+			continue
+		}
+		// A session with no readable manifest cannot say how far it has committed, so "collected"
+		// is claimed only where fx's own numbers confirm it rather than assumed from having read
+		// something.
+		if ref.Manifest != nil && cursor.Generation == ref.Manifest.LogGeneration &&
+			cursor.LastSeq >= ref.Manifest.LastEventSeq {
+			collected++
+		}
+	}
+
+	switch {
+	case collected == 0:
+		return TelemetryDisabled, fmt.Sprintf("%d fx session(s) present and none collected; run `beacon endpoint fx sync`", len(refs))
+	case collected < len(refs):
+		return TelemetryEnabled, fmt.Sprintf("fx session telemetry collected for %d of %d session(s); run `beacon endpoint fx sync` to catch up", collected, len(refs))
+	default:
+		return TelemetryEnabled, fmt.Sprintf("fx session telemetry collected for all %d session(s)", len(refs))
+	}
+}

--- a/cli/beacon/internal/endpoint/harness/fx_test.go
+++ b/cli/beacon/internal/endpoint/harness/fx_test.go
@@ -1,0 +1,182 @@
+package harness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/fxsession"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+)
+
+const (
+	fxTestGeneration = "1f4b2c8e6d3a5a7c9b613f0d5e8c2a14"
+	fxTestSession    = "1770000000000-1770000000000000000-a1b2c3d4e5f60718"
+)
+
+// writeFxSession lays out one fx session under home, as fx leaves it once a turn is committed.
+func writeFxSession(t *testing.T, home, id string) {
+	t.Helper()
+	dir := filepath.Join(home, ".fx", "sessions", id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := fmt.Sprintf(
+		`{"schema_version":1,"log_generation":%q,"seq":1,"event_id":"a1","timestamp_ms":1770000000000,"kind":"session_started",`+
+			`"payload":{"id":%q,"created_at_ms":1770000000000,"origin_workspace_root":"/repo","workspace_root":"/repo",`+
+			`"conversation_language":"en","preferences":{"provider":"gateway","model":"m","effort":"medium","fast_mode":false},"usage":null}}`,
+		fxTestGeneration, id) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(line), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifest := fmt.Sprintf(
+		`{"schema_version":3,"storage_format":"event_log_v1","id":%q,"authority_id":"ab","log_generation":%q,`+
+			`"created_at_ms":1770000000000,"updated_at_ms":1770000000000,"origin_workspace_root":"/repo","workspace_root":"/repo",`+
+			`"conversation_language":"en","history_len":0,"total_input_tokens":0,"total_output_tokens":0,`+
+			`"last_event_seq":1,"event_log_bytes":%d,"event_log_stat_fingerprint":"cd",`+
+			`"generation_base_seq":0,"generation_base_bytes":0,"checkpoint_seq":null,"checkpoint_sha256":null,`+
+			`"preferences":{"provider":"gateway","model":"m","effort":"medium","fast_mode":false}}`,
+		id, fxTestGeneration, len(line))
+	if err := os.WriteFile(filepath.Join(dir, "session.json"), []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeFxCursor(t *testing.T, home string, cursor fxsession.Cursor, id string) {
+	t.Helper()
+	state := &fxsession.State{Version: fxsession.StateVersion, Sessions: map[string]*fxsession.Cursor{id: &cursor}}
+	if err := state.Save(filepath.Join(home, ".beacon", "endpoint", "state", "fx.json")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fxHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
+
+// The harness name discovery reports has to be the one the collector writes, or `endpoint discover`
+// and the runtime log describe the same runtime under two names.
+func TestDiscoverFxUsesTheCanonicalHarnessName(t *testing.T) {
+	if FxName != fxsession.Harness {
+		t.Fatalf("discovery reports %q while the collector writes %q", FxName, fxsession.Harness)
+	}
+	if got := asymptoteobserve.NormalizeHarnessName(FxName); got != FxName {
+		t.Fatalf("NormalizeHarnessName(%q) = %q", FxName, got)
+	}
+}
+
+// A machine that has never run fx must report that plainly rather than as a broken install.
+func TestDiscoverFxOnAMachineWithoutFx(t *testing.T) {
+	fxHome(t)
+
+	h := DiscoverFx()
+	if h.TelemetryStatus != TelemetryMissing {
+		t.Errorf("status = %q, want %q", h.TelemetryStatus, TelemetryMissing)
+	}
+	if !strings.Contains(h.Message, "no sessions") {
+		t.Errorf("message = %q", h.Message)
+	}
+	if h.Capability != "session_log" {
+		t.Errorf("capability = %q, want session_log", h.Capability)
+	}
+}
+
+// fx has been used and nothing has collected from it. This is the case where a "telemetry enabled"
+// answer would be a lie: the sessions are there, the events are not.
+func TestDiscoverFxReportsUncollectedSessionsAsDisabled(t *testing.T) {
+	home := fxHome(t)
+	writeFxSession(t, home, fxTestSession)
+
+	h := DiscoverFx()
+	if h.TelemetryStatus != TelemetryDisabled {
+		t.Fatalf("status = %q, want %q -- sessions exist but nothing has read them", h.TelemetryStatus, TelemetryDisabled)
+	}
+	if !strings.Contains(h.Message, "beacon endpoint fx sync") {
+		t.Errorf("message = %q, want it to name the command that fixes this", h.Message)
+	}
+	if !h.Detected {
+		t.Error("fx was not detected despite its profile directory being present")
+	}
+}
+
+func TestDiscoverFxReportsCollectedSessionsAsEnabled(t *testing.T) {
+	home := fxHome(t)
+	writeFxSession(t, home, fxTestSession)
+	writeFxCursor(t, home, fxsession.Cursor{Generation: fxTestGeneration, LastSeq: 1, Started: true}, fxTestSession)
+
+	h := DiscoverFx()
+	if h.TelemetryStatus != TelemetryEnabled {
+		t.Fatalf("status = %q, want %q", h.TelemetryStatus, TelemetryEnabled)
+	}
+	if !strings.Contains(h.Message, "all 1 session") {
+		t.Errorf("message = %q", h.Message)
+	}
+}
+
+// A cursor from an earlier sweep that has fallen behind is not the same as no collection at all,
+// and the difference decides whether someone goes looking for a broken setup or just runs a sweep.
+func TestDiscoverFxDistinguishesStaleCollectionFromNone(t *testing.T) {
+	home := fxHome(t)
+	writeFxSession(t, home, fxTestSession)
+	other := "1770000000001-1770000000000000001-b1b2c3d4e5f60718"
+	writeFxSession(t, home, other)
+	writeFxCursor(t, home, fxsession.Cursor{Generation: fxTestGeneration, LastSeq: 1, Started: true}, fxTestSession)
+
+	h := DiscoverFx()
+	if h.TelemetryStatus != TelemetryEnabled {
+		t.Fatalf("status = %q, want %q", h.TelemetryStatus, TelemetryEnabled)
+	}
+	if !strings.Contains(h.Message, "1 of 2") {
+		t.Errorf("message = %q, want it to say how far behind collection is", h.Message)
+	}
+}
+
+// A cursor pointing at a generation the session no longer has means fx compacted the log after the
+// last sweep. That session is not collected, and saying it is would hide a real gap.
+func TestDiscoverFxDoesNotCountACursorFromAnotherGeneration(t *testing.T) {
+	home := fxHome(t)
+	writeFxSession(t, home, fxTestSession)
+	writeFxCursor(t, home, fxsession.Cursor{Generation: "ffffffffffffffffffffffffffffffff", LastSeq: 99, Started: true}, fxTestSession)
+
+	h := DiscoverFx()
+	if h.TelemetryStatus != TelemetryDisabled {
+		t.Fatalf("status = %q, want %q -- the cursor describes a log generation that is gone", h.TelemetryStatus, TelemetryDisabled)
+	}
+}
+
+// Discovery is a read. It must not create fx's directory, Beacon's state directory, or anything
+// else in the home of someone who does not run fx.
+func TestDiscoverFxWritesNothing(t *testing.T) {
+	home := fxHome(t)
+
+	DiscoverFx()
+
+	entries, err := os.ReadDir(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		t.Fatalf("discovery created %v in a home that had nothing", names)
+	}
+}
+
+// fx is part of the discovery sweep, not a separate command someone has to know to run.
+func TestDiscoverAllIncludesFx(t *testing.T) {
+	fxHome(t)
+	for _, h := range DiscoverAll() {
+		if h.Name == FxName {
+			return
+		}
+	}
+	t.Fatalf("DiscoverAll does not include %q", FxName)
+}

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -58,6 +58,7 @@ func DiscoverAll() []Harness {
 		DiscoverOpenCode(),
 		DiscoverCline(),
 		DiscoverPi(),
+		DiscoverFx(),
 		DiscoverQwen(),
 		DiscoverHermes(),
 		DiscoverFactory(),

--- a/cli/beacon/internal/fxsession/collect.go
+++ b/cli/beacon/internal/fxsession/collect.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/writer"
@@ -99,6 +100,23 @@ func (s *State) cursor(sessionID string) *Cursor {
 		s.Sessions[sessionID] = c
 	}
 	return c
+}
+
+// DefaultStatePath is where the collector keeps its cursor for the current user.
+//
+// It lives beside Beacon's other endpoint state rather than in fx's directory: it is Beacon's
+// record of what Beacon has read, and writing it into ~/.fx would put a file fx does not know about
+// inside the store fx owns.
+//
+// Falls back to the OS temp directory when there is no home to put it in. Some cron and service
+// environments have none, and a sweep with a cursor somewhere volatile still beats a sweep with no
+// cursor at all -- the latter re-appends every session's whole history on every run.
+func DefaultStatePath() string {
+	base := filepath.Join(os.TempDir(), "beacon")
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		base = filepath.Join(home, ".beacon")
+	}
+	return filepath.Join(base, "endpoint", "state", "fx.json")
 }
 
 // CollectOptions configures one sweep over fx's session store.


### PR DESCRIPTION
**Stack 5/8 — fx (vercel-labs/fx) support.** Base: `claude/fx-04-collector-command` (#403).

fx gets a capability no other runtime here has: `session_log`. The existing four all name something Beacon *writes into* the runtime — a hooks file, a plugin, an OTel environment, an admin-managed config — after which the runtime calls Beacon. fx offers none of those, so there is no file to check for a marker.

### What "telemetry enabled" can honestly mean here

For a hook runtime the config file answers it: the hook is installed or it is not. For fx the only evidence telemetry is flowing is that a sweep has run and is level with the sessions on the machine — so that is what discovery reports, in four states, because the remedy differs:

| State | Meaning |
| --- | --- |
| `missing` | fx has written no sessions here |
| `disabled` | sessions exist and nothing has read them → run `beacon endpoint fx sync` |
| `enabled` (partial) | collection set up but behind — says how far |
| `enabled` | everything fx has committed has been read |

A cursor pointing at a log generation fx has since compacted away counts as **not** collected, because it is.

Doctor's remedy for the capability is `beacon endpoint fx sync` rather than `hooks install`, which for this harness would name a command that cannot succeed.

### Tests

Canonical name matches what the collector writes; each of the four states; a stale-generation cursor is not counted as collected; `DiscoverAll` includes fx; and discovery **writes nothing** — the absence of `~/.fx` is the evidence that fx has not run, and a probe that creates it destroys that evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhLzasbgAsNZWN35ZxKZGE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only discovery and doctor action strings; cursor path refactor aligns CLI with shared defaults with limited blast radius.
> 
> **Overview**
> **fx** is now part of endpoint harness discovery via a new **`session_log`** capability (poll-based collection, not hooks/OTel). **`DiscoverFx`** detects fx from the binary or `~/.fx`, then classifies telemetry from whether Beacon’s collector cursor is caught up with fx session manifests—not from install markers.
> 
> Discovery distinguishes **missing**, **disabled** (sessions exist, never synced), **partial**, and **fully collected** states, including cursors stale after log compaction. **`DiscoverAll`** includes fx; endpoint doctor’s harness remedy for **`session_log`** is **`beacon endpoint fx sync`** instead of hooks install.
> 
> Collector cursor defaults are centralized in **`fxsession.DefaultStatePath()`**; user-mode **`resolveFxStatePath`** delegates there while system mode still keeps the cursor beside the system runtime log. Tests cover the four states, canonical harness naming, read-only discovery, and **`DiscoverAll`** inclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9acbea4b8ab0467739912613c4d4593e9134680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->