### PR TITLE
feat(fx): inventory fx configuration and its MCP servers

### DIFF
--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -43,6 +43,11 @@ const (
 	ScopeSystem    = "system"
 	ScopeUnknown   = "unknown"
 
+	// fxRuntime is the runtime key inventory files fx's configuration under. It is the same
+	// canonical harness name the collector writes on every fx event, so an inventory row and a log
+	// line describe one runtime rather than two.
+	fxRuntime = "vercel_fx"
+
 	StatusOK          = "ok"
 	StatusPartial     = "partial"
 	StatusParseFailed = "parse_failed"
@@ -209,6 +214,7 @@ func candidates(home, wd string) []candidate {
 	items = append(items, devinCandidates(home, wd)...)
 	items = append(items, grokCandidates(home, wd)...)
 	items = append(items, qwenCandidates(home, wd)...)
+	items = append(items, fxCandidates(home, wd)...)
 	seen := map[string]bool{}
 	out := make([]candidate, 0, len(items))
 	for _, item := range items {
@@ -342,6 +348,28 @@ func qwenCandidates(home, wd string) []candidate {
 	return []candidate{
 		{runtime: "qwen_code", path: filepath.Join(home, ".qwen", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		{runtime: "qwen_code", path: filepath.Join(wd, ".qwen", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+	}
+}
+
+// fx keeps no Beacon-written file, so every entry here is fx's own configuration rather than
+// something Beacon installed -- which is why they are all KindNativeConfig and why beacon_managed
+// stays false for them. Reporting them is still the point of an inventory: what runtimes are on
+// this machine and what they are wired to.
+//
+// The MCP files are the reason this is worth having at all. fx's profile server list lives in
+// ~/.fx/mcp.json under an `mcp` key (with `mcpServers` accepted as an alias), and a workspace can
+// add a Claude-compatible .mcp.json with `mcpServers` -- both keys the scanner already reads, so
+// fx's MCP servers land in the same inventory as every other runtime's with no parser of their own.
+//
+// The workspace .mcp.json is attributed to fx and to nothing else here, even though other runtimes
+// read the same file: attributing one file to several runtimes would report one server as several,
+// and fx is the runtime this pass is adding. A machine running two agents over one .mcp.json still
+// gets its servers inventoried once.
+func fxCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: fxRuntime, path: filepath.Join(home, ".fx", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: fxRuntime, path: filepath.Join(home, ".fx", "mcp.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: fxRuntime, path: filepath.Join(wd, ".mcp.json"), scope: ScopeProject, format: formatJSON, kind: KindNativeConfig},
 	}
 }
 

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -353,6 +353,12 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 		{runtime: "grok", path: filepath.Join(work, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 		{runtime: "qwen_code", path: filepath.Join(home, ".qwen", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		{runtime: "qwen_code", path: filepath.Join(work, ".qwen", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+		// fx has no Beacon-written file, so all three are its own configuration. The two MCP files
+		// are the ones that carry information nothing else here reports: fx's profile server list
+		// and the workspace servers it shares with Claude-compatible runtimes.
+		{runtime: fxRuntime, path: filepath.Join(home, ".fx", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: fxRuntime, path: filepath.Join(home, ".fx", "mcp.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
+		{runtime: fxRuntime, path: filepath.Join(work, ".mcp.json"), scope: ScopeProject, format: formatJSON, kind: KindNativeConfig},
 	}
 	if got, want := len(result.Configs), len(expected); got != want {
 		t.Fatalf("config candidates = %d, want %d", got, want)
@@ -918,5 +924,76 @@ func TestQwenManagedDetectionReadsTheHookCommand(t *testing.T) {
 				t.Errorf("beaconManaged(qwen_code) = %t, want %t for %s", got, tc.want, tc.settings)
 			}
 		})
+	}
+}
+
+// fx keeps its profile MCP servers under an `mcp` key and accepts `mcpServers` as an alias, and a
+// workspace can add a Claude-compatible .mcp.json. Both keys are ones the scanner already reads, so
+// what this test protects is the wiring: fx's files being scanned at all, and being attributed to
+// the same harness name the collector writes on fx events.
+func TestScanFxMCPInventory(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	writeFile(t, filepath.Join(home, ".fx", "mcp.json"), `{
+  "mcp": {
+    "docs": {
+      "command": "docs-server",
+      "args": ["--stdio"],
+      "env": {"DOCS_TOKEN": "secret"}
+    }
+  }
+}`)
+	writeFile(t, filepath.Join(work, ".mcp.json"), `{
+  "mcpServers": {
+    "issues": {
+      "url": "https://example.test/mcp",
+      "transport": "http"
+    }
+  }
+}`)
+	writeFile(t, filepath.Join(home, ".fx", "settings.json"), `{"collapse_tool_calls": true}`)
+
+	result := Scan(Options{HomeDir: home, WorkingDir: work, Now: fixedNow})
+
+	// One env key, and its name is withheld: DOCS_TOKEN reads as a secret, so the inventory counts
+	// it without naming it. The count is the point -- a server with credentials in its environment
+	// is worth knowing about even when the key names are not safe to print.
+	assertServer(t, result.MCPServers, fxRuntime, "docs", TransportStdio, true, 1, 0, 1)
+	assertServer(t, result.MCPServers, fxRuntime, "issues", TransportHTTP, false, 0, 0, 0)
+
+	settings := findConfig(result.Configs, fxRuntime, filepath.Join(home, ".fx", "settings.json"))
+	if settings == nil {
+		t.Fatal("fx settings.json is not in the inventory")
+	}
+	if !settings.Exists || settings.ParserStatus != StatusOK {
+		t.Fatalf("fx settings status = exists:%t parser:%s", settings.Exists, settings.ParserStatus)
+	}
+	// Beacon writes nothing into fx, so claiming these files as Beacon-managed would assert an
+	// install that does not exist -- and would make `endpoint inventory` disagree with
+	// `endpoint discover`, which reports fx as a runtime Beacon reads rather than configures.
+	if settings.BeaconManaged {
+		t.Error("fx settings.json is reported as Beacon-managed; Beacon writes nothing into fx")
+	}
+}
+
+// A machine with fx installed and no MCP servers configured must produce inventory rows saying the
+// files are absent, not an error and not a phantom server.
+func TestScanFxWithoutMCPConfigurationIsQuiet(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+
+	result := Scan(Options{HomeDir: home, WorkingDir: work, Now: fixedNow})
+
+	for _, server := range result.MCPServers {
+		if server.Runtime == fxRuntime {
+			t.Fatalf("fx server reported with no fx configuration on disk: %#v", server)
+		}
+	}
+	config := findConfig(result.Configs, fxRuntime, filepath.Join(home, ".fx", "mcp.json"))
+	if config == nil {
+		t.Fatal("fx mcp.json candidate is missing from the inventory")
+	}
+	if config.Exists || config.ParserStatus != StatusNotFound {
+		t.Errorf("absent fx mcp.json reported as exists:%t parser:%s", config.Exists, config.ParserStatus)
 	}
 }


### PR DESCRIPTION
**Stack 6/8 — fx (vercel-labs/fx) support.** Base: `claude/fx-05-discovery` (#404).

Adds `~/.fx/settings.json`, `~/.fx/mcp.json`, and the workspace `.mcp.json` to the endpoint inventory scan.

All three are fx's **own** configuration, not a Beacon-written file: `KindNativeConfig`, and `beacon_managed` stays false. That is what keeps `endpoint inventory` agreeing with `endpoint discover` about fx being a runtime Beacon reads rather than one it configures.

### Why it earns its place

The MCP files. fx keeps its profile server list in `~/.fx/mcp.json` under an `mcp` key (with `mcpServers` accepted as an alias) and a workspace can add a Claude-compatible `.mcp.json` — both keys the scanner already reads, so fx's MCP servers land in the same inventory as every other runtime's without a parser of their own.

The workspace `.mcp.json` is attributed to fx alone. Shared between runtimes as it is, attributing it to several would report one server as several.

### Tests

Both files' servers appear under the canonical harness name with transport, args and env-key counts; a server whose env key reads as a secret is counted without being named; the config rows are not claimed as Beacon-managed; and a machine with no fx MCP configuration produces "absent" rows rather than an error or a phantom server.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhLzasbgAsNZWN35ZxKZGE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only inventory expansion with no auth or install-path changes; main nuance is fx-only attribution of workspace `.mcp.json`, which may omit that file from other runtime filters until those runtimes add their own candidates.
> 
> **Overview**
> Extends **endpoint inventory** so **vercel fx** (`vercel_fx`) appears alongside other agent runtimes: `~/.fx/settings.json`, `~/.fx/mcp.json`, and workspace `.mcp.json` are scanned as **native fx config** (`KindNativeConfig`), with **`beacon_managed` false** because Beacon does not install into fx.
> 
> MCP servers from fx profile files are picked up via existing parsers for the `mcp` and `mcpServers` keys (stdio and HTTP transports, env-key counts with secret names withheld). Workspace `.mcp.json` is attributed **only to fx** in this pass so shared Claude-style MCP files are not double-counted under multiple runtimes.
> 
> Tests cover MCP wiring under `vercel_fx`, non-managed config rows, and quiet **not_found** behavior when fx MCP files are absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd83a10cc1ba5745e141837f2ad1ab4822699e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->