### PR TITLE
feat(omp): record approvals, operator Python, and MCP attribution

### DIFF
--- a/cli/beacon-hooks/cmd/omp_approval_test.go
+++ b/cli/beacon-hooks/cmd/omp_approval_test.go
@@ -1,0 +1,274 @@
+package cmd
+
+import "testing"
+
+// The capability Oh My Pi has and Pi does not, and the reason it gets its own mapping rather than
+// being folded into the tool events: these are decisions an operator was actually asked to make.
+//
+// Beacon has always refused to synthesize an approval from a tool call, because a `tool_call`
+// handler that blocks is an extension deciding and recording that as an approval would be
+// indistinguishable from a human's answer. Here the runtime reports the prompt and the answer, so
+// the events are real and are marked `observed`.
+func TestOmpApprovalRequestedIsRecorded(t *testing.T) {
+	logPath := ompTestLog(t)
+
+	runHookWithInput(t, runOmpEvent, map[string]interface{}{
+		"type": "tool_approval_requested", "sessionId": "sess-1",
+		"toolName": "bash", "toolCallId": "call-1",
+		"reason": "writes outside the workspace", "approvalMode": "always-ask",
+	})
+
+	event := ompEventWithAction(t, logPath, "approval.requested")
+	approval := nested(t, event, "approval")
+	if approval["required"] != true || approval["decision"] != "requested" {
+		t.Fatalf("approval = %v, want a required, still-pending decision", approval)
+	}
+	// The runtime's own words for why, not a Beacon-authored sentence.
+	if approval["reason"] != "writes outside the workspace" {
+		t.Fatalf("approval.reason = %v, want the runtime's reason", approval["reason"])
+	}
+	if meta := nested(t, event, "event"); meta["category"] != "approval" {
+		t.Fatalf("category = %v, want approval", meta["category"])
+	}
+	// A decision the operator was genuinely asked for is observed, never inferred.
+	if fidelity := nested(t, event, "event")["fidelity"]; fidelity != "observed" {
+		t.Fatalf("event.fidelity = %v, want observed", fidelity)
+	}
+}
+
+func TestOmpApprovalResolvedRecordsTheDecision(t *testing.T) {
+	for _, tc := range []struct {
+		approved bool
+		action   string
+		decision string
+	}{
+		{true, "approval.allowed", "approve"},
+		{false, "approval.denied", "deny"},
+	} {
+		t.Run(tc.action, func(t *testing.T) {
+			logPath := ompTestLog(t)
+
+			runHookWithInput(t, runOmpEvent, map[string]interface{}{
+				"type": "tool_approval_resolved", "sessionId": "sess-1",
+				"toolName": "bash", "toolCallId": "call-1", "approved": tc.approved,
+			})
+
+			event := ompEventWithAction(t, logPath, tc.action)
+			if approval := nested(t, event, "approval"); approval["decision"] != tc.decision {
+				t.Fatalf("approval.decision = %v, want %q", approval["decision"], tc.decision)
+			}
+			if tool := nested(t, event, "tool"); tool["name"] != "bash" {
+				t.Fatalf("tool.name = %v, want bash", tool["name"])
+			}
+		})
+	}
+}
+
+// A resolved approval that carries no `approved` field is a denial, not an allow.
+//
+// The runtime states the outcome as a boolean, so a missing or non-boolean value means Beacon
+// cannot see an approval -- and the safe reading of "no evidence the operator said yes" is not
+// "the operator said yes". Defaulting the other way would turn a malformed payload into a clean
+// record of consent.
+func TestOmpApprovalWithoutAnAffirmativeIsNotAnAllow(t *testing.T) {
+	for _, payload := range []map[string]interface{}{
+		{"type": "tool_approval_resolved", "toolName": "bash", "toolCallId": "c1"},
+		{"type": "tool_approval_resolved", "toolName": "bash", "toolCallId": "c1", "approved": "yes"},
+		{"type": "tool_approval_resolved", "toolName": "bash", "toolCallId": "c1", "approved": nil},
+	} {
+		events := ompRuntime.endpointEvents(payload, "sess-1")
+		if len(events) != 1 {
+			t.Fatalf("payload %v produced %d events, want 1", payload, len(events))
+		}
+		if events[0].action != "approval.denied" {
+			t.Fatalf("payload %v produced %q; an unreadable outcome must not be recorded as consent",
+				payload, events[0].action)
+		}
+	}
+}
+
+// The single most load-bearing fact about any approval row: whether the prompts were on at all.
+// "yolo" means the operator turned them off, which is the difference between a decision someone
+// made and a decision nobody was asked to make.
+func TestOmpApprovalRecordsTheApprovalMode(t *testing.T) {
+	for _, mode := range []string{"always-ask", "write", "yolo"} {
+		t.Run(mode, func(t *testing.T) {
+			logPath := ompTestLog(t)
+
+			runHookWithInput(t, runOmpEvent, map[string]interface{}{
+				"type": "tool_approval_requested", "sessionId": "sess-1",
+				"toolName": "bash", "toolCallId": "call-1", "approvalMode": mode,
+			})
+
+			event := ompEventWithAction(t, logPath, "approval.requested")
+			if raw := nested(t, event, "raw"); raw["omp_approval_mode"] != mode {
+				t.Fatalf("raw.omp_approval_mode = %v, want %q", raw["omp_approval_mode"], mode)
+			}
+		})
+	}
+}
+
+// An approval carries no tool arguments, because the runtime does not put them on these events. The
+// call id is the join back to the tool.invoked that does carry them -- so an investigation can go
+// from "this was approved" to "this is what was approved". Without it the approval names a tool and
+// nothing else.
+func TestOmpApprovalJoinsToTheToolCallItDecided(t *testing.T) {
+	for _, payload := range []map[string]interface{}{
+		{"type": "tool_approval_requested", "toolName": "bash", "toolCallId": "call-77"},
+		{"type": "tool_approval_resolved", "toolName": "bash", "toolCallId": "call-77", "approved": true},
+	} {
+		t.Run(payload["type"].(string), func(t *testing.T) {
+			events := ompRuntime.endpointEvents(payload, "sess-1")
+			if len(events) != 1 {
+				t.Fatalf("produced %d events, want 1", len(events))
+			}
+			if got := piFamilyToolCallID(t, events[0]); got != "call-77" {
+				t.Fatalf("gen_ai.tool.call.id = %q, want call-77 -- an approval that cannot be "+
+					"joined to its tool call names a tool and nothing else", got)
+			}
+		})
+	}
+}
+
+// Pi must not gain approvals by sharing the mapper. It never sends these events, so the cases are
+// unreachable for it -- a stronger guarantee than a platform check, which could be forgotten.
+func TestOmpOnlyEventTypesAreNotInPis(t *testing.T) {
+	pi := map[string]bool{}
+	for _, name := range supportedPiEventTypes() {
+		pi[name] = true
+	}
+	for _, name := range []string{"tool_approval_requested", "tool_approval_resolved", "user_python"} {
+		if pi[name] {
+			t.Fatalf("Pi's extension subscribes to %q; Pi exposes no such event, and subscribing "+
+				"to one would put a decision nobody made into the log", name)
+		}
+	}
+}
+
+// The `$` prefix runs Python in the runtime's own REPL. It is the operator's code, executed as
+// literally as a shell command -- os.system("rm -rf /") is a shell command wearing a Python hat --
+// so it lands in the command category where the risky-command rules can see it, marked as the
+// operator's and as Python rather than passed off as a shell command.
+func TestOmpUserPythonIsRecordedAsAnOperatorCommand(t *testing.T) {
+	logPath := ompTestLog(t)
+	code := "import os; os.system('id')"
+
+	runHookWithInput(t, runOmpEvent, map[string]interface{}{
+		"type": "user_python", "code": code, "excludeFromContext": false,
+		"cwd": "/repo", "sessionId": "sess-1",
+	})
+
+	event := ompEventWithAction(t, logPath, "command.executed")
+	if command := nested(t, event, "command"); command["command"] != code {
+		t.Fatalf("command.command = %v, want the Python source", command["command"])
+	}
+	if tool := nested(t, event, "tool"); tool["name"] != "user_python" {
+		t.Fatalf("tool.name = %v, want user_python -- it must be distinguishable from a shell "+
+			"command that happens to have been run by the operator", tool["name"])
+	}
+	raw := nested(t, event, "raw")
+	if raw["omp_user_initiated"] != true || raw["omp_user_python"] != true {
+		t.Fatalf("raw = %v, want it marked operator-initiated and Python", raw)
+	}
+}
+
+func TestOmpEmptyUserPythonProducesNothing(t *testing.T) {
+	events := ompRuntime.endpointEvents(map[string]interface{}{
+		"type": "user_python", "cwd": "/repo",
+	}, "sess-1")
+	if len(events) != 0 {
+		t.Fatalf("empty user_python produced %d events, want none", len(events))
+	}
+}
+
+// MCP attribution. Without it an MCP call lands in the log as a tool named
+// `mcp__github_create_issue` and nothing else, so the two questions actually asked about MCP
+// activity -- which server did this agent reach, and what did it call there -- have no field to
+// answer them.
+func TestOmpMCPToolIsAttributedToItsServer(t *testing.T) {
+	logPath := ompTestLog(t)
+
+	runHookWithInput(t, runOmpEvent, map[string]interface{}{
+		"type": "tool_result", "toolName": "mcp__github_create_issue", "toolCallId": "call-1",
+		"input": map[string]interface{}{"title": "bug"}, "sessionId": "sess-1",
+	})
+
+	event := ompEventWithAction(t, logPath, "mcp.tool_invoked")
+	mcp := nested(t, event, "mcp")
+	if mcp["server"] != "github" || mcp["tool"] != "create_issue" {
+		t.Fatalf("mcp = %v, want the github server and its create_issue tool", mcp)
+	}
+	if meta := nested(t, event, "event"); meta["category"] != "mcp" {
+		t.Fatalf("category = %v, want mcp", meta["category"])
+	}
+}
+
+// Both spellings must resolve. `mcp__<server>__<tool>` is the widely used double-underscore form;
+// Oh My Pi mints `mcp__<server>_<tool>` with a single underscore. The single-underscore split
+// deliberately reproduces Oh My Pi's own parseMCPToolName, ambiguity included -- a server named
+// `my_server` reads as `my` in both, so Beacon's mcp.server always says what the runtime would say.
+func TestPiMCPServerToolReadsBothSpellings(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		server, tool string
+	}{
+		{"mcp__github_create_issue", "github", "create_issue"},
+		{"mcp__github__create_issue", "github", "create_issue"},
+		{"mcp__puppeteer_screenshot", "puppeteer", "screenshot"},
+		{"mcp__my_server_run", "my", "server_run"},
+		// Not MCP names, and must not be forced into one.
+		{"bash", "", ""},
+		{"read", "", ""},
+		{"my_custom_tool", "", ""},
+		{"", "", ""},
+		// Prefixed but with no tool half to speak of.
+		{"mcp__github", "", ""},
+		{"mcp__", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server, tool := piMCPServerTool(tc.name)
+			if server != tc.server || tool != tc.tool {
+				t.Fatalf("piMCPServerTool(%q) = (%q, %q), want (%q, %q)",
+					tc.name, server, tool, tc.server, tc.tool)
+			}
+		})
+	}
+}
+
+// An approval for an MCP tool is attributed too. "Who approved a call to which server" is the
+// question an approval-abuse investigation asks, and it cannot be answered from a tool name alone.
+func TestOmpApprovalForAnMCPToolCarriesTheServer(t *testing.T) {
+	logPath := ompTestLog(t)
+
+	runHookWithInput(t, runOmpEvent, map[string]interface{}{
+		"type": "tool_approval_resolved", "sessionId": "sess-1",
+		"toolName": "mcp__github_create_issue", "toolCallId": "call-1", "approved": true,
+	})
+
+	event := ompEventWithAction(t, logPath, "approval.allowed")
+	if mcp := nested(t, event, "mcp"); mcp["server"] != "github" || mcp["tool"] != "create_issue" {
+		t.Fatalf("mcp = %v, want the github server and its create_issue tool", mcp)
+	}
+}
+
+// A non-MCP tool must not grow an mcp block. A row with an mcp block is one every MCP-scoped query
+// matches, and a bash call is not MCP activity.
+func TestOmpNonMCPToolsHaveNoMCPBlock(t *testing.T) {
+	for _, tool := range []string{"bash", "read", "edit", "write", "grep", "my_custom_tool"} {
+		t.Run(tool, func(t *testing.T) {
+			events := ompRuntime.endpointEvents(map[string]interface{}{
+				"type": "tool_result", "toolName": tool,
+				"input": map[string]interface{}{"command": "ls", "path": "/repo/a.go"},
+			}, "sess-1")
+			if len(events) != 1 {
+				t.Fatalf("produced %d events, want 1", len(events))
+			}
+			if _, ok := events[0].fields["mcp"]; ok {
+				t.Fatalf("%s grew an mcp block: %v", tool, events[0].fields["mcp"])
+			}
+			if events[0].action == "mcp.tool_invoked" {
+				t.Fatalf("%s was recorded as MCP activity", tool)
+			}
+		})
+	}
+}

--- a/cli/beacon-hooks/cmd/omp_event.go
+++ b/cli/beacon-hooks/cmd/omp_event.go
@@ -40,6 +40,17 @@ func runOmpEvent(cmd *cobra.Command, args []string) {
 // message updates, compaction and retry signals, TUI plumbing. Those describe how the runtime got
 // its work done rather than what the agent did, and subscribing to them would fill the runtime log
 // with rows no investigation asks for while putting Beacon in the path of every streaming token.
+//
+// The three entries Pi's list does not have are the ones Oh My Pi exposes and Pi does not:
+// `tool_approval_requested`/`tool_approval_resolved` are real operator decisions, which is the
+// signal Beacon has always refused to synthesize on runtimes that do not report it; `user_python`
+// is the operator's own `$` code, which no tool event covers.
+//
+// `mcp_notification` is deliberately absent. It fires for every JSON-RPC notification a connected
+// server sends, most of them routine tools/resources list refreshes, and it describes MCP transport
+// plumbing rather than an action the agent took. The MCP activity worth recording is the agent
+// calling an MCP tool, which arrives as an ordinary tool_call/tool_result pair and is attributed to
+// its server by piMCPServerTool.
 func supportedOmpEventTypes() []string {
 	return []string{
 		"session_start",
@@ -48,6 +59,9 @@ func supportedOmpEventTypes() []string {
 		"tool_call",
 		"tool_result",
 		"user_bash",
+		"user_python",
+		"tool_approval_requested",
+		"tool_approval_resolved",
 		"message_end",
 	}
 }

--- a/cli/beacon-hooks/cmd/omp_event_test.go
+++ b/cli/beacon-hooks/cmd/omp_event_test.go
@@ -50,6 +50,11 @@ func ompPayloads() map[string]map[string]interface{} {
 		"tool_call":        {"type": "tool_call", "toolName": "bash", "toolCallId": "c1", "input": map[string]interface{}{"command": "ls"}},
 		"tool_result":      {"type": "tool_result", "toolName": "bash", "toolCallId": "c1", "input": map[string]interface{}{"command": "ls"}},
 		"user_bash":        {"type": "user_bash", "command": "git status", "cwd": "/repo"},
+		"user_python":      {"type": "user_python", "code": "print(1)", "cwd": "/repo"},
+		"tool_approval_requested": {"type": "tool_approval_requested", "toolName": "bash", "toolCallId": "c1",
+			"approvalMode": "always-ask", "reason": "writes outside the workspace"},
+		"tool_approval_resolved": {"type": "tool_approval_resolved", "toolName": "bash", "toolCallId": "c1",
+			"approved": true},
 		"message_end": {"type": "message_end", "message": map[string]interface{}{
 			"role":  "assistant",
 			"usage": map[string]interface{}{"input": float64(10), "output": float64(5)},
@@ -132,7 +137,17 @@ func TestOmpEventIsAttributedToOhMyPiNotPi(t *testing.T) {
 // above, this pins the property that matters -- one shared shape, two identities -- rather than
 // just asserting each side in isolation.
 func TestPiAndOmpProduceTheSameShapeUnderDifferentIdentities(t *testing.T) {
+	shared := map[string]bool{}
+	for _, name := range supportedPiEventTypes() {
+		shared[name] = true
+	}
 	for name, payload := range ompPayloads() {
+		// The Oh My Pi-only types are excluded rather than expected to match: Pi's extension never
+		// sends them, so there is no Pi behavior to compare against. TestOmpOnlyEventTypesAreNotInPis
+		// pins that asymmetry from the other side.
+		if !shared[name] {
+			continue
+		}
 		t.Run(name, func(t *testing.T) {
 			piEvents := piRuntime.endpointEvents(cloneFields(payload), "sess-1")
 			ompEvents := ompRuntime.endpointEvents(cloneFields(payload), "sess-1")

--- a/cli/beacon-hooks/cmd/pi_family.go
+++ b/cli/beacon-hooks/cmd/pi_family.go
@@ -22,9 +22,12 @@ import (
 // names (see asymptoteobserve.NormalizeHarnessName), and every event carries its own runtime's
 // name in `raw` so an operator reading a row can tell which binary produced it.
 //
-// Events one runtime has and the other does not are mapped by that runtime, not here. Oh My Pi
-// exposes operator approval decisions and Pi does not, and inventing a Pi approval to keep the two
-// symmetric would put a decision nobody made into the log.
+// Events one runtime has and the other does not are mapped here too, and gated by the subscription
+// list rather than by a branch: Oh My Pi's extension subscribes to its approval and user_python
+// events, Pi's does not, so those cases are simply never reached for Pi. That is a stronger
+// guarantee than a platform check would be -- Beacon cannot synthesize a Pi approval because Pi
+// never sends one, not because a condition remembered to say so. Inventing one to keep the two
+// runtimes symmetric would put a decision nobody made into the log.
 type piFamily struct {
 	// platform is the `--platform` value the runtime's hook is installed with. It selects the
 	// session-id and working-directory readers in helpers.go, keys this runtime's block inside
@@ -119,12 +122,80 @@ func (f piFamily) endpointEvents(input map[string]interface{}, sessionID string)
 		})
 		return f.one("command.executed", "command", "info", "user command executed", fields)
 
+	case "user_python":
+		// The `$` prefix runs Python in the runtime's own REPL rather than a shell. It is the
+		// operator's code, not the agent's, and it is executed just as literally as a bash command
+		// -- `os.system("rm -rf /")` is a shell command wearing a Python hat -- so it is recorded
+		// in the command category where the risky-command rules can see it, marked as the
+		// operator's and as Python rather than being passed off as a shell command.
+		code := getFirstStr(input, "code")
+		if code == "" {
+			return nil
+		}
+		fields["command"] = map[string]interface{}{"command": code}
+		fields["tool"] = map[string]interface{}{"name": "user_python", "command": code}
+		fields["content"] = retainedContentFields(code)
+		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{
+			f.rawKey("user_initiated"):       true,
+			f.rawKey("user_python"):          true,
+			f.rawKey("exclude_from_context"): input["excludeFromContext"],
+		})
+		return f.one("command.executed", "command", "info", "user Python executed", fields)
+
+	case "tool_approval_requested":
+		return f.approvalEvents(input, fields, "approval.requested", "requested", "approval requested")
+
+	case "tool_approval_resolved":
+		// The runtime states the outcome as a boolean rather than as a word, so there is no
+		// unknown case to fall back to: an event that reached here had a decision made on it.
+		if approved, _ := input["approved"].(bool); approved {
+			return f.approvalEvents(input, fields, "approval.allowed", "approve", "approval allowed")
+		}
+		return f.approvalEvents(input, fields, "approval.denied", "deny", "approval denied")
+
 	case "message_end":
 		return f.messageEndEvents(input, fields)
 
 	default:
 		return nil
 	}
+}
+
+// approvalEvents records an operator approval decision the runtime actually asked for.
+//
+// This is the one thing Oh My Pi exposes that Pi does not. It matters because Beacon has always
+// refused to synthesize an approval from a tool call: a `tool_call` handler that blocks is an
+// extension deciding, and recording that as an approval would be indistinguishable from a decision
+// a human made. Here the runtime reports a real prompt and a real answer, so the event is
+// `observed` rather than `inferred` and carries the operator's decision verbatim.
+//
+// The approval carries the tool's name and the runtime's `toolCallId` but not its arguments -- the
+// runtime does not put them on these events. The call id is the join back to the tool.invoked that
+// does carry them, which is why it is promoted here as carefully as on the tool events themselves.
+func (f piFamily) approvalEvents(input, fields map[string]interface{}, action, decision, messageSuffix string) []normalizedEvent {
+	toolName := piToolName(input)
+	if toolName != "" {
+		fields["tool"] = mergeNested(fields["tool"], map[string]interface{}{"name": toolName})
+		f.applyMCPAttribution(fields, toolName)
+	}
+
+	approval := map[string]interface{}{"required": true, "decision": decision}
+	// The runtime's own words for why, when it gave any. Left absent rather than filled with a
+	// Beacon-authored sentence, so a reader can tell an operator's reason from a default.
+	if reason := getFirstStr(input, "reason"); reason != "" {
+		approval["reason"] = reason
+	}
+	fields["approval"] = approval
+
+	// Which approval policy the session was running under. "yolo" means the operator turned the
+	// prompts off, which is the single most load-bearing fact about any approval row: it is the
+	// difference between a decision someone made and a decision nobody was asked to make.
+	if mode := getFirstStr(input, "approvalMode"); mode != "" {
+		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{f.rawKey("approval_mode"): mode})
+	}
+
+	applyToolCallID(fields, input)
+	return f.one(action, "approval", "info", messageSuffix, fields)
 }
 
 // one wraps a single event, prefixing the runtime's display name onto the message.
@@ -222,6 +293,7 @@ func (f piFamily) toolFields(input map[string]interface{}, withResult bool) map[
 	if len(tool) > 0 {
 		fields["tool"] = tool
 	}
+	f.applyMCPAttribution(fields, name)
 	if withResult {
 		if usage := piUsage(firstMap(input, "usage")); len(usage) > 0 {
 			fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{"usage": usage})
@@ -240,6 +312,57 @@ func piFileOperation(name string) string {
 	default:
 		return "modify"
 	}
+}
+
+// applyMCPAttribution fills the `mcp` block when a tool name names an MCP-routed tool.
+//
+// Without it an MCP call lands in the log as a tool named `mcp__github_create_issue` and nothing
+// else -- no server, no tool -- so the two questions actually asked about MCP activity ("which
+// server did this agent reach, and what did it call there") have no field to answer them.
+func (f piFamily) applyMCPAttribution(fields map[string]interface{}, toolName string) {
+	server, tool := piMCPServerTool(toolName)
+	if server == "" && tool == "" {
+		return
+	}
+	mcp := map[string]interface{}{}
+	if server != "" {
+		mcp["server"] = server
+	}
+	if tool != "" {
+		mcp["tool"] = tool
+	}
+	fields["mcp"] = mergeNested(fields["mcp"], mcp)
+	fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{
+		"operation": map[string]interface{}{"name": "execute_tool"},
+	})
+}
+
+// piMCPServerTool splits a Pi-family MCP tool name into its server and tool halves.
+//
+// Two spellings reach here and they disagree about the separator. `mcp__<server>__<tool>` is the
+// widely used double-underscore form, and deriveMCPServerTool already reads it; Oh My Pi mints
+// `mcp__<server>_<tool>` with a single underscore (createMCPToolName in its mcp/tool-bridge.ts),
+// which that function returns nothing for because it needs three `__`-separated parts.
+//
+// The double-underscore form is tried first because it is unambiguous. The single-underscore
+// fallback splits on the first underscore, which is exactly what Oh My Pi's own parseMCPToolName
+// does -- including its ambiguity, since a server named `my_server` yields `mcp__my_server_run` and
+// both parsers read that as server `my`. Reproducing the runtime's reading rather than inventing a
+// better one is deliberate: Beacon's `mcp.server` should say what the runtime itself would say, so
+// an operator comparing the two never finds them disagreeing.
+func piMCPServerTool(toolName string) (string, string) {
+	if server, tool := deriveMCPServerTool(toolName); server != "" || tool != "" {
+		return server, tool
+	}
+	rest, ok := strings.CutPrefix(strings.TrimSpace(toolName), "mcp__")
+	if !ok {
+		return "", ""
+	}
+	server, tool, ok := strings.Cut(rest, "_")
+	if !ok || server == "" || tool == "" {
+		return "", ""
+	}
+	return server, tool
 }
 
 // toolResultEvents maps a completed tool call onto its outcome event.
@@ -300,6 +423,13 @@ func piToolAction(name string) (string, string) {
 	case "write":
 		return "file.created", "file"
 	default:
+		// An MCP-routed tool is real, attributable activity rather than an anonymous custom tool,
+		// and mcp.tool_invoked is the action every other Beacon capture path already uses for it --
+		// so an MCP call through Oh My Pi joins the same rows a detection reads for Cline, Cursor
+		// and Claude Code rather than hiding under tool.completed.
+		if server, tool := piMCPServerTool(name); server != "" || tool != "" {
+			return "mcp.tool_invoked", "mcp"
+		}
 		// grep, glob, and any tool another extension registered. These are real tool activity with
 		// no file or command semantics worth asserting: grep takes a pattern, not a path, and a
 		// custom tool's arguments mean whatever its author decided.
@@ -320,6 +450,8 @@ func piToolMessageSuffix(action string) string {
 		return "file modified"
 	case "tool.failed":
 		return "tool failed"
+	case "mcp.tool_invoked":
+		return "MCP tool invoked"
 	default:
 		return "tool completed"
 	}


### PR DESCRIPTION
**4 of 8** in the Oh My Pi stack. Targets #410.

Three signals Oh My Pi exposes that the shared Pi-family mapper did not read.

## Approvals — the capability gain

Beacon has always refused to synthesize an approval from a tool call, because a `tool_call` handler that blocks is *an extension deciding*, and recording that as an approval would be indistinguishable from an answer a human gave. That is why Pi and Cline carry no approval telemetry at all.

Oh My Pi reports the prompt and the answer as their own events, so these are real decisions: `observed`, with the operator's own reason when there was one, and joined to the execution they decided through the tool call id (which is why #410 landed first).

They also carry `approvalMode` — **`yolo` means the prompts were off**, which is the difference between a decision someone made and a decision nobody was asked to make.

**A resolved approval with no readable `approved` value is recorded as a denial.** The safe reading of "no evidence the operator said yes" is not "the operator said yes"; defaulting the other way would turn a malformed payload into a clean record of consent.

## Operator Python

`user_python` is the operator's own `$` code. It executes as literally as a shell command — `os.system("rm -rf /")` is a shell command wearing a Python hat — so it lands in the command category where the `rules/risky-command/` rules can see it, marked as the operator's *and* as Python rather than passed off as a shell command.

## MCP attribution

Oh My Pi mints `mcp__<server>_<tool>` with a **single** underscore, which the existing double-underscore split returns nothing for — so an MCP call was landing as a tool name and nothing else, with no field to answer "which server did this agent reach, and what did it call there".

The fallback reproduces Oh My Pi's own `parseMCPToolName`, **ambiguity included** (a server named `my_server` reads as `my` in both), so Beacon's `mcp.server` says what the runtime itself would say. Resolved calls now use the existing `mcp.tool_invoked` action, so they join the same rows detections already read for Cline, Cursor and Claude Code.

## Gating

These cases are gated by the extension's subscription list rather than by a platform check: Pi never sends them, so they are unreachable for Pi **by construction** rather than by a condition that could be forgotten. `TestOmpOnlyEventTypesAreNotInPis` pins that.

`mcp_notification` is deliberately not subscribed to — it fires for every JSON-RPC notification a server sends, most of them routine list refreshes, and describes MCP transport plumbing rather than an action the agent took.

---
_Generated by [Claude Code](https://claude.ai/code/session_011frg4bzQrR3uEipYVNcSrp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes audit semantics for approvals (deny-by-default on bad payloads) and command/MCP categorization used by investigations and risky-command rules, though behavior is heavily test-backed and Pi remains gated by subscriptions.
> 
> **Overview**
> Extends the shared Pi-family Oh My Pi mapper so Beacon can log **real operator approvals**, **`$` Python**, and **MCP server/tool** fields instead of treating those as generic tool activity.
> 
> **Approvals:** Subscribes to `tool_approval_requested` / `tool_approval_resolved` and maps them to `approval.requested`, `approval.allowed`, and `approval.denied` with runtime reason, `approvalMode` in `raw`, tool call id for joins, and MCP blocks when the tool is MCP-routed. Non-boolean or missing `approved` is always **denied**, not allowed.
> 
> **Operator Python:** `user_python` becomes `command.executed` with `tool.name` `user_python` and operator/Python flags in `raw`; empty code emits nothing.
> 
> **MCP:** Adds `piMCPServerTool` (double-underscore plus Oh My Pi single-underscore parsing) and `applyMCPAttribution` so MCP tools emit `mcp.tool_invoked` with `mcp.server` / `mcp.tool` on results and approvals. Pi’s subscription list still excludes OMP-only types so Pi cannot synthesize these events.
> 
> Tests in `omp_approval_test.go` and updated OMP fixtures/contracts cover the above; `mcp_notification` stays unsubscribed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c6d555187a363507ee3465175101f008215560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->