### PR TITLE
feat(omp): wire Oh My Pi through the endpoint CLI surface

### DIFF
--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -876,7 +876,7 @@ func hookTargets() ([]string, error) {
 }
 
 func allHookTargetsForLevel() []string {
-	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "cline", "pi", "grok", "qwen", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "cline", "pi", "omp", "grok", "qwen", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 	if endpointOpts.hookLevel != "project" {
 		return all
 	}
@@ -929,6 +929,9 @@ func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[str
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.PluginPath, Raw: status}
 		case "pi":
 			status := endpointhooks.PiHookStatus(endpointhooks.PiOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ExtensionPath, Raw: status}
+		case "omp":
+			status := endpointhooks.OmpHookStatus(endpointhooks.OmpOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ExtensionPath, Raw: status}
 		case "grok":
 			status := endpointhooks.GrokHookStatus(endpointhooks.GrokOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})

--- a/cli/beacon/cmd/endpoint_hooks.go
+++ b/cli/beacon/cmd/endpoint_hooks.go
@@ -153,6 +153,23 @@ func installEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 		if endpointhooks.Level(endpointOpts.hookLevel) == endpointhooks.LevelProject {
 			fmt.Println("Project-level Pi extensions are subject to Pi's project-trust prompt; a user-level install needs no further interaction.")
 		}
+	case "omp":
+		status, err := endpointhooks.InstallOmp(endpointhooks.OmpOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Oh My Pi extension installed: %s\n", status.ExtensionPath)
+		if endpointhooks.Level(endpointOpts.hookLevel) == endpointhooks.LevelProject {
+			// Unlike Pi, Oh My Pi has no per-directory trust gate -- its own isProjectTrusted()
+			// always returns true because `.omp` project inputs are loaded unconditionally. So the
+			// note here is about scope rather than about a prompt: a project install covers one
+			// checkout, and the operator's other Oh My Pi sessions stay uninstrumented.
+			fmt.Println("Project-level Oh My Pi extensions cover only this working directory; a user-level install follows the operator across checkouts.")
+		}
 	case "grok":
 		status, err := endpointhooks.InstallGrok(endpointhooks.GrokOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -334,6 +351,16 @@ func uninstallEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 			return err
 		}
 		fmt.Println(status.Message)
+	case "omp":
+		status, err := endpointhooks.UninstallOmp(endpointhooks.OmpOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
 	case "grok":
 		status, err := endpointhooks.UninstallGrok(endpointhooks.GrokOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -454,6 +481,12 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
+		case "omp":
+			statuses["omp"] = endpointhooks.OmpHookStatus(endpointhooks.OmpOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
 		case "grok":
 			statuses["grok"] = endpointhooks.GrokHookStatus(endpointhooks.GrokOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -525,6 +558,10 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 		case "pi":
 			status := statuses["pi"].(endpointhooks.PiStatus)
 			fmt.Printf("Pi extension: installed=%t path=%s\n", status.Installed, status.ExtensionPath)
+			fmt.Println(status.Message)
+		case "omp":
+			status := statuses["omp"].(endpointhooks.OmpStatus)
+			fmt.Printf("Oh My Pi extension: installed=%t path=%s\n", status.Installed, status.ExtensionPath)
 			fmt.Println(status.Message)
 		case "grok":
 			status := statuses["grok"].(endpointhooks.GrokStatus)

--- a/cli/beacon/cmd/endpoint_hooks_repair.go
+++ b/cli/beacon/cmd/endpoint_hooks_repair.go
@@ -148,7 +148,7 @@ func installedHookTargetsForUser(homeDir, logPath string) ([]string, error) {
 }
 
 func repairTargetOrder() []string {
-	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "cline", "pi", "grok", "qwen", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "cline", "pi", "omp", "grok", "qwen", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 }
 
 // withUserHome runs fn as if it were executing inside another user's profile.

--- a/cli/beacon/cmd/endpoint_targets.go
+++ b/cli/beacon/cmd/endpoint_targets.go
@@ -50,6 +50,12 @@ var harnessTargets = []harnessTarget{
 	// under, so anyone reading a Pi row out of the runtime log and passing it back to a --harness
 	// flag gets the runtime they are looking at rather than an "unsupported harness" error.
 	{name: "pi", endpointKind: endpointTargetHook, endpointAliases: []string{"pi", "pi-cli", "pi_cli"}, hookAliases: []string{"pi", "pi-cli", "pi_cli"}},
+	// Oh My Pi is a separate row from Pi rather than an alias of it. The two are separately
+	// installed products with different config roots and different capability surfaces, and folding
+	// either spelling into the other would install one runtime's extension while the operator asked
+	// for the other's. "oh-my-pi" is accepted because it is the repository name people reach for;
+	// "omp" is the binary, and the canonical harness name events are written under.
+	{name: "omp", endpointKind: endpointTargetHook, endpointAliases: []string{"omp", "oh-my-pi", "ohmypi"}, hookAliases: []string{"omp", "oh-my-pi", "ohmypi"}},
 	{name: "grok", endpointKind: endpointTargetHook, endpointAliases: []string{"grok"}, hookAliases: []string{"grok"}},
 	// "qwen-code" and "qwen_code" both normalize to "qwen-code" through normalizeHarnessKey, so the
 	// two spellings need one alias between them. "qwen-cli" is not accepted: the product is Qwen

--- a/cli/beacon/cmd/omp_target_test.go
+++ b/cli/beacon/cmd/omp_target_test.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
+)
+
+// The spellings an operator actually types. "omp" is the binary and the canonical harness name;
+// "oh-my-pi" is the repository name people reach for; the underscore form arrives from anyone
+// copying a harness name out of a log, since normalizeHarnessKey maps `_` to `-`.
+func TestOmpHookTargetAliases(t *testing.T) {
+	for _, in := range []string{"omp", "OMP", "  omp  ", "oh-my-pi", "oh_my_pi", "ohmypi", "Oh-My-Pi"} {
+		t.Run(in, func(t *testing.T) {
+			got, ok := normalizeHookTarget(in)
+			if !ok {
+				t.Fatalf("normalizeHookTarget(%q) was not recognized", in)
+			}
+			if got != "omp" {
+				t.Fatalf("normalizeHookTarget(%q) = %q, want omp", in, got)
+			}
+		})
+	}
+}
+
+// Oh My Pi and Pi are separately installed products. A `--harness` value for one must never resolve
+// to the other, or an operator asking to instrument one gets the other's extension written into a
+// directory the runtime they meant does not read.
+func TestOmpAndPiTargetsDoNotAlias(t *testing.T) {
+	for in, want := range map[string]string{
+		"pi":       "pi",
+		"pi-cli":   "pi",
+		"pi_cli":   "pi",
+		"omp":      "omp",
+		"oh-my-pi": "omp",
+		"ohmypi":   "omp",
+	} {
+		t.Run(in, func(t *testing.T) {
+			got, ok := normalizeHookTarget(in)
+			if !ok || got != want {
+				t.Fatalf("normalizeHookTarget(%q) = (%q, %v), want %q", in, got, ok, want)
+			}
+		})
+	}
+}
+
+// Oh My Pi is a hook (extension) target, not an OTLP one: it exports no OpenTelemetry, so an
+// endpoint install has nothing to point at it.
+func TestOmpEndpointTargetIsHookShaped(t *testing.T) {
+	got, ok := normalizeEndpointTarget("omp")
+	if !ok {
+		t.Fatal("normalizeEndpointTarget(omp) was not recognized")
+	}
+	if got.Name != "omp" || got.Kind != endpointTargetHook {
+		t.Fatalf("normalizeEndpointTarget(omp) = %+v, want an omp hook target", got)
+	}
+}
+
+// The wiring test. A harness the target table advertises but the install switch has no case for
+// falls through to `unsupported hook harness`, so this is what catches a runtime added to the table
+// and nowhere else -- the way a half-added integration ships.
+func TestInstallEndpointHookTargetHandlesOmp(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv("PI_CONFIG_DIR", "")
+
+	previousLevel := endpointOpts.hookLevel
+	endpointOpts.hookLevel = string(endpointhooks.LevelUser)
+	t.Cleanup(func() { endpointOpts.hookLevel = previousLevel })
+
+	cfg := endpointconfig.Config{
+		LogPath:  filepath.Join(t.TempDir(), "runtime.jsonl"),
+		UserMode: true,
+	}
+
+	if err := installEndpointHookTarget("omp", cfg); err != nil {
+		t.Fatalf("installEndpointHookTarget(omp) returned error: %v", err)
+	}
+
+	path := filepath.Join(home, ".omp", "agent", "extensions", "beacon.ts")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the install wrote no extension at %s: %v", path, err)
+	}
+	if !strings.Contains(string(data), endpointhooks.OmpManagedExtensionMarker) {
+		t.Fatal("the installed extension carries no Beacon marker")
+	}
+	// The invocation has to name Oh My Pi's own mapper. `pi-event` here would attribute every Oh My
+	// Pi session to Pi, which is the failure the separate harness name exists to prevent.
+	if !strings.Contains(string(data), `"omp-event"`) {
+		t.Fatalf("the installed extension does not invoke omp-event:\n%s", data)
+	}
+	if strings.Contains(string(data), `"pi-event"`) {
+		t.Fatal("the installed Oh My Pi extension invokes Pi's mapper")
+	}
+
+	// Installing Oh My Pi must not touch Pi's directory.
+	if _, err := os.Stat(filepath.Join(home, ".pi")); !os.IsNotExist(err) {
+		t.Fatalf("installing Oh My Pi created a Pi extension directory: %v", err)
+	}
+
+	// And the same command removes it again.
+	if err := uninstallEndpointHookTarget("omp", cfg); err != nil {
+		t.Fatalf("uninstallEndpointHookTarget(omp) returned error: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("the extension survived uninstall: %v", err)
+	}
+}

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -58,6 +58,7 @@ func DiscoverAll() []Harness {
 		DiscoverOpenCode(),
 		DiscoverCline(),
 		DiscoverPi(),
+		DiscoverOmp(),
 		DiscoverQwen(),
 		DiscoverHermes(),
 		DiscoverFactory(),

--- a/cli/beacon/internal/endpoint/harness/omp.go
+++ b/cli/beacon/internal/endpoint/harness/omp.go
@@ -1,0 +1,73 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
+)
+
+// DiscoverOmp reports whether Oh My Pi is present and whether Beacon is observing it.
+//
+// Its capability is "plugin" rather than "hooks" or "otel_env" for the same reason Pi's is: it has
+// neither surface -- no hooks configuration file to merge into and no OpenTelemetry export to point
+// at the local collector. Its documented observation surface is the TypeScript extension API, so
+// what Beacon installs is one extension file, and what this function reports is the state of that
+// file.
+func DiscoverOmp() Harness {
+	h := Harness{Name: "omp", DisplayName: "Oh My Pi", Capability: "plugin"}
+	detectExecutable(&h, "omp")
+
+	// A missing home directory leaves the config path empty rather than resolving to a relative
+	// path like ".omp/agent/extensions/beacon.ts", which would make discovery report on whatever
+	// happens to sit under the current working directory.
+	extensionPath, err := hooks.OmpExtensionPath(hooks.LevelUser)
+	if err != nil {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = "Oh My Pi extension directory could not be resolved: " + err.Error()
+		return h
+	}
+	h.ConfigPath = extensionPath
+
+	// Oh My Pi installed through npm/pnpm/bun, or through its own installer into a directory this
+	// process did not inherit on PATH, is still detectable by its state directory -- a shell alias,
+	// a version manager, or a per-project install all hide the binary while the directory remains.
+	// Treating that directory as evidence keeps `endpoint discover` from reporting "not detected"
+	// for a runtime the operator is actively using, the same fallback the Pi, opencode, Cursor and
+	// Hermes probes make for the same reason.
+	//
+	// The directory checked is the one the resolved extension path lives under rather than a
+	// rebuilt `~/.omp`, so a profile or a PI_CODING_AGENT_DIR override is detected where it
+	// actually is instead of being missed at the default location.
+	if !h.Detected && dirExists(filepath.Dir(filepath.Dir(extensionPath))) {
+		h.Detected = true
+	}
+
+	h.TelemetryStatus, h.Message = ompStatus(extensionPath)
+	return h
+}
+
+// ompStatus classifies the extension file at path.
+//
+// The middle case is the one worth spelling out: a beacon.ts that exists without Beacon's marker is
+// somebody else's extension sharing the filename, so it is reported as disabled rather than
+// enabled. Reporting it as enabled would claim telemetry Beacon is not collecting, and install
+// refuses to overwrite the same file for the same reason.
+//
+// A file carrying Pi's marker at this path is also not an Oh My Pi install. The two runtimes read
+// different directories today, so it should not happen -- but the markers are distinct precisely so
+// that the answer does not depend on that staying true.
+func ompStatus(path string) (TelemetryStatus, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return TelemetryMissing, "Beacon Oh My Pi extension was not found"
+		}
+		return TelemetryMissing, err.Error()
+	}
+	if !strings.Contains(string(data), hooks.OmpManagedExtensionMarker) {
+		return TelemetryDisabled, "Oh My Pi extension file exists but Beacon endpoint extension was not found"
+	}
+	return TelemetryEnabled, "Beacon Oh My Pi extension is configured"
+}

--- a/cli/beacon/internal/endpoint/harness/omp_test.go
+++ b/cli/beacon/internal/endpoint/harness/omp_test.go
@@ -1,0 +1,165 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+)
+
+// writeOmpExtension creates a user-level Oh My Pi extension file with the given contents.
+func writeOmpExtension(t *testing.T, home, contents string) string {
+	t.Helper()
+	path := filepath.Join(home, ".omp", "agent", "extensions", "beacon.ts")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir omp extensions dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("write omp extension: %v", err)
+	}
+	return path
+}
+
+// Every Oh My Pi discovery test empties PATH and the two environment variables that move its
+// extension directory. Without that, the result depends on whether the machine running the suite
+// happens to have `omp` installed or a profile active -- exactly the kind of environment-dependent
+// assertion the repo's deterministic-test rule exists to prevent.
+func setupOmpDiscovery(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv("PI_CONFIG_DIR", "")
+	return home
+}
+
+func TestDiscoverOmpReportsMissingExtension(t *testing.T) {
+	home := setupOmpDiscovery(t)
+
+	h := DiscoverOmp()
+	if h.Detected {
+		t.Fatalf("DiscoverOmp detected Oh My Pi with no executable and no state directory: %#v", h)
+	}
+	want := filepath.Join(home, ".omp", "agent", "extensions", "beacon.ts")
+	if h.ConfigPath != want {
+		t.Fatalf("ConfigPath = %q, want %q", h.ConfigPath, want)
+	}
+	if h.TelemetryStatus != TelemetryMissing {
+		t.Fatalf("TelemetryStatus = %q, want %q", h.TelemetryStatus, TelemetryMissing)
+	}
+	if h.Capability != "plugin" {
+		t.Fatalf("Capability = %q, want %q -- Oh My Pi has no hooks file and no OTel support, so "+
+			"the integration is extension-shaped", h.Capability, "plugin")
+	}
+}
+
+// Oh My Pi installed through bun, a version manager, or its own installer into a directory this
+// process did not inherit on PATH is not visible as an executable, so the state directory has to
+// count as evidence. The alternative is reporting "not detected" for a runtime the operator is
+// actively running, which reads as "Beacon cannot see this" when the truth is "Beacon has not been
+// installed into it yet".
+func TestDiscoverOmpTreatsTheStateDirectoryAsEvidence(t *testing.T) {
+	home := setupOmpDiscovery(t)
+	if err := os.MkdirAll(filepath.Join(home, ".omp", "agent"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	h := DiscoverOmp()
+	if !h.Detected {
+		t.Fatal("DiscoverOmp reported not detected with an Oh My Pi agent directory present")
+	}
+	if h.TelemetryStatus != TelemetryMissing {
+		t.Fatalf("TelemetryStatus = %q, want %q -- the runtime is present but Beacon is not "+
+			"installed into it", h.TelemetryStatus, TelemetryMissing)
+	}
+}
+
+// The directory checked is the one the resolved extension path lives under, not a rebuilt `~/.omp`,
+// so a profiled install is detected where it actually is rather than being missed at the default.
+func TestDiscoverOmpFollowsTheAgentDirOverride(t *testing.T) {
+	home := setupOmpDiscovery(t)
+	agentDir := filepath.Join(home, ".omp", "profiles", "work", "agent")
+	t.Setenv("PI_CODING_AGENT_DIR", agentDir)
+	if err := os.MkdirAll(agentDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	h := DiscoverOmp()
+	want := filepath.Join(agentDir, "extensions", "beacon.ts")
+	if h.ConfigPath != want {
+		t.Fatalf("ConfigPath = %q, want %q", h.ConfigPath, want)
+	}
+	if !h.Detected {
+		t.Fatal("DiscoverOmp reported not detected with a profiled Oh My Pi agent directory present")
+	}
+}
+
+func TestDiscoverOmpReportsAManagedExtensionAsEnabled(t *testing.T) {
+	home := setupOmpDiscovery(t)
+	writeOmpExtension(t, home, "// "+hooks.OmpManagedExtensionMarker+"\nexport default function () {}\n")
+
+	h := DiscoverOmp()
+	if h.TelemetryStatus != TelemetryEnabled {
+		t.Fatalf("TelemetryStatus = %q, want %q", h.TelemetryStatus, TelemetryEnabled)
+	}
+	if !h.Detected {
+		t.Fatal("an installed Beacon extension implies the runtime is present")
+	}
+}
+
+// Somebody else's extension can legitimately be called beacon.ts. Reporting it as enabled would
+// claim telemetry Beacon is not collecting -- and install refuses to overwrite it for the same
+// reason, so "disabled" is the honest reading rather than a pessimistic one.
+func TestDiscoverOmpReportsAnUnmanagedExtensionAsDisabled(t *testing.T) {
+	home := setupOmpDiscovery(t)
+	writeOmpExtension(t, home, "// somebody else's extension\nexport default function () {}\n")
+
+	h := DiscoverOmp()
+	if h.TelemetryStatus != TelemetryDisabled {
+		t.Fatalf("TelemetryStatus = %q, want %q", h.TelemetryStatus, TelemetryDisabled)
+	}
+}
+
+// Pi's extension is not an Oh My Pi install. The two runtimes read different directories today, so
+// this should not arise -- but the markers are distinct precisely so the answer does not depend on
+// that staying true.
+func TestDiscoverOmpDoesNotAcceptPisMarker(t *testing.T) {
+	home := setupOmpDiscovery(t)
+	writeOmpExtension(t, home, "// "+hooks.PiManagedExtensionMarker+"\nexport default function () {}\n")
+
+	if h := DiscoverOmp(); h.TelemetryStatus == TelemetryEnabled {
+		t.Fatal("DiscoverOmp reported Pi's extension as an Oh My Pi install")
+	}
+}
+
+// The harness name discovery reports must be the canonical one events are written under, or the
+// dashboard groups a runtime's discovery row and its telemetry rows separately.
+func TestDiscoverOmpUsesTheCanonicalHarnessName(t *testing.T) {
+	setupOmpDiscovery(t)
+
+	h := DiscoverOmp()
+	if got := asymptoteobserve.NormalizeHarnessName(h.Name); got != h.Name {
+		t.Fatalf("DiscoverOmp reports %q, which normalizes to %q; discovery and telemetry would "+
+			"not join", h.Name, got)
+	}
+	if h.Name == DiscoverPi().Name {
+		t.Fatal("Oh My Pi and Pi discovery report the same harness name")
+	}
+}
+
+// A runtime absent from DiscoverAll is a runtime `beacon endpoint discover` never mentions, which
+// is how support ships without anyone being able to find it.
+func TestDiscoverAllIncludesOmp(t *testing.T) {
+	setupOmpDiscovery(t)
+
+	for _, h := range DiscoverAll() {
+		if h.Name == "omp" {
+			return
+		}
+	}
+	t.Fatal("DiscoverAll does not include Oh My Pi")
+}

--- a/cli/beacon/internal/endpoint/hooks/omp.go
+++ b/cli/beacon/internal/endpoint/hooks/omp.go
@@ -118,7 +118,26 @@ func ompRootExtensionSourcePath() string {
 // project-local inputs are already loaded unconditionally. A user-level install is still the
 // default, because it follows the operator rather than one checkout.
 func OmpExtensionPath(level Level) (string, error) {
-	dir, err := ompExtensionDir(level)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// Only the user level needs a home directory. Failing here for a project install would
+		// refuse a path that does not depend on the value that could not be read.
+		if level == LevelProject {
+			return OmpExtensionPathForHome("", level)
+		}
+		return "", err
+	}
+	return OmpExtensionPathForHome(home, level)
+}
+
+// OmpExtensionPathForHome is OmpExtensionPath against a caller-supplied home directory.
+//
+// Exported for inventory, which scans a home directory it was handed rather than the process's own
+// -- a scan of another user's tree, or of a fixture. Sharing the resolution rather than rebuilding
+// the path there is what keeps inventory from reporting on a file the installer does not write:
+// this path is not a fixed string, since a profile or a PI_CODING_AGENT_DIR override moves it.
+func OmpExtensionPathForHome(home string, level Level) (string, error) {
+	dir, err := ompExtensionDir(home, level)
 	if err != nil {
 		return "", err
 	}
@@ -138,15 +157,14 @@ func OmpExtensionPath(level Level) (string, error) {
 //
 // Deriving either path from the other, or applying `PI_CONFIG_DIR` to both, would write the file
 // where Oh My Pi does not look -- and the install would report success and collect nothing.
-func ompExtensionDir(level Level) (string, error) {
+func ompExtensionDir(home string, level Level) (string, error) {
 	switch level {
 	case "", LevelUser:
 		if agentDir := os.Getenv(ompAgentDirEnv); agentDir != "" {
 			return filepath.Join(agentDir, "extensions"), nil
 		}
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
+		if home == "" {
+			return "", fmt.Errorf("home directory is required to resolve the Oh My Pi extension path")
 		}
 		configDir := ompConfigDirName
 		if named := os.Getenv(ompConfigDirEnv); named != "" {

--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -205,6 +205,7 @@ func candidates(home, wd string) []candidate {
 	items = append(items, opencodeCandidates(home, wd)...)
 	items = append(items, clineCandidates(home, wd)...)
 	items = append(items, piCandidates(home, wd)...)
+	items = append(items, ompCandidates(home, wd)...)
 	items = append(items, hermesCandidates(home)...)
 	items = append(items, devinCandidates(home, wd)...)
 	items = append(items, grokCandidates(home, wd)...)
@@ -315,6 +316,33 @@ func piCandidates(home, wd string) []candidate {
 		items = append(items, candidate{
 			runtime: "pi_cli",
 			path:    filepath.Join(wd, ".pi", "extensions", "beacon.ts"),
+			scope:   ScopeProject, format: formatMetadataOnly, kind: KindPlugin,
+		})
+	}
+	return items
+}
+
+// ompCandidates covers both Oh My Pi extension locations.
+//
+// Like piCandidates, the paths come from the installer rather than being rebuilt here: a second
+// copy of the path is how inventory comes to report on a file the installer does not touch. That
+// matters more for Oh My Pi than for Pi, because its user path is not a fixed string -- a profile
+// or a PI_CODING_AGENT_DIR override moves it, and only the installer knows the rule.
+func ompCandidates(home, wd string) []candidate {
+	items := []candidate{}
+	if home != "" {
+		if path, err := hooks.OmpExtensionPathForHome(home, hooks.LevelUser); err == nil {
+			items = append(items, candidate{
+				runtime: "omp",
+				path:    path,
+				scope:   ScopeUser, format: formatMetadataOnly, kind: KindPlugin,
+			})
+		}
+	}
+	if wd != "" {
+		items = append(items, candidate{
+			runtime: "omp",
+			path:    filepath.Join(wd, ".omp", "extensions", "beacon.ts"),
 			scope:   ScopeProject, format: formatMetadataOnly, kind: KindPlugin,
 		})
 	}
@@ -668,6 +696,10 @@ func beaconManaged(item candidate, data []byte) bool {
 	// installer does not write -- the reason hooks.PiManagedExtensionMarker is exported at all.
 	case "pi_cli":
 		return strings.Contains(text, hooks.PiManagedExtensionMarker)
+	// Distinct from Pi's marker, and matched separately, so a file found at either runtime's path
+	// is attributed to the runtime that actually loads it rather than to whichever case ran first.
+	case "omp":
+		return strings.Contains(text, hooks.OmpManagedExtensionMarker)
 	case "grok":
 		return strings.Contains(text, "beacon-managed-grok-hooks:v1")
 	// Matched on the hook command rather than on a marker, because Beacon merges into Qwen's own

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -305,6 +305,11 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 	home := t.TempDir()
 	work := t.TempDir()
 	t.Setenv("SHELL", "/bin/bash")
+	// Oh My Pi's user extension path is the one candidate an environment variable can move, so the
+	// two it reads are cleared: a developer who happens to run Oh My Pi under a profile would
+	// otherwise see this test fail on a path that is correct for their machine.
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv("PI_CONFIG_DIR", "")
 
 	result := Scan(Options{
 		HomeDir:    home,
@@ -344,6 +349,10 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 		// not, so the two paths are spelled out rather than derived from each other.
 		{runtime: "pi_cli", path: filepath.Join(home, ".pi", "agent", "extensions", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
 		{runtime: "pi_cli", path: filepath.Join(work, ".pi", "extensions", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
+		// Oh My Pi's paths mirror Pi's asymmetry -- an `agent` segment under home and none in the
+		// project -- but under its own `.omp` root, because the two runtimes install separately.
+		{runtime: "omp", path: filepath.Join(home, ".omp", "agent", "extensions", "beacon.ts"), scope: ScopeUser, format: formatMetadataOnly, kind: KindPlugin},
+		{runtime: "omp", path: filepath.Join(work, ".omp", "extensions", "beacon.ts"), scope: ScopeProject, format: formatMetadataOnly, kind: KindPlugin},
 		{runtime: "hermes", path: filepath.Join(home, ".hermes", "config.yaml"), scope: ScopeUser, format: formatYAML, kind: KindNativeConfig},
 		{runtime: "devin-cli", path: filepath.Join(home, ".config", "devin", "config.json"), scope: ScopeUser, format: formatJSON, kind: KindNativeConfig},
 		{runtime: "devin-cli", path: filepath.Join(work, ".devin", "hooks.v1.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -827,6 +827,8 @@ func configureHarnesses(cfg endpointconfig.Config) ([]string, error) {
 			return paths, fmt.Errorf("Cline telemetry is installed with `beacon endpoint hooks install --harness cline`, not endpoint install")
 		case "pi", "pi_cli":
 			return paths, fmt.Errorf("Pi telemetry is installed with `beacon endpoint hooks install --harness pi`, not endpoint install")
+		case "omp", "oh_my_pi", "oh-my-pi":
+			return paths, fmt.Errorf("Oh My Pi telemetry is installed with `beacon endpoint hooks install --harness omp`, not endpoint install")
 		// Qwen Code has no OpenTelemetry export to point at the local collector, so `endpoint
 		// install --harness qwen` has nothing to configure. Saying so beats the generic
 		// "unsupported harness", which reads as "Beacon does not support Qwen Code" when the


### PR DESCRIPTION
**6 of 8** in the Oh My Pi stack. Targets #412.

## What

`beacon endpoint hooks install|uninstall|status --harness omp` now works, and Oh My Pi appears in discovery, diagnostics, repair, inventory, and the lifecycle guidance that points operators at the right command.

```
$ beacon endpoint hooks status --harness omp
Oh My Pi extension: installed=false path=/root/.omp/agent/extensions/beacon.ts
Oh My Pi endpoint hooks are not installed
```

## Separate target row, not an alias

Folding either spelling into the other would write one runtime's extension while the operator asked for the other's, into a directory the runtime they meant does not read. `oh-my-pi` and `ohmypi` are accepted alongside `omp` because the repository name is what people reach for; `omp` is the binary and the canonical harness name.

## Inventory bug caught in review

`ompCandidates` initially resolved the *process's* home rather than the home the scan was given. Fixed properly by parameterizing the resolver (`OmpExtensionPathForHome`) rather than rebuilding the path in inventory — which matters more for Oh My Pi than for Pi, because its user path is not a fixed string: a profile or `PI_CODING_AGENT_DIR` moves it, and only the installer knows the rule. Rebuilding it is exactly how inventory comes to report on a file the installer does not write.

## Project-install note differs from Pi's on purpose

Pi warns about its project-trust prompt. Oh My Pi has no such gate — its own `isProjectTrusted()` always returns true because `.omp` project inputs load unconditionally — so the note is about **scope** instead: a project install covers one checkout.

## Tests

- Alias normalization, including that `omp`/`pi` never resolve to each other.
- `TestInstallEndpointHookTargetHandlesOmp` runs the real install → asserts the marker, that it invokes `omp-event` and **not** `pi-event`, that no `.pi` directory was created, then uninstalls. This is what catches a runtime added to the target table and nowhere else, since a missing case falls through to `unsupported hook harness`.
- Discovery tests for missing/disabled/enabled, the state-directory fallback, following `PI_CODING_AGENT_DIR`, rejecting Pi's marker, canonical-name round-tripping, and presence in `DiscoverAll`.
- Inventory's full candidate enumeration updated, with the two environment variables cleared for determinism.

---
_Generated by [Claude Code](https://claude.ai/code/session_011frg4bzQrR3uEipYVNcSrp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI and filesystem integration for a new harness; no changes to auth, collector, or existing Pi behavior beyond shared env var names for path resolution.
> 
> **Overview**
> Adds **Oh My Pi** (`omp`) as its own hook/extension target end-to-end, parallel to Pi but not aliased to it—`oh-my-pi` / `ohmypi` normalize to `omp` so installs land under `.omp` and events use `omp-event`, not Pi’s paths or mapper.
> 
> `beacon endpoint hooks install|uninstall|status --harness omp` is wired through the CLI, plus `omp` in diagnostics “all targets,” repair order, inventory candidates, harness discovery (`DiscoverOmp`, plugin capability), and lifecycle guidance that points OTLP-style `endpoint install` at the hooks command instead.
> 
> Path resolution is shared via **`OmpExtensionPathForHome`** so inventory scans the same user extension location as the installer (including `PI_CODING_AGENT_DIR` / profile overrides). Project-level install messaging explains checkout scope rather than Pi’s trust prompt.
> 
> Tests cover alias normalization, Pi/omp separation, real install/uninstall (marker, `omp-event`, no `.pi` touch), and discovery/inventory enumeration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b9e3ca2f48e40f0d49f730224b4a376db68a73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->