### PR TITLE
Split browser extension docs into per-site pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -161,13 +161,15 @@
                       "runtimes/hermes-agent",
                       "runtimes/openclaw-gateway"
                     ]
-                  },
-                  {
-                    "group": "Browser Chat",
-                    "pages": [
-                      "runtimes/browser-extension"
-                    ]
                   }
+                ]
+              },
+              {
+                "group": "Browser Chat",
+                "pages": [
+                  "runtimes/browser-extension",
+                  "runtimes/claude-web",
+                  "runtimes/chatgpt-web"
                 ]
               },
               {

--- a/docs/runtimes/browser-extension.mdx
+++ b/docs/runtimes/browser-extension.mdx
@@ -1,23 +1,36 @@
 ---
 title: "Browser Extension"
-description: "Asymptote support details for Claude.ai and ChatGPT browser chat telemetry"
+description: "Install and configure the Asymptote browser extension that collects Claude.ai and ChatGPT chat telemetry"
 ---
 
-## Runtime overview
+## Overview
 
-Asymptote supports browser chat on Claude.ai and ChatGPT through an optional Chrome MV3 extension that relays conversation telemetry into the same local pipeline as agent activity.
+Asymptote collects browser chat telemetry through an optional Chrome MV3 extension. It reads the chat streams of the sites you enable and relays them into the same local pipeline as agent activity, so browser conversations land in the runtime log next to CLI agent events.
 
-The extension is in beta. It is not published on the Chrome Web Store and installs unpacked. It also reads the chat streams of two sites whose APIs are private and undocumented, so a change on either site can interrupt capture until the adapter is updated.
+One extension covers both supported sites:
 
-Browser chat resolves to two harness names, `claude_web` and `chatgpt_web`, so browser activity is attributed separately from CLI agents in the runtime log and the dashboard.
+<Columns cols={2}>
+  <Card title="Claude.ai" icon="message" href="/runtimes/claude-web">
+    Prompts, responses, tool calls, and token usage from the claude.ai chat stream.
+  </Card>
+  <Card title="ChatGPT" icon="message" href="/runtimes/chatgpt-web">
+    Prompts, responses, and tool activity from the chatgpt.com chat stream.
+  </Card>
+</Columns>
+
+This page covers install, configuration, and verification, which are the same for both sites. The site pages cover what each one captures and where each one falls short.
+
+<Note>
+The extension is in beta. It is not published on the Chrome Web Store and installs unpacked. It reads two chat streams whose APIs are private and undocumented, so a change on either site can interrupt capture until the adapter is updated.
+</Note>
 
 ## Prerequisites
 
-Before enabling browser chat telemetry, make sure:
+Before installing the extension, make sure:
 
 - The Beacon endpoint is [installed](/cli/install) and running. The extension posts to the local collector on `http://127.0.0.1:4318/v1/logs`, which a default endpoint install already listens on, so no collector configuration is needed.
-- Chrome, or another Chromium browser that can load an unpacked MV3 extension. Firefox and Safari are not supported.
-- Node 22 or newer, if you are building from source rather than using a release archive.
+- You have Chrome, or another Chromium browser that can load an unpacked MV3 extension. Firefox and Safari are not supported.
+- You have Node 22 or newer, if you are building from source rather than using a release archive.
 - You have reviewed what the extension retains. It captures full prompt and response text by default.
 - The people whose browsers it runs in know it is there, since it reads their Claude.ai and ChatGPT conversations.
 
@@ -33,7 +46,7 @@ A content script running in the page's main world tees the streamed chat respons
 
 The extension never writes files and never contacts a remote endpoint. Delivery is queued in local extension storage and retried with backoff, so a turn survives the service worker being suspended mid-stream.
 
-Events collected this way carry `harness.collection_method` of `otlp`.
+Events collected this way carry `harness.collection_method` of `otlp`, and a harness name of `claude_web` or `chatgpt_web`, so browser activity stays distinguishable from CLI agents in the runtime log and the dashboard.
 
 ## Discovery and status
 
@@ -41,13 +54,11 @@ Asymptote treats the browser extension as a user-installed source. It is not con
 
 Its presence is therefore observed rather than declared: the evidence that it is working is `claude_web` or `chatgpt_web` events arriving in the runtime log. See [Confirm it is working](#confirm-it-is-working).
 
-## Install or configuration support
+## Install
 
-<Note>
-The browser extension is in beta and is not published on the Chrome Web Store. It installs unpacked through Chrome's developer mode, so Chrome will not auto-update it: to move to a new version, download it again and reload. The published archive is unsigned, and its `.sha256` is the only integrity check it has.
-</Note>
+The extension installs unpacked through Chrome's developer mode, so Chrome will not auto-update it. To move to a new version, download or build it again and reload.
 
-### Build it
+### Build from source
 
 No prebuilt archive is published yet, so building from source is currently the only way to get the extension. It needs Node 22 or newer and takes a few seconds:
 
@@ -58,13 +69,13 @@ npm ci
 npm run build
 ```
 
-That writes the loadable extension to `browser-extension/dist`. Note the full path, because Chrome asks for it in the next step:
+That writes the loadable extension to `browser-extension/dist`. Note the full path, because Chrome asks for it when you load it:
 
 ```bash
 pwd -P  # then append /dist
 ```
 
-### From a release archive
+### Use a release archive
 
 Once an `ext-v*` release is published, you will be able to skip the build and download `agent-beacon-browser-extension-<version>-chrome.zip` with its `.sha256` from the [releases page](https://github.com/Asymptote-Labs/agent-beacon/releases), then verify and unzip it:
 
@@ -73,26 +84,40 @@ shasum -a 256 -c agent-beacon-browser-extension-<version>-chrome.zip.sha256
 unzip agent-beacon-browser-extension-<version>-chrome.zip -d agent-beacon-extension
 ```
 
-The unzipped folder is what you load, in place of `dist`.
+The archive is unsigned, so its `.sha256` is the only integrity check it has. The unzipped folder is what you load, in place of `dist`.
 
 ### Load it in Chrome
 
 1. Open `chrome://extensions`.
 2. Turn on **Developer mode**, top right.
-3. Choose **Load unpacked**, then select the `dist` folder you built (or the unzipped release folder).
-4. Confirm "Agent Beacon — Browser Collector" now appears in the list and is enabled.
+3. Choose **Load unpacked**, then select the `dist` folder you built, or the unzipped release folder.
+4. Confirm the Agent Beacon browser collector now appears in the list and is enabled.
 5. Click the extension's toolbar icon to check its status and, if you want, change the retention mode before capturing anything.
 
-### Configuration
+## Configuration
 
 The extension is configured in its own UI, not by `beacon`. There is no CLI command and no config file on disk. Settings are split across two surfaces:
 
 | Surface | How to open it | Settings |
 |---------|----------------|----------|
-| Popup | Click the extension's toolbar icon | Capture on/off, content retention (`full`, `redacted`, `metadata`), plus live queue depth and active stream count |
+| Popup | Click the extension's toolbar icon | Capture on or off, content retention (`full`, `redacted`, `metadata`), plus live queue depth and active stream count |
 | Options page | Right-click the icon and choose **Options**, or use **Details** then **Extension options** in `chrome://extensions` | OTLP logs endpoint, and per-site checkboxes for claude.ai and chatgpt.com |
 
-Review the retention mode in the popup before capturing anything on a machine where the same browser profile is used for personal conversations. The default retains full chat text.
+Both sites are enabled by default. Turn one off in the options page to collect from the other alone.
+
+## Retained content
+
+Retention defaults to `full`. Browser chat telemetry has little investigative value without content, so the default keeps it, and the tradeoff is documented rather than defaulted away.
+
+| Mode | What is retained |
+|------|------------------|
+| `full` (default) | Complete prompt text, full assistant response, tool call arguments and results |
+| `redacted` | The same text with emails and API-key-shaped tokens scrubbed in the browser |
+| `metadata` | No chat text. Actions, models, token counts, and tool names only |
+
+Retention is enforced in the browser before anything is sent, so under `metadata` the text never leaves the page. Endpoint-side redaction, sanitization, truncation, and event-size limits apply to whatever is sent.
+
+Change the mode in the extension's popup before enabling it on a machine where the same browser profile is used for personal conversations.
 
 ## Confirm it is working
 
@@ -110,11 +135,13 @@ grep '"claude_web"\|"chatgpt_web"' ~/.beacon/endpoint/logs/runtime.jsonl | tail 
 
 On a system-mode install the log lives at `/var/log/beacon-agent/runtime.jsonl` instead, and reading it needs `sudo`.
 
-Or browse them in the [local dashboard](/cli/dashboard):
+Or browse the events in the [local dashboard](/cli/dashboard):
 
 ```bash
 beacon endpoint dashboard
 ```
+
+## Troubleshooting
 
 If nothing arrives, work through it in this order:
 
@@ -126,30 +153,29 @@ If nothing arrives, work through it in this order:
 
 Chrome also disables unpacked extensions on restart in some managed configurations. If capture stops after a browser restart, check that it is still enabled in `chrome://extensions`.
 
-## Retained content
-
-Retention defaults to `full`. Browser chat telemetry has little investigative value without content, so the default keeps it, and the tradeoff is documented rather than defaulted away.
-
-| Mode | What is retained |
-|------|------------------|
-| `full` (default) | Complete prompt text, full assistant response, tool call arguments and results |
-| `redacted` | The same text with emails and API-key-shaped tokens scrubbed in the browser |
-| `metadata` | No chat text. Actions, models, token counts, and tool names only |
-
-Retention is enforced in the browser before anything is sent, so under `metadata` the text never leaves the page. Endpoint-side redaction, sanitization, truncation, and event-size limits apply to whatever is sent.
-
-Change the mode in the extension's popup before enabling it on a machine where the same browser profile is used for personal conversations.
-
 ## Telemetry coverage
+
+Coverage that is the same for both sites:
 
 | Area | Support |
 |------|---------|
 | Prompt telemetry | Supported, with full prompt text under `full` and `redacted` retention |
 | Assistant response telemetry | Supported, including the response text and model |
-| Tool telemetry | Supported where the chat stream exposes tool calls, including call id, arguments, and results |
-| Token usage | Supported for Claude.ai. ChatGPT web does not report usage in its stream |
 | Command and file telemetry | Not applicable. Browser chat performs no local commands or file edits |
 | Approval telemetry | Not available. Neither site exposes approval decisions to a page script |
 | Session lifecycle | Partial. Turns are correlated by conversation id; there is no session start or stop signal |
 | Local JSONL and dashboard | Supported after events reach the collector |
 | MDM deployment | Not covered by Beacon's MDM assets. Distribute through browser policy instead |
+
+Tool telemetry and token usage differ by site. See [Claude.ai](/runtimes/claude-web) and [ChatGPT](/runtimes/chatgpt-web).
+
+## Related
+
+<Columns cols={2}>
+  <Card title="Supported agent harnesses" icon="list-check" href="/runtimes">
+    Return to the runtime support overview.
+  </Card>
+  <Card title="Retention and redaction" icon="shield" href="/security/retention-redaction">
+    How retained content is handled once it reaches the endpoint.
+  </Card>
+</Columns>

--- a/docs/runtimes/chatgpt-web.mdx
+++ b/docs/runtimes/chatgpt-web.mdx
@@ -1,0 +1,108 @@
+---
+title: "ChatGPT"
+description: "Asymptote support details for ChatGPT browser chat telemetry"
+---
+
+## Runtime overview
+
+Asymptote collects ChatGPT chat telemetry through the optional [browser extension](/runtimes/browser-extension). Every turn on chatgpt.com becomes prompt and response events in the local runtime log, attributed to the `chatgpt_web` harness so it stays separate from Codex CLI and other agents.
+
+Both `chatgpt.com` and the older `chat.openai.com` host are covered.
+
+Support is in beta. The ChatGPT chat API is private and undocumented, so a change on the site can interrupt capture until the adapter is updated.
+
+## Prerequisites
+
+- The Beacon endpoint is installed and running, and the browser extension is loaded. See [Browser Extension](/runtimes/browser-extension) for both steps.
+- chatgpt.com is enabled in the extension's options page. It is enabled by default.
+
+## Collection path
+
+The extension's main-world interceptor tees the streamed response from the message-send endpoint, `POST /backend-api/f/conversation`. The ChatGPT adapter reads the site's `delta_encoding: v1` Server-Sent Event stream, where each frame patches a running document rather than carrying a finished message, and rebuilds one turn from it:
+
+| Stream signal | What Asymptote takes from it |
+|---------------|------------------------------|
+| The outbound request body | Prompt text, the input messages, and the requested model |
+| `conversation_id` in the request body or the resume token | `session.id` and `gen_ai.conversation.id` |
+| `add`, `append`, `replace`, and `patch` delta frames | Assistant response text, assembled as it streams |
+| The assistant message metadata | The model that actually answered, which can differ from the requested one |
+| `message_stream_complete` or `[DONE]` | Turn completion |
+
+Only the visible assistant message is tracked. Tool and aside messages addressed to another recipient are skipped, so the recorded response is what the user saw.
+
+The service worker then posts the turn to the local collector as OTLP GenAI logs. Events carry `harness.collection_method` of `otlp`.
+
+A turn whose stream is cut off before completion is still delivered, recorded as `agent.response` rather than `agent.response.completed`.
+
+## Events
+
+One ChatGPT turn produces:
+
+| Event | When |
+|-------|------|
+| `prompt.submitted` | The request body carried prompt text or input messages |
+| `agent.response.completed` | The stream finished normally |
+| `agent.response` | The stream ended early, so the response is partial |
+| `tool.invoked` | The turn included web search results, recorded as a `web_search` call |
+
+Turns from one conversation share a session id, so a conversation reads as a session in the dashboard even though the site sends no session start or stop signal.
+
+## Telemetry coverage
+
+| Area | Support |
+|------|---------|
+| Prompt telemetry | Supported, with full prompt text under `full` and `redacted` retention |
+| Assistant response telemetry | Supported, including the response text, the requested model, and the model that answered |
+| Tool telemetry | Partial. Web search activity is captured from the assistant message metadata; other built-in tools are not exposed in a form the adapter can read |
+| Token usage | Not available. ChatGPT web does not report token counts in its stream |
+| Cost | Not available. ChatGPT web does not report per-turn cost to the page |
+| Command and file telemetry | Not applicable. Browser chat performs no local commands or file edits |
+| Approval telemetry | Not available. ChatGPT does not expose approval decisions to a page script |
+| Session lifecycle | Partial. Turns are correlated by conversation id; there is no session start or stop signal |
+| Local JSONL and dashboard | Supported after events reach the collector |
+| MDM deployment | Not covered by Beacon's MDM assets. Distribute through browser policy instead |
+
+Token usage is the main difference from [Claude.ai](/runtimes/claude-web), which does report counts. Reports that roll up token usage will show ChatGPT web turns with no token attribution.
+
+## Confirm it is working
+
+Send one message on chatgpt.com, then look for the event:
+
+```bash
+grep -c '"chatgpt_web"' ~/.beacon/endpoint/logs/runtime.jsonl
+```
+
+To read the most recent one:
+
+```bash
+grep '"chatgpt_web"' ~/.beacon/endpoint/logs/runtime.jsonl | tail -1 | jq '{action: .event.action, harness: .harness.name, model, session: .session.id}'
+```
+
+On a system-mode install the log lives at `/var/log/beacon-agent/runtime.jsonl` instead, and reading it needs `sudo`.
+
+If nothing arrives, work through the [troubleshooting steps](/runtimes/browser-extension#troubleshooting) on the extension page.
+
+## Limits
+
+- **The stream format is private.** The adapter is written defensively and degrades to a partial turn rather than failing, but a site change can still stop capture until the adapter is updated.
+- **Handed-off streams are not captured yet.** ChatGPT sometimes moves a response to a separate resume endpoint instead of streaming it inline. Those turns are missed today; capturing them is a planned follow-up.
+- **No token usage.** Nothing in the stream carries token counts, and Asymptote does not estimate them.
+- **Only the chat stream is read.** Uploaded files, canvas documents, and content rendered outside the stream are not captured.
+- **Retention defaults to `full`.** Prompt and response text is retained unless you change the mode in the extension's popup. See [retained content](/runtimes/browser-extension#retained-content).
+
+## Related
+
+<Columns cols={2}>
+  <Card title="Browser Extension" icon="download" href="/runtimes/browser-extension">
+    Install, configure, and verify the extension.
+  </Card>
+  <Card title="Claude.ai" icon="message" href="/runtimes/claude-web">
+    The other supported browser chat surface.
+  </Card>
+  <Card title="Supported agent harnesses" icon="list-check" href="/runtimes">
+    Return to the runtime support overview.
+  </Card>
+  <Card title="Retention and redaction" icon="shield" href="/security/retention-redaction">
+    How retained content is handled once it reaches the endpoint.
+  </Card>
+</Columns>

--- a/docs/runtimes/claude-web.mdx
+++ b/docs/runtimes/claude-web.mdx
@@ -1,0 +1,104 @@
+---
+title: "Claude.ai"
+description: "Asymptote support details for Claude.ai browser chat telemetry"
+---
+
+## Runtime overview
+
+Asymptote collects Claude.ai chat telemetry through the optional [browser extension](/runtimes/browser-extension). Every turn on claude.ai becomes prompt, response, and tool events in the local runtime log, attributed to the `claude_web` harness so it stays separate from Claude Code and other CLI agents.
+
+Support is in beta. The claude.ai chat API is private and undocumented, so a change on the site can interrupt capture until the adapter is updated.
+
+## Prerequisites
+
+- The Beacon endpoint is installed and running, and the browser extension is loaded. See [Browser Extension](/runtimes/browser-extension) for both steps.
+- claude.ai is enabled in the extension's options page. It is enabled by default.
+
+## Collection path
+
+The extension's main-world interceptor tees the streamed response from claude.ai's completion endpoint. The Claude adapter reads the Anthropic-style Server-Sent Event stream and rebuilds one turn from it:
+
+| Stream signal | What Asymptote takes from it |
+|---------------|------------------------------|
+| The outbound request body | Prompt text and the input messages |
+| The conversation id in the request URL or body | `session.id` and `gen_ai.conversation.id` |
+| `message_start` | Response model and input token count |
+| `content_block_delta` | Assistant response text, and tool call arguments as they stream |
+| `content_block_start` for a `tool_use` block | Tool call id and name |
+| `message_delta` | Output token count |
+| `message_stop` | Turn completion |
+
+The service worker then posts the turn to the local collector as OTLP GenAI logs. Events carry `harness.collection_method` of `otlp`.
+
+A turn whose stream is cut off before `message_stop` is still delivered, recorded as `agent.response` rather than `agent.response.completed`.
+
+## Events
+
+One claude.ai turn produces:
+
+| Event | When |
+|-------|------|
+| `prompt.submitted` | The request body carried prompt text or input messages |
+| `agent.response.completed` | The stream finished normally |
+| `agent.response` | The stream ended early, so the response is partial |
+| `tool.invoked` | Once per `tool_use` block in the turn, with the call id, name, and arguments |
+
+Turns from one conversation share a session id, so a conversation reads as a session in the dashboard even though the site sends no session start or stop signal.
+
+## Telemetry coverage
+
+| Area | Support |
+|------|---------|
+| Prompt telemetry | Supported, with full prompt text under `full` and `redacted` retention |
+| Assistant response telemetry | Supported, including the response text and the model reported by the stream |
+| Tool telemetry | Supported. Tool call id, name, and arguments are captured from `tool_use` blocks |
+| Tool results | Not available. The chat stream carries the tool call, not the result Anthropic computed for it |
+| Token usage | Supported. Input and output token counts are normalized into `gen_ai.usage` |
+| Cost | Not available. claude.ai does not report per-turn cost to the page |
+| Command and file telemetry | Not applicable. Browser chat performs no local commands or file edits |
+| Approval telemetry | Not available. claude.ai does not expose approval decisions to a page script |
+| Session lifecycle | Partial. Turns are correlated by conversation id; there is no session start or stop signal |
+| Local JSONL and dashboard | Supported after events reach the collector |
+| MDM deployment | Not covered by Beacon's MDM assets. Distribute through browser policy instead |
+
+## Confirm it is working
+
+Send one message on claude.ai, then look for the event:
+
+```bash
+grep -c '"claude_web"' ~/.beacon/endpoint/logs/runtime.jsonl
+```
+
+To read the most recent one, including its token counts:
+
+```bash
+grep '"claude_web"' ~/.beacon/endpoint/logs/runtime.jsonl | tail -1 | jq '{action: .event.action, harness: .harness.name, model, session: .session.id, usage: .gen_ai.usage}'
+```
+
+On a system-mode install the log lives at `/var/log/beacon-agent/runtime.jsonl` instead, and reading it needs `sudo`.
+
+If nothing arrives, work through the [troubleshooting steps](/runtimes/browser-extension#troubleshooting) on the extension page.
+
+## Limits
+
+- **The stream format is private.** The adapter is written defensively and degrades to a partial turn rather than failing, but a site change can still stop capture until the adapter is updated.
+- **Only the chat stream is read.** Attachments, artifacts rendered outside the stream, and project files are not captured.
+- **Prompt text comes from the request body.** A turn sent through a path the adapter does not recognize arrives with the response but without the prompt.
+- **Retention defaults to `full`.** Prompt and response text is retained unless you change the mode in the extension's popup. See [retained content](/runtimes/browser-extension#retained-content).
+
+## Related
+
+<Columns cols={2}>
+  <Card title="Browser Extension" icon="download" href="/runtimes/browser-extension">
+    Install, configure, and verify the extension.
+  </Card>
+  <Card title="ChatGPT" icon="message" href="/runtimes/chatgpt-web">
+    The other supported browser chat surface.
+  </Card>
+  <Card title="Supported agent harnesses" icon="list-check" href="/runtimes">
+    Return to the runtime support overview.
+  </Card>
+  <Card title="Retention and redaction" icon="shield" href="/security/retention-redaction">
+    How retained content is handled once it reaches the endpoint.
+  </Card>
+</Columns>

--- a/docs/runtimes/index.mdx
+++ b/docs/runtimes/index.mdx
@@ -10,6 +10,7 @@ Asymptote supports multiple [runtime surfaces](/concepts/core-concepts#runtime-s
 These integrations are grouped by where the agent runs and how telemetry is collected:
 
 - **Local**: Agent harnesses running on an endpoint write telemetry to Asymptote's local collector, hook adapter, plugin, or gateway path.
+- **Browser chat**: An optional Chrome extension reads the chat streams of supported sites in the browser and posts them to the same local collector.
 - **[CI](/concepts/core-concepts#ci-telemetry)**: Ephemeral CI jobs use a temporary collector and write normalized runtime JSONL as a build artifact or upload target instead of installing a persistent endpoint service.
 - **[Cloud](/concepts/core-concepts#cloud-agent-telemetry)**: Provider-managed cloud agents can write session telemetry from the cloud sandbox to customer-managed storage, while [SDK integrations](/concepts/core-concepts#observe-sdk) instrument agent applications that run in servers, serverless functions, workers, and hosted agent platforms.
 
@@ -44,14 +45,14 @@ These integrations are grouped by where the agent runs and how telemetry is coll
 | [Hermes Agent](/runtimes/hermes-agent) | Shell hooks | Prompt, observed tool, command, file, approval request and response, session lifecycle, and subagent stop telemetry |
 | [OpenClaw Gateway](/runtimes/openclaw-gateway) | Gateway-configured OTLP/HTTP | OTLP logs, traces, and metrics from the Gateway diagnostics plugin |
 
-### Local browser chat surfaces
+### Browser chat surfaces
 
 | Agent harness | Collection path | Telemetry coverage |
 |----------------|-----------------|--------------------|
-| [Claude.ai](/runtimes/browser-extension) (beta) | Managed browser extension over local OTLP | Prompt, assistant response, tool call, and token usage telemetry from the claude.ai chat stream |
-| [ChatGPT](/runtimes/browser-extension) (beta) | Managed browser extension over local OTLP | Prompt, assistant response, and tool call telemetry from the chatgpt.com chat stream |
+| [Claude.ai](/runtimes/claude-web) (beta) | Managed browser extension over local OTLP | Prompt, assistant response, tool call, and token usage telemetry from the claude.ai chat stream |
+| [ChatGPT](/runtimes/chatgpt-web) (beta) | Managed browser extension over local OTLP | Prompt, assistant response, and web search tool telemetry from the chatgpt.com chat stream. No token usage, which the site does not report |
 
-Browser chat resolves to the `claude_web` and `chatgpt_web` harness names, so it stays distinguishable from CLI agents. The extension retains full prompt and response text by default. See [Browser Extension](/runtimes/browser-extension) for the retention modes.
+Both sites are collected by one optional Chrome extension. Browser chat resolves to the `claude_web` and `chatgpt_web` harness names, so it stays distinguishable from CLI agents. The extension retains full prompt and response text by default. See [Browser Extension](/runtimes/browser-extension) to install it and to change the retention mode.
 
 ### CI harnesses
 

--- a/docs/runtimes/integration-model.mdx
+++ b/docs/runtimes/integration-model.mdx
@@ -67,7 +67,7 @@ During install, Beacon configures the runtime surfaces it can safely manage:
 | [Cursor](/runtimes/cursor) | Native hook payloads through `beacon-hooks` | Hooks emit session, prompt, tool, command, MCP-like, approval, and file edit telemetry where Cursor exposes payloads. |
 | [Claude Cowork](/runtimes/claude-cowork) | Admin-configured OTLP from Anthropic's service | Production Cowork telemetry should use a durable customer-managed HTTPS collector endpoint. |
 | [OpenClaw Gateway](/runtimes/openclaw-gateway) | Gateway-configured OTLP/HTTP export | Beacon prints Gateway diagnostics settings and validates OpenClaw-derived events in the runtime log. |
-| [Browser Extension](/runtimes/browser-extension) | Managed browser extension over local OTLP | A Chrome MV3 extension parses the claude.ai and chatgpt.com chat streams and posts OTLP GenAI logs to the local collector. Beta, installed unpacked rather than from the Chrome Web Store, and configured in the extension's own options page rather than by `beacon`. |
+| [Browser Extension](/runtimes/browser-extension) | Managed browser extension over local OTLP | A Chrome MV3 extension parses the [claude.ai](/runtimes/claude-web) and [chatgpt.com](/runtimes/chatgpt-web) chat streams and posts OTLP GenAI logs to the local collector. Beta, installed unpacked rather than from the Chrome Web Store, and configured in the extension's own options page rather than by `beacon`. |
 
 ## Hook telemetry
 

--- a/docs/security/data-inventory.mdx
+++ b/docs/security/data-inventory.mdx
@@ -24,8 +24,8 @@ Beacon writes normalized endpoint events only when supported runtimes provide te
 | Cursor | Native hooks | Prompt, tool, shell command, MCP-like, approval, and file edit telemetry |
 | Claude Cowork | Admin-configured OTLP | Prompt, command, tool, and file telemetry when emitted through Claude Cowork OTLP |
 | OpenClaw Gateway | Gateway-configured OTLP/HTTP | OTLP logs, traces, and metrics from the Gateway diagnostics plugin |
-| Claude.ai (`claude_web`) | Managed browser extension over local OTLP | Prompt text, assistant response text, request and response model, tool call id/name/arguments/results, token usage, and conversation id from the claude.ai chat stream |
-| ChatGPT (`chatgpt_web`) | Managed browser extension over local OTLP | Prompt text, assistant response text, model, tool call activity, and conversation id from the chatgpt.com chat stream. ChatGPT web does not report token usage in its stream |
+| [Claude.ai](/runtimes/claude-web) (`claude_web`) | Managed browser extension over local OTLP | Prompt text, assistant response text, request and response model, tool call id/name/arguments/results, token usage, and conversation id from the claude.ai chat stream |
+| [ChatGPT](/runtimes/chatgpt-web) (`chatgpt_web`) | Managed browser extension over local OTLP | Prompt text, assistant response text, model, tool call activity, and conversation id from the chatgpt.com chat stream. ChatGPT web does not report token usage in its stream |
 
 The browser extension is the only surface that reads content from a site the
 person is signed into personally, so its boundaries are worth stating explicitly.


### PR DESCRIPTION
Reorganize browser extension documentation to separate concerns between the extension itself and per-site telemetry coverage.

## Summary

The browser extension documentation was previously a single page covering both Claude.ai and ChatGPT, mixing installation/configuration guidance with site-specific telemetry details. This change splits it into three focused pages:

1. **Browser Extension** (`browser-extension.mdx`) — Install, configure, and verify the extension itself
2. **Claude.ai** (`claude-web.mdx`) — Claude.ai-specific telemetry coverage and limits
3. **ChatGPT** (`chatgpt-web.mdx`) — ChatGPT-specific telemetry coverage and limits

## Key changes

- **New Claude.ai page** — Documents collection path, events, telemetry coverage table, confirmation steps, and limits specific to claude.ai (including token usage support and tool results availability)
- **New ChatGPT page** — Documents collection path, events, telemetry coverage table, confirmation steps, and limits specific to chatgpt.com (including lack of token usage and handed-off stream limitations)
- **Refactored Browser Extension page** — Focuses on install, configuration, and verification that apply to both sites; moves site-specific coverage details to the per-site pages; adds navigation cards linking to both sites and related docs
- **Updated navigation** — Moves browser chat from a subsection under "Local" to a top-level "Browser Chat" group in `docs.json` with all three pages
- **Updated index and data inventory** — Adds browser chat as a distinct collection category and updates references to point to the new per-site pages

## Implementation details

- Shared telemetry coverage (prompt, response, command/file, approval, session, JSONL/dashboard, MDM) remains on the Browser Extension page with a note that tool and token coverage differs by site
- Each site page includes its own "Confirm it is working" section with site-specific grep/jq examples
- Retention and redaction guidance stays on the Browser Extension page since it applies to both sites
- Related links at the bottom of each page cross-reference the other site and the extension page
- The extension page now opens with an overview card showing both supported sites

https://claude.ai/code/session_016cn5aaP7Z9FujpDZiBsoRp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only restructure with no runtime, extension, or collector behavior changes.
> 
> **Overview**
> **Reorganizes browser chat documentation** so install/configuration stays on one page and Claude.ai vs ChatGPT telemetry details live on dedicated runtime pages.
> 
> The **Browser Extension** page is refocused on shared prerequisites, install (build/release/load), extension UI configuration, retention modes, verification, troubleshooting, and coverage that applies to both sites; it adds overview cards linking to the site pages and defers per-site tool/token differences to those pages.
> 
> **New `claude-web` and `chatgpt-web` pages** document each harness’s stream parsing, emitted events, telemetry matrix, site-specific limits (e.g. Claude token usage vs ChatGPT’s missing tokens and handed-off streams), and harness-specific `grep`/`jq` checks, with cross-links back to the extension page.
> 
> **Navigation and cross-references** move **Browser Chat** to a top-level sidebar group in `docs.json` (extension + both sites), add browser chat as its own category on the runtimes index, and point the support matrix, integration model, and data inventory at `/runtimes/claude-web` and `/runtimes/chatgpt-web` instead of folding everything into `browser-extension`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91883dc96ffdaf99e34b8419ea225ca21313e28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->