### PR TITLE
Clarify Agent Beacon positioning and onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,32 +161,20 @@ destinations.
 
 ### MDM Deployment
 
-Version tags publish a signed, notarized, and stapled Apple Silicon endpoint
-`.pkg`, `.deb` and `.rpm` packages for Linux on amd64 and arm64, and an x64 `.msi`
-for Windows. Homebrew and release archives remain available for CLI installs.
-
-Installing a native package performs the system-mode install itself: it registers
-and starts the service, writes machine-wide configuration, and points the
-interactive user's agent runtimes at the local collector. See the
-[Linux](https://docs.asymptotelabs.ai/platforms/linux) and
-[Windows](https://docs.asymptotelabs.ai/platforms/windows) install guides.
+Every version tag publishes native packages that perform the system-mode install
+themselves: they register and start the service, write machine-wide configuration, and
+point the interactive user's agent runtimes at the local collector. Homebrew and release
+archives remain available for CLI installs.
 
 | Platform | Package | Service manager | Notes |
 | --- | --- | --- | --- |
-| macOS | Signed, notarized `.pkg` (Apple Silicon) | launchd | Homebrew for single machines |
-| Linux | `.deb` / `.rpm` (amd64, arm64) | systemd | Supervised fallback without systemd |
-| Windows | `.msi` (x64) | Service Control Manager | Unsigned for now; verify the published `.sha256` |
+| [macOS](https://docs.asymptotelabs.ai/platforms/macos) | Signed, notarized `.pkg` (Apple Silicon) | launchd | [Jamf Pro](https://docs.asymptotelabs.ai/mdm/jamf), [Fleet](https://docs.asymptotelabs.ai/mdm/fleet), and [Rippling](https://docs.asymptotelabs.ai/mdm/rippling) assets; Homebrew for single machines |
+| [Linux](https://docs.asymptotelabs.ai/platforms/linux) | `.deb` / `.rpm` (amd64, arm64) | systemd | Supervised fallback without systemd |
+| [Windows](https://docs.asymptotelabs.ai/platforms/windows) | `.msi` (x64) | Service Control Manager | Unsigned for now; verify the published `.sha256` |
 
-| MDM platform | Support path |
-| --- | --- |
-| [Fleet](https://docs.asymptotelabs.ai/cli/fleet) | macOS package and user-context deployment helpers |
-| [Jamf Pro](https://docs.asymptotelabs.ai/cli/jamf) | macOS package, policy scripts, validation, and Extension Attributes |
-
-The macOS package includes GCS forwarder helpers at
-`/opt/beacon/jamf/claude/gcs/{install-forwarder.sh,run-forwarder.sh,repair-hooks-and-forwarder.sh}`.
-They run bundled Vector as `com.beacon.endpoint.gcs-forwarder`, write runtime and
-inventory objects below one root prefix, and reference an externally delivered
-service-account JSON through `GOOGLE_APPLICATION_CREDENTIALS`.
+The macOS package also ships
+[GCS forwarder helpers](https://docs.asymptotelabs.ai/mdm/jamf/claude) under
+`/opt/beacon/jamf/claude/gcs/` that run bundled Vector as a launchd job.
 
 ## Dashboard and Local Detection
 

--- a/README.md
+++ b/README.md
@@ -34,16 +34,15 @@
 ## What is Agent Beacon
 
 Agent Beacon is the world's first [open-source telemetry layer](https://justindsouza.substack.com/p/introducing-beacon-endpoint-telemetry)
-for AI agents, giving you one record of what every agent did, wherever it ran.
-Agent activity is fragmented across runtimes and environments. The same agent can
-run on a laptop, in CI, in the browser, or in the cloud, and every runtime records
-what it did differently, or not at all, so there is no one place to look. Beacon
-supports 21+ local runtimes and covers every surface agents run on, normalizing
-all of them into one data model built on the OpenTelemetry GenAI standard.
+for AI agents. Today there is no way to see all of your agent activity in one
+place: it is fragmented across runtimes and environments, from laptops to CI to
+the browser to the cloud. Beacon supports 21+ local runtimes and covers every
+surface agents run on, normalizing all of it into one data model built on the
+OpenTelemetry GenAI standard.
 
-It ships as a single endpoint binary plus a TypeScript SDK, installs on one
-machine in one command or across a fleet through [MDM](#mdm-deployment), and
-forwards to the [major SIEM and log destinations](#output-destinations).
+It ships as a single endpoint binary plus a TypeScript SDK, installs in one
+command or across a fleet through [MDM](#mdm-deployment), and forwards to the
+[major SIEM and log destinations](#output-destinations).
 
 Learn more in the [Agent Beacon documentation](https://docs.asymptotelabs.ai).
 

--- a/README.md
+++ b/README.md
@@ -222,10 +222,13 @@ setup paths.
 
 ### First-Run Onboarding
 
-The first time you run `beacon endpoint install` in a terminal, Beacon asks two
-questions — your email and whether this is work or personal use — and sends the
-answers to Asymptote once. Knowing who runs Beacon is how we decide which runtimes
-and integrations to build next. Exactly what is sent, and nothing else:
+The first time you run `beacon endpoint install` in a terminal, Beacon asks for your
+email and whether this is work or personal use, and sends that to Asymptote once.
+Knowing who runs Beacon is how we decide which runtimes and integrations to build
+next. It happens once per machine and never runs non-interactively: MDM deployments,
+package postinstall scripts, `--system` installs, CI, `--dry-run`, and piped stdin all
+skip it silently, and `--no-onboarding` or `BEACON_ONBOARDING=0` turns it off. Exactly
+what is sent, and nothing else:
 
 | Field | Example |
 | --- | --- |
@@ -237,37 +240,12 @@ and integrations to build next. Exactly what is sent, and nothing else:
 | A random install ID | `64871b2b…` |
 
 **Never sent:** prompts, file contents, commands, telemetry events, repository names,
-or anything else Beacon captures. The endpoint agent itself stays local-only — this is
+or anything else Beacon captures. The endpoint agent itself stays local-only; this is
 one HTTP request at install time, not an ongoing channel.
 
-It happens once per machine, recorded in `~/.beacon/profile.json`, which survives
-uninstall so a reinstall does not ask again.
-
-**It never runs non-interactively.** Package postinstall scripts, MDM deployments,
-`--system` installs, CI, `--dry-run`, and any piped or redirected stdin skip it
-silently. Unattended installs that still need it suppressed can set:
-
-```bash
-BEACON_ONBOARDING=0 beacon endpoint install
-```
-
-For a fleet rollout where you *do* want attribution but have no terminal, supply the
-answers up front:
-
-```bash
-BEACON_ONBOARDING_EMAIL=it@company.com BEACON_ONBOARDING_USAGE=work \
-  beacon endpoint install
-```
-
-Inspect or clear the record at any time:
-
-```bash
-beacon endpoint onboarding          # show what was recorded
-beacon endpoint onboarding --reset  # clear it
-```
-
-To have your record deleted, email the install ID shown by
-`beacon endpoint onboarding` to <support@asymptotelabs.ai>.
+See the [first-run onboarding docs](https://docs.asymptotelabs.ai/cli/endpoint-onboarding#first-run-onboarding)
+for fleet attribution without a terminal, inspecting or clearing the record, and
+deletion requests.
 
 ### For Security & IT Teams
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,15 @@
 Agent Beacon is the world's first [open-source telemetry layer](https://justindsouza.substack.com/p/introducing-beacon-endpoint-telemetry)
 for AI agents. Today there is no way to see all of your agent activity in one
 place: it is fragmented across runtimes and environments, from laptops to CI to
-the browser to the cloud. Beacon supports 21+ local runtimes and covers every
-surface agents run on, normalizing all of it into one data model built on the
-OpenTelemetry GenAI standard.
+the browser to the cloud. Beacon supports [21+ local runtimes](#local-agents) and
+covers [every surface agents run on](#supported-surfaces), normalizing all of it
+into [one data model](https://docs.asymptotelabs.ai/cli/event-schema) built on the
+[OpenTelemetry GenAI standard](https://opentelemetry.io/docs/specs/semconv/gen-ai/).
 
-It ships as a single endpoint binary plus a TypeScript SDK, installs in one
-command or across a fleet through [MDM](#mdm-deployment), and forwards to the
+It ships as a single [endpoint binary](https://docs.asymptotelabs.ai/cli/endpoint)
+plus a [TypeScript SDK](#cloud-agents), installs in
+[one command](https://docs.asymptotelabs.ai/cli/installation) or across a fleet
+through [MDM](#mdm-deployment), and forwards to the
 [major SIEM and log destinations](#output-destinations).
 
 Learn more in the [Agent Beacon documentation](https://docs.asymptotelabs.ai).

--- a/README.md
+++ b/README.md
@@ -34,22 +34,16 @@
 ## What is Agent Beacon
 
 Agent Beacon is the world's first [open-source telemetry layer](https://justindsouza.substack.com/p/introducing-beacon-endpoint-telemetry)
-for AI agents — one normalized record of what every agent did, wherever it ran.
-Agents now work across dozens of runtimes and four environments — the laptop, CI,
-the browser, and the cloud — and each one reports differently, or not at all, so
-there is no single place to answer what an agent touched. Beacon covers 31 of
-those surfaces today — 21 local runtimes, 2 browser chat surfaces, CI jobs, and 7
-cloud SDK integrations — extending the OpenTelemetry GenAI standard to normalize
-all of them into one data model.
-
-It ships in two pieces: a single endpoint binary for anything running on a
-machine, and a TypeScript SDK for cloud agents and applications. A machine is
-covered in one command, a fleet through [MDM](#mdm-deployment) with a signed macOS
-`.pkg` plus `.deb`, `.rpm`, and `.msi` packages that register and start the service
-themselves, and the resulting logs forward into
-[13 SIEM, log aggregation, and object storage destinations](#output-destinations),
-Splunk, Microsoft Sentinel, CrowdStrike Falcon LogScale, Elastic, and Datadog
-among them.
+for AI agents, giving you one record of what every agent did, wherever it ran.
+Agents run in a lot of places now: on laptops, in CI, in the browser, and in the
+cloud, and every runtime logs differently or not at all. Beacon covers 31 of
+those surfaces today (21 local runtimes, 2 browser chat surfaces, CI jobs, and 7
+cloud SDK integrations) and normalizes them into one data model built on the
+OpenTelemetry GenAI standard. It ships as a single endpoint binary plus a
+TypeScript SDK, installs on one machine in one command or across a fleet through
+[MDM](#mdm-deployment), and forwards to
+[13 SIEM, log, and storage destinations](#output-destinations) including Splunk,
+Microsoft Sentinel, CrowdStrike Falcon LogScale, Elastic, and Datadog.
 
 Learn more in the [Agent Beacon documentation](https://docs.asymptotelabs.ai).
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,22 @@
 ## What is Agent Beacon
 
 Agent Beacon is the world's first [open-source telemetry layer](https://justindsouza.substack.com/p/introducing-beacon-endpoint-telemetry)
-for AI agents wherever they run: locally, in CI, in the browser, or in the cloud.
-Agent activity is fragmented across runtimes, so Beacon extends the OpenTelemetry
-GenAI standard and normalizes runtime events into one data model.
+for AI agents — one normalized record of what every agent did, wherever it ran.
+Agents now work across dozens of runtimes and four environments — the laptop, CI,
+the browser, and the cloud — and each one reports differently, or not at all, so
+there is no single place to answer what an agent touched. Beacon covers 31 of
+those surfaces today — 21 local runtimes, 2 browser chat surfaces, CI jobs, and 7
+cloud SDK integrations — extending the OpenTelemetry GenAI standard to normalize
+all of them into one data model.
 
-Security and IT teams deploy it through [MDM](#mdm-deployment), CI workflows, and
-cloud-agent setup paths, then forward the resulting logs to the
-[major enterprise-grade SIEMs](#output-destinations).
+It ships in two pieces: a single endpoint binary for anything running on a
+machine, and a TypeScript SDK for cloud agents and applications. A machine is
+covered in one command, a fleet through [MDM](#mdm-deployment) with a signed macOS
+`.pkg` plus `.deb`, `.rpm`, and `.msi` packages that register and start the service
+themselves, and the resulting logs forward into
+[13 SIEM, log aggregation, and object storage destinations](#output-destinations),
+Splunk, Microsoft Sentinel, CrowdStrike Falcon LogScale, Elastic, and Datadog
+among them.
 
 Learn more in the [Agent Beacon documentation](https://docs.asymptotelabs.ai).
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,13 @@
 Agent Beacon is the world's first [open-source telemetry layer](https://justindsouza.substack.com/p/introducing-beacon-endpoint-telemetry)
 for AI agents, giving you one record of what every agent did, wherever it ran.
 Agents run in a lot of places now: on laptops, in CI, in the browser, and in the
-cloud, and every runtime logs differently or not at all. Beacon covers 31 of
-those surfaces today (21 local runtimes, 2 browser chat surfaces, CI jobs, and 7
-cloud SDK integrations) and normalizes them into one data model built on the
-OpenTelemetry GenAI standard. It ships as a single endpoint binary plus a
-TypeScript SDK, installs on one machine in one command or across a fleet through
-[MDM](#mdm-deployment), and forwards to
-[13 SIEM, log, and storage destinations](#output-destinations) including Splunk,
-Microsoft Sentinel, CrowdStrike Falcon LogScale, Elastic, and Datadog.
+cloud, and every runtime logs differently or not at all. Beacon supports 21+
+local runtimes and covers every surface agents run on, normalizing all of them
+into one data model built on the OpenTelemetry GenAI standard.
+
+It ships as a single endpoint binary plus a TypeScript SDK, installs on one
+machine in one command or across a fleet through [MDM](#mdm-deployment), and
+forwards to the [major SIEM and log destinations](#output-destinations).
 
 Learn more in the [Agent Beacon documentation](https://docs.asymptotelabs.ai).
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@
 
 Agent Beacon is the world's first [open-source telemetry layer](https://justindsouza.substack.com/p/introducing-beacon-endpoint-telemetry)
 for AI agents, giving you one record of what every agent did, wherever it ran.
-Agents run in a lot of places now: on laptops, in CI, in the browser, and in the
-cloud, and every runtime logs differently or not at all. Beacon supports 21+
-local runtimes and covers every surface agents run on, normalizing all of them
-into one data model built on the OpenTelemetry GenAI standard.
+Agent activity is fragmented across runtimes and environments. The same agent can
+run on a laptop, in CI, in the browser, or in the cloud, and every runtime records
+what it did differently, or not at all, so there is no one place to look. Beacon
+supports 21+ local runtimes and covers every surface agents run on, normalizing
+all of them into one data model built on the OpenTelemetry GenAI standard.
 
 It ships as a single endpoint binary plus a TypeScript SDK, installs on one
 machine in one command or across a fleet through [MDM](#mdm-deployment), and


### PR DESCRIPTION
## Summary

This PR updates the README to better communicate Agent Beacon's core value proposition and consolidates onboarding documentation by linking to the dedicated docs site rather than duplicating detailed instructions.

## Key Changes

- **Repositioned product description**: Rewrote the "What is Agent Beacon" section to lead with the core problem (fragmented agent activity across runtimes) and emphasize breadth of coverage (21+ local runtimes, all surfaces) before diving into technical details
- **Clarified deployment model**: Simplified language around how Beacon ships (single endpoint binary + TypeScript SDK) and how it's deployed (one command, MDM, or cloud setup)
- **Consolidated onboarding documentation**: Moved detailed first-run onboarding instructions (environment variables, fleet attribution, inspection/reset commands, deletion requests) to the dedicated docs site, keeping only the essential payload table and core behavior in the README
- **Improved onboarding section clarity**: Reorganized the first-run onboarding explanation to front-load the key guarantee (never runs non-interactively) and clarify all the contexts where it's skipped, then point to docs for advanced scenarios
- **Minor copy refinements**: Fixed punctuation (semicolon instead of dash) and tightened phrasing throughout

## Implementation Details

The changes preserve all product commitments documented in CLAUDE.md:
- The local-only posture and intentional exception for the one-time install signup remain clearly stated
- The payload table documenting exactly what is sent is retained for transparency
- The guarantee that onboarding never runs non-interactively is emphasized
- All advanced configuration options are documented in the linked docs site rather than cluttering the README

This aligns the README with the current documentation structure at docs.asymptotelabs.ai while maintaining the transparency and clarity expected for an open-source security tool.

https://claude.ai/code/session_01N4Gat3pZWjcqKKXJxJSAD2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits; product behavior and onboarding logic are unchanged and detailed guidance remains on the docs site.
> 
> **Overview**
> This PR **rewrites README marketing and ops copy** only—no code or runtime behavior changes.
> 
> The **“What is Agent Beacon”** section now leads with fragmented agent activity as the problem, then highlights **21+ local runtimes**, **all surfaces**, the **OpenTelemetry GenAI** data model, and how Beacon ships (**endpoint binary**, **TypeScript SDK**, one-command / MDM install, SIEM forwarding).
> 
> **MDM deployment** is tightened: native packages are described generically, platform rows link to install guides and Jamf/Fleet/Rippling assets, the separate MDM platform table and long GCS forwarder path details are replaced with a short link to Jamf GCS docs.
> 
> **First-run onboarding** keeps the transparency table and “never sent” guarantees but **front-loads** non-interactive skip behavior (`--no-onboarding`, `BEACON_ONBOARDING=0`, MDM/CI, etc.). Detailed env vars, CLI examples, and deletion instructions are **removed from the README** and pointed to [first-run onboarding docs](https://docs.asymptotelabs.ai/cli/endpoint-onboarding#first-run-onboarding), where that content already lives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb753db4aa7425ec1cc3c5488e1741c1e87e963a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->