### PR TITLE
docs: add architecture summary and docs links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Learn more in the [Agent Beacon documentation](https://docs.asymptotelabs.ai).
 
 ## High-Level Architecture
 
-Beacon captures activity where each agent actually runs, then normalizes it on the
-endpoint into a single OpenTelemetry-based event model. That one stream is what the
-local dashboard, JSONL retention, and every SIEM destination read from.
+Beacon captures activity where each agent actually runs, then normalizes it into a
+single OpenTelemetry-based event model. That one stream is what the local dashboard,
+JSONL retention, and every SIEM destination read from.
 
 <p align="center">
   <img src="images/beacon-architecture.png" alt="Beacon endpoint architecture" width="860">
@@ -61,8 +61,8 @@ local dashboard, JSONL retention, and every SIEM destination read from.
 
 - **Agent runtime layer** — hooks, OpenTelemetry sources, CI wrappers, SDKs, and an
   optional browser extension capture supported agent activity.
-- **Beacon endpoint layer** — local processing normalizes events, applies retention
-  and redaction settings, and writes durable endpoint telemetry.
+- **Beacon processing layer** — normalizes events, applies retention and redaction
+  settings, and writes durable telemetry.
 - **Output layer** — inspect events in the local dashboard, retain JSONL, or forward
   records into the [major enterprise-grade SIEMs](#output-destinations).
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Learn more in the [Agent Beacon documentation](https://docs.asymptotelabs.ai).
 
 ## High-Level Architecture
 
+Beacon captures activity where each agent actually runs, then normalizes it on the
+endpoint into a single OpenTelemetry-based event model. That one stream is what the
+local dashboard, JSONL retention, and every SIEM destination read from.
+
 <p align="center">
   <img src="images/beacon-architecture.png" alt="Beacon endpoint architecture" width="860">
 </p>
@@ -63,7 +67,11 @@ Learn more in the [Agent Beacon documentation](https://docs.asymptotelabs.ai).
   records into the [major enterprise-grade SIEMs](#output-destinations).
 
 Collection, processing, and inspection stay local by default; the same normalized
-event model extends to CI and cloud-agent paths under customer control.
+event model extends to CI and cloud-agent paths under customer control. See the
+[open-source architecture reference](https://docs.asymptotelabs.ai/architecture/architecture)
+for the full collection, normalization, storage, and forwarding pipeline, or the
+[system architecture overview](https://docs.asymptotelabs.ai/architecture/system-architecture)
+to compare it with the managed path.
 
 ## Supported Surfaces
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ Learn more in the [Agent Beacon documentation](https://docs.asymptotelabs.ai).
 ## High-Level Architecture
 
 Beacon captures activity where each agent actually runs, then normalizes it into a
-single OpenTelemetry-based event model. That one stream is what the local dashboard,
-JSONL retention, and every SIEM destination read from.
+single OpenTelemetry-based event model.
 
 <p align="center">
   <img src="images/beacon-architecture.png" alt="Beacon endpoint architecture" width="860">


### PR DESCRIPTION
## Summary

The `High-Level Architecture` section in `README.md` jumped straight from the heading to the diagram, so a reader hit the image before any explanation of what it shows, and the section had no path onward to the fuller architecture docs.

This adds a two-sentence summary above the diagram and links out to the architecture docs below the layer bullets.

## Changes

- Two-sentence lead-in before `images/beacon-architecture.png`: Beacon captures activity where each agent runs and normalizes it on the endpoint into a single OpenTelemetry-based event model, and that one stream is what the dashboard, JSONL retention, and SIEM destinations read from.
- Appended two doc links to the existing local-by-default paragraph that closes the section:
  - [open-source architecture reference](https://docs.asymptotelabs.ai/architecture/architecture) for the full collection, normalization, storage, and forwarding pipeline
  - [system architecture overview](https://docs.asymptotelabs.ai/architecture/system-architecture) for the open-source vs. managed comparison

Both URLs were taken from `docs/architecture/*.mdx` and the nav entries in `docs/docs.json` so they match the published doc paths.

## Notes

Documentation only — no code, install, packaging, collector, or dashboard behavior changes, and no test-affecting edits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QU55Pq6ZdpFbfXsPQKrpxU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation edits with no runtime, install, or API impact.
> 
> **Overview**
> The **High-Level Architecture** section now opens with a short lead-in (capture at the agent, normalize to one OpenTelemetry event model) before the diagram, so readers get context before the image.
> 
> The middle layer bullet is renamed from **Beacon endpoint layer** to **Beacon processing layer**, with wording tightened to match that framing. The closing paragraph adds links to the [open-source architecture reference](https://docs.asymptotelabs.ai/architecture/architecture) and [system architecture overview](https://docs.asymptotelabs.ai/architecture/system-architecture) for deeper reading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ccb504f1311bdbcc5c2c1cd09d69a1c5b1384b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->