### PR TITLE
Fix Claude Cowork OTLP event normalization

### DIFF
--- a/collector-builder/exporter/beaconjsonexporter/README.md
+++ b/collector-builder/exporter/beaconjsonexporter/README.md
@@ -15,7 +15,7 @@ Required behavior:
 - Identify Claude Code and Claude Cowork OTLP resources and map prompts,
   tool/MCP calls, file access, approval decisions, API usage, token counts,
   costs, and errors into Beacon endpoint events.
-- For Claude Code logs, decode JSON-string `tool_input` and `tool_parameters`
+- For Claude Code and Claude Cowork logs, decode JSON-string `tool_input` and `tool_parameters`
   attributes into canonical `command.*` and `file.*` fields. Only actual tool
   results may become tool, command, or file actions; API, assistant, plugin,
   hook, skill, and other lifecycle logs use session actions, while MCP

--- a/collector-builder/exporter/beaconjsonexporter/exporter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/exporter_test.go
@@ -1290,6 +1290,56 @@ func TestConsumeLogsNormalizesCapturedClaudeCodeToolEvents(t *testing.T) {
 	}
 }
 
+func TestConsumeLogsNormalizesCapturedClaudeCoworkEvents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.jsonl")
+	exp, err := newExporter(&Config{
+		Path:          path,
+		MaxEventBytes: defaultMaxEventBytes,
+		RotateBytes:   defaultRotateBytes,
+		RedactSecrets: true,
+	}, exporter.Settings{})
+	if err != nil {
+		t.Fatalf("newExporter returned error: %v", err)
+	}
+
+	if err := exp.consumeLogs(context.Background(), capturedClaudeLogs(t, "claude-cowork-2.1.251.json")); err != nil {
+		t.Fatalf("consumeLogs returned error: %v", err)
+	}
+
+	output, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime JSONL: %v", err)
+	}
+	var sawPrompt, sawResponse, sawApproval, sawCommand, sawConnection, sawLifecycle bool
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		var event beaconEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("decode runtime event: %v", err)
+		}
+		if event.Harness.Name != "claude_cowork" || event.Harness.CollectionMethod != asymptoteobserve.CollectionMethodOTLP {
+			t.Fatalf("unexpected Cowork harness: %#v", event.Harness)
+		}
+		switch event.Message {
+		case "claude_code.user_prompt":
+			sawPrompt = event.Event.Action == "prompt.submitted" && event.Prompt != nil
+		case "claude_code.assistant_response":
+			sawResponse = event.Event.Action == "session.activity" && event.GenAI != nil && event.GenAI.Output != nil
+		case "claude_code.tool_decision":
+			sawApproval = event.Event.Action == "approval.allowed" && event.MCP != nil && event.MCP.Tool == "device_bash"
+		case "claude_code.tool_result":
+			sawCommand = event.Event.Action == "command.executed" && event.Command != nil && event.Command.Command == "printf COWORK_COMMAND_MARKER"
+		case "claude_code.mcp_server_connection":
+			sawConnection = event.Event.Action == "mcp.connection" && event.MCP != nil && event.MCP.Server == "remote-devices"
+		case "claude_code.hook_execution_complete":
+			sawLifecycle = event.Event.Action == "session.activity" && event.Event.Category == "session"
+		}
+	}
+	if !sawPrompt || !sawResponse || !sawApproval || !sawCommand || !sawConnection || !sawLifecycle {
+		t.Fatalf("normalized Cowork events missing: prompt=%v response=%v approval=%v command=%v connection=%v lifecycle=%v\n%s",
+			sawPrompt, sawResponse, sawApproval, sawCommand, sawConnection, sawLifecycle, output)
+	}
+}
+
 func TestConsumeLogsClassifiesCapturedClaudeCodeLifecycleEvents(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "runtime.jsonl")
 	exp, err := newExporter(&Config{

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/content.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/content.go
@@ -50,7 +50,7 @@ var assistantTextKeys = []string{
 // which is what keeps a survey answer from being recorded as something the model
 // said.
 func claudeAssistantText(harness, eventName string, attrs map[string]interface{}) string {
-	if harness != "claude_code" || eventName != ClaudeAssistantResponse {
+	if !isClaudeOTelLogHarness(harness) || eventName != ClaudeAssistantResponse {
 		return ""
 	}
 	return FirstTextAttr(attrs, "response")

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -576,10 +576,20 @@ func codexArgumentCommand(args string) string {
 	return strings.TrimSpace(payload.Cmd)
 }
 
+func isClaudeOTelLogHarness(name string) bool {
+	switch name {
+	case "claude_code", "claude_cowork":
+		return true
+	default:
+		return false
+	}
+}
+
 func (c Converter) NormalizeClaudeLogEvent(event *Event, attrs map[string]interface{}, body string) {
-	if event == nil || event.Harness.Name != "claude_code" {
+	if event == nil || !isClaudeOTelLogHarness(event.Harness.Name) {
 		return
 	}
+	normalizeClaudeCoworkContext(event, attrs)
 	originalAction := event.Event.Action
 	originalCategory := event.Event.Category
 	preserveAction := FirstString(attrs, "beacon.event.action", "event.action", "gen_ai.agent.action", "ai.agent.action") != ""
@@ -667,6 +677,7 @@ func NormalizeClaudeToolDecision(event *Event, attrs map[string]interface{}) {
 	ensureClaudeTool(event, toolName)
 
 	params := JSONMapAttr(attrs, "tool_parameters")
+	normalizeClaudeMCPTool(event, params)
 	if command := claudeCommand(nil, params); command != "" {
 		event.Command = &CommandInfo{Command: command}
 		event.Tool.Command = command
@@ -682,6 +693,7 @@ func NormalizeClaudeToolResult(event *Event, attrs map[string]interface{}) {
 	ensureClaudeTool(event, toolName)
 	input := JSONMapAttr(attrs, "tool_input")
 	params := JSONMapAttr(attrs, "tool_parameters")
+	mcpServer, mcpTool := normalizeClaudeMCPTool(event, params)
 
 	switch strings.ToLower(toolName) {
 	// PowerShell alongside Bash, because they are the same signal under different names.
@@ -709,7 +721,59 @@ func NormalizeClaudeToolResult(event *Event, attrs map[string]interface{}) {
 		normalizeClaudeFileResult(event, toolName, input, "file.read")
 	case "write", "edit", "notebookedit":
 		normalizeClaudeFileResult(event, toolName, input, "file.modified")
+	default:
+		if mcpServer != "" || mcpTool != "" {
+			event.Event.Action = "mcp.tool_invoked"
+			event.Event.Category = "mcp"
+		}
+		if strings.EqualFold(mcpServer, "remote-devices") && strings.EqualFold(mcpTool, "device_bash") {
+			if command := FirstString(input, "command", "cmd"); command != "" {
+				event.Event.Action = "command.executed"
+				event.Event.Category = "command"
+				event.Command = &CommandInfo{Command: command}
+				if duration, ok := Int64Attr(attrs, "duration_ms"); ok {
+					event.Command.DurationMS = duration
+				}
+				event.Tool.Command = command
+			}
+		}
 	}
+}
+
+func normalizeClaudeCoworkContext(event *Event, attrs map[string]interface{}) {
+	if event.Harness.Name != "claude_cowork" {
+		return
+	}
+	switch strings.ToLower(FirstString(attrs, "cowork.surface")) {
+	case "remote", "cloud", "web", "mobile":
+		event.Origin = asymptoteobserve.OriginCloud
+	case "local", "desktop":
+		event.Origin = asymptoteobserve.OriginLocal
+	}
+	if name := FirstString(attrs, "user.email", "enduser.id", "user.account_id", "user.account_uuid", "user.id"); name != "" {
+		event.User.Name = name
+	}
+	if uid := FirstString(attrs, "user.account_uuid", "user.account_id", "user.id"); uid != "" {
+		event.User.UID = uid
+	}
+}
+
+func normalizeClaudeMCPTool(event *Event, params map[string]interface{}) (string, string) {
+	server := FirstString(params, "mcp_server_name", "mcp.server", "mcp.server.name")
+	tool := FirstString(params, "mcp_tool_name", "mcp.tool", "mcp.tool.name")
+	if server == "" && tool == "" {
+		return "", ""
+	}
+	if event.MCP == nil {
+		event.MCP = &MCPInfo{}
+	}
+	if event.MCP.Server == "" {
+		event.MCP.Server = server
+	}
+	if event.MCP.Tool == "" {
+		event.MCP.Tool = tool
+	}
+	return server, tool
 }
 
 // normalizeClaudeMCPConnection gives an mcp.connection event the mcp payload its
@@ -1019,6 +1083,9 @@ func (c Converter) PopulateCommon(event *Event, attrs map[string]interface{}) {
 		event.Sequence = uint64(sequence)
 	}
 	event.GenAI = GenAIFromAttrs(attrs)
+	if version := FirstString(attrs, "service.version"); version != "" {
+		event.Harness.Version = version
+	}
 	event.Model = FirstString(attrs, "gen_ai.request.model", "gen_ai.response.model", "model", "ai.model")
 	event.Repository = FirstString(attrs, "vcs.repository.url", "repository", "repo.path", "workspace.repository")
 	event.Branch = FirstString(attrs, "vcs.branch.name", "git.branch", "branch")
@@ -1274,7 +1341,7 @@ func GenAIUsageFromAttrs(attrs map[string]interface{}) *GenAIUsageInfo {
 	if value, ok := Int64Attr(attrs, "gen_ai.usage.reasoning.output_tokens"); ok {
 		usage.Reasoning = &GenAIUsageReasoningInfo{OutputTokens: &value}
 	}
-	if value, ok := FloatAttr(attrs, "gen_ai.usage.cost"); ok {
+	if value, ok := FloatAttr(attrs, "gen_ai.usage.cost_usd", "gen_ai.usage.cost", "cost_usd"); ok {
 		usage.CostUSD = &value
 	}
 	if IsZeroJSON(usage) {

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -752,9 +752,10 @@ func normalizeClaudeCoworkContext(event *Event, attrs map[string]interface{}) {
 	}
 	if name := FirstString(attrs, "user.email", "enduser.id", "user.account_id", "user.account_uuid", "user.id"); name != "" {
 		event.User.Name = name
-	}
-	if uid := FirstString(attrs, "user.account_uuid", "user.account_id", "user.id"); uid != "" {
-		event.User.UID = uid
+		// The base event carries the collector process UID. Once a cloud identity
+		// replaces that process user, keep only a source-provided account ID;
+		// otherwise the record would mix a Cowork operator with the collector UID.
+		event.User.UID = FirstString(attrs, "user.account_uuid", "user.account_id", "user.id")
 	}
 }
 

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
@@ -1231,7 +1231,6 @@ func TestClaudeNormalizerDoesNotAffectOtherHarnesses(t *testing.T) {
 		"github-copilot",
 		"copilot-chat",
 		"cursor",
-		"claude-cowork",
 		"claude_agent_sdk",
 		"claude_web",
 	} {
@@ -1247,6 +1246,101 @@ func TestClaudeNormalizerDoesNotAffectOtherHarnesses(t *testing.T) {
 				t.Fatalf("%s event changed by Claude normalizer: %#v", serviceName, event)
 			}
 		})
+	}
+}
+
+func TestCapturedClaudeCoworkNormalizesThroughClaudeOTelPipeline(t *testing.T) {
+	fixture, events := capturedLogEvents(t, "claude-cowork-2.1.251.json")
+	if len(events) != len(fixture.Records) {
+		t.Fatalf("events = %d, want %d", len(events), len(fixture.Records))
+	}
+	byName := map[string]Event{}
+	for i, record := range fixture.Records {
+		byName[record.Name] = events[i]
+		event := events[i]
+		if event.Harness.Name != "claude_cowork" {
+			t.Fatalf("%s harness = %q, want claude_cowork", record.Name, event.Harness.Name)
+		}
+		if event.Harness.Version != fixture.Version {
+			t.Fatalf("%s harness version = %q, want %q", record.Name, event.Harness.Version, fixture.Version)
+		}
+		if event.Origin != asymptoteobserve.OriginCloud {
+			t.Fatalf("%s origin = %q, want cloud", record.Name, event.Origin)
+		}
+	}
+
+	prompt := byName["user_prompt"]
+	if prompt.Event.Action != "prompt.submitted" || prompt.Event.Category != "prompt" || prompt.Event.Fidelity != asymptoteobserve.FidelityObserved {
+		t.Fatalf("prompt event = %#v, want observed prompt.submitted/prompt", prompt.Event)
+	}
+	if prompt.Prompt == nil || prompt.Prompt.Text != "COWORK_PROMPT_MARKER" {
+		t.Fatalf("prompt = %#v, want retained Cowork prompt", prompt.Prompt)
+	}
+	if prompt.User.Name != "operator@example.com" || prompt.User.UID != "account-fixture" {
+		t.Fatalf("prompt user = %#v, want source account identity", prompt.User)
+	}
+
+	response := byName["assistant_response"]
+	if response.Event.Action != "session.activity" || response.Event.Category != "session" {
+		t.Fatalf("assistant response event = %#v, want session.activity/session", response.Event)
+	}
+	if response.GenAI == nil || response.GenAI.Output == nil || firstPartContent(t, response.GenAI.Output.Messages) != "COWORK_RESPONSE_MARKER" {
+		t.Fatalf("assistant response content = %#v, want promoted output message", response.GenAI)
+	}
+	if response.Content == nil || !response.Content.Included {
+		t.Fatalf("assistant response content marker = %#v, want retained content", response.Content)
+	}
+
+	apiRequest := byName["api_request"]
+	if apiRequest.Event.Action != "session.activity" || apiRequest.GenAI == nil || apiRequest.GenAI.Usage == nil {
+		t.Fatalf("api request = %#v, want normalized session usage", apiRequest)
+	}
+	if apiRequest.GenAI.Usage.InputTokens == nil || *apiRequest.GenAI.Usage.InputTokens != 3 ||
+		apiRequest.GenAI.Usage.OutputTokens == nil || *apiRequest.GenAI.Usage.OutputTokens != 5 {
+		t.Fatalf("api request usage = %#v, want input/output tokens", apiRequest.GenAI.Usage)
+	}
+	if apiRequest.GenAI.Usage.CostUSD == nil || *apiRequest.GenAI.Usage.CostUSD != 0.01 {
+		t.Fatalf("api request cost = %#v, want 0.01", apiRequest.GenAI.Usage.CostUSD)
+	}
+
+	decision := byName["tool_decision"]
+	if decision.Event.Action != "approval.allowed" || decision.Event.Category != "approval" {
+		t.Fatalf("decision event = %#v, want approval.allowed/approval", decision.Event)
+	}
+	if decision.Approval == nil || decision.Approval.Decision != "accept" || decision.Approval.Reason != "user_temporary" {
+		t.Fatalf("decision approval = %#v, want accept/user_temporary", decision.Approval)
+	}
+	if decision.MCP == nil || decision.MCP.Server != "remote-devices" || decision.MCP.Tool != "device_bash" {
+		t.Fatalf("decision MCP = %#v, want remote-devices/device_bash", decision.MCP)
+	}
+
+	result := byName["tool_result"]
+	if result.Event.Action != "command.executed" || result.Event.Category != "command" {
+		t.Fatalf("tool result event = %#v, want command.executed/command", result.Event)
+	}
+	if result.Command == nil || result.Command.Command != "printf COWORK_COMMAND_MARKER" || result.Command.DurationMS != 25 {
+		t.Fatalf("tool result command = %#v, want promoted remote device command", result.Command)
+	}
+	if result.MCP == nil || result.MCP.Server != "remote-devices" || result.MCP.Tool != "device_bash" {
+		t.Fatalf("tool result MCP = %#v, want remote-devices/device_bash", result.MCP)
+	}
+	if toolCallIDOfEvent(result) != "toolu-cowork-command" {
+		t.Fatalf("tool result call ID = %q", toolCallIDOfEvent(result))
+	}
+
+	connection := byName["mcp_server_connection"]
+	if connection.Event.Action != "mcp.connection" || connection.MCP == nil || connection.MCP.Server != "remote-devices" {
+		t.Fatalf("MCP connection = %#v, want mcp.connection with server", connection)
+	}
+	for _, name := range []string{"hook_execution_start", "hook_execution_complete"} {
+		event := byName[name]
+		if event.Event.Action != "session.activity" || event.Event.Category != "session" || event.Event.Fidelity != asymptoteobserve.FidelityObserved {
+			t.Fatalf("%s event = %#v, want observed session activity", name, event.Event)
+		}
+	}
+	retention := byName["retention_sweep"]
+	if retention.Event.Action != "session.activity" || retention.Event.Category != "session" || retention.Event.Fidelity != asymptoteobserve.FidelityInferred {
+		t.Fatalf("retention event = %#v, want inferred session activity", retention.Event)
 	}
 }
 

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter_test.go
@@ -1250,6 +1250,7 @@ func TestClaudeNormalizerDoesNotAffectOtherHarnesses(t *testing.T) {
 }
 
 func TestCapturedClaudeCoworkNormalizesThroughClaudeOTelPipeline(t *testing.T) {
+	t.Setenv("UID", "501")
 	fixture, events := capturedLogEvents(t, "claude-cowork-2.1.251.json")
 	if len(events) != len(fixture.Records) {
 		t.Fatalf("events = %d, want %d", len(events), len(fixture.Records))
@@ -1289,6 +1290,9 @@ func TestCapturedClaudeCoworkNormalizesThroughClaudeOTelPipeline(t *testing.T) {
 	}
 	if response.Content == nil || !response.Content.Included {
 		t.Fatalf("assistant response content marker = %#v, want retained content", response.Content)
+	}
+	if response.User.Name != "operator@example.com" || response.User.UID != "" {
+		t.Fatalf("assistant response user = %#v, want cloud identity without collector UID", response.User)
 	}
 
 	apiRequest := byName["api_request"]

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/testdata/claude-cowork-2.1.251.json
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/testdata/claude-cowork-2.1.251.json
@@ -1,0 +1,151 @@
+{
+  "runtime": "Claude Cowork",
+  "version": "2.1.251",
+  "records": [
+    {
+      "name": "user_prompt",
+      "body": "claude_code.user_prompt",
+      "attributes": {
+        "service.name": "claude-cowork",
+        "service.version": "2.1.251",
+        "cowork.surface": "remote",
+        "event.name": "user_prompt",
+        "event.sequence": 1,
+        "session.id": "cowork-session",
+        "prompt.id": "cowork-prompt",
+        "prompt": "COWORK_PROMPT_MARKER",
+        "user.email": "operator@example.com",
+        "user.account_uuid": "account-fixture"
+      }
+    },
+    {
+      "name": "assistant_response",
+      "body": "claude_code.assistant_response",
+      "attributes": {
+        "service.name": "claude-cowork",
+        "service.version": "2.1.251",
+        "cowork.surface": "remote",
+        "event.name": "assistant_response",
+        "event.sequence": 2,
+        "session.id": "cowork-session",
+        "prompt.id": "cowork-prompt",
+        "model": "claude-sonnet-5",
+        "response": "COWORK_RESPONSE_MARKER",
+        "user.email": "operator@example.com"
+      }
+    },
+    {
+      "name": "api_request",
+      "body": "claude_code.api_request",
+      "attributes": {
+        "service.name": "claude-cowork",
+        "service.version": "2.1.251",
+        "cowork.surface": "remote",
+        "event.name": "api_request",
+        "event.sequence": 3,
+        "session.id": "cowork-session",
+        "prompt.id": "cowork-prompt",
+        "model": "claude-sonnet-5",
+        "input_tokens": 3,
+        "output_tokens": 5,
+        "cache_read_tokens": 7,
+        "cache_creation_tokens": 11,
+        "cost_usd": 0.01
+      }
+    },
+    {
+      "name": "tool_decision",
+      "body": "claude_code.tool_decision",
+      "attributes": {
+        "service.name": "claude-cowork",
+        "service.version": "2.1.251",
+        "cowork.surface": "remote",
+        "event.name": "tool_decision",
+        "event.sequence": 4,
+        "session.id": "cowork-session",
+        "prompt.id": "cowork-prompt",
+        "tool_name": "mcp_tool",
+        "tool_use_id": "toolu-cowork-command",
+        "decision": "accept",
+        "source": "user_temporary",
+        "tool_parameters": "{\"mcp_server_name\":\"remote-devices\",\"mcp_tool_name\":\"device_bash\"}"
+      }
+    },
+    {
+      "name": "tool_result",
+      "body": "claude_code.tool_result",
+      "attributes": {
+        "service.name": "claude-cowork",
+        "service.version": "2.1.251",
+        "cowork.surface": "remote",
+        "event.name": "tool_result",
+        "event.sequence": 5,
+        "session.id": "cowork-session",
+        "prompt.id": "cowork-prompt",
+        "tool_name": "mcp_tool",
+        "tool_use_id": "toolu-cowork-command",
+        "success": "true",
+        "duration_ms": 25,
+        "tool_parameters": "{\"mcp_server_name\":\"remote-devices\",\"mcp_tool_name\":\"device_bash\"}",
+        "tool_input": "{\"command\":\"printf COWORK_COMMAND_MARKER\"}"
+      }
+    },
+    {
+      "name": "mcp_server_connection",
+      "body": "claude_code.mcp_server_connection",
+      "attributes": {
+        "service.name": "claude-cowork",
+        "service.version": "2.1.251",
+        "cowork.surface": "remote",
+        "event.name": "mcp_server_connection",
+        "event.sequence": 6,
+        "session.id": "cowork-session",
+        "server_name": "remote-devices",
+        "status": "connected",
+        "transport_type": "http"
+      }
+    },
+    {
+      "name": "hook_execution_start",
+      "body": "claude_code.hook_execution_start",
+      "attributes": {
+        "service.name": "claude-cowork",
+        "service.version": "2.1.251",
+        "cowork.surface": "remote",
+        "event.name": "hook_execution_start",
+        "event.sequence": 7,
+        "session.id": "cowork-session",
+        "hook_event": "Stop",
+        "hook_name": "Stop"
+      }
+    },
+    {
+      "name": "hook_execution_complete",
+      "body": "claude_code.hook_execution_complete",
+      "attributes": {
+        "service.name": "claude-cowork",
+        "service.version": "2.1.251",
+        "cowork.surface": "remote",
+        "event.name": "hook_execution_complete",
+        "event.sequence": 8,
+        "session.id": "cowork-session",
+        "hook_event": "Stop",
+        "hook_name": "Stop",
+        "num_success": 1
+      }
+    },
+    {
+      "name": "retention_sweep",
+      "body": "claude_code.retention_sweep",
+      "attributes": {
+        "service.name": "claude-cowork",
+        "service.version": "2.1.251",
+        "cowork.surface": "remote",
+        "event.name": "retention_sweep",
+        "event.sequence": 9,
+        "session.id": "cowork-session",
+        "result": "complete"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- route Claude Cowork's `claude_code.*` OTLP vocabulary through the established Claude normalizer
- promote Cowork cloud origin, source identity, harness version, MCP context, remote-device commands, assistant content, and runtime-reported cost
- add a sanitized captured Cowork fixture and end-to-end exporter coverage

## Test plan
- [x] `go test ./...` in `collector-builder/exporter/beaconjsonexporter`
- [x] `go test ./...` in `cli/beacon`
- [x] `go test ./...` in `pkg/asymptoteobserve`
- [x] build the custom collector and replay Cowork-shaped OTLP through it into canonical JSONL


Made with [Cursor](https://cursor.com)