### PR TITLE
Muse Code support (1/5): harness identity

### DIFF
--- a/pkg/asymptoteobserve/harness.go
+++ b/pkg/asymptoteobserve/harness.go
@@ -123,6 +123,27 @@ func NormalizeHarnessName(name string) string {
 		lower == "qwencode" || lower == "qwen_cli" || lower == "qwen-cli" || lower == "qwen cli" ||
 		lower == "qwen_coder" || lower == "qwen-coder" || lower == "qwen coder":
 		return "qwen_code"
+	// Muse Code is Meta's terminal coding agent; Muse Spark is the model it runs. Beacon hooks the
+	// agent, so the harness is muse_code -- the canonical spelling follows claude_code and
+	// qwen_code, because Muse Code is the product's name rather than a CLI suffix.
+	//
+	// Muse Spark spellings are deliberately absent from this set, and that is the whole reason the
+	// case is written as equality against a closed set rather than Contains(lower, "muse"). Every
+	// Muse Spark model id begins with the same four letters the harness does -- muse-spark-1.2,
+	// muse-spark-1.3, muse-spark-1.2-contributor -- so a substring rule would report any event
+	// whose harness attribute happened to carry a model string as a Muse Code session. That is the
+	// Qwen failure exactly (see TestQwenModelNamesAreNotTreatedAsTheHarness), and here it would be
+	// worse: the model and the agent ship under one brand, so a reader seeing "muse_spark" in
+	// harness.name has no way to tell a misattributed model id from a real runtime. Leaving those
+	// spellings unmapped means they fall to the passthrough case below and show up as themselves,
+	// which is visible as an anomaly rather than silently filed under the agent.
+	//
+	// "muse" alone is also an ordinary English word, so the closed set is what keeps a harness
+	// attribute that merely contains it from being claimed. There is no prefix rule for the same
+	// reason: a future runtime named "musey" is not this one.
+	case lower == "muse" || lower == "muse_code" || lower == "muse-code" || lower == "muse code" ||
+		lower == "musecode" || lower == "muse_cli" || lower == "muse-cli" || lower == "muse cli":
+		return "muse_code"
 	// Prime Agent (Prime Intellect) ships the same extension API as Pi, which is why Beacon
 	// observes it the same way -- but it is a separate product, and recording its sessions as
 	// pi_cli would merge two runtimes' activity under one name in every query that groups by

--- a/pkg/asymptoteobserve/harness_test.go
+++ b/pkg/asymptoteobserve/harness_test.go
@@ -21,6 +21,7 @@ func TestHookPlatformsConvergeOnCanonicalNames(t *testing.T) {
 		"cline":       "cline",
 		"qwen":        "qwen_code",
 		"prime":       "prime_agent",
+		"muse":        "muse_code",
 	} {
 		t.Run(platform, func(t *testing.T) {
 			if got := NormalizeHarnessName(platform); got != want {
@@ -40,6 +41,7 @@ func TestCanonicalNamesAreStableUnderRenormalization(t *testing.T) {
 		"claude_code", "codex_cli", "gemini_cli", "antigravity_cli", "vscode_copilot",
 		"copilot_cli", "claude_web", "chatgpt_web", "claude_cowork", "claude_agent_sdk",
 		"openclaw_gateway", "pi_cli", "omp", "cline", "qwen_code", "prime_agent", "vercel_fx",
+		"muse_code",
 	} {
 		t.Run(canonical, func(t *testing.T) {
 			if got := NormalizeHarnessName(canonical); got != canonical {
@@ -364,5 +366,59 @@ func TestFxIsNotAttributedToItsModelProviders(t *testing.T) {
 	// Codex CLI, and fx's own events say "fx".
 	if got := NormalizeHarnessName("codex"); got != "codex_cli" {
 		t.Errorf("NormalizeHarnessName(%q) = %q, want codex_cli", "codex", got)
+	}
+}
+
+// Muse Code reaches Beacon under more than one spelling for the same reason every other runtime
+// does: the hook path installs with --platform muse, while anything deriving a name from the
+// runtime's own strings reports what Meta calls the product. Pinning them here is what keeps one
+// Muse Code session from being recorded under two names.
+func TestMuseSpellingsConvergeOnMuseCode(t *testing.T) {
+	for _, in := range []string{
+		"muse", "Muse", "MUSE", " muse ", "muse_code", "muse-code", "Muse Code", "musecode",
+		"muse_cli", "muse-cli", "Muse CLI",
+	} {
+		t.Run(in, func(t *testing.T) {
+			if got := NormalizeHarnessName(in); got != "muse_code" {
+				t.Errorf("NormalizeHarnessName(%q) = %q, want %q", in, got, "muse_code")
+			}
+		})
+	}
+}
+
+// The reason the Muse case is an equality match rather than a Contains rule, and the sharpest
+// version of it in the whole function: Meta ships the agent (Muse Code) and the model it runs
+// (Muse Spark) under one brand, so every Muse Spark model id begins with the same four letters
+// the harness does. A Contains(lower, "muse") rule would report any event whose harness attribute
+// carried a model string as a Muse Code session -- and unlike the Qwen case, a reader seeing a
+// Muse-prefixed value in harness.name could not tell the misattribution from the real thing.
+//
+// Falling through to the passthrough case is the wanted behavior, not a gap: a model id that has
+// somehow reached harness.name shows up as itself, which is visible as an anomaly, rather than
+// being silently filed under the agent.
+func TestMuseSparkModelNamesAreNotTreatedAsTheHarness(t *testing.T) {
+	for _, name := range []string{
+		"muse-spark", "muse_spark", "muse-spark-1.2", "muse-spark-1.3",
+		"muse-spark-1.2-contributor", "Muse Spark 1.2",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := NormalizeHarnessName(name); got == "muse_code" {
+				t.Errorf("NormalizeHarnessName(%q) = %q; a Muse Spark model id must not be "+
+					"reported as the Muse Code harness", name, got)
+			}
+		})
+	}
+}
+
+// "muse" is an ordinary English word and a substring of several others. The closed set is what
+// keeps a harness attribute that merely contains it from being claimed by this case.
+func TestOrdinaryWordsContainingMuseAreNotMuseCode(t *testing.T) {
+	for _, name := range []string{"amuse", "museum", "amusement", "musement", "bemuse"} {
+		t.Run(name, func(t *testing.T) {
+			if got := NormalizeHarnessName(name); got == "muse_code" {
+				t.Errorf("NormalizeHarnessName(%q) = %q; a word merely containing \"muse\" must "+
+					"not be reported as the Muse Code harness", name, got)
+			}
+		})
 	}
 }

--- a/pkg/asymptoteobserve/provenance_test.go
+++ b/pkg/asymptoteobserve/provenance_test.go
@@ -105,6 +105,13 @@ func TestCollectionMethodForPlatform(t *testing.T) {
 		"hermes":        CollectionMethodHook,
 		"factory":       CollectionMethodHook,
 		"copilot":       CollectionMethodHook,
+		// Muse Code is hook-shaped even though Beacon writes the whole hooks file rather than
+		// merging into one the vendor already has. The distinction this field draws is about what
+		// Beacon ships, not who owns the file: the events are Meta's own lifecycle events and the
+		// payloads are Meta's to change, so a coverage gap is the vendor's to expose. Grok is the
+		// same shape for the same reason. A `plugin` here would claim Beacon ships and versions
+		// source the runtime loads, which for Muse Code it does not.
+		"muse": CollectionMethodHook,
 		// vscode is the case that justifies keying on --platform rather than on the normalized
 		// harness name: its hook and OTLP telemetry both normalize to vscode_copilot, so the
 		// harness name cannot distinguish them and only the flag can.


### PR DESCRIPTION
First of five PRs adding Beacon support for **Meta Muse Code**. This one is identity only — no capture path yet, nothing installs, nothing changes for an existing user.

## What and why

Meta ships two things under one brand: **Muse Code**, the terminal coding agent, and **Muse Spark**, the model it runs. Beacon hooks the agent, so the canonical harness name is `muse_code`, following `claude_code` and `qwen_code` — Muse Code is the product's name, not a CLI suffix.

## The interesting part: why this is an equality match

The new case matches a closed set of spellings rather than `Contains(lower, "muse")`. Every Muse Spark model id starts with the same four letters the harness does — `muse-spark-1.2`, `muse-spark-1.3`, `muse-spark-1.2-contributor` — so a substring rule would report any event whose harness attribute happened to carry a model string as a Muse Code session.

That is the Qwen failure the neighbouring case already guards against, except sharper: the model and the agent share a brand, so a reader seeing a Muse-prefixed value in `harness.name` could not tell a misattributed model id from a real runtime. Muse Spark spellings are therefore deliberately **not** mapped — they fall through to the passthrough case and show up as themselves, which is visible as an anomaly rather than silently filed under the agent. `muse` is also an ordinary English word (`amuse`, `museum`), which the closed set covers for the same reason.

## Provenance

`CollectionMethodForPlatform` needs no code change — Muse Code is hook-shaped and `hook` is the default — so the decision is pinned as a test row instead.

Beacon writes the whole hooks file rather than merging into one Meta already keeps, but the distinction that field draws is about what Beacon *ships*, not who owns the file: the events and payloads are Meta's, so a coverage gap is the vendor's to expose. Grok is the same shape for the same reason. A `plugin` value would claim Beacon ships and versions source the runtime loads, which here it does not.

## Tests

- `muse` (the `--platform` value) converges with the runtime's own spellings on `muse_code`
- `muse_code` is stable under re-normalization
- Muse Spark model ids are **not** reported as the harness
- Ordinary words containing "muse" are not claimed
- `CollectionMethodForPlatform("muse") == hook`

```
cd pkg/asymptoteobserve && go test ./...   # all packages ok
```

## Contract sourcing — please read

`dev.meta.ai` and `developer.meta.com` are blocked by this session's egress policy, so I could not read Meta's own docs. The contract the later PRs implement against was recovered from three independent third-party Muse Code hook integrations published on npm, one of which (`@pinta-ai/pinta-musecode`) documents its findings as measured against a real `muse 0.1.0-R708.1` binary. Nothing in *this* PR depends on that — it is naming only — but the PRs that follow do, and every inferred field there carries a comment saying so. Worth an allowlist for those two domains, or a spot-check against the real docs, before PR 2 and 3 land.

## Stack

1. **← you are here** — harness identity
2. `beacon-hooks --platform muse` event mapping
3. Installer: managed hooks file + `managed_hooks_path`
4. CLI, diagnostics, dashboard and inventory wiring
5. Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVyyNuWcnaF1yMQKesA965

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVyyNuWcnaF1yMQKesA965)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability naming and tests only; no install path or event capture yet, with regression guards mirroring existing Qwen/Prime harness rules.
> 
> **Overview**
> Adds **Muse Code** harness identity ahead of later Beacon capture work: `NormalizeHarnessName` now maps a closed set of agent spellings (`muse`, `muse_code`, `muse-cli`, etc.) to the canonical **`muse_code`**, matching the `--platform muse` hook path to OTLP-style names so one session is not split in `harness.name` queries.
> 
> The match is **equality-only** on purpose—**Muse Spark** model ids and ordinary words containing `muse` are **not** folded into `muse_code`; they pass through unchanged so model strings in `harness.name` stay visible as anomalies instead of looking like the agent.
> 
> Tests cover convergence, re-normalization stability, negative cases (Spark models, `museum`/`amuse`), and pin **`CollectionMethodForPlatform("muse")` → hook** (default behavior, documented in `provenance_test`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9eec677a81a31f25b4168cf69ad600a95bf61b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->