### PR TITLE
Muse Code support (4/5): CLI, diagnostics, dashboard and inventory

### DIFF
--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -876,7 +876,7 @@ func hookTargets() ([]string, error) {
 }
 
 func allHookTargetsForLevel() []string {
-	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "cline", "pi", "omp", "grok", "qwen", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 	if endpointOpts.hookLevel != "project" {
 		return all
 	}
@@ -935,6 +935,9 @@ func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[str
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ExtensionPath, Raw: status}
 		case "grok":
 			status := endpointhooks.GrokHookStatus(endpointhooks.GrokOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
+		case "muse":
+			status := endpointhooks.MuseHookStatus(endpointhooks.MuseOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
 		case "qwen":
 			status := endpointhooks.QwenHookStatus(endpointhooks.QwenOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})

--- a/cli/beacon/cmd/endpoint_hooks.go
+++ b/cli/beacon/cmd/endpoint_hooks.go
@@ -183,6 +183,21 @@ func installEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 		if strings.Contains(status.Message, "/hooks-trust") {
 			fmt.Println(status.Message)
 		}
+	case "muse":
+		status, err := endpointhooks.InstallMuse(endpointhooks.MuseOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		// Both paths, because an install is only complete with both and neither is guessable from
+		// the other: Beacon owns the hooks file, while the settings key that makes Muse read it
+		// lives in the user's own settings.json. Anyone verifying the install by hand needs to look
+		// at both files.
+		fmt.Printf("Muse Code hooks installed: %s\n", status.HooksPath)
+		fmt.Printf("Muse Code settings updated: %s\n", status.SettingsPath)
 	case "qwen":
 		status, err := endpointhooks.InstallQwen(endpointhooks.QwenOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -371,6 +386,16 @@ func uninstallEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 			return err
 		}
 		fmt.Println(status.Message)
+	case "muse":
+		status, err := endpointhooks.UninstallMuse(endpointhooks.MuseOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
 	case "qwen":
 		status, err := endpointhooks.UninstallQwen(endpointhooks.QwenOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -493,6 +518,12 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
+		case "muse":
+			statuses["muse"] = endpointhooks.MuseHookStatus(endpointhooks.MuseOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
 		case "qwen":
 			statuses["qwen"] = endpointhooks.QwenHookStatus(endpointhooks.QwenOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -566,6 +597,10 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 		case "grok":
 			status := statuses["grok"].(endpointhooks.GrokStatus)
 			fmt.Printf("Grok hooks: installed=%t path=%s\n", status.Installed, status.HooksPath)
+			fmt.Println(status.Message)
+		case "muse":
+			status := statuses["muse"].(endpointhooks.MuseStatus)
+			fmt.Printf("Muse Code hooks: installed=%t path=%s settings=%s\n", status.Installed, status.HooksPath, status.SettingsPath)
 			fmt.Println(status.Message)
 		case "qwen":
 			status := statuses["qwen"].(endpointhooks.QwenStatus)

--- a/cli/beacon/cmd/endpoint_hooks_repair.go
+++ b/cli/beacon/cmd/endpoint_hooks_repair.go
@@ -148,7 +148,7 @@ func installedHookTargetsForUser(homeDir, logPath string) ([]string, error) {
 }
 
 func repairTargetOrder() []string {
-	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "cline", "pi", "omp", "grok", "qwen", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 }
 
 // withUserHome runs fn as if it were executing inside another user's profile.

--- a/cli/beacon/cmd/endpoint_targets.go
+++ b/cli/beacon/cmd/endpoint_targets.go
@@ -61,6 +61,13 @@ var harnessTargets = []harnessTarget{
 	// two spellings need one alias between them. "qwen-cli" is not accepted: the product is Qwen
 	// Code, and an alias nobody uses is an alias to keep working.
 	{name: "qwen", endpointKind: endpointTargetHook, endpointAliases: []string{"qwen", "qwen-code"}, hookAliases: []string{"qwen", "qwen-code"}},
+	// Muse Code, Meta's terminal agent. "muse-code" and "muse_code" both normalize to "muse-code"
+	// through normalizeHarnessKey, so the two spellings need one alias between them; it is accepted
+	// because muse_code is the canonical harness name events are written under, so a row read out
+	// of the runtime log and passed back to --harness resolves to the runtime it names. "spark" is
+	// deliberately not an alias: Muse Spark is the model, and accepting it here would let someone
+	// ask to install hooks for a model.
+	{name: "muse", endpointKind: endpointTargetHook, endpointAliases: []string{"muse", "muse-code"}, hookAliases: []string{"muse", "muse-code"}},
 	{name: "hermes", endpointKind: endpointTargetHook, endpointAliases: []string{"hermes", "hermes-agent"}, hookAliases: []string{"hermes", "hermes-agent"}},
 	{name: "antigravity", endpointKind: endpointTargetHook, endpointAliases: []string{"antigravity", "antigravity-cli"}, hookAliases: []string{"antigravity", "antigravity-cli"}},
 	{name: "devin-cli", endpointKind: endpointTargetHook, endpointAliases: []string{"devin", "devin-cli"}, hookAliases: []string{"devin", "devin-cli"}},

--- a/cli/beacon/cmd/muse_target_test.go
+++ b/cli/beacon/cmd/muse_target_test.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+)
+
+// The install -> status -> uninstall round trip for Muse Code, through the CLI entry points rather
+// than the package API.
+//
+// Wiring a runtime into `beacon endpoint hooks` means five separate switches (install, uninstall,
+// status collection, status printing, repair) plus a registry row, and every one of them fails by
+// omission rather than by error. TestEveryHookTargetIsWired proves each switch has a case; this
+// proves the cases do the thing their name claims -- and for Muse that means both files, since
+// either one alone is a broken install the runtime says nothing about.
+func TestEndpointHooksInstallAndUninstallMuse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	cfg := endpointconfig.Config{LogPath: filepath.Join(home, "runtime.jsonl"), UserMode: true}
+
+	origLevel := endpointOpts.hookLevel
+	t.Cleanup(func() { endpointOpts.hookLevel = origLevel })
+	endpointOpts.hookLevel = "user"
+
+	hooksPath := filepath.Join(home, ".config", "muse", "beacon-endpoint-hooks.json")
+	settingsPath := filepath.Join(home, ".config", "muse", "settings.json")
+
+	if err := installEndpointHookTarget("muse", cfg); err != nil {
+		t.Fatalf("installEndpointHookTarget(muse) returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("install did not write %s: %v", hooksPath, err)
+	}
+	if !strings.Contains(string(data), "--platform muse") {
+		t.Fatalf("hooks file does not carry the Muse hook command:\n%s", data)
+	}
+
+	// The half that is easy to leave out and impossible to notice: without this key Muse never
+	// opens the file above, and reports nothing about it.
+	settings := map[string]interface{}{}
+	settingsData, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("install did not write %s: %v", settingsPath, err)
+	}
+	if err := json.Unmarshal(settingsData, &settings); err != nil {
+		t.Fatalf("settings.json is not valid JSON: %v", err)
+	}
+	if got := settings["managed_hooks_path"]; got != hooksPath {
+		t.Fatalf("managed_hooks_path = %v, want %q", got, hooksPath)
+	}
+
+	if err := uninstallEndpointHookTarget("muse", cfg); err != nil {
+		t.Fatalf("uninstallEndpointHookTarget(muse) returned error: %v", err)
+	}
+	if _, err := os.Stat(hooksPath); !os.IsNotExist(err) {
+		t.Fatalf("uninstall left the hooks file behind: %v", err)
+	}
+	settingsData, err = os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("uninstall removed settings.json itself: %v", err)
+	}
+	if strings.Contains(string(settingsData), "managed_hooks_path") {
+		t.Fatalf("uninstall left a registration pointing at a deleted file:\n%s", settingsData)
+	}
+}
+
+// `endpoint hooks repair` walks a hard-coded list rather than the registry, so a runtime absent
+// from it is never repaired -- and repair is what fixes a hook whose binary path went stale after
+// an upgrade. It fails silently: repair reports success having skipped the runtime entirely.
+func TestMuseIsInTheRepairTargetList(t *testing.T) {
+	for _, name := range repairTargetOrder() {
+		if name == "muse" {
+			return
+		}
+	}
+	t.Fatal("muse is missing from the repair target list; `endpoint repair` would silently skip it")
+}
+
+// Both spellings a person plausibly types resolve to the hook target, in both namespaces.
+func TestMuseHarnessSpellingsResolveToTheHookTarget(t *testing.T) {
+	for _, spelling := range []string{"muse", "Muse", " muse ", "muse-code", "muse_code", "MUSE-CODE"} {
+		t.Run(spelling, func(t *testing.T) {
+			target, ok := normalizeEndpointTarget(spelling)
+			if !ok {
+				t.Fatalf("normalizeEndpointTarget(%q) = not found", spelling)
+			}
+			if target.Name != "muse" || target.Kind != endpointTargetHook {
+				t.Fatalf("normalizeEndpointTarget(%q) = %+v, want the muse hook target", spelling, target)
+			}
+			if got, ok := normalizeHookTarget(spelling); !ok || got != "muse" {
+				t.Fatalf("normalizeHookTarget(%q) = %q, %t; want muse, true", spelling, got, ok)
+			}
+		})
+	}
+}
+
+// Muse Spark is the model, not the runtime. Accepting it as a harness alias would let someone ask
+// Beacon to install hooks for a model and get an install for the agent instead -- a silent
+// substitution, since the install would then report success under a different name.
+func TestMuseSparkIsNotAHarnessAlias(t *testing.T) {
+	for _, spelling := range []string{"spark", "muse-spark", "muse_spark"} {
+		t.Run(spelling, func(t *testing.T) {
+			if target, ok := normalizeEndpointTarget(spelling); ok {
+				t.Fatalf("normalizeEndpointTarget(%q) = %+v; Muse Spark is a model, not a harness", spelling, target)
+			}
+		})
+	}
+}

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -347,6 +347,8 @@ func hookStatuses(logPath string, userMode bool) []HookStatus {
 	add("hermes", hermes.Installed, hermes.ConfigPath, hermes.BinaryPath, hermes.Message)
 	opencode := endpointhooks.OpenCodeHookStatus(endpointhooks.OpenCodeOptions{Level: level, LogPath: logPath, UserMode: userMode})
 	add("opencode", opencode.Installed, opencode.PluginPath, opencode.BinaryPath, opencode.Message)
+	muse := endpointhooks.MuseHookStatus(endpointhooks.MuseOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("muse", muse.Installed, muse.HooksPath, muse.BinaryPath, muse.Message)
 	qwen := endpointhooks.QwenHookStatus(endpointhooks.QwenOptions{Level: level, LogPath: logPath, UserMode: userMode})
 	add("qwen", qwen.Installed, qwen.SettingsPath, qwen.BinaryPath, qwen.Message)
 	vscode := endpointhooks.VSCodeHookStatus(endpointhooks.VSCodeOptions{Level: level, LogPath: logPath, UserMode: userMode})

--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -215,6 +215,7 @@ func candidates(home, wd string) []candidate {
 	items = append(items, devinCandidates(home, wd)...)
 	items = append(items, grokCandidates(home, wd)...)
 	items = append(items, qwenCandidates(home, wd)...)
+	items = append(items, museCandidates(home)...)
 	items = append(items, fxCandidates(home, wd)...)
 	seen := map[string]bool{}
 	out := make([]candidate, 0, len(items))
@@ -377,6 +378,43 @@ func qwenCandidates(home, wd string) []candidate {
 		{runtime: "qwen_code", path: filepath.Join(home, ".qwen", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		{runtime: "qwen_code", path: filepath.Join(wd, ".qwen", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 	}
+}
+
+// Muse Code is two files: the managed hooks file Beacon owns outright, and Muse's own settings.json,
+// which Beacon edits by exactly one key. Both are reported, because either one alone is a broken
+// install and Muse says nothing about either -- a hooks file nothing points at is never read, and a
+// managed_hooks_path with no file behind it registers nothing. An inventory that showed only the
+// file Beacon wrote would report a half-install as a whole one.
+//
+// User scope only, with no project entry: Muse's project .muse/hooks.json is ignored by the
+// shipping build, so the installer refuses that scope and there is no project path to find.
+//
+// XDG_CONFIG_HOME is read here rather than assumed away, for the same reason the installer reads
+// it: on a machine that sets it, ~/.config/muse is not where Muse looks, and an inventory scanning
+// the wrong directory reports "not installed" for a working install.
+func museCandidates(home string) []candidate {
+	dir := museConfigDir(home)
+	return []candidate{
+		{runtime: "muse_code", path: filepath.Join(dir, "beacon-endpoint-hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "muse_code", path: filepath.Join(dir, "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+	}
+}
+
+// museConfigDir resolves the directory Muse Code keeps settings.json in, mirroring the installer.
+//
+// XDG_CONFIG_HOME is read from the process environment, the same way vscodeUserSettingsPath does
+// it: on a machine that sets it, ~/.config/muse is not where Muse looks, and scanning the wrong
+// directory reports "not installed" for a working install. Exported to the test as a function
+// rather than restated there as a literal path, so the expected-candidate list stays correct on a
+// developer machine that happens to set the variable.
+//
+// No GOOS switch, unlike VS Code's: Muse Code ships for macOS and Linux only, and uses the same
+// ~/.config location on both rather than a Library path on macOS.
+func museConfigDir(home string) string {
+	if base := os.Getenv("XDG_CONFIG_HOME"); base != "" {
+		return filepath.Join(base, "muse")
+	}
+	return filepath.Join(home, ".config", "muse")
 }
 
 // fx keeps no Beacon-written file, so every entry here is fx's own configuration rather than
@@ -735,6 +773,14 @@ func beaconManaged(item candidate, data []byte) bool {
 	// installer writes and what uninstall keys on, so it is the same string in all three places.
 	case "qwen_code":
 		return strings.Contains(text, "--platform qwen") || strings.Contains(text, "--platform=qwen")
+	// Two files with two different tells, both matched by one case because both are Muse Code's.
+	// The managed hooks file carries Beacon's marker, since Beacon owns it outright; settings.json
+	// does not, because Beacon edits one key of a file the user also edits, so it is recognized by
+	// the path that key names. Matching either is what lets the inventory report a half-install --
+	// which on Muse is the failure that looks most like success.
+	case "muse_code":
+		return strings.Contains(text, "beacon-managed-muse-hooks:v1") ||
+			strings.Contains(text, "beacon-endpoint-hooks.json")
 	}
 	if item.runtime == "claude_code" || item.runtime == "codex_cli" {
 		if strings.Contains(text, "OTEL_EXPORTER_OTLP_ENDPOINT") && localEndpointText(text) {

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -362,6 +362,12 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 		{runtime: "grok", path: filepath.Join(work, ".grok", "hooks", "beacon-endpoint.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 		{runtime: "qwen_code", path: filepath.Join(home, ".qwen", "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		{runtime: "qwen_code", path: filepath.Join(work, ".qwen", "settings.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+		// Muse Code is two files and no project entry. Both halves are reported because either one
+		// alone is a broken install that Muse says nothing about; the project scope is absent
+		// because Muse's project .muse/hooks.json is ignored by the shipping build, so the
+		// installer refuses it and there is no project path to find.
+		{runtime: "muse_code", path: filepath.Join(museConfigDir(home), "beacon-endpoint-hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "muse_code", path: filepath.Join(museConfigDir(home), "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		// fx has no Beacon-written file, so all three are its own configuration. The two MCP files
 		// are the ones that carry information nothing else here reports: fx's profile server list
 		// and the workspace servers it shares with Claude-compatible runtimes.


### PR DESCRIPTION
Fourth of five. **Stacked on #440** — this PR's diff is against it. This is the one that makes Muse Code reachable: after this, `beacon endpoint hooks install --harness muse` works.

Verified through the real CLI:

```
$ beacon endpoint hooks status --harness muse --user
Muse Code hooks: installed=false path=~/.config/muse/beacon-endpoint-hooks.json settings=~/.config/muse/settings.json
Muse Code endpoint hooks are not installed
```

## Five switches, each failing by omission

Wiring a runtime in means install, uninstall, status collection, status printing and repair, plus a registry row. None of them errors when a case is missing — the runtime just silently isn't there. The existing `TestEveryHookTargetIsWired` covers the uninstall switch for free once the registry row exists; `TestEndpointHooksInstallAndUninstallMuse` proves the rest do what their names claim, round-tripping through the CLI entry points rather than the package API.

## Install and status print both paths

Neither file is guessable from the other — Beacon owns the hooks file, while the settings key that makes Muse read it lives in the user's own `settings.json` — and either alone is a broken install that Muse reports nothing about. Anyone verifying an install by hand needs both, so both are printed.

## Registry aliases

`muse` and `muse-code` (`muse_code` normalizes onto the latter through `normalizeHarnessKey`, so the two spellings share one alias). Accepting `muse_code` matters because it is the canonical harness name events are written under — a row read out of the runtime log and passed back to `--harness` resolves to the runtime it names.

**Muse Spark spellings are deliberately not aliases.** `TestMuseSparkIsNotAHarnessAlias` pins it. Muse Spark is the model; accepting it here would let someone ask Beacon to install hooks for a model and get an install for the agent instead — a silent substitution, since the install would then report success under a different name. Same reasoning as the harness normalizer in #438, one layer up.

## Inventory reports both files

Showing only the file Beacon wrote would report a half-install as a whole one, which on Muse is the failure mode that looks most like success. The two halves have two different tells, matched by one case:

- the managed hooks file carries Beacon's marker (Beacon owns it outright);
- `settings.json` does not, because Beacon edits one key of a file the user also edits and has nothing there to stamp — so it is recognized by the path that key names.

User scope only, no project entry: Muse's project `.muse/hooks.json` is ignored by the shipping build, the installer refuses that scope, and there is no project path to find.

## One small refactor

`museConfigDir(home)` is shared rather than restated, following the `vscodeUserSettingsPath` precedent: `XDG_CONFIG_HOME` wins, matching how Muse resolves it, and an inventory scanning `~/.config/muse` on a machine that sets the variable would report "not installed" for a working install. The inventory's exhaustive expected-candidate test calls the same function rather than hardcoding a path, so it stays correct on a developer machine that happens to set it — that was a real failure while writing this, not a hypothetical.

No `GOOS` switch, unlike VS Code's: Muse Code ships for macOS and Linux only and uses the same `~/.config` location on both rather than a `Library` path on macOS.

## Tests

```
cd cli/beacon       && go test ./...   # all packages ok
cd cli/beacon-hooks && go test ./...   # all packages ok
cd pkg/asymptoteobserve && go test ./...   # all packages ok
```

## Stack

1. #438 — harness identity
2. #439 — `beacon-hooks --platform muse` event mapping
3. #440 — installer
4. **← you are here** — CLI, diagnostics, dashboard and inventory
5. Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVyyNuWcnaF1yMQKesA965

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVyyNuWcnaF1yMQKesA965)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive harness wiring and user-scope config edits mirroring other agents; no auth or collector core changes.
> 
> **Overview**
> **Muse Code** is now a first-class hook target end-to-end: `beacon endpoint hooks install|uninstall|status --harness muse` (and `--all` / diagnostics / repair paths) call the existing `InstallMuse` / `MuseHookStatus` APIs from the stacked installer work.
> 
> The harness registry accepts **`muse`** and **`muse-code`** (with `muse_code` normalizing to the latter); **Muse Spark** spellings are explicitly rejected. Install and status output show **both** the managed hooks file and **`settings.json`** (`managed_hooks_path`), since either alone is a silent broken install.
> 
> **Inventory** scans both user-scope Muse config files under `museConfigDir` (honoring **`XDG_CONFIG_HOME`**), and **`beacon_managed`** detection covers the hooks marker and settings registration. The local **dashboard** inventory API includes Muse hook status. New CLI tests round-trip install/uninstall and guard repair ordering and alias behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aa265fdb7b0853cd2ff9c8c92cab3caaaf6332b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->