### PR TITLE
status: report managed ingest for the requested install mode

### DIFF
--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -561,6 +561,16 @@ func GetStatus(userMode bool, logPath string) Status {
 		effectiveCfg = loadOrDefault(runtimeLog.EffectiveUserMode, runtimeLog.EffectiveLogPath)
 	}
 	effectiveCfg.LogPath = runtimeLog.EffectiveLogPath
+	return buildStatus(userMode, effectiveCfg, runtimeLog, asymptote.StatusOptions{})
+}
+
+// buildStatus assembles the status from the effective collector configuration. Everything
+// about the collector and the runtime log follows effectiveCfg, which may have switched to
+// the system install when its collector holds the OTLP ports. Managed ingest does not: a
+// connection belongs to the install the caller asked about (`--user` or `--system`), each
+// mode keeps its own enrollment and forwarder, and the system record is unreadable
+// without root anyway.
+func buildStatus(requestedUserMode bool, effectiveCfg endpointconfig.Config, runtimeLog RuntimeLogSource, managedOpts asymptote.StatusOptions) Status {
 	last, _ := writer.LastLine(effectiveCfg.LogPath)
 	checks := diagnostics.Run(effectiveCfg)
 	if runtimeLog.Warning != "" {
@@ -582,7 +592,7 @@ func GetStatus(userMode bool, logPath string) Status {
 		Diagnostics:   checks,
 		LastEvent:     last,
 		Destinations:  destinationStatus(effectiveCfg),
-		ManagedIngest: asymptote.Status(effectiveCfg.UserMode, asymptote.StatusOptions{}),
+		ManagedIngest: asymptote.Status(requestedUserMode, managedOpts),
 	}
 }
 

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/asymptote"
 	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/harness"
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
@@ -903,6 +904,30 @@ func TestDestinationStatusAndInstallDestinationReportEnabledHEC(t *testing.T) {
 	localOnly := installDestination(endpointconfig.Config{})
 	if localOnly.Type != "local_jsonl" {
 		t.Fatalf("installDestination with no HEC = %q, want local_jsonl", localOnly.Type)
+	}
+}
+
+// `status --user` on a machine whose system collector holds the OTLP ports switches the
+// runtime-log view to the system install, but the managed-ingest connection it reports must
+// still be the user's: each mode has its own enrollment, and the system one is root-only.
+func TestStatusReportsManagedIngestForRequestedMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := asymptote.SaveEnrollment(true, asymptote.Enrollment{InstallID: "i", IngestURL: "https://ingest.example", DeviceID: "user-device", OrganizationID: "org", OrganizationName: "Org"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(asymptote.VectorConfigPath(true), []byte("# rendered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	systemCfg := endpointconfig.Default(false, filepath.Join(home, "system", "runtime.jsonl"))
+	runtimeLog := RuntimeLogSource{RequestedUserMode: true, EffectiveUserMode: false, EffectiveLogPath: systemCfg.LogPath}
+
+	status := buildStatus(true, systemCfg, runtimeLog, asymptote.StatusOptions{SkipCredentialCheck: true})
+	if !status.ManagedIngest.Enabled || status.ManagedIngest.DeviceID != "user-device" {
+		t.Fatalf("status --user must report the user-mode connection, got %+v", status.ManagedIngest)
+	}
+	if status.LogPath != systemCfg.LogPath {
+		t.Fatalf("runtime log view should still follow the effective (system) config, got %q", status.LogPath)
 	}
 }
 


### PR DESCRIPTION
## Summary

`beacon endpoint status --user` on a machine whose system collector holds the OTLP ports switches its collector and runtime-log view to the system install (existing behavior, with a warning). It also used that effective mode for the managed-ingest line, so it reported the **system** connection, and without root that read as:

```
Asymptote managed ingest: not connected (open /Library/Application Support/Beacon/Endpoint/asymptote/enrollment.json: permission denied)
```

A managed-ingest connection belongs to the install mode the caller asked about: each mode has its own enrollment and forwarder. `GetStatus` now reads the requested mode's record; the collector view still follows the effective config. `buildStatus` is split out so the flipped case is unit-testable.

Found during the v1.3.0 end-to-end test on the maintainer's Mac (signed package in system mode plus a user-mode connect). With a dev build of this branch, `status --user` there shows the user device and `sudo status --system` the system device.

## Verification

- `go test ./...` and `go test -race ./internal/endpoint/...` in `cli/beacon` pass; new `TestStatusReportsManagedIngestForRequestedMode` covers the flipped case.
- Live: on the Mac described above, `status --user` → `connected to Asymptote Test as device 97d8cc46-…; forwarder loaded=true running=true; credential valid`.

Related follow-up: #447 (user and system collectors cannot coexist because the health-check port is fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to status assembly and managed-ingest lookup; collector/runtime resolution is unchanged and covered by a new unit test.
> 
> **Overview**
> Fixes **`beacon endpoint status --user`** showing the wrong (or permission-denied) **managed ingest** line when the system collector owns the OTLP ports. Collector, service, and runtime-log fields still follow the **effective** install after that flip; only managed ingest now keys off the **requested** `--user` / `--system` mode.
> 
> `GetStatus` delegates assembly to new **`buildStatus`**, which passes `requestedUserMode` into `asymptote.Status` instead of `effectiveCfg.UserMode`. **`TestStatusReportsManagedIngestForRequestedMode`** covers the flipped runtime-log case (user enrollment + system effective log path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d50a187ac0a1ac96b60f8f583dc45ff3c69435e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->