### PR TITLE
Homebrew: depend on the tap's own vector formula; accept Vector 0.50+

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ go run . endpoint fx status        # sessions fx has written and how much Beacon
 go run . endpoint fx sync --print  # map records to events without writing anything
 ```
 
-Connect an endpoint to Asymptote Managed during manual testing (needs Vector 0.56+ on the machine;
+Connect an endpoint to Asymptote Managed during manual testing (needs Vector 0.50+ on the machine;
 `/opt/beacon/bin/vector` from the signed package works, and a browser signed in to an org that has
 managed ingest enabled):
 

--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ for rollout, validation, retention, and SIEM forwarding. For vendor review, see 
 ### For Developers
 
 Install the released CLI with Homebrew, or build from source. The Homebrew formula
-depends on `vector`, so a Homebrew install can connect to Asymptote Managed without a
-second step; on Linux, install the `vector` package from [vector.dev](https://vector.dev)
+depends on the tap's own `vector` formula (Vector is not in homebrew-core), so a Homebrew
+install can connect to Asymptote Managed without a second step; on Linux, install the `vector` package from [vector.dev](https://vector.dev)
 if you want managed forwarding.
 
 ```bash

--- a/cli/beacon/.goreleaser.yaml
+++ b/cli/beacon/.goreleaser.yaml
@@ -221,8 +221,11 @@ brews:
     commit_msg_template: "Homebrew formula update for {{ .ProjectName }} version {{ .Tag }}"
     # Vector runs the optional Asymptote managed forwarder (`beacon endpoint connect`);
     # pulling it in here means a Homebrew install can connect without a second step.
+    # Vector is not in homebrew-core (it ships from vectordotdev/brew, and Homebrew no
+    # longer taps third-party dependencies on its own), so the tap carries its own
+    # Formula/vector.rb, mirrored from Vector's release tarballs, and depends on that.
     dependencies:
-      - name: vector
+      - name: asymptote-labs/tap/vector
     install: |
       bin.install "beacon"
       bin.install "beacon-hooks"

--- a/cli/beacon/README.md
+++ b/cli/beacon/README.md
@@ -512,7 +512,7 @@ stores the per-device key in a `0600` secrets file, and runs Vector as the
 `beacon-asymptote-forwarder.service` (systemd) service. Beacon stays the local
 JSONL producer and Vector does the network. Only lines written after approval
 are shipped, and revoking the device from the dashboard stops ingestion within
-about a minute. Vector 0.56 or newer is required: `/opt/beacon/bin/vector` from
+about a minute. Vector 0.50 or newer is required: `/opt/beacon/bin/vector` from
 the signed package, `vector` from Homebrew, or the Linux package from
 vector.dev.
 

--- a/cli/beacon/cmd/endpoint_connect.go
+++ b/cli/beacon/cmd/endpoint_connect.go
@@ -35,7 +35,7 @@ and starts a Vector forwarder that ships the runtime and inventory JSONL to
 Asymptote. Nothing recorded before approval is sent. Re-running on a connected
 machine rotates its key in place.
 
-Requires Vector 0.56 or newer: the signed macOS package installs it at
+Requires Vector 0.50 or newer: the signed macOS package installs it at
 /opt/beacon/bin/vector, Homebrew provides it as "vector", and Linux packages are
 at https://vector.dev. Revoke a device from the dashboard's Beacon Endpoints
 page; run "beacon endpoint disconnect" to stop forwarding locally.`,

--- a/cli/beacon/internal/endpoint/asymptote/connect_test.go
+++ b/cli/beacon/internal/endpoint/asymptote/connect_test.go
@@ -207,9 +207,9 @@ func TestConnectStopsBeforeTheBrowserWhenVectorIsMissingOrOld(t *testing.T) {
 	if _, err := Connect(context.Background(), opts); err == nil || (!errors.Is(err, ErrVectorNotFound) && !strings.Contains(err.Error(), "vector")) {
 		t.Fatalf("expected a Vector error, got %v", err)
 	}
-	opts = connectOptions(t, fd, fwd, fakeVector(t, "0.55.9", 0))
+	opts = connectOptions(t, fd, fwd, fakeVector(t, "0.44.9", 0))
 	opts.Enroll.OpenBrowser = func(string) error { opened = true; return nil }
-	if _, err := Connect(context.Background(), opts); err == nil || !strings.Contains(err.Error(), "0.56.0 or newer") {
+	if _, err := Connect(context.Background(), opts); err == nil || !strings.Contains(err.Error(), "0.50.0 or newer") {
 		t.Fatalf("expected a too-old error, got %v", err)
 	}
 	if opened {

--- a/cli/beacon/internal/endpoint/asymptote/vector.go
+++ b/cli/beacon/internal/endpoint/asymptote/vector.go
@@ -14,7 +14,7 @@ import (
 
 // MinVectorVersion is the oldest Vector the forwarder template is validated against; the
 // `secret` file backend and the http sink options it uses exist from here on.
-const MinVectorVersion = "0.56.0"
+const MinVectorVersion = "0.50.0"
 
 // VectorBinEnv names an explicit Vector binary, ahead of every search location.
 const VectorBinEnv = "BEACON_VECTOR_BIN"

--- a/cli/beacon/internal/endpoint/asymptote/vector_test.go
+++ b/cli/beacon/internal/endpoint/asymptote/vector_test.go
@@ -40,7 +40,7 @@ func TestFindVectorPrefersExplicitThenEnvAndChecksVersion(t *testing.T) {
 
 func TestFindVectorRejectsTooOldOrUnparsableVersions(t *testing.T) {
 	old := fakeVector(t, "0.44.0", 0)
-	if _, err := FindVector(old); err == nil || !strings.Contains(err.Error(), "0.56.0 or newer") {
+	if _, err := FindVector(old); err == nil || !strings.Contains(err.Error(), "0.50.0 or newer") {
 		t.Fatalf("expected too-old error, got %v", err)
 	}
 	dir := t.TempDir()

--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -11,6 +11,16 @@ Stay up to date with the latest changes to the Agent Beacon CLI.
 
 ## September 2026
 
+### Unreleased
+
+- **Homebrew installs Vector again** · `brew install asymptote-labs/tap/beacon` failed
+  with "No available formula with the name vector": Vector is not in homebrew-core and
+  Homebrew no longer taps third-party dependencies on its own. The tap now carries its
+  own `vector` formula, mirrored from Vector's release tarballs (0.58.0 on Apple
+  Silicon, 0.50.0 on Intel, the last x86_64 build Vector published), and the Beacon
+  formula depends on that. The minimum Vector version `connect` accepts drops from
+  0.56 to 0.50, validated against the forwarder template, so Intel Macs can connect.
+
 ### v1.3.2 · September 4, 2026
 
 - **Re-connecting no longer loses the forwarder** · `beacon endpoint connect` on an

--- a/docs/cli/endpoint-connect.mdx
+++ b/docs/cli/endpoint-connect.mdx
@@ -17,7 +17,7 @@ beacon endpoint disconnect [flags]
 ## Prerequisites
 
 - Beacon endpoint installed (`beacon endpoint install`) and writing local JSONL.
-- Vector 0.56 or newer on the machine. The signed macOS package installs it at `/opt/beacon/bin/vector`; Homebrew provides it as `vector` (the Beacon formula depends on it); on Linux install the `vector` package from [vector.dev](https://vector.dev). `connect` stops before opening a browser if no usable Vector is found.
+- Vector 0.50 or newer on the machine (Apple Silicon gets 0.58 from Homebrew or the package; Intel Macs get 0.50.0, the last x86_64 build Vector published). The signed macOS package installs it at `/opt/beacon/bin/vector`; Homebrew installs it with Beacon (the `asymptote-labs/tap/beacon` formula depends on the tap's own `vector` formula, since Vector is not in homebrew-core); on Linux install the `vector` package from [vector.dev](https://vector.dev). `connect` stops before opening a browser if no usable Vector is found.
 - A browser where you can sign in to the Asymptote dashboard as a member of an organization that has managed ingest enabled.
 
 ## What connect does

--- a/docs/cli/install.mdx
+++ b/docs/cli/install.mdx
@@ -26,7 +26,7 @@ brew install beacon
 beacon version
 ```
 
-The formula depends on `vector`, which runs the optional [Asymptote Managed forwarder](/cli/endpoint-connect); Homebrew installs it alongside Beacon.
+The formula depends on the tap's own `vector` formula (`asymptote-labs/tap/vector`, mirrored from Vector's releases because Vector is not in homebrew-core), which runs the optional [Asymptote Managed forwarder](/cli/endpoint-connect); Homebrew installs it alongside Beacon.
 
 <Accordion title="Example output">
 ```bash title="beacon version output"

--- a/docs/get-started/quickstart-developers.mdx
+++ b/docs/get-started/quickstart-developers.mdx
@@ -40,7 +40,7 @@ mkdir -p ~/.local/bin && mv beacon beacon-hooks beacon-otelcol ~/.local/bin/
 </CodeGroup>
 
 Homebrew also installs [Vector](https://vector.dev), which Beacon uses to forward telemetry when you
-ask it to. On Linux, install Vector 0.56 or newer from vector.dev if you plan to forward.
+ask it to. On Linux, install Vector 0.50 or newer from vector.dev if you plan to forward.
 
 <Note>
   The Linux tab uses the tarball on purpose. This page is a per-user setup; the `.deb`/`.rpm`


### PR DESCRIPTION
## Summary

`brew install asymptote-labs/tap/beacon` failed on a clean machine with `No available formula with the name "vector"`. Vector is not in homebrew-core (it ships from `vectordotdev/brew`), and current Homebrew refuses to tap third-party dependencies automatically, so `depends_on "vector"` could never resolve.

- **Tap** (already pushed, `asymptote-labs/homebrew-tap@cd83787`): new `Formula/vector.rb` mirroring Vector's official macOS release tarballs, 0.58.0 on Apple Silicon and 0.50.0 on Intel (the last x86_64 build Vector published), and `beacon.rb` now `depends_on "asymptote-labs/tap/vector"`.
- **GoReleaser** (`cli/beacon/.goreleaser.yaml`): the brews dependency is `asymptote-labs/tap/vector`, so the next release regenerates `beacon.rb` with the same dependency.
- **Minimum Vector version** 0.56.0 → 0.50.0 (`asymptote.MinVectorVersion`, connect help text), so Intel Macs can connect. Validated: our forwarder template passes `vector validate --skip-healthchecks` on Vector 0.50.0 (x86_64 binary under Rosetta).
- Docs (connect, install, developer quickstart, CLI README, CLAUDE.md, README) and changelog updated.

## Verification

- Clean `brew tap asymptote-labs/tap && brew install asymptote-labs/tap/beacon` on macOS arm64 after the tap fix: `vector 0.58.0` and `beacon 1.3.2` installed together; `brew deps` lists `asymptote-labs/tap/vector`. (Uninstalled again afterwards; this Mac runs the system package.)
- `go test ./...` in `cli/beacon` passes. `goreleaser check` reports only the pre-existing `brews` deprecation, same as main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Homebrew packaging and the managed-forwarding Vector version gate; impact is bounded to install/connect paths and was validated against the forwarder template on Vector 0.50.
> 
> **Overview**
> Fixes **`brew install asymptote-labs/tap/beacon`** failing when Homebrew cannot resolve a bare **`vector`** dependency (Vector is not in homebrew-core and third-party taps are no longer pulled automatically). **GoReleaser** now declares **`depends_on asymptote-labs/tap/vector`**, matching the tap’s mirrored **`Formula/vector.rb`**, so future releases regenerate **`beacon.rb`** with a resolvable dependency and Vector installs alongside Beacon.
> 
> **`beacon endpoint connect`** lowers **`MinVectorVersion`** from **0.56.0** to **0.50.0** so Intel Macs (last published x86_64 Vector) can connect; user-facing help and docs now describe the tap-owned Vector formula and the **0.50+** prerequisite. Tests were updated for the new floor and changelog/README/CLAUDE notes document the Homebrew fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b986e2517c5653234f9e8c93c7a4e2956019671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->