### PR TITLE
Accept malformed emails in onboarding, validate on server

### DIFF
--- a/cli/beacon/cmd/endpoint_onboarding_test.go
+++ b/cli/beacon/cmd/endpoint_onboarding_test.go
@@ -234,6 +234,29 @@ func TestMaybeRunOnboardingPropagatesPromptFailure(t *testing.T) {
 	}
 }
 
+// An address the local checks cannot parse is still an answer: it is recorded and sent
+// like any other, with the domain reported as unknown rather than counted as a company.
+func TestMaybeRunOnboardingKeepsUnvalidatedEmail(t *testing.T) {
+	h := newOnboardingHarness(t)
+	h.answers = onboarding.Answers{Email: "shukan@nodot", Usage: onboarding.UsageWork}
+
+	if _, err := maybeRunOnboarding(h.cmd); err != nil {
+		t.Fatalf("maybeRunOnboarding returned error: %v", err)
+	}
+	if len(h.saved) != 1 || h.saved[0].Onboarding.Email != "shukan@nodot" {
+		t.Fatalf("saved = %+v, want the typed address recorded", h.saved)
+	}
+	if !h.saved[0].Prompted() {
+		t.Fatalf("saved profile is not marked prompted: %+v", h.saved[0])
+	}
+	if len(h.sent) != 1 || h.sent[0].Email != "shukan@nodot" {
+		t.Fatalf("sent = %+v, want the typed address submitted", h.sent)
+	}
+	if h.sent[0].EmailDomainKind != onboarding.DomainUnknown {
+		t.Fatalf("email_domain_kind = %q, want %q", h.sent[0].EmailDomainKind, onboarding.DomainUnknown)
+	}
+}
+
 // The user answered; the network did not cooperate. That is our problem, not theirs.
 func TestMaybeRunOnboardingSurvivesSubmissionFailure(t *testing.T) {
 	h := newOnboardingHarness(t)

--- a/cli/beacon/internal/onboarding/prompt.go
+++ b/cli/beacon/internal/onboarding/prompt.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 )
 
-// maxAttempts bounds the email question so someone who cannot produce an address ends
-// with a clear message instead of looping.
+// maxAttempts bounds every question so someone who answers nothing usable ends with a
+// clear message instead of looping. For the email question that now means an empty
+// line, since any typed answer is accepted on the first try.
 const maxAttempts = 5
 
 // ErrPromptAborted means the user ended input (Ctrl-C or Ctrl-D) without answering.
@@ -249,17 +250,34 @@ func askUsage(reader *bufio.Reader, in io.Reader, out io.Writer, color bool) (st
 	return "", ErrTooManyAttempts
 }
 
+// askEmail asks for the address once and keeps whatever comes back.
+//
+// A malformed address is pointed out but not rejected: the local checks cannot tell a
+// typo from an address they simply do not understand, and re-asking until the answer
+// parses means the people who cannot satisfy them leave with nothing recorded at all --
+// no address, no usage answer, and a failed install to show for it. The note is there
+// so someone who mistyped can fix it on the spot; anyone who meant what they typed is
+// taken at their word, and the signup endpoint decides whether the mailbox is real.
+//
+// The loop remains for the answers that carry nothing to keep: an empty line, and a
+// paste longer than any address can be.
 func askEmail(reader *bufio.Reader, out io.Writer, color bool) (string, error) {
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		line, err := readLine(reader, out, fmt.Sprintf("  %sEmail%s › ", title(color), reset(color)))
 		if err != nil {
 			return "", err
 		}
-		email, invalid := NormalizeEmail(line)
-		if invalid == nil {
+		email, invalid := AcceptEmail(line)
+		switch {
+		case invalid == nil:
+			return email, nil
+		case errors.Is(invalid, ErrEmailEmpty), errors.Is(invalid, ErrEmailTooLong):
+			// Nothing to keep from either one, so these are the answers still asked again.
+			fmt.Fprintf(out, "  %s✗ %s%s\n", warn(color), invalid, reset(color))
+		default:
+			fmt.Fprintf(out, "  %s! %s — using it anyway.%s\n", warn(color), invalid, reset(color))
 			return email, nil
 		}
-		fmt.Fprintf(out, "  %s✗ %s%s\n", warn(color), invalid, reset(color))
 	}
 	return "", ErrTooManyAttempts
 }

--- a/cli/beacon/internal/onboarding/prompt_test.go
+++ b/cli/beacon/internal/onboarding/prompt_test.go
@@ -48,9 +48,12 @@ func TestPromptExplainsWhyItIsAsking(t *testing.T) {
 }
 
 func TestPromptNormalizesAnswers(t *testing.T) {
-	answers, _, err := runPrompt(t, "  work  \n  <Shukan@AsymptoteLabs.AI>  \n")
+	answers, out, err := runPrompt(t, "  work  \n  <Shukan@AsymptoteLabs.AI>  \n")
 	if err != nil {
 		t.Fatalf("Prompt returned error: %v", err)
+	}
+	if strings.Contains(out, "using it anyway") {
+		t.Fatalf("an address that parses was flagged:\n%s", out)
 	}
 	if answers.Usage != UsageWork {
 		t.Fatalf("Usage = %q, want %q", answers.Usage, UsageWork)
@@ -60,19 +63,76 @@ func TestPromptNormalizesAnswers(t *testing.T) {
 	}
 }
 
-func TestPromptRetriesInvalidEmailThenAccepts(t *testing.T) {
-	answers, out, err := runPrompt(t, "1\nnot-an-email\nstill@bad\nshukan@asymptotelabs.ai\n")
+// A malformed address is kept, not thrown away. The whole point of the prompt is to
+// end up with an answer on disk; refusing one we cannot parse loses the email, the
+// usage answer and the install alongside it.
+func TestPromptKeepsInvalidEmail(t *testing.T) {
+	cases := map[string]struct {
+		typed, want string
+		reason      error
+	}{
+		"no at":       {"not-an-email", "not-an-email", ErrEmailNoAt},
+		"no dot":      {"still@bad", "still@bad", ErrEmailNoDot},
+		"placeholder": {"you@example.com", "you@example.com", ErrEmailPlaceholder},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			answers, out, err := runPrompt(t, "1\n"+tc.typed+"\n")
+			if err != nil {
+				t.Fatalf("Prompt returned error: %v", err)
+			}
+			if answers.Email != tc.want {
+				t.Fatalf("Email = %q, want the typed answer %q", answers.Email, tc.want)
+			}
+			if answers.Usage != UsageWork {
+				t.Fatalf("Usage = %q, want the usage answer kept too", answers.Usage)
+			}
+			if !strings.Contains(out, tc.reason.Error()) {
+				t.Fatalf("output did not say what looked wrong:\n%s", out)
+			}
+			if !strings.Contains(out, "using it anyway") {
+				t.Fatalf("output did not say the answer was kept:\n%s", out)
+			}
+			// One note, then on to the next question -- not a second ask.
+			if strings.Count(out, "Email") != 1 {
+				t.Fatalf("asked for an email %d times, want once:\n%s", strings.Count(out, "Email"), out)
+			}
+		})
+	}
+}
+
+// A pasted wall of text is not an answer either, so it is asked again rather than
+// written to the profile and sent.
+func TestPromptRepromptsForOverlongEmail(t *testing.T) {
+	answers, out, err := runPrompt(t, "1\n"+strings.Repeat("x", maxEmail+1)+"\nshukan@asymptotelabs.ai\n")
 	if err != nil {
 		t.Fatalf("Prompt returned error: %v", err)
 	}
 	if answers.Email != "shukan@asymptotelabs.ai" {
-		t.Fatalf("Email = %q, want the third answer accepted", answers.Email)
+		t.Fatalf("Email = %q, want the second answer", answers.Email)
 	}
-	if !strings.Contains(out, ErrEmailNoAt.Error()) {
-		t.Fatalf("output did not explain the first failure:\n%s", out)
+	if !strings.Contains(out, ErrEmailTooLong.Error()) {
+		t.Fatalf("output did not say the answer was too long:\n%s", out)
 	}
-	if !strings.Contains(out, ErrEmailNoDot.Error()) {
-		t.Fatalf("output did not explain the second failure:\n%s", out)
+	if strings.Contains(out, "using it anyway") {
+		t.Fatalf("an overlong answer was kept:\n%s", out)
+	}
+}
+
+// An empty line is the one answer with nothing to keep, so it is asked again.
+func TestPromptRepromptsForEmptyEmail(t *testing.T) {
+	answers, out, err := runPrompt(t, "1\n\n   \nshukan@asymptotelabs.ai\n")
+	if err != nil {
+		t.Fatalf("Prompt returned error: %v", err)
+	}
+	if answers.Email != "shukan@asymptotelabs.ai" {
+		t.Fatalf("Email = %q, want the typed answer", answers.Email)
+	}
+	if !strings.Contains(out, ErrEmailEmpty.Error()) {
+		t.Fatalf("output did not ask again for a blank answer:\n%s", out)
+	}
+	if strings.Contains(out, "using it anyway") {
+		t.Fatalf("a blank answer was kept:\n%s", out)
 	}
 }
 
@@ -89,8 +149,8 @@ func TestPromptRetriesInvalidUsageThenAccepts(t *testing.T) {
 	}
 }
 
-func TestPromptGivesUpAfterTooManyBadEmails(t *testing.T) {
-	input := "1\n" + strings.Repeat("nope\n", maxAttempts+2)
+func TestPromptGivesUpAfterTooManyEmptyEmails(t *testing.T) {
+	input := "1\n" + strings.Repeat(" \n", maxAttempts+2)
 	_, out, err := runPrompt(t, input)
 	if !errors.Is(err, ErrTooManyAttempts) {
 		t.Fatalf("error = %v, want ErrTooManyAttempts", err)

--- a/cli/beacon/internal/onboarding/validate.go
+++ b/cli/beacon/internal/onboarding/validate.go
@@ -59,11 +59,16 @@ var (
 	ErrEmailEmptyLabel    = errors.New("the domain has an empty part, like a doubled or trailing dot")
 	ErrEmailBadTLD        = errors.New("the domain doesn't end in a valid extension")
 	ErrEmailPlaceholder   = errors.New("that looks like a placeholder address")
+	ErrEmailTooLong       = errors.New("that is too long to be an email address")
 )
 
 const (
 	maxLocalPart = 64
 	maxDomain    = 255
+	// maxEmail is the longest an address can be (RFC 3696 erratum 1690). Since a
+	// malformed answer is kept as typed, this is also what bounds what a pasted wall of
+	// text can put in the profile and on the wire.
+	maxEmail = maxLocalPart + 1 + maxDomain
 )
 
 // placeholderDomains are domains that cannot belong to a real mailbox. Accepting one
@@ -134,15 +139,19 @@ var freeProviders = map[string]bool{
 	"duck.com":       true,
 }
 
+// cleanEmail strips the wrappers people paste around an address. It says nothing
+// about whether what is left is a usable address.
+func cleanEmail(input string) string {
+	// People paste addresses out of mail clients, which often wrap them.
+	return strings.TrimSpace(strings.Trim(strings.TrimSpace(input), "<>"))
+}
+
 // NormalizeEmail validates an address and returns it in canonical lowercase form.
 //
 // The returned error is meant to be shown to the user verbatim, so each failure mode
 // gets its own message.
 func NormalizeEmail(input string) (string, error) {
-	email := strings.TrimSpace(input)
-	// People paste addresses out of mail clients, which often wrap them.
-	email = strings.Trim(email, "<>")
-	email = strings.TrimSpace(email)
+	email := cleanEmail(input)
 	if email == "" {
 		return "", ErrEmailEmpty
 	}
@@ -170,43 +179,81 @@ func NormalizeEmail(input string) (string, error) {
 	}
 
 	domain = strings.ToLower(domain)
+	if err := checkDomain(domain); err != nil {
+		return "", err
+	}
+
+	return strings.ToLower(local) + "@" + domain, nil
+}
+
+// checkDomain reports why a lowercase domain cannot belong to a real mailbox, or nil
+// if it looks like one.
+func checkDomain(domain string) error {
 	if domain == "" {
-		return "", ErrEmailNoDomain
+		return ErrEmailNoDomain
 	}
 	if len(domain) > maxDomain {
-		return "", ErrEmailDomainTooLong
+		return ErrEmailDomainTooLong
 	}
 	if !strings.Contains(domain, ".") {
-		return "", ErrEmailNoDot
+		return ErrEmailNoDot
 	}
 	labels := strings.Split(domain, ".")
 	for _, label := range labels {
 		if label == "" {
-			return "", ErrEmailEmptyLabel
+			return ErrEmailEmptyLabel
 		}
 		for _, r := range label {
 			isLower := r >= 'a' && r <= 'z'
 			isDigit := r >= '0' && r <= '9'
 			if !isLower && !isDigit && r != '-' {
-				return "", ErrEmailBadTLD
+				return ErrEmailBadTLD
 			}
 		}
 	}
 	tld := labels[len(labels)-1]
 	if len(tld) < 2 {
-		return "", ErrEmailBadTLD
+		return ErrEmailBadTLD
 	}
 	for _, r := range tld {
 		if r < 'a' || r > 'z' {
-			return "", ErrEmailBadTLD
+			return ErrEmailBadTLD
 		}
 	}
-
 	if placeholderDomains[domain] || reservedTLDs[tld] {
-		return "", ErrEmailPlaceholder
+		return ErrEmailPlaceholder
 	}
+	return nil
+}
 
-	return strings.ToLower(local) + "@" + domain, nil
+// AcceptEmail takes the address as the user's answer whatever it looks like.
+//
+// A well-formed address comes back normalized with a nil error. Anything else comes
+// back as typed, alongside the reason it did not validate so the caller can say so
+// once and move on.
+//
+// The local checks are a hint, not a gate: a malformed answer is still the only answer
+// the user gave, and discarding it loses the one thing the prompt exists to collect --
+// along with the usage answer and the install context that came with it. Whether a
+// mailbox actually exists was never something this code could know; the server-side MX
+// check decides that.
+//
+// Two answers are still refused, because neither leaves anything to keep: a blank line,
+// and something longer than any address can be -- a pasted file or a stuck key, which
+// would otherwise land in the profile and on the wire as-is.
+func AcceptEmail(input string) (string, error) {
+	cleaned := cleanEmail(input)
+	if cleaned == "" {
+		return "", ErrEmailEmpty
+	}
+	if len(cleaned) > maxEmail {
+		return "", ErrEmailTooLong
+	}
+	normalized, err := NormalizeEmail(cleaned)
+	if err != nil {
+		return cleaned, err
+	}
+	return normalized, nil
 }
 
 // EmailDomain returns the domain of an already-normalized address.
@@ -222,6 +269,12 @@ func EmailDomain(email string) string {
 func ClassifyDomain(domain string) string {
 	domain = strings.ToLower(strings.TrimSpace(domain))
 	if domain == "" {
+		return DomainUnknown
+	}
+	// A domain that cannot belong to a real mailbox says nothing about who the user
+	// works for. This is reachable because the prompt keeps whatever was typed, so
+	// junk is reported as unknown rather than counted as a company.
+	if checkDomain(domain) != nil {
 		return DomainUnknown
 	}
 	if freeProviders[domain] {

--- a/cli/beacon/internal/onboarding/validate_test.go
+++ b/cli/beacon/internal/onboarding/validate_test.go
@@ -2,6 +2,7 @@ package onboarding
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -101,6 +102,74 @@ func TestEmailDomain(t *testing.T) {
 	}
 }
 
+// AcceptEmail hands back an answer for anything the user actually typed. Whether it
+// validated is a note for the prompt, not grounds for dropping the address.
+func TestAcceptEmailKeepsWhatWasTyped(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		want   string
+		reason error
+	}{
+		{"valid is normalized", "  <Shukan@AsymptoteLabs.AI> ", "shukan@asymptotelabs.ai", nil},
+		{"no at", "shukan", "shukan", ErrEmailNoAt},
+		{"no dot", "shukan@localhostish", "shukan@localhostish", ErrEmailNoDot},
+		{"placeholder domain", "you@example.com", "you@example.com", ErrEmailPlaceholder},
+		{"reserved tld", "dev@beacon.test", "dev@beacon.test", ErrEmailPlaceholder},
+		{"two ats", "a@b@company.com", "a@b@company.com", ErrEmailMultipleAt},
+		{"wrappers still trimmed", " <nope> ", "nope", ErrEmailNoAt},
+		{"case kept when it does not parse", "Shukan@Bad", "Shukan@Bad", ErrEmailNoDot},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := AcceptEmail(tc.input)
+			if got != tc.want {
+				t.Fatalf("AcceptEmail(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+			if tc.reason == nil {
+				if err != nil {
+					t.Fatalf("AcceptEmail(%q) returned error: %v", tc.input, err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.reason) {
+				t.Fatalf("AcceptEmail(%q) error = %v, want %v", tc.input, err, tc.reason)
+			}
+		})
+	}
+}
+
+// A blank answer leaves nothing to keep, so the caller can ask again.
+func TestAcceptEmailRefusesBlank(t *testing.T) {
+	for _, input := range []string{"", "   ", "<>", " <> "} {
+		got, err := AcceptEmail(input)
+		if got != "" {
+			t.Fatalf("AcceptEmail(%q) = %q, want empty", input, got)
+		}
+		if !errors.Is(err, ErrEmailEmpty) {
+			t.Fatalf("AcceptEmail(%q) error = %v, want ErrEmailEmpty", input, err)
+		}
+	}
+}
+
+// Keeping what was typed must not mean keeping a pasted file. An answer longer than any
+// address can be is refused rather than written to the profile and sent.
+func TestAcceptEmailRefusesOverlongInput(t *testing.T) {
+	longest := strings.Repeat("a", maxLocalPart) + "@" + strings.Repeat("b", maxDomain-4) + ".com"
+	if got, err := AcceptEmail(longest); err != nil || got != longest {
+		t.Fatalf("AcceptEmail(<%d chars>) = %q, %v; want the longest legal address kept", len(longest), got, err)
+	}
+	for _, input := range []string{strings.Repeat("x", maxEmail+1), "a@" + strings.Repeat("b", maxEmail)} {
+		got, err := AcceptEmail(input)
+		if got != "" {
+			t.Fatalf("AcceptEmail(<%d chars>) = %q, want empty", len(input), got)
+		}
+		if !errors.Is(err, ErrEmailTooLong) {
+			t.Fatalf("AcceptEmail(<%d chars>) error = %v, want ErrEmailTooLong", len(input), err)
+		}
+	}
+}
+
 func TestClassifyDomain(t *testing.T) {
 	cases := []struct {
 		domain string
@@ -114,6 +183,12 @@ func TestClassifyDomain(t *testing.T) {
 		{"proton.me", DomainFree},
 		{"", DomainUnknown},
 		{"   ", DomainUnknown},
+		// Reachable now that a malformed address is kept: a domain that cannot hold a
+		// mailbox must not be counted as a company.
+		{"bad", DomainUnknown},
+		{"example.com", DomainUnknown},
+		{"beacon.test", DomainUnknown},
+		{"company..com", DomainUnknown},
 	}
 	for _, tc := range cases {
 		if got := ClassifyDomain(tc.domain); got != tc.want {


### PR DESCRIPTION
## Summary

Changes the email validation strategy in the onboarding flow to accept and preserve any non-empty, non-overlong email address the user types, even if it fails local validation checks. Invalid addresses are flagged with a note ("using it anyway") but still recorded and submitted. This shifts validation responsibility to the server-side MX check while preserving user input that might be valid but unrecognized by local heuristics.

## Key Changes

- **New `AcceptEmail()` function**: Accepts any cleaned, non-empty input up to `maxEmail` length, returning the typed answer alongside validation errors rather than rejecting it
- **Refactored `NormalizeEmail()`**: Extracted domain validation into a separate `checkDomain()` helper for reuse
- **New `cleanEmail()` helper**: Centralizes the logic for stripping whitespace and angle brackets that users paste from mail clients
- **Updated `askEmail()` prompt logic**: 
  - Calls `AcceptEmail()` instead of `NormalizeEmail()`
  - Only re-prompts for truly empty answers or pastes longer than `maxEmail`
  - Shows "using it anyway" note for malformed but typed addresses
  - Returns normalized form if valid, typed form if invalid
- **Updated `ClassifyDomain()`**: Now returns `DomainUnknown` for domains that fail validation checks, since malformed addresses are now kept and may reach this function
- **New error constant**: `ErrEmailTooLong` for inputs exceeding the RFC 3696 limit

## Notable Implementation Details

- The `maxEmail` constant is set to `maxLocalPart + 1 + maxDomain` (64 + 1 + 255 = 320 chars) per RFC 3696 erratum 1690, bounding what a pasted file or stuck key could put in the profile
- Malformed addresses preserve their original case when returned, only normalizing if they pass validation
- The prompt loop still enforces `maxAttempts` but only for truly unanswerable inputs (blank/overlong), not for validation failures
- Tests confirm that valid addresses are normalized, invalid ones are kept as typed, and the usage answer is preserved alongside the email answer even when it fails validation

https://claude.ai/code/session_01MBMYfbPp3d2TniV2kfVsUL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI onboarding UX and telemetry classification; signup payloads may include more malformed strings but length is capped and server MX validation remains authoritative.
> 
> **Overview**
> **Interactive onboarding no longer blocks installs on local email validation failures.** The email prompt keeps any non-empty answer up to RFC 3696 length on the first try, shows a one-line warning (including “using it anyway”) when `AcceptEmail` still reports a validation issue, and only re-asks for blank or overlong input.
> 
> Validation helpers are split so **`AcceptEmail`** returns normalized text when parsing succeeds or the cleaned typed string plus an error when it does not; **`checkDomain`** is shared by **`NormalizeEmail`** and **`ClassifyDomain`**, which now labels invalid domains as **`unknown`** so junk like `shukan@nodot` is saved and submitted without being counted as corporate. Headless **`BEACON_ONBOARDING_*`** env answers still go through strict **`NormalizeEmail`** (unchanged).
> 
> Tests cover the new prompt behavior, `AcceptEmail` edge cases, and end-to-end install save/submit with `email_domain_kind: unknown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 375b548c53ff1547539f96a50dafb2687179eec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->