### PR TITLE
OpenHands support (1/5): harness identity

### DIFF
--- a/pkg/asymptoteobserve/harness.go
+++ b/pkg/asymptoteobserve/harness.go
@@ -177,6 +177,27 @@ func NormalizeHarnessName(name string) string {
 		lower == "fx.sh" || lower == "vercel_fx" || lower == "vercel-fx" || lower == "vercel fx" ||
 		lower == "vercel fx cli" || lower == "fx_agent" || lower == "fx-agent":
 		return "vercel_fx"
+	// OpenHands (formerly All Hands AI) is matched by equality against a closed set for the same
+	// reason Qwen Code and Muse Code are, and it is the Muse case exactly: the same organization
+	// ships the agent and a model family under one name, so every OpenHands LM model id begins
+	// with the letters the harness does -- openhands-lm-32b-v0.1, openhands-lm-7b-v0.1. A
+	// Contains(lower, "openhands") rule would report any event whose harness attribute happened to
+	// carry one of those model strings as an OpenHands session, and a reader could not tell the
+	// misattribution from the real thing because both start with the same word.
+	//
+	// Model spellings are therefore deliberately left out of the set: they fall to the passthrough
+	// case and show up as themselves, which is visible as an anomaly rather than silently filed
+	// under the agent.
+	//
+	// The canonical spelling is plain `openhands` rather than `openhands_cli`, because OpenHands
+	// is one product that runs the same agent in Cloud, the CLI and the local GUI -- Beacon hooks
+	// all three through the same `.openhands/hooks.json`, so a CLI suffix would name only one of
+	// the places the events come from. It follows `cline` and `omp`, not `codex_cli`.
+	case lower == "openhands" || lower == "open_hands" || lower == "open-hands" || lower == "open hands" ||
+		lower == "openhands_cli" || lower == "openhands-cli" || lower == "openhands cli" ||
+		lower == "openhands_agent" || lower == "openhands-agent" || lower == "openhands agent" ||
+		lower == "openhands.dev":
+		return "openhands"
 	case name != "":
 		// An unrecognized runtime keeps its own name rather than being coerced or dropped. A new
 		// harness should show up in the log as itself, not as "unknown".

--- a/pkg/asymptoteobserve/harness_test.go
+++ b/pkg/asymptoteobserve/harness_test.go
@@ -422,3 +422,74 @@ func TestOrdinaryWordsContainingMuseAreNotMuseCode(t *testing.T) {
 		})
 	}
 }
+
+func TestOpenHandsSpellingsConvergeOnOpenHands(t *testing.T) {
+	for _, in := range []string{
+		"openhands", "OpenHands", "OPENHANDS", " openhands ", "open_hands", "open-hands",
+		"Open Hands", "openhands_cli", "openhands-cli", "OpenHands CLI", "openhands_agent",
+		"openhands-agent", "OpenHands Agent", "openhands.dev",
+	} {
+		t.Run(in, func(t *testing.T) {
+			if got := NormalizeHarnessName(in); got != "openhands" {
+				t.Errorf("NormalizeHarnessName(%q) = %q, want %q", in, got, "openhands")
+			}
+		})
+	}
+}
+
+// The reason the OpenHands case is an equality match rather than a Contains rule. The same
+// organization publishes the agent and the OpenHands LM model family, so every one of those model
+// ids begins with the word the harness does; a substring rule would report an event whose harness
+// attribute carried a model string as an OpenHands session, and the value would look plausible
+// either way. Falling through to the passthrough case is the wanted behavior: the model id shows
+// up as itself, which reads as an anomaly rather than as the agent.
+func TestOpenHandsModelNamesAreNotTreatedAsTheHarness(t *testing.T) {
+	for _, name := range []string{
+		"openhands-lm", "openhands-lm-32b", "openhands-lm-32b-v0.1", "openhands-lm-7b-v0.1",
+		"all-hands/openhands-lm-32b-v0.1", "OpenHands LM 32B",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := NormalizeHarnessName(name); got == "openhands" {
+				t.Errorf("NormalizeHarnessName(%q) = %q; an OpenHands LM model id must not be "+
+					"reported as the OpenHands harness", name, got)
+			}
+		})
+	}
+}
+
+// "hands" is an ordinary English word and "open" prefixes several unrelated product names, so the
+// closed set is what keeps a harness attribute that merely contains either from being claimed.
+func TestOrdinaryNamesContainingOpenOrHandsAreNotOpenHands(t *testing.T) {
+	for _, name := range []string{
+		"openai", "opencode", "openclaw", "open-interpreter", "handsfree", "hands",
+		"openhands-runtime-sandbox",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := NormalizeHarnessName(name); got == "openhands" {
+				t.Errorf("NormalizeHarnessName(%q) = %q; a name merely containing \"open\" or "+
+					"\"hands\" must not be reported as the OpenHands harness", name, got)
+			}
+		})
+	}
+}
+
+// opencode resolves before anything OpenHands-shaped could claim it. Both start with "open", both
+// are hook-installable runtimes Beacon supports, and recording one under the other's name would
+// merge two separately installed products in every query that groups by harness.name.
+func TestOpenHandsAndOpenCodeStaySeparateRuntimes(t *testing.T) {
+	if got := NormalizeHarnessName("openhands"); got != "openhands" {
+		t.Fatalf("NormalizeHarnessName(openhands) = %q, want openhands", got)
+	}
+	if got := NormalizeHarnessName("opencode"); got == "openhands" {
+		t.Fatalf("NormalizeHarnessName(opencode) = %q; opencode must not resolve to openhands", got)
+	}
+}
+
+// The normalized name is itself a spelling this function accepts, so a row read out of the runtime
+// log and fed back in resolves to the same harness rather than drifting to a second name.
+func TestOpenHandsCanonicalNameIsStableUnderRenormalization(t *testing.T) {
+	once := NormalizeHarnessName("openhands-cli")
+	if got := NormalizeHarnessName(once); got != once {
+		t.Fatalf("NormalizeHarnessName(%q) = %q, want %q", once, got, once)
+	}
+}

--- a/pkg/asymptoteobserve/provenance_test.go
+++ b/pkg/asymptoteobserve/provenance_test.go
@@ -112,6 +112,12 @@ func TestCollectionMethodForPlatform(t *testing.T) {
 		// same shape for the same reason. A `plugin` here would claim Beacon ships and versions
 		// source the runtime loads, which for Muse Code it does not.
 		"muse": CollectionMethodHook,
+		// OpenHands is hook-shaped: the events, the payload shapes and the .openhands/hooks.json
+		// contract are all the vendor's, and Beacon only registers commands in a file the runtime
+		// already reads. A `plugin` here would claim Beacon ships and versions source OpenHands
+		// loads, which it does not -- and would send someone to fix Beacon for a field OpenHands
+		// never sent.
+		"openhands": CollectionMethodHook,
 		// vscode is the case that justifies keying on --platform rather than on the normalized
 		// harness name: its hook and OTLP telemetry both normalize to vscode_copilot, so the
 		// harness name cannot distinguish them and only the flag can.


### PR DESCRIPTION
First of a five-PR stack adding OpenHands (All Hands) endpoint telemetry, in the shape the Muse Code stack used: identity, then the mapper, then the installer, then the CLI wiring, then the docs.

## What this changes

`NormalizeHarnessName` gains an `openhands` case, and `CollectionMethodForPlatform` gains a test pinning OpenHands as hook-shaped.

Identity lands before the mappers so the hook path and anything that later reports OpenHands over OTLP cannot disagree about what to call it. `harness.name` is a release contract every downstream query groups by.

## Why the case is a closed set

Equality against a closed set rather than `Contains(lower, "openhands")`, and this is the Muse Spark case exactly: All Hands publishes both the agent and the **OpenHands LM** model family, so every one of those model ids begins with the same word the harness does. A substring rule would file an event whose harness attribute carried `openhands-lm-32b-v0.1` under the agent, and a reader would have no way to tell that from a real session.

Model spellings are deliberately left out of the set. They fall to the passthrough case and show up as themselves, which reads as an anomaly rather than as the agent.

## Why the canonical name is `openhands`

Plain `openhands` rather than `openhands_cli`. OpenHands runs one agent in Cloud, the CLI and the local GUI, and Beacon hooks all three through the same `.openhands/hooks.json` — a CLI suffix would name one of the places the events come from and not the others. It follows `cline` and `omp`, not `codex_cli`.

`CollectionMethodForPlatform` needs no code change (`hook` is its default, and OpenHands is hook-shaped: the events, payloads and `hooks.json` contract are all the vendor's), but the mapping is pinned by a test so a later edit cannot quietly reclassify it as a plugin.

## Tests

`go test ./...` in `pkg/asymptoteobserve`. New cases cover the accepted spellings, that OpenHands LM model ids are *not* claimed by the harness, that ordinary names containing "open" or "hands" are not either, that `opencode` and `openhands` stay separate runtimes, and that the canonical name is stable under re-normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014A1KXwcjN7RutVkoF7UbXL

---
_Generated by [Claude Code](https://claude.ai/code/session_014A1KXwcjN7RutVkoF7UbXL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to harness naming and test expectations in asymptoteobserve; no auth or runtime behavior changes, with misclassification risk mitigated by closed-set matching and broad tests.
> 
> **Overview**
> Adds **OpenHands** to shared harness identity in `pkg/asymptoteobserve` as the first step of a five-PR telemetry stack, so hook and OTLP paths agree on `harness.name` before mappers and installers land.
> 
> `NormalizeHarnessName` now maps a **closed set** of spellings (e.g. `openhands`, `open-hands`, `openhands_cli`, `openhands.dev`) to the canonical **`openhands`**—not `openhands_cli`—because Cloud, CLI, and GUI share `.openhands/hooks.json`. Matching is **equality only** (same pattern as Muse/Qwen): OpenHands LM model ids start with `openhands`, so a substring rule would mislabel model strings as agent sessions.
> 
> Tests cover convergence, LM model passthrough, separation from `opencode` and generic “open”/“hands” names, and stable re-normalization. **`CollectionMethodForPlatform`** gains a test expectation that **`openhands`** is **hook-shaped** (no production change; unknown platforms already default to hook).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44bcf8364718d525cfc1070185ba0f33127bac2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->