### PR TITLE
OpenHands support (4/5): wire into the CLI, diagnostics, dashboard and inventory

### DIFF
--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -888,7 +888,7 @@ var userScopeOnlyHookTargets = map[string]bool{
 }
 
 func allHookTargetsForLevel() []string {
-	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "openhands", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 	if endpointOpts.hookLevel != "project" {
 		return all
 	}
@@ -947,6 +947,9 @@ func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[str
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.ExtensionPath, Raw: status}
 		case "grok":
 			status := endpointhooks.GrokHookStatus(endpointhooks.GrokOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
+		case "openhands":
+			status := endpointhooks.OpenHandsHookStatus(endpointhooks.OpenHandsOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
 		case "muse":
 			status := endpointhooks.MuseHookStatus(endpointhooks.MuseOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})

--- a/cli/beacon/cmd/endpoint_hooks.go
+++ b/cli/beacon/cmd/endpoint_hooks.go
@@ -183,6 +183,26 @@ func installEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 		if strings.Contains(status.Message, "/hooks-trust") {
 			fmt.Println(status.Message)
 		}
+	case "openhands":
+		status, err := endpointhooks.InstallOpenHands(endpointhooks.OpenHandsOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("OpenHands hooks installed: %s\n", status.HooksPath)
+		// Said at user scope only, because it is the case where a successful install still collects
+		// nothing. OpenHands reads the first hooks.json it finds rather than merging the two, and
+		// the agent server behind the CLI and the GUI reads only the project file -- so a
+		// user-scope install is right for someone driving the SDK directly and silently inert for
+		// everyone else. Better to say it here than to have somebody discover it from an empty log.
+		if endpointhooks.Level(endpointOpts.hookLevel) != endpointhooks.LevelProject {
+			fmt.Println("OpenHands reads a repository's own .openhands/hooks.json in preference to this one, " +
+				"and its agent server (used by the CLI and the GUI) reads only the repository file. " +
+				"Run the install again with --level project inside a repository to cover those.")
+		}
 	case "muse":
 		status, err := endpointhooks.InstallMuse(endpointhooks.MuseOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -386,6 +406,16 @@ func uninstallEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 			return err
 		}
 		fmt.Println(status.Message)
+	case "openhands":
+		status, err := endpointhooks.UninstallOpenHands(endpointhooks.OpenHandsOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
 	case "muse":
 		status, err := endpointhooks.UninstallMuse(endpointhooks.MuseOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -518,6 +548,12 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
+		case "openhands":
+			statuses["openhands"] = endpointhooks.OpenHandsHookStatus(endpointhooks.OpenHandsOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
 		case "muse":
 			statuses["muse"] = endpointhooks.MuseHookStatus(endpointhooks.MuseOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -597,6 +633,10 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 		case "grok":
 			status := statuses["grok"].(endpointhooks.GrokStatus)
 			fmt.Printf("Grok hooks: installed=%t path=%s\n", status.Installed, status.HooksPath)
+			fmt.Println(status.Message)
+		case "openhands":
+			status := statuses["openhands"].(endpointhooks.OpenHandsStatus)
+			fmt.Printf("OpenHands hooks: installed=%t path=%s\n", status.Installed, status.HooksPath)
 			fmt.Println(status.Message)
 		case "muse":
 			status := statuses["muse"].(endpointhooks.MuseStatus)

--- a/cli/beacon/cmd/endpoint_hooks_repair.go
+++ b/cli/beacon/cmd/endpoint_hooks_repair.go
@@ -148,7 +148,7 @@ func installedHookTargetsForUser(homeDir, logPath string) ([]string, error) {
 }
 
 func repairTargetOrder() []string {
-	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "openhands", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 }
 
 // withUserHome runs fn as if it were executing inside another user's profile.

--- a/cli/beacon/cmd/endpoint_targets.go
+++ b/cli/beacon/cmd/endpoint_targets.go
@@ -56,6 +56,13 @@ var harnessTargets = []harnessTarget{
 	// for the other's. "oh-my-pi" is accepted because it is the repository name people reach for;
 	// "omp" is the binary, and the canonical harness name events are written under.
 	{name: "omp", endpointKind: endpointTargetHook, endpointAliases: []string{"omp", "oh-my-pi", "ohmypi"}, hookAliases: []string{"omp", "oh-my-pi", "ohmypi"}},
+	// OpenHands. "open-hands" is accepted because the product is written as two words as often as
+	// one, and normalizeHarnessKey folds "open_hands" onto it. "openhands" is also the canonical
+	// harness name events are written under, so a row read out of the runtime log and passed back
+	// to --harness resolves to the runtime it names. "openhands-lm" is deliberately not an alias:
+	// that is All Hands' model family, and accepting it would let someone ask to install hooks for
+	// a model.
+	{name: "openhands", endpointKind: endpointTargetHook, endpointAliases: []string{"openhands", "open-hands"}, hookAliases: []string{"openhands", "open-hands"}},
 	{name: "grok", endpointKind: endpointTargetHook, endpointAliases: []string{"grok"}, hookAliases: []string{"grok"}},
 	// "qwen-code" and "qwen_code" both normalize to "qwen-code" through normalizeHarnessKey, so the
 	// two spellings need one alias between them. "qwen-cli" is not accepted: the product is Qwen

--- a/cli/beacon/cmd/openhands_target_test.go
+++ b/cli/beacon/cmd/openhands_target_test.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
+)
+
+// The install -> status -> uninstall round trip for OpenHands, through the CLI entry points rather
+// than the package API.
+//
+// Wiring a runtime into `beacon endpoint hooks` means five separate switches (install, uninstall,
+// status collection, status printing, repair) plus a registry row, and every one of them fails by
+// omission rather than by error. TestEveryHookTargetIsWired proves each switch has a case; this
+// proves the cases do the thing their name claims.
+func TestEndpointHooksInstallAndUninstallOpenHands(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("OH_PERSISTENCE_DIR", "")
+	cfg := endpointconfig.Config{LogPath: filepath.Join(home, "runtime.jsonl"), UserMode: true}
+
+	origLevel := endpointOpts.hookLevel
+	t.Cleanup(func() { endpointOpts.hookLevel = origLevel })
+	endpointOpts.hookLevel = "user"
+
+	hooksPath := filepath.Join(home, ".openhands", "hooks.json")
+	if err := installEndpointHookTarget("openhands", cfg); err != nil {
+		t.Fatalf("installEndpointHookTarget(openhands) returned error: %v", err)
+	}
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("install did not write %s: %v", hooksPath, err)
+	}
+	if !strings.Contains(string(data), "--platform openhands") {
+		t.Fatalf("hooks.json does not carry the OpenHands hook command:\n%s", data)
+	}
+	// The file OpenHands reads is the event map itself, and it forbids fields it does not know --
+	// so a stray top-level key is not untidy, it is the whole file failing to load.
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("hooks.json is not valid JSON: %v", err)
+	}
+	for _, event := range []string{"session_start", "user_prompt_submit", "pre_tool_use", "post_tool_use", "stop", "session_end"} {
+		if _, ok := document[event]; !ok {
+			t.Errorf("hooks.json is missing the %q event:\n%s", event, data)
+		}
+	}
+	if len(document) != 6 {
+		t.Fatalf("hooks.json has %d top-level keys, want exactly the six events:\n%s", len(document), data)
+	}
+
+	if !endpointhooks.IsOpenHandsInstalled(endpointhooks.OpenHandsOptions{
+		Level: endpointhooks.LevelUser, LogPath: cfg.LogPath, UserMode: true,
+	}) {
+		t.Fatal("IsOpenHandsInstalled = false after installEndpointHookTarget")
+	}
+
+	if err := uninstallEndpointHookTarget("openhands", cfg); err != nil {
+		t.Fatalf("uninstallEndpointHookTarget(openhands) returned error: %v", err)
+	}
+	if _, err := os.Stat(hooksPath); !os.IsNotExist(err) {
+		t.Fatalf("uninstall left an empty hooks.json behind: %v", err)
+	}
+}
+
+// `endpoint hooks repair` walks a hard-coded list rather than the registry, so a runtime absent
+// from it is never repaired -- and repair is what fixes a hook whose binary path went stale after
+// an upgrade. It fails silently: repair reports success having skipped the runtime entirely.
+func TestOpenHandsIsInTheRepairTargetList(t *testing.T) {
+	for _, name := range repairTargetOrder() {
+		if name == "openhands" {
+			return
+		}
+	}
+	t.Fatal("openhands is missing from the repair target list; `endpoint repair` would silently skip it")
+}
+
+// Both spellings a person plausibly types resolve to the hook target, in both namespaces.
+func TestOpenHandsHarnessSpellingsResolveToTheHookTarget(t *testing.T) {
+	for _, spelling := range []string{"openhands", "OpenHands", " openhands ", "open-hands", "open_hands", "OPEN-HANDS"} {
+		t.Run(spelling, func(t *testing.T) {
+			target, ok := normalizeEndpointTarget(spelling)
+			if !ok {
+				t.Fatalf("normalizeEndpointTarget(%q) = not found", spelling)
+			}
+			if target.Name != "openhands" || target.Kind != endpointTargetHook {
+				t.Fatalf("normalizeEndpointTarget(%q) = %+v, want the openhands hook target", spelling, target)
+			}
+			if got, ok := normalizeHookTarget(spelling); !ok || got != "openhands" {
+				t.Fatalf("normalizeHookTarget(%q) = %q, %t; want openhands, true", spelling, got, ok)
+			}
+		})
+	}
+}
+
+// OpenHands LM is All Hands' model family, not the runtime. Accepting it as a harness alias would
+// let someone ask Beacon to install hooks for a model and get an install for the agent instead --
+// a silent substitution, since the install would then report success under a different name.
+func TestOpenHandsModelNamesAreNotHarnessAliases(t *testing.T) {
+	for _, spelling := range []string{"openhands-lm", "openhands_lm", "openhands-lm-32b"} {
+		t.Run(spelling, func(t *testing.T) {
+			if target, ok := normalizeEndpointTarget(spelling); ok {
+				t.Fatalf("normalizeEndpointTarget(%q) = %+v; OpenHands LM is a model, not a harness", spelling, target)
+			}
+		})
+	}
+}
+
+// opencode and openhands are two separately installed runtimes whose names begin the same way.
+// Resolving one to the other would install a plugin for the runtime the operator did not name.
+func TestOpenHandsAndOpenCodeAreSeparateTargets(t *testing.T) {
+	openhands, ok := normalizeHookTarget("openhands")
+	if !ok || openhands != "openhands" {
+		t.Fatalf("normalizeHookTarget(openhands) = %q, %t", openhands, ok)
+	}
+	opencode, ok := normalizeHookTarget("opencode")
+	if !ok || opencode != "opencode" {
+		t.Fatalf("normalizeHookTarget(opencode) = %q, %t", opencode, ok)
+	}
+}
+
+// Both scopes are real for OpenHands, unlike Hermes and Muse Code -- project scope is the
+// documented location every host reads, so it must stay in the project-level --all sweep. Install
+// and uninstall both return on the first target error, so a target wrongly filtered out is not the
+// only thing missing: everything ordered after it in the list is skipped too.
+func TestOpenHandsIsSweptAtBothLevels(t *testing.T) {
+	origLevel := endpointOpts.hookLevel
+	t.Cleanup(func() { endpointOpts.hookLevel = origLevel })
+
+	for _, level := range []string{"user", "project"} {
+		endpointOpts.hookLevel = level
+		if !containsTarget(allHookTargetsForLevel(), "openhands") {
+			t.Fatalf("%s-level --all dropped openhands:\n%v", level, allHookTargetsForLevel())
+		}
+	}
+	if userScopeOnlyHookTargets["openhands"] {
+		t.Fatal("openhands is marked user scope only; its project scope is the documented one")
+	}
+}
+
+// A project-scope install writes into the repository the operator is standing in, which is the
+// location the agent server -- and so the CLI and the GUI -- reads.
+func TestEndpointHooksInstallOpenHandsAtProjectLevel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("OH_PERSISTENCE_DIR", "")
+	cfg := endpointconfig.Config{LogPath: filepath.Join(home, "runtime.jsonl"), UserMode: true}
+
+	project := t.TempDir()
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	origLevel := endpointOpts.hookLevel
+	t.Cleanup(func() { endpointOpts.hookLevel = origLevel })
+	endpointOpts.hookLevel = "project"
+
+	if err := installEndpointHookTarget("openhands", cfg); err != nil {
+		t.Fatalf("installEndpointHookTarget(openhands, project) returned error: %v", err)
+	}
+	// os.Getwd resolves symlinks on macOS, where TempDir hands back a /var path that is really
+	// /private/var, so the written path is compared through the same resolution rather than
+	// against the temp directory name.
+	resolved, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if _, err := os.ReadFile(filepath.Join(resolved, ".openhands", "hooks.json")); err != nil {
+		t.Fatalf("project install did not write .openhands/hooks.json: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".openhands", "hooks.json")); !os.IsNotExist(err) {
+		t.Fatalf("project install also wrote the user-scope file: %v", err)
+	}
+}

--- a/cli/beacon/internal/endpoint/dashboard/openhands_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/openhands_test.go
@@ -1,0 +1,60 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
+)
+
+// The dashboard's harness list is a hand-written sequence of calls, one per runtime, so a runtime
+// left out of it is simply absent from the page with nothing to say it should have been there.
+// That is the failure this guards: an operator looking at the dashboard to check their coverage
+// would conclude OpenHands is not a supported runtime.
+func TestHookStatusesIncludesOpenHands(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("OH_PERSISTENCE_DIR", "")
+
+	logPath := filepath.Join(home, "runtime.jsonl")
+	var openhands *HookStatus
+	statuses := hookStatuses(logPath, true)
+	for i := range statuses {
+		if statuses[i].Target == "openhands" {
+			openhands = &statuses[i]
+			break
+		}
+	}
+	if openhands == nil {
+		t.Fatal("hookStatuses omits openhands; the dashboard would show it as an unsupported runtime")
+	}
+	if openhands.Installed {
+		t.Fatalf("openhands reported installed with no hooks.json present: %+v", openhands)
+	}
+	if openhands.Path == "" {
+		t.Fatalf("openhands reported no path: %+v", openhands)
+	}
+
+	// And it flips once the hooks are actually there, so the row reflects the install rather than
+	// being a permanently empty placeholder.
+	if err := os.MkdirAll(filepath.Join(home, ".openhands"), 0755); err != nil {
+		t.Fatalf("create .openhands: %v", err)
+	}
+	if _, err := endpointhooks.InstallOpenHands(endpointhooks.OpenHandsOptions{
+		Level: endpointhooks.LevelUser, LogPath: logPath, UserMode: true,
+	}); err != nil {
+		t.Fatalf("InstallOpenHands: %v", err)
+	}
+	for _, status := range hookStatuses(logPath, true) {
+		if status.Target != "openhands" {
+			continue
+		}
+		if !status.Installed {
+			t.Fatalf("openhands still reported not installed after an install: %+v", status)
+		}
+		return
+	}
+	t.Fatal("openhands disappeared from hookStatuses after an install")
+}

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -347,6 +347,8 @@ func hookStatuses(logPath string, userMode bool) []HookStatus {
 	add("hermes", hermes.Installed, hermes.ConfigPath, hermes.BinaryPath, hermes.Message)
 	opencode := endpointhooks.OpenCodeHookStatus(endpointhooks.OpenCodeOptions{Level: level, LogPath: logPath, UserMode: userMode})
 	add("opencode", opencode.Installed, opencode.PluginPath, opencode.BinaryPath, opencode.Message)
+	openhands := endpointhooks.OpenHandsHookStatus(endpointhooks.OpenHandsOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("openhands", openhands.Installed, openhands.HooksPath, openhands.BinaryPath, openhands.Message)
 	muse := endpointhooks.MuseHookStatus(endpointhooks.MuseOptions{Level: level, LogPath: logPath, UserMode: userMode})
 	add("muse", muse.Installed, muse.HooksPath, muse.BinaryPath, muse.Message)
 	qwen := endpointhooks.QwenHookStatus(endpointhooks.QwenOptions{Level: level, LogPath: logPath, UserMode: userMode})

--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -216,6 +216,7 @@ func candidates(home, wd string) []candidate {
 	items = append(items, grokCandidates(home, wd)...)
 	items = append(items, qwenCandidates(home, wd)...)
 	items = append(items, museCandidates(home)...)
+	items = append(items, openHandsCandidates(home, wd)...)
 	items = append(items, fxCandidates(home, wd)...)
 	seen := map[string]bool{}
 	out := make([]candidate, 0, len(items))
@@ -398,6 +399,36 @@ func museCandidates(home string) []candidate {
 		{runtime: "muse_code", path: filepath.Join(dir, "beacon-endpoint-hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		{runtime: "muse_code", path: filepath.Join(dir, "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 	}
+}
+
+// OpenHands keeps hooks in .openhands/hooks.json, which the user also edits, so this is a native
+// config file Beacon merges into rather than one it owns -- KindHookConfig, detected by the hook
+// command it contains, because there is no marker to write into a file with a closed schema.
+//
+// Both scopes are reported, and reporting both is the point rather than thoroughness. OpenHands
+// reads the first hooks.json it finds instead of merging the two, so a project file shadows the
+// user one entirely; an inventory that showed only the user file would report a working install
+// for a repository whose own hooks.json means Beacon's never runs.
+//
+// OH_PERSISTENCE_DIR is read here rather than assumed away, for the same reason the installer
+// reads it: on a machine that sets it, ~/.openhands is not where OpenHands looks, and an inventory
+// scanning the wrong directory reports "not installed" for a working install.
+func openHandsCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "openhands", path: filepath.Join(openHandsUserDir(home), "hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "openhands", path: filepath.Join(wd, ".openhands", "hooks.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+	}
+}
+
+// openHandsUserDir resolves the user-level OpenHands state directory, mirroring the installer.
+//
+// Exported to the test as a function rather than restated there as a literal path, so the
+// expected-candidate list stays correct on a developer machine that happens to set the variable.
+func openHandsUserDir(home string) string {
+	if base := strings.TrimSpace(os.Getenv("OH_PERSISTENCE_DIR")); base != "" {
+		return base
+	}
+	return filepath.Join(home, ".openhands")
 }
 
 // museConfigDir resolves the directory Muse Code keeps settings.json in, mirroring the installer.
@@ -781,6 +812,13 @@ func beaconManaged(item candidate, data []byte) bool {
 	case "muse_code":
 		return strings.Contains(text, "beacon-managed-muse-hooks:v1") ||
 			strings.Contains(text, "beacon-endpoint-hooks.json")
+	// Matched on the hook command, like Qwen Code above and for a stronger version of the same
+	// reason: OpenHands' hooks.json forbids top-level fields it does not know, so a Beacon marker
+	// would not merely be untidy -- it would fail validation and take every hook in the file down.
+	// `--platform openhands` is what the installer writes and what uninstall keys on, so it is the
+	// same string in all three places.
+	case "openhands":
+		return strings.Contains(text, "--platform openhands") || strings.Contains(text, "--platform=openhands")
 	}
 	if item.runtime == "claude_code" || item.runtime == "codex_cli" {
 		if strings.Contains(text, "OTEL_EXPORTER_OTLP_ENDPOINT") && localEndpointText(text) {

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -368,6 +368,12 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 		// installer refuses it and there is no project path to find.
 		{runtime: "muse_code", path: filepath.Join(museConfigDir(home), "beacon-endpoint-hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		{runtime: "muse_code", path: filepath.Join(museConfigDir(home), "settings.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		// OpenHands is one file per scope, and both are reported because the runtime reads the
+		// first it finds rather than merging them: a repository with its own hooks.json shadows the
+		// user one entirely, so an inventory showing only the user file would report a working
+		// install for a machine where Beacon's hooks never run.
+		{runtime: "openhands", path: filepath.Join(openHandsUserDir(home), "hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "openhands", path: filepath.Join(work, ".openhands", "hooks.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 		// fx has no Beacon-written file, so all three are its own configuration. The two MCP files
 		// are the ones that carry information nothing else here reports: fx's profile server list
 		// and the workspace servers it shares with Claude-compatible runtimes.

--- a/cli/beacon/internal/endpoint/inventory/openhands_test.go
+++ b/cli/beacon/internal/endpoint/inventory/openhands_test.go
@@ -1,0 +1,90 @@
+package inventory
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// OpenHands' hooks.json is a file the user also edits, and its schema forbids top-level fields it
+// does not know -- so Beacon has no marker it could stamp there without failing validation and
+// taking every hook in the file down. Detection keys on the hook command instead, and both
+// directions matter: missing the install reports telemetry as absent on a machine that has it, and
+// claiming another runtime's hooks attributes someone else's install to OpenHands.
+func TestOpenHandsManagedDetectionReadsTheHookCommand(t *testing.T) {
+	for name, tc := range map[string]struct {
+		hooks string
+		want  bool
+	}{
+		"flag form":       {`{"stop":[{"matcher":"*","hooks":[{"type":"command","command":"'/opt/beacon/hooks/beacon-hooks' --platform openhands --log '/tmp/runtime.jsonl' stop"}]}]}`, true},
+		"equals form":     {`{"stop":[{"matcher":"*","hooks":[{"type":"command","command":"beacon-hooks --platform=openhands stop"}]}]}`, true},
+		"wrapper form":    {`{"hooks":{"Stop":[{"matcher":"*","hooks":[{"type":"command","command":"beacon-hooks --platform openhands stop"}]}]}}`, true},
+		"another runtime": {`{"stop":[{"matcher":"*","hooks":[{"type":"command","command":"beacon-hooks --platform claude stop"}]}]}`, false},
+		"opencode":        {`{"stop":[{"matcher":"*","hooks":[{"type":"command","command":"beacon-hooks --platform opencode stop"}]}]}`, false},
+		"the user's own":  {`{"stop":[{"matcher":"*","hooks":[{"type":"command","command":".openhands/hooks/on_stop.sh"}]}]}`, false},
+		"no hooks at all": {`{}`, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := beaconManaged(candidate{runtime: "openhands"}, []byte(tc.hooks))
+			if got != tc.want {
+				t.Errorf("beaconManaged(openhands) = %t, want %t for %s", got, tc.want, tc.hooks)
+			}
+		})
+	}
+}
+
+// OpenHands reads the first hooks.json it finds rather than merging the two, so a repository with
+// its own file shadows the user-level one entirely. Reporting both scopes is what lets an operator
+// see that -- an inventory showing only the user file would report a working install for a machine
+// where Beacon's hooks never run.
+func TestOpenHandsCandidatesCoverBothScopes(t *testing.T) {
+	t.Setenv("OH_PERSISTENCE_DIR", "")
+	home := t.TempDir()
+	work := t.TempDir()
+
+	items := openHandsCandidates(home, work)
+	if len(items) != 2 {
+		t.Fatalf("openHandsCandidates returned %d entries, want one per scope: %+v", len(items), items)
+	}
+	byScope := map[string]candidate{}
+	for _, item := range items {
+		byScope[item.scope] = item
+	}
+	if got, want := byScope[ScopeUser].path, filepath.Join(home, ".openhands", "hooks.json"); got != want {
+		t.Errorf("user candidate = %q, want %q", got, want)
+	}
+	if got, want := byScope[ScopeProject].path, filepath.Join(work, ".openhands", "hooks.json"); got != want {
+		t.Errorf("project candidate = %q, want %q", got, want)
+	}
+	for _, item := range items {
+		// KindHookConfig rather than KindManagedConfig: Beacon merges into a file the user owns,
+		// it does not own the file.
+		if item.kind != KindHookConfig {
+			t.Errorf("candidate %q kind = %q, want %q", item.path, item.kind, KindHookConfig)
+		}
+		// The runtime name is the canonical harness name, so an inventory row and a telemetry row
+		// for the same machine name the same runtime.
+		if item.runtime != "openhands" {
+			t.Errorf("candidate %q runtime = %q, want openhands", item.path, item.runtime)
+		}
+	}
+}
+
+// Sandboxed and containerized setups redirect OpenHands state onto a volume with
+// OH_PERSISTENCE_DIR, and on a machine that sets it ~/.openhands is not where OpenHands looks. An
+// inventory scanning the wrong directory reports "not installed" for a working install.
+func TestOpenHandsUserCandidateHonorsThePersistenceDirEnv(t *testing.T) {
+	persistence := t.TempDir()
+	t.Setenv("OH_PERSISTENCE_DIR", persistence)
+
+	items := openHandsCandidates(t.TempDir(), t.TempDir())
+	for _, item := range items {
+		if item.scope != ScopeUser {
+			continue
+		}
+		if want := filepath.Join(persistence, "hooks.json"); item.path != want {
+			t.Fatalf("user candidate = %q, want %q", item.path, want)
+		}
+		return
+	}
+	t.Fatal("openHandsCandidates returned no user-scope entry")
+}


### PR DESCRIPTION
Fourth of five. Stacked on [#458](https://github.com/Asymptote-Labs/agent-beacon/pull/458) — review that one first.

## What this changes

The installer from [#458](https://github.com/Asymptote-Labs/agent-beacon/pull/458) is unreachable until this lands. Registering a runtime with `beacon endpoint hooks` means a registry row plus five switches — install, uninstall, status collection, status printing, repair — and every one of them fails by omission rather than by error. A missing repair case means `endpoint repair` reports success having skipped the runtime; a missing dashboard row means an operator checking their coverage concludes OpenHands is not supported.

## Aliases

`open-hands` is accepted alongside `openhands`, because the product is written as two words about as often as one and `normalizeHarnessKey` folds `open_hands` onto it.

`openhands-lm` is deliberately **not** an alias: that is All Hands' model family, and accepting it would let someone ask to install hooks for a model and get an install for the agent under a different name.

## OpenHands stays in the `--all` sweep at both levels

Unlike Hermes and Muse Code. Its project scope is the documented one — the only one the agent server behind the CLI and the GUI reads — so filtering it out of the project sweep would drop the scope that matters most.

## A user-scope install says what it does not cover

One line at install time, because that is the case where a successful install still collects nothing: OpenHands reads the first `hooks.json` it finds rather than merging the two, so a repository with its own file shadows the user one, and the agent server never consults the user file at all. Better said here than discovered from an empty log.

## Inventory

Reports both scopes, for the same reason — showing only the user file would report a working install for a machine where Beacon's hooks never run — and detects the install by the hook command rather than by a marker, because `hooks.json` forbids top-level fields it does not know and a marker would fail validation and take every hook in the file down with it.

## Tests

`go test ./...` and `go test -race ./internal/endpoint/...` in `cli/beacon`. New: `cmd/openhands_target_test.go` (install → status → uninstall through the CLI entry points, at both levels; repair-list membership; alias resolution; that OpenHands LM ids are not aliases; that `opencode` and `openhands` stay separate targets; that neither `--all` level drops it), `internal/endpoint/dashboard/openhands_test.go`, and `internal/endpoint/inventory/openhands_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014A1KXwcjN7RutVkoF7UbXL

---
_Generated by [Claude Code](https://claude.ai/code/session_014A1KXwcjN7RutVkoF7UbXL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive wiring and inventory/dashboard reporting around existing hook installers; no auth or data-path changes beyond writing/reading known OpenHands config locations.
> 
> **Overview**
> **OpenHands** is registered end-to-end so the hook installer from the stacked PR is reachable through `beacon endpoint hooks` and related surfaces.
> 
> The harness registry accepts `openhands` and `open-hands` (not model names like `openhands-lm`), and **openhands** is included in `--all` sweeps at **both** user and project levels—unlike Hermes/Muse—because project `.openhands/hooks.json` is what the agent server reads. Install/uninstall/status/repair lists and diagnostics hook status collection all gain **openhands** cases; **user-scope install** prints a one-line note that repo-level hooks shadow user hooks and that CLI/GUI need `--level project`.
> 
> The endpoint **dashboard** inventory API reports OpenHands hook status. **Inventory** scans user and project `hooks.json` paths (honoring `OH_PERSISTENCE_DIR`), classifies them as hook configs merged into user-owned files, and detects Beacon installs via `--platform openhands` instead of a file marker (schema forbids extra top-level keys).
> 
> New tests cover CLI round-trips, repair-list membership, alias rules, dashboard presence, and inventory detection/candidates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 471cb9ea626344c7bdb5210885ade1a1f9fa9599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->