### PR TITLE
Grok Bot support (1/4): harness identity

### DIFF
--- a/pkg/asymptoteobserve/harness.go
+++ b/pkg/asymptoteobserve/harness.go
@@ -198,6 +198,28 @@ func NormalizeHarnessName(name string) string {
 		lower == "openhands_agent" || lower == "openhands-agent" || lower == "openhands agent" ||
 		lower == "openhands.dev":
 		return "openhands"
+	// Grok Bot is xAI's always-on agent product: each Bot runs on a Cursor-hosted cloud computer
+	// and the desktop app is a client to it. It is a different product from Grok Build, the xAI
+	// terminal coding agent Beacon hooks under the `grok` harness, and the two must never share a
+	// name: one runs on the endpoint under the operator's own account, the other runs in a vendor
+	// cloud and reaches Beacon only through Cursor's server-side OpenTelemetry export (resource
+	// attribute cursor.surface=grok_bot). A query grouping by harness.name that merged them would
+	// file cloud-computer shell commands under a local CLI.
+	//
+	// Equality against a closed set, and deliberately narrower than every other xAI spelling.
+	// "grok" alone is Grok Build and stays on the passthrough path as itself; "grok-4", "grok-4.6"
+	// and the other model ids also begin with the same four letters, so a Contains(lower, "grok")
+	// rule would claim both the sibling product and any event whose harness attribute carried a
+	// model string. Those fall through and show up as themselves, which is the visible anomaly a
+	// reader can act on rather than a silent misattribution.
+	//
+	// The canonical spelling is grok_bot because that is what the product is called and what
+	// Cursor's own export writes for the surface; it follows claude_code and muse_code, not a CLI
+	// suffix, because there is no CLI.
+	case lower == "grok_bot" || lower == "grok-bot" || lower == "grok bot" || lower == "grokbot" ||
+		lower == "grok_bot_desktop" || lower == "grok-bot-desktop" || lower == "cursor.grok_bot" ||
+		lower == "cursor/grok_bot" || lower == "xai_grok_bot" || lower == "xai-grok-bot":
+		return "grok_bot"
 	case name != "":
 		// An unrecognized runtime keeps its own name rather than being coerced or dropped. A new
 		// harness should show up in the log as itself, not as "unknown".

--- a/pkg/asymptoteobserve/harness_test.go
+++ b/pkg/asymptoteobserve/harness_test.go
@@ -41,7 +41,7 @@ func TestCanonicalNamesAreStableUnderRenormalization(t *testing.T) {
 		"claude_code", "codex_cli", "gemini_cli", "antigravity_cli", "vscode_copilot",
 		"copilot_cli", "claude_web", "chatgpt_web", "claude_cowork", "claude_agent_sdk",
 		"openclaw_gateway", "pi_cli", "omp", "cline", "qwen_code", "prime_agent", "vercel_fx",
-		"muse_code",
+		"muse_code", "grok_bot",
 	} {
 		t.Run(canonical, func(t *testing.T) {
 			if got := NormalizeHarnessName(canonical); got != canonical {
@@ -491,5 +491,59 @@ func TestOpenHandsCanonicalNameIsStableUnderRenormalization(t *testing.T) {
 	once := NormalizeHarnessName("openhands-cli")
 	if got := NormalizeHarnessName(once); got != once {
 		t.Fatalf("NormalizeHarnessName(%q) = %q, want %q", once, got, once)
+	}
+}
+
+// Grok Bot reaches Beacon under the spelling Cursor's server-side OpenTelemetry export writes for
+// its surface (grok_bot) and under whatever a reader types for the product's name. Pinning them
+// here is what keeps one Bot's actions from being recorded under two names.
+func TestGrokBotSpellingsConvergeOnGrokBot(t *testing.T) {
+	for _, in := range []string{
+		"grok_bot", "Grok_Bot", "GROK_BOT", " grok_bot ", "grok-bot", "Grok Bot", "grokbot",
+		"grok_bot_desktop", "grok-bot-desktop", "cursor.grok_bot", "cursor/grok_bot",
+		"xai_grok_bot", "xai-grok-bot",
+	} {
+		t.Run(in, func(t *testing.T) {
+			if got := NormalizeHarnessName(in); got != "grok_bot" {
+				t.Errorf("NormalizeHarnessName(%q) = %q, want %q", in, got, "grok_bot")
+			}
+		})
+	}
+}
+
+// Grok Build is the sibling product: xAI's terminal coding agent, hooked by Beacon under the
+// `grok` harness, running on the endpoint under the operator's account. Grok Bot runs on a
+// Cursor-hosted cloud computer. The two must never normalize into each other -- in either
+// direction -- because a query grouping by harness.name would then file cloud-computer shell
+// commands under a local CLI, or the reverse. `grok` stays on the passthrough path as itself,
+// which is the name Grok Build's hook installer already uses.
+func TestGrokBuildIsNotGrokBot(t *testing.T) {
+	for _, name := range []string{"grok", "Grok", "grok_build", "grok-build", "Grok Build", "grok_cli", "grok-cli"} {
+		t.Run(name, func(t *testing.T) {
+			if got := NormalizeHarnessName(name); got == "grok_bot" {
+				t.Errorf("NormalizeHarnessName(%q) = %q; Grok Build must not be reported as the "+
+					"Grok Bot harness", name, got)
+			}
+		})
+	}
+	if got := NormalizeHarnessName("grok"); got != "grok" {
+		t.Errorf("NormalizeHarnessName(%q) = %q, want the passthrough value the Grok Build hook "+
+			"installer already records", "grok", got)
+	}
+}
+
+// Every Grok model id begins with the same four letters as both products, which is the reason
+// the case is a closed set rather than Contains(lower, "grok"). A model string that somehow
+// reaches harness.name shows up as itself rather than being filed under the cloud agent.
+func TestGrokModelNamesAreNotTreatedAsGrokBot(t *testing.T) {
+	for _, name := range []string{
+		"grok-4", "grok-4.6", "grok-4-fast", "grok-code-fast-1", "grok_4", "Grok 4.6", "xai", "x.ai",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := NormalizeHarnessName(name); got == "grok_bot" {
+				t.Errorf("NormalizeHarnessName(%q) = %q; a Grok model id must not be reported as "+
+					"the Grok Bot harness", name, got)
+			}
+		})
 	}
 }

--- a/pkg/asymptoteobserve/identity.go
+++ b/pkg/asymptoteobserve/identity.go
@@ -33,6 +33,10 @@ var ToolCallIDKeys = []string{
 	"call_id",
 	"callId",
 	"callID",
+	// Cursor's server-side OpenTelemetry export names a Grok Bot MCP tool call and computer-use
+	// session by this key. It is the only place Beacon learns the id, because Grok Bot runs on
+	// a Cursor-hosted computer and has no hook path that would carry a runtime-native spelling.
+	"cursor.grok_bot.tool_call.id",
 }
 
 // eventIDNamespace is the fixed UUID namespace every Beacon event ID is derived

--- a/pkg/asymptoteobserve/identity_test.go
+++ b/pkg/asymptoteobserve/identity_test.go
@@ -112,3 +112,16 @@ func TestEventIDForLineIgnoresProvenanceMarkers(t *testing.T) {
 		t.Fatalf("provenance markers split one call into two IDs: %s and %s", hook, collector)
 	}
 }
+
+// Cursor's export is the only path that carries a Grok Bot tool-call id, and it carries it under
+// a vendor-prefixed key no other runtime writes. The alias belongs in this list rather than in
+// the exporter's Grok Bot normalizer so that gen_ai.tool.call.id is promoted the same way on
+// every capture path, which is the property the list exists for.
+func TestToolCallIDKeysIncludeCursorGrokBotSpelling(t *testing.T) {
+	for _, key := range ToolCallIDKeys {
+		if key == "cursor.grok_bot.tool_call.id" {
+			return
+		}
+	}
+	t.Fatal("ToolCallIDKeys does not include cursor.grok_bot.tool_call.id")
+}


### PR DESCRIPTION
First of a four-PR stack adding Grok Bot (xAI) telemetry, in the shape the Muse Code and OpenHands stacks used: identity, then the mapper, then the CLI, then the docs.

## What Grok Bot is, and why this stack looks different

Grok Bot is xAI's always-on agent product. Each Bot runs on a **Cursor-hosted cloud computer**, and the desktop app on a member's machine is a client to it. It exposes no hook API, no plugin or extension surface, no on-disk session store, and no local OpenTelemetry export, so there is no installer PR and no `beacon-hooks` mapper in this stack. The one telemetry channel is Cursor's Enterprise server-side OpenTelemetry Export, which tags Bot traffic with `cursor.surface=grok_bot`. PR 2 teaches the collector exporter that shape; PR 3 detects the desktop app; PR 4 documents it.

Grok Bot is a **different product from Grok Build**, the xAI terminal coding agent Beacon already hooks under the `grok` harness.

## What this changes

`NormalizeHarnessName` gains a `grok_bot` case, and `ToolCallIDKeys` gains `cursor.grok_bot.tool_call.id`, the key Cursor's export uses for a Bot's MCP tool call and computer-use session.

Identity lands first so the exporter (PR 2) and the discovery path (PR 3) cannot disagree about what to call it. `harness.name` is a release contract every downstream query groups by.

## Why the case is a closed set

Equality against a closed set rather than `Contains(lower, "grok")`, for two reasons at once:

- `grok` alone is Grok Build. A substring rule would fold the sibling product's local CLI sessions into the cloud agent, and a query grouping by `harness.name` would file cloud-computer shell commands under a laptop CLI. `grok` stays on the passthrough path as itself, which is the name Grok Build's hook installer already records.
- Every Grok model id (`grok-4`, `grok-4.6`, `grok-code-fast-1`) begins with the same four letters. Model spellings are deliberately left out of the set and fall through as themselves, which reads as an anomaly rather than as the agent.

The canonical spelling is `grok_bot` because that is the product's name and the value Cursor's own export writes for the surface. It follows `claude_code` and `muse_code`, not a CLI suffix, because there is no CLI.

## Tests

`go test ./...` in `pkg/asymptoteobserve`. New cases cover the accepted spellings, that `grok` and Grok Build spellings are never claimed, that Grok model ids are not either, that the canonical name is stable under re-normalization, and that the tool-call id alias is present.

## Stack

1. **← you are here** — harness identity
2. `claude/grok-bot-desktop-support-j20hm7-exporter` — collector exporter maps Cursor's Grok Bot export
3. `claude/grok-bot-desktop-support-j20hm7-discovery` — desktop app discovery in the CLI
4. `claude/grok-bot-desktop-support-j20hm7` — documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToDZaTnvpr59S5X16iPwDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToDZaTnvpr59S5X16iPwDZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release contract for `harness.name` and tool-call id promotion; mis-attributing `grok` vs `grok_bot` would skew security analytics, though the closed-set rules and new tests target that failure mode.
> 
> **Overview**
> Adds **Grok Bot** (`grok_bot`) to Beacon’s shared identity layer so Cursor’s server-side OTLP export and any other writers agree on `harness.name` before later stack PRs map and discover the product.
> 
> **`NormalizeHarnessName`** now maps a fixed set of Grok Bot spellings (e.g. `grok-bot`, `cursor.grok_bot`, `xai-grok-bot`) to **`grok_bot`**, deliberately **not** folding in **`grok`** (Grok Build), Grok Build variants, or model ids like `grok-4`, so cloud Bot activity is not merged with the local terminal agent in harness-grouped queries.
> 
> **`ToolCallIDKeys`** gains **`cursor.grok_bot.tool_call.id`**, the vendor key Cursor uses for Grok Bot MCP/computer-use sessions where no hook path supplies a runtime-native id, so promotion to **`gen_ai.tool.call.id`** stays consistent across capture paths.
> 
> Tests cover spelling convergence, stability under re-normalization, separation from Grok Build and model strings, and presence of the new tool-call id key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b76129fbefcb4110a76b212a0b8acea7ef252658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->