### PR TITLE
Grok Bot support (2/4): map Cursor's Grok Bot OpenTelemetry export

### DIFF
--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -327,6 +327,7 @@ func (c Converter) EventFromLog(resourceAttrs map[string]interface{}, record plo
 	})
 	c.NormalizeCodexLogEvent(&event, attrs)
 	c.NormalizeClaudeLogEvent(&event, attrs, body)
+	c.NormalizeCursorGrokBotLogEvent(&event, attrs, body)
 	// Last, so it sees the action and category the normalizers settled on rather
 	// than the ones InferAction guessed.
 	c.PromoteRetainedContent(&event, attrs, body)
@@ -1023,8 +1024,9 @@ func (c Converter) usageEventFromDataPoint(resourceAttrs map[string]interface{},
 		}
 		event.GenAI.Usage.CostUSD = &cost
 	} else {
-		ApplyTokenUsage(&event, FirstString(attrs, "type", "token_type", "gen_ai.token.type"), int64(math.Round(value)))
+		ApplyTokenUsage(&event, FirstString(attrs, "type", "token_type", "gen_ai.token.type", "cursor.token.type"), int64(math.Round(value)))
 	}
+	applyCursorGrokBotContext(&event, attrs)
 	rawExtra := map[string]interface{}{
 		"otel_signal":        "metrics",
 		"metric_name":        metric.Name(),
@@ -1087,7 +1089,7 @@ func (c Converter) PopulateCommon(event *Event, attrs map[string]interface{}) {
 	if version := FirstString(attrs, "service.version"); version != "" {
 		event.Harness.Version = version
 	}
-	event.Model = FirstString(attrs, "gen_ai.request.model", "gen_ai.response.model", "model", "ai.model")
+	event.Model = FirstString(attrs, "gen_ai.request.model", "gen_ai.response.model", "model", "ai.model", "cursor.model.name")
 	event.Repository = FirstString(attrs, "vcs.repository.url", "repository", "repo.path", "workspace.repository")
 	event.Branch = FirstString(attrs, "vcs.branch.name", "git.branch", "branch")
 	if id := FirstString(attrs, "gen_ai.conversation.id", "beacon.session.id", "copilot_chat.session_id", "copilot_chat.chat_session_id", "conversation.id", "conversation_id", "session.id"); id != "" || FirstString(attrs, "cwd", "working_directory", "workspace") != "" {
@@ -1881,6 +1883,12 @@ func HarnessName(attrs map[string]interface{}, hints ...string) string {
 	name := FirstString(attrs, "beacon.harness.name", "harness.name", "service.name", "telemetry.sdk.name")
 	if explicit := FirstString(attrs, "beacon.harness.name", "harness.name"); explicit != "" {
 		return NormalizeHarnessName(explicit)
+	}
+	// Cursor's server-side export reports service.name=cursor for every surface it carries, so
+	// the service name alone would file a Grok Bot's cloud-computer shell commands under the
+	// Cursor IDE harness. The surface attribute is the only thing that tells them apart.
+	if IsCursorGrokBotSurface(attrs) {
+		return "grok_bot"
 	}
 	candidates := append([]string{name}, hints...)
 	for _, candidate := range candidates {

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/cursor_grokbot.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/cursor_grokbot.go
@@ -1,0 +1,191 @@
+package beaconevent
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+)
+
+// Grok Bot is xAI's always-on agent product. Each Bot runs on a Cursor-hosted cloud computer,
+// and the desktop app is a client to it, so there is no hook, plugin, or session store on the
+// endpoint for Beacon to read. The one telemetry channel is Cursor's server-side OpenTelemetry
+// export: OTLP/HTTP logs and metrics pushed from Cursor's infrastructure to a collector the
+// customer runs, with the resource attribute cursor.surface=grok_bot marking Bot traffic and the
+// log body carrying the event name (grok_bot_shell_command, grok_bot_mcp_tool_call, ...).
+//
+// The shapes below follow Cursor's published wire reference for that export. Every attribute is
+// vendor-prefixed and none of them appear on any other runtime, so this normalizer is selected by
+// the surface attribute alone and is a no-op for everything else -- including Cursor's other
+// surfaces (desktop, cli, cloud_agent, bugbot), which keep the passthrough `cursor` name.
+//
+// What is deliberately not done here: no approval is synthesized. Cursor names the shell-policy
+// decision itself on every shell event (cursor.grok_bot.shell.allowed), so a blocked command is
+// an observed denial, not one Beacon derived. Tool arguments, results, prompts, screenshots, and
+// coordinates never leave Cursor's side of the export, so none of those fields are promoted or
+// invented.
+
+const (
+	cursorSurfaceKey     = "cursor.surface"
+	cursorSurfaceGrokBot = "grok_bot"
+
+	cursorGrokBotShellCommand       = "grok_bot_shell_command"
+	cursorGrokBotMCPToolCall        = "grok_bot_mcp_tool_call"
+	cursorGrokBotBrowserNavigation  = "grok_bot_browser_navigation"
+	cursorGrokBotComputerUseSession = "grok_bot_computer_use_session"
+	cursorAPIRequest                = "api_request"
+	cursorAPIError                  = "api_error"
+)
+
+// IsCursorGrokBotSurface reports whether the merged attributes carry Cursor's marker for Grok
+// Bot traffic. It is the sole selector for the Grok Bot harness on the OTLP path: the export's
+// service.name is `cursor` for every surface, so the service name alone cannot tell a Bot's
+// cloud-computer shell command from a Cursor IDE session.
+func IsCursorGrokBotSurface(attrs map[string]interface{}) bool {
+	return strings.EqualFold(strings.TrimSpace(FirstString(attrs, cursorSurfaceKey)), cursorSurfaceGrokBot)
+}
+
+// CursorLogEventName reads the event name Cursor's export writes in the log body, falling back to
+// an event.name attribute for a collector pipeline that has already moved it there.
+func CursorLogEventName(attrs map[string]interface{}, body string) string {
+	return strings.ToLower(strings.TrimSpace(FirstNonEmpty(body, FirstString(attrs, "event.name"))))
+}
+
+// NormalizeCursorGrokBotLogEvent maps one Grok Bot log record onto Beacon's event vocabulary.
+// Runs after InferActionWithFidelity, whose keyword fallback has no idea what a
+// `grok_bot_shell_command` body is; every arm below is selected by an exact body match, so the
+// action it settles on is observed rather than inferred. An unrecognized body keeps the fallback
+// action and its inferred fidelity, which is the honest reading of a Cursor event Beacon has not
+// seen before.
+func (c Converter) NormalizeCursorGrokBotLogEvent(event *Event, attrs map[string]interface{}, body string) {
+	if event == nil || event.Harness.Name != "grok_bot" {
+		return
+	}
+	applyCursorGrokBotContext(event, attrs)
+	observed := asymptoteobserve.FidelityObserved
+	switch CursorLogEventName(attrs, body) {
+	case cursorGrokBotShellCommand:
+		command := FirstString(attrs, "cursor.grok_bot.shell.command")
+		target := strings.ToLower(FirstString(attrs, "cursor.grok_bot.shell.target"))
+		// The Bot's cloud computer is the default; only a command Cursor says ran on the member's
+		// own desktop through the local-execution helper is local. That is the one Grok Bot action
+		// that touches an endpoint, and origin is how a reader finds it.
+		if target == "user_machine" {
+			event.Origin = asymptoteobserve.OriginLocal
+		}
+		if allowed, ok := BoolAttr(attrs, "cursor.grok_bot.shell.allowed"); ok && !allowed {
+			// Cursor's shell policy stopped the command before it ran. The decision is Cursor's own
+			// field, not something read off an adjacent event, so it is recorded as an observed
+			// denial rather than withheld.
+			event.Event.Action = "approval.denied"
+			event.Event.Category = "approval"
+			event.Approval = &ApprovalInfo{Required: true, Decision: "denied", Reason: FirstString(attrs, "cursor.grok_bot.shell.blocked_reason")}
+			if event.Severity == "info" {
+				event.Severity = "medium"
+			}
+			event.Message = "Grok Bot shell command blocked by policy"
+		} else {
+			event.Event.Action = "command.executed"
+			event.Event.Category = "command"
+			event.Message = "Grok Bot shell command executed"
+		}
+		event.Event.Fidelity = observed
+		if command != "" {
+			event.Command = &CommandInfo{Command: command}
+			event.Tool = &ToolInfo{Name: "shell", Command: command}
+		}
+	case cursorGrokBotMCPToolCall:
+		tool := FirstString(attrs, "cursor.tool.name")
+		server := FirstString(attrs, "cursor.mcp.server.name")
+		if strings.EqualFold(FirstString(attrs, "cursor.tool.status"), "failure") {
+			event.Event.Action = "tool.failed"
+			event.Event.Category = "tool"
+			if event.Severity == "info" {
+				event.Severity = "high"
+			}
+			event.Message = "Grok Bot MCP tool call failed"
+		} else {
+			event.Event.Action = "mcp.tool_invoked"
+			event.Event.Category = "mcp"
+			event.Message = "Grok Bot MCP tool call"
+		}
+		event.Event.Fidelity = observed
+		if tool != "" || server != "" {
+			event.MCP = &MCPInfo{Server: server, Tool: tool}
+		}
+		if tool != "" {
+			event.Tool = &ToolInfo{Name: tool}
+		}
+	case cursorGrokBotBrowserNavigation:
+		event.Event.Action = "tool.invoked"
+		event.Event.Category = "tool"
+		event.Event.Fidelity = observed
+		event.Tool = &ToolInfo{Name: "browser_navigation"}
+		event.Message = "Grok Bot browser navigation"
+		// Cursor normalizes the URL to scheme://host/path before export. The host is the part a
+		// detection can match on, and server.address is the schema field that already means "the
+		// remote end of this action".
+		if raw := FirstString(attrs, "cursor.grok_bot.browser.url"); raw != "" {
+			event.Message = raw
+			if parsed, err := url.Parse(raw); err == nil && parsed.Host != "" {
+				event.Server = &ServerInfo{Address: parsed.Hostname()}
+			}
+		}
+	case cursorGrokBotComputerUseSession:
+		event.Event.Action = "tool.invoked"
+		event.Event.Category = "tool"
+		event.Event.Fidelity = observed
+		event.Tool = &ToolInfo{Name: "computer_use"}
+		event.Message = "Grok Bot computer use session"
+	case cursorAPIRequest:
+		// Same classification Claude Code's api_request gets: a model call is session activity,
+		// and the token counts on it are the only per-request usage this export carries.
+		event.Event.Action = "session.activity"
+		event.Event.Category = "session"
+		event.Event.Fidelity = observed
+		event.Message = "Grok Bot model request"
+		for tokenType, key := range map[string]string{
+			"input":          "cursor.api.request.input_tokens",
+			"output":         "cursor.api.request.output_tokens",
+			"cache_read":     "cursor.api.request.cache_read_tokens",
+			"cache_creation": "cursor.api.request.cache_creation_tokens",
+		} {
+			if value, ok := Int64Attr(attrs, key); ok {
+				ApplyTokenUsage(event, tokenType, value)
+			}
+		}
+		if event.GenAI != nil {
+			// ApplyTokenUsage records the last type it saw as gen_ai.token.type, which describes a
+			// single-count datapoint and not a request carrying all four counts at once.
+			event.GenAI.Token = nil
+		}
+	case cursorAPIError:
+		event.Event.Action = "session.error"
+		event.Event.Category = "session"
+		event.Event.Fidelity = observed
+		event.Message = "Grok Bot model request failed"
+	}
+}
+
+// applyCursorGrokBotContext sets the fields every Grok Bot record shares, on the log and the
+// metric path alike: the conversation id Cursor uses as the session key, a cloud origin (the
+// shell normalizer overrides it for a command that ran on the member's machine), and the export's
+// opaque team-scoped user id in place of the collector process user, which has nothing to do
+// with whoever was driving the Bot.
+func applyCursorGrokBotContext(event *Event, attrs map[string]interface{}) {
+	if event == nil || !IsCursorGrokBotSurface(attrs) {
+		return
+	}
+	if id := FirstString(attrs, "cursor.conversation.id"); id != "" {
+		if event.Session == nil {
+			event.Session = &SessionInfo{}
+		}
+		if event.Session.ID == "" {
+			event.Session.ID = id
+		}
+	}
+	if event.Origin == "" {
+		event.Origin = asymptoteobserve.OriginCloud
+	}
+	event.User = UserInfo{UID: FirstString(attrs, "cursor.user.id")}
+}

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/cursor_grokbot_test.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/cursor_grokbot_test.go
@@ -1,0 +1,270 @@
+package beaconevent
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
+)
+
+// The fixture is built from Cursor's published wire reference for its server-side OpenTelemetry
+// export, restricted to the grok_bot surface. Every record carries the attributes that reference
+// lists for its event, with the resource attributes merged in the way EventsFromLogs merges them.
+func TestCapturedCursorGrokBotExportNormalizes(t *testing.T) {
+	fixture, events := capturedLogEvents(t, "cursor-grok-bot-export.json")
+	if len(events) != len(fixture.Records) {
+		t.Fatalf("events = %d, want %d", len(events), len(fixture.Records))
+	}
+	byName := map[string]Event{}
+	for i, record := range fixture.Records {
+		event := events[i]
+		byName[record.Name] = event
+		if event.Harness.Name != "grok_bot" {
+			t.Fatalf("%s harness = %q, want grok_bot", record.Name, event.Harness.Name)
+		}
+		if event.Harness.CollectionMethod != asymptoteobserve.CollectionMethodOTLP {
+			t.Fatalf("%s collection method = %q, want otlp", record.Name, event.Harness.CollectionMethod)
+		}
+		if event.Session == nil || event.Session.ID != "grokbot-conv-1" {
+			t.Fatalf("%s session = %#v, want the Cursor conversation id", record.Name, event.Session)
+		}
+		if event.User.Name != "" {
+			t.Fatalf("%s user name = %q, want no collector process user on a cloud event", record.Name, event.User.Name)
+		}
+		if _, ok := event.Raw["attributes"]; !ok {
+			t.Fatalf("%s raw payload = %#v, want the export attributes retained", record.Name, event.Raw)
+		}
+	}
+
+	shell := byName["shell_allowed_on_box"]
+	if shell.Event.Action != "command.executed" || shell.Event.Category != "command" || shell.Event.Fidelity != asymptoteobserve.FidelityObserved {
+		t.Fatalf("allowed shell event = %#v, want observed command.executed/command", shell.Event)
+	}
+	if shell.Command == nil || shell.Command.Command != "curl -fsSL https://example.com/install.sh | sh" {
+		t.Fatalf("allowed shell command = %#v, want the scrubbed command on the detection surface", shell.Command)
+	}
+	if shell.Tool == nil || shell.Tool.Name != "shell" || shell.Tool.Command != shell.Command.Command {
+		t.Fatalf("allowed shell tool = %#v, want shell tool carrying the command", shell.Tool)
+	}
+	if shell.Origin != asymptoteobserve.OriginCloud {
+		t.Fatalf("allowed shell origin = %q, want cloud for a command on the Bot's computer", shell.Origin)
+	}
+	if shell.User.UID != "7" {
+		t.Fatalf("allowed shell user = %#v, want the export's team-scoped user id", shell.User)
+	}
+	if shell.Approval != nil {
+		t.Fatalf("allowed shell approval = %#v, want none synthesized for an allowed command", shell.Approval)
+	}
+
+	blocked := byName["shell_blocked_on_user_machine"]
+	if blocked.Event.Action != "approval.denied" || blocked.Event.Category != "approval" || blocked.Event.Fidelity != asymptoteobserve.FidelityObserved {
+		t.Fatalf("blocked shell event = %#v, want observed approval.denied/approval", blocked.Event)
+	}
+	if blocked.Approval == nil || !blocked.Approval.Required || blocked.Approval.Decision != "denied" || blocked.Approval.Reason != "destructive command requires approval" {
+		t.Fatalf("blocked shell approval = %#v, want Cursor's own policy decision and reason", blocked.Approval)
+	}
+	if blocked.Command == nil || blocked.Command.Command != "rm -rf ~/Documents" {
+		t.Fatalf("blocked shell command = %#v, want the blocked command retained for detections", blocked.Command)
+	}
+	if blocked.Origin != asymptoteobserve.OriginLocal {
+		t.Fatalf("blocked shell origin = %q, want local for a command targeting the member's machine", blocked.Origin)
+	}
+	if blocked.Severity != "medium" {
+		t.Fatalf("blocked shell severity = %q, want medium", blocked.Severity)
+	}
+
+	mcp := byName["mcp_tool_success"]
+	if mcp.Event.Action != "mcp.tool_invoked" || mcp.Event.Category != "mcp" || mcp.Event.Fidelity != asymptoteobserve.FidelityObserved {
+		t.Fatalf("mcp event = %#v, want observed mcp.tool_invoked/mcp", mcp.Event)
+	}
+	if mcp.MCP == nil || mcp.MCP.Server != "linear" || mcp.MCP.Tool != "create_issue" {
+		t.Fatalf("mcp = %#v, want server and tool from the export", mcp.MCP)
+	}
+	if mcp.GenAI == nil || mcp.GenAI.Tool == nil || mcp.GenAI.Tool.Call == nil || mcp.GenAI.Tool.Call.ID != "call-mcp-1" {
+		t.Fatalf("mcp gen_ai = %#v, want cursor.grok_bot.tool_call.id promoted to gen_ai.tool.call.id", mcp.GenAI)
+	}
+
+	failed := byName["mcp_tool_failure"]
+	if failed.Event.Action != "tool.failed" || failed.Event.Category != "tool" {
+		t.Fatalf("failed mcp event = %#v, want tool.failed/tool", failed.Event)
+	}
+	if failed.MCP == nil || failed.MCP.Server != "postgres" || failed.MCP.Tool != "query" {
+		t.Fatalf("failed mcp = %#v, want server and tool retained on failure", failed.MCP)
+	}
+	if failed.Severity != "high" {
+		t.Fatalf("failed mcp severity = %q, want high", failed.Severity)
+	}
+
+	nav := byName["browser_navigation"]
+	if nav.Event.Action != "tool.invoked" || nav.Tool == nil || nav.Tool.Name != "browser_navigation" {
+		t.Fatalf("navigation event = %#v tool = %#v, want tool.invoked by browser_navigation", nav.Event, nav.Tool)
+	}
+	if nav.Server == nil || nav.Server.Address != "admin.example.com" {
+		t.Fatalf("navigation server = %#v, want the URL host on server.address", nav.Server)
+	}
+	if nav.Message != "https://admin.example.com/billing/export" {
+		t.Fatalf("navigation message = %q, want the normalized URL", nav.Message)
+	}
+
+	computer := byName["computer_use_session"]
+	if computer.Event.Action != "tool.invoked" || computer.Tool == nil || computer.Tool.Name != "computer_use" {
+		t.Fatalf("computer use event = %#v tool = %#v, want tool.invoked by computer_use", computer.Event, computer.Tool)
+	}
+	if computer.GenAI == nil || computer.GenAI.Tool == nil || computer.GenAI.Tool.Call == nil || computer.GenAI.Tool.Call.ID != "call-cu-1" {
+		t.Fatalf("computer use gen_ai = %#v, want the tool-call id promoted", computer.GenAI)
+	}
+
+	request := byName["api_request"]
+	if request.Event.Action != "session.activity" || request.Event.Category != "session" || request.Event.Fidelity != asymptoteobserve.FidelityObserved {
+		t.Fatalf("api_request event = %#v, want observed session.activity/session", request.Event)
+	}
+	if request.Model != "grok-4.6" {
+		t.Fatalf("api_request model = %q, want cursor.model.name", request.Model)
+	}
+	usage := request.GenAI
+	if usage == nil || usage.Usage == nil || usage.Usage.InputTokens == nil || *usage.Usage.InputTokens != 1200 ||
+		usage.Usage.OutputTokens == nil || *usage.Usage.OutputTokens != 340 ||
+		usage.Usage.CacheRead == nil || usage.Usage.CacheRead.InputTokens == nil || *usage.Usage.CacheRead.InputTokens != 900 {
+		t.Fatalf("api_request usage = %#v, want input/output/cache_read from the request counts", request.GenAI)
+	}
+	if usage.Token != nil {
+		t.Fatalf("api_request token = %#v, want no single token type on a multi-count request", usage.Token)
+	}
+
+	apiError := byName["api_error"]
+	if apiError.Event.Action != "session.error" || apiError.Severity != "info" {
+		// Severity follows the record's own severity text, which the fixture leaves unset.
+		t.Fatalf("api_error event = %#v severity = %q, want session.error", apiError.Event, apiError.Severity)
+	}
+
+	future := byName["unknown_future_event"]
+	if future.Event.Fidelity != asymptoteobserve.FidelityInferred {
+		t.Fatalf("unknown body fidelity = %q, want inferred: a Cursor event Beacon has not seen keeps the fallback classification", future.Event.Fidelity)
+	}
+}
+
+// The export writes service.name=cursor on every surface, so the surface attribute is the only
+// thing that separates a Bot's cloud-computer shell command from a Cursor IDE session. Only the
+// grok_bot surface is claimed; the others keep the passthrough name Cursor's hook path already
+// records, and an explicit harness.name still wins over both.
+func TestCursorSurfaceSelectsGrokBotHarness(t *testing.T) {
+	for name, tc := range map[string]struct {
+		attrs map[string]interface{}
+		want  string
+	}{
+		"grok_bot surface":         {map[string]interface{}{"service.name": "cursor", "cursor.surface": "grok_bot"}, "grok_bot"},
+		"surface case-insensitive": {map[string]interface{}{"service.name": "cursor", "cursor.surface": "GROK_BOT"}, "grok_bot"},
+		"desktop surface":          {map[string]interface{}{"service.name": "cursor", "cursor.surface": "desktop"}, "cursor"},
+		"cloud_agent surface":      {map[string]interface{}{"service.name": "cursor", "cursor.surface": "cloud_agent"}, "cursor"},
+		"no surface":               {map[string]interface{}{"service.name": "cursor"}, "cursor"},
+		"explicit harness wins":    {map[string]interface{}{"harness.name": "muse", "cursor.surface": "grok_bot"}, "muse_code"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := HarnessName(tc.attrs); got != tc.want {
+				t.Fatalf("HarnessName(%v) = %q, want %q", tc.attrs, got, tc.want)
+			}
+		})
+	}
+}
+
+// A Cursor export record from another surface must not be touched by the Grok Bot normalizer,
+// even when its body is one the normalizer knows.
+func TestCursorGrokBotNormalizerIgnoresOtherCursorSurfaces(t *testing.T) {
+	record := plog.NewLogRecord()
+	record.Body().SetStr("api_request")
+	record.Attributes().PutStr("service.name", "cursor")
+	record.Attributes().PutStr("cursor.surface", "desktop")
+	record.Attributes().PutStr("cursor.conversation.id", "ide-conv")
+	record.Attributes().PutInt("cursor.user.id", 9)
+
+	event := NewConverter(Options{}).EventFromLog(nil, record)
+	if event.Harness.Name != "cursor" {
+		t.Fatalf("harness = %q, want cursor passthrough", event.Harness.Name)
+	}
+	if event.Origin != "" {
+		t.Fatalf("origin = %q, want unset: only grok_bot records are known to be cloud", event.Origin)
+	}
+	if event.Session != nil && event.Session.ID == "ide-conv" {
+		t.Fatalf("session = %#v, want cursor.conversation.id left alone off the grok_bot surface", event.Session)
+	}
+	if event.Message != "api_request" {
+		t.Fatalf("message = %q, want the untouched body", event.Message)
+	}
+}
+
+// Cursor's token metric names its type with cursor.token.type and its model with
+// cursor.model.name, and carries the surface on the resource; the datapoint has to land under
+// grok_bot with the type folded into gen_ai.usage like every other runtime's counter.
+func TestCursorGrokBotTokenUsageMetricNormalizes(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetrics.Resource().Attributes().PutStr("service.name", "cursor")
+	resourceMetrics.Resource().Attributes().PutStr("cursor.surface", "grok_bot")
+	resourceMetrics.Resource().Attributes().PutInt("cursor.team.id", 42)
+	resourceMetrics.Resource().Attributes().PutInt("cursor.user.id", 7)
+	metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("cursor.token.usage")
+	metric.SetUnit("{token}")
+	sum := metric.SetEmptySum()
+	sum.SetIsMonotonic(true)
+	sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	dp := sum.DataPoints().AppendEmpty()
+	dp.SetIntValue(512)
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(1700000300, 0).UTC()))
+	dp.Attributes().PutStr("cursor.token.type", "cache_read")
+	dp.Attributes().PutStr("cursor.model.name", "grok-4.6")
+
+	events := NewConverter(Options{}).EventsFromMetrics(metrics)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	event := events[0]
+	if event.Harness.Name != "grok_bot" {
+		t.Fatalf("harness = %q, want grok_bot from the resource surface", event.Harness.Name)
+	}
+	if event.Event.Action != "token.usage" {
+		t.Fatalf("action = %q, want token.usage", event.Event.Action)
+	}
+	if event.GenAI == nil || event.GenAI.Usage == nil || event.GenAI.Usage.CacheRead == nil || event.GenAI.Usage.CacheRead.InputTokens == nil || *event.GenAI.Usage.CacheRead.InputTokens != 512 {
+		t.Fatalf("usage = %#v, want cache_read input tokens 512", event.GenAI)
+	}
+	if event.Model != "grok-4.6" {
+		t.Fatalf("model = %q, want cursor.model.name", event.Model)
+	}
+	if event.Origin != asymptoteobserve.OriginCloud || event.User.UID != "7" || event.User.Name != "" {
+		t.Fatalf("origin/user = %q/%#v, want cloud origin and the export's user id", event.Origin, event.User)
+	}
+}
+
+// Cursor's cost metric follows the same suffix convention Beacon already keys on.
+func TestCursorGrokBotCostUsageMetricNormalizes(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetrics.Resource().Attributes().PutStr("service.name", "cursor")
+	resourceMetrics.Resource().Attributes().PutStr("cursor.surface", "grok_bot")
+	metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("cursor.cost.usage")
+	metric.SetUnit("USD")
+	sum := metric.SetEmptySum()
+	sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	dp := sum.DataPoints().AppendEmpty()
+	dp.SetDoubleValue(0.031)
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(1700000400, 0).UTC()))
+	dp.Attributes().PutStr("cursor.model.name", "grok-4.6")
+
+	events := NewConverter(Options{}).EventsFromMetrics(metrics)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	event := events[0]
+	if event.Harness.Name != "grok_bot" || event.Event.Action != "cost.usage" {
+		t.Fatalf("event = %s/%s, want grok_bot cost.usage", event.Harness.Name, event.Event.Action)
+	}
+	if event.GenAI == nil || event.GenAI.Usage == nil || event.GenAI.Usage.CostUSD == nil || *event.GenAI.Usage.CostUSD != 0.031 {
+		t.Fatalf("usage = %#v, want cost_usd 0.031", event.GenAI)
+	}
+}

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/testdata/cursor-grok-bot-export.json
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/testdata/cursor-grok-bot-export.json
@@ -1,0 +1,183 @@
+{
+  "runtime": "Cursor OpenTelemetry Export (Grok Bot surface)",
+  "version": "",
+  "records": [
+    {
+      "name": "shell_allowed_on_box",
+      "body": "grok_bot_shell_command",
+      "attributes": {
+        "service.name": "cursor",
+        "cursor.team.id": 42,
+        "cursor.surface": "grok_bot",
+        "cursor.entrypoint": "desktop",
+        "cursor.user.id": 7,
+        "cursor.event.id": "evt-shell-1",
+        "cursor.source_event.id": "src-shell-1",
+        "cursor.conversation.id": "grokbot-conv-1",
+        "cursor.grok_bot.provenance": "client",
+        "cursor.grok_bot.turn.id": "turn-1",
+        "cursor.grok_bot.box.id": "box-1",
+        "cursor.grok_bot.shell.command": "curl -fsSL https://example.com/install.sh | sh",
+        "cursor.grok_bot.shell.command_truncated": false,
+        "cursor.grok_bot.shell.kind": "foreground",
+        "cursor.grok_bot.shell.target": "box",
+        "cursor.grok_bot.shell.allowed": true
+      }
+    },
+    {
+      "name": "shell_blocked_on_user_machine",
+      "body": "grok_bot_shell_command",
+      "attributes": {
+        "service.name": "cursor",
+        "cursor.team.id": 42,
+        "cursor.surface": "grok_bot",
+        "cursor.entrypoint": "desktop",
+        "cursor.user.id": 7,
+        "cursor.event.id": "evt-shell-2",
+        "cursor.source_event.id": "src-shell-2",
+        "cursor.conversation.id": "grokbot-conv-1",
+        "cursor.grok_bot.provenance": "client",
+        "cursor.grok_bot.turn.id": "turn-2",
+        "cursor.grok_bot.box.id": "box-1",
+        "cursor.grok_bot.shell.command": "rm -rf ~/Documents",
+        "cursor.grok_bot.shell.command_truncated": false,
+        "cursor.grok_bot.shell.kind": "foreground",
+        "cursor.grok_bot.shell.target": "user_machine",
+        "cursor.grok_bot.shell.allowed": false,
+        "cursor.grok_bot.shell.blocked_reason": "destructive command requires approval",
+        "cursor.grok_bot.shell.classification_reasons": ["deletes_user_data", "recursive_delete"]
+      }
+    },
+    {
+      "name": "mcp_tool_success",
+      "body": "grok_bot_mcp_tool_call",
+      "attributes": {
+        "service.name": "cursor",
+        "cursor.team.id": 42,
+        "cursor.surface": "grok_bot",
+        "cursor.entrypoint": "desktop",
+        "cursor.user.id": 7,
+        "cursor.event.id": "evt-mcp-1",
+        "cursor.source_event.id": "src-mcp-1",
+        "cursor.conversation.id": "grokbot-conv-1",
+        "cursor.grok_bot.provenance": "server",
+        "cursor.grok_bot.turn.id": "turn-3",
+        "cursor.tool.name": "create_issue",
+        "cursor.tool.status": "success",
+        "cursor.grok_bot.mcp.transport": "http",
+        "cursor.grok_bot.mcp.duration_ms": 812,
+        "cursor.mcp.server.name": "linear",
+        "cursor.grok_bot.tool_call.id": "call-mcp-1"
+      }
+    },
+    {
+      "name": "mcp_tool_failure",
+      "body": "grok_bot_mcp_tool_call",
+      "attributes": {
+        "service.name": "cursor",
+        "cursor.team.id": 42,
+        "cursor.surface": "grok_bot",
+        "cursor.entrypoint": "desktop",
+        "cursor.user.id": 7,
+        "cursor.event.id": "evt-mcp-2",
+        "cursor.source_event.id": "src-mcp-2",
+        "cursor.conversation.id": "grokbot-conv-1",
+        "cursor.grok_bot.provenance": "client",
+        "cursor.grok_bot.box.id": "box-1",
+        "cursor.tool.name": "query",
+        "cursor.tool.status": "failure",
+        "cursor.grok_bot.mcp.transport": "stdio",
+        "cursor.grok_bot.mcp.duration_ms": 40,
+        "cursor.mcp.server.name": "postgres",
+        "cursor.grok_bot.tool_call.id": "call-mcp-2"
+      }
+    },
+    {
+      "name": "browser_navigation",
+      "body": "grok_bot_browser_navigation",
+      "attributes": {
+        "service.name": "cursor",
+        "cursor.team.id": 42,
+        "cursor.surface": "grok_bot",
+        "cursor.entrypoint": "desktop",
+        "cursor.user.id": 7,
+        "cursor.event.id": "evt-nav-1",
+        "cursor.source_event.id": "src-nav-1",
+        "cursor.conversation.id": "grokbot-conv-1",
+        "cursor.grok_bot.provenance": "client",
+        "cursor.grok_bot.box.id": "box-1",
+        "cursor.grok_bot.browser.url": "https://admin.example.com/billing/export",
+        "cursor.grok_bot.browser.page_title": "Billing export"
+      }
+    },
+    {
+      "name": "computer_use_session",
+      "body": "grok_bot_computer_use_session",
+      "attributes": {
+        "service.name": "cursor",
+        "cursor.team.id": 42,
+        "cursor.surface": "grok_bot",
+        "cursor.entrypoint": "desktop",
+        "cursor.user.id": 7,
+        "cursor.event.id": "evt-cu-1",
+        "cursor.source_event.id": "src-cu-1",
+        "cursor.conversation.id": "grokbot-conv-1",
+        "cursor.grok_bot.provenance": "client",
+        "cursor.grok_bot.box.id": "box-1",
+        "cursor.grok_bot.computer_use.action_count": 23,
+        "cursor.grok_bot.computer_use.duration_ms": 91000,
+        "cursor.grok_bot.computer_use.screenshot_count": 12,
+        "cursor.grok_bot.tool_call.id": "call-cu-1"
+      }
+    },
+    {
+      "name": "api_request",
+      "body": "api_request",
+      "attributes": {
+        "service.name": "cursor",
+        "cursor.team.id": 42,
+        "cursor.surface": "grok_bot",
+        "cursor.entrypoint": "desktop",
+        "cursor.user.id": 7,
+        "cursor.event.id": "evt-api-1",
+        "cursor.source_event.id": "src-api-1",
+        "cursor.conversation.id": "grokbot-conv-1",
+        "cursor.usage_event.id": "usage-1",
+        "cursor.api.request.input_tokens": 1200,
+        "cursor.api.request.output_tokens": 340,
+        "cursor.api.request.cache_read_tokens": 900,
+        "cursor.api.request.cache_creation_tokens": 0,
+        "cursor.model.name": "grok-4.6",
+        "cursor.api.billable": true
+      }
+    },
+    {
+      "name": "api_error",
+      "body": "api_error",
+      "attributes": {
+        "service.name": "cursor",
+        "cursor.team.id": 42,
+        "cursor.surface": "grok_bot",
+        "cursor.entrypoint": "desktop",
+        "cursor.event.id": "evt-api-2",
+        "cursor.source_event.id": "src-api-2",
+        "cursor.conversation.id": "grokbot-conv-1",
+        "cursor.model.name": "grok-4.6"
+      }
+    },
+    {
+      "name": "unknown_future_event",
+      "body": "grok_bot_file_transfer",
+      "attributes": {
+        "service.name": "cursor",
+        "cursor.team.id": 42,
+        "cursor.surface": "grok_bot",
+        "cursor.entrypoint": "desktop",
+        "cursor.user.id": 7,
+        "cursor.event.id": "evt-future-1",
+        "cursor.source_event.id": "src-future-1",
+        "cursor.conversation.id": "grokbot-conv-1"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Second of four. **Stacked on the identity PR** (`claude/grok-bot-desktop-support-j20hm7-identity`); this PR's diff is against it.

## The one channel Grok Bot has

Grok Bot runs on Cursor-hosted cloud computers and exposes nothing on the endpoint. Its telemetry reaches a customer only through **Cursor Enterprise OpenTelemetry Export** with Action Recording turned on: OTLP/HTTP protobuf logs and metrics pushed from Cursor's own servers to a collector the customer runs, with `cursor.surface=grok_bot` on the resource and the event name in the log body. This PR teaches the `beaconjson` exporter that shape, so a collector built from `collector-builder` files those records under `grok_bot` instead of the passthrough `cursor` name every surface of the export shares.

The mapping follows Cursor's published wire reference field by field; the fixture is built from it.

## What is mapped

Log records map by **exact body match**, so every classified action is `event.fidelity=observed`:

| Cursor body | Beacon action | Notes |
|---|---|---|
| `grok_bot_shell_command`, `shell.allowed=true` | `command.executed` | Secret-scrubbed command on `command.command` and `tool.command` |
| `grok_bot_shell_command`, `shell.allowed=false` | `approval.denied` | Cursor's own shell-policy decision and `blocked_reason`; the command stays on `command.command` so detections still see it |
| `grok_bot_mcp_tool_call` | `mcp.tool_invoked`, or `tool.failed` on `status=failure` | `mcp.server`, `mcp.tool`, `gen_ai.tool.call.id` |
| `grok_bot_browser_navigation` | `tool.invoked` (`browser_navigation`) | URL in `message`, host on `server.address` |
| `grok_bot_computer_use_session` | `tool.invoked` (`computer_use`) | Counts stay in `raw` |
| `api_request` | `session.activity` | Four request token counts folded into `gen_ai.usage`; model from `cursor.model.name` |
| `api_error` | `session.error` | |

Metrics pick up `cursor.token.type` and `cursor.model.name` as aliases, so `cursor.token.usage` and `cursor.cost.usage` land under `grok_bot` like every other runtime's counters.

Every Grok Bot record gets `session.id` from `cursor.conversation.id`, `origin=cloud`, and `cursor.user.id` in place of the collector process user, which has nothing to do with whoever drove the Bot. A shell command Cursor reports as `shell.target=user_machine` gets `origin=local`, because that is the one Grok Bot action that touches an endpoint.

## What is deliberately not done

- **No approval is synthesized.** Cursor names the shell-policy decision on every shell event, so a blocked command is an observed denial, not one Beacon derived from an adjacent event.
- **No fields are invented.** Tool arguments, results, prompts, file activity, screenshots and coordinates never leave Cursor's side of the export, so none are promoted.
- **Other Cursor surfaces are untouched.** The normalizer is selected by the surface attribute alone; `desktop`, `cli`, `cloud_agent` and `bugbot` keep the passthrough `cursor` name. A test pins that.
- **Unknown bodies keep the inferred fallback**, which is the honest reading of a Cursor event Beacon has not seen.

## Tests

`go test ./...` in `collector-builder/exporter/beaconjsonexporter`. A nine-record fixture (`testdata/cursor-grok-bot-export.json`) exercises every arm above plus an unknown body; further tests cover the surface-selects-harness rule with an explicit `harness.name` still winning, other surfaces staying untouched, and the token and cost metrics.

## Stack

1. `claude/grok-bot-desktop-support-j20hm7-identity` — harness identity
2. **← you are here** — collector exporter
3. `claude/grok-bot-desktop-support-j20hm7-discovery` — desktop app discovery in the CLI
4. `claude/grok-bot-desktop-support-j20hm7` — documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToDZaTnvpr59S5X16iPwDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToDZaTnvpr59S5X16iPwDZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event classification and harness naming for OTLP Cursor traffic (shell denials, commands, MCP), which affects downstream detections and dashboards; scope is limited to the grok_bot surface selector and additive normalizer.
> 
> **Overview**
> Teaches the **beaconjson** exporter to ingest **Cursor Enterprise OTLP** traffic for **Grok Bot** (`cursor.surface=grok_bot`), so cloud-agent telemetry is filed under harness **`grok_bot`** instead of generic **`cursor`** (every export surface shares `service.name=cursor`).
> 
> A new **`NormalizeCursorGrokBotLogEvent`** path maps log bodies by exact name—shell (executed vs **observed** `approval.denied` from `shell.allowed`), MCP, browser navigation, computer use, `api_request` / `api_error`—with shared context: **`cursor.conversation.id`** as session, **`origin=cloud`** (local when `shell.target=user_machine`), and **`cursor.user.id`** as user. **`HarnessName`** and metric handling gain **`cursor.token.type`** / **`cursor.model.name`** aliases plus the same Grok Bot context on token/cost usage metrics.
> 
> Other Cursor surfaces stay on the existing **`cursor`** path; unknown Grok Bot bodies keep inferred classification. Coverage is a wire-reference fixture and targeted harness/metric tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a80715a88421e70dfd90bf5bf8e6ca99b82536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->