### PR TITLE
Token spend coverage, wave 2 (1/n): record context size as its own field, not as usage

### DIFF
--- a/cli/beacon-hooks/cmd/endpoint_events.go
+++ b/cli/beacon-hooks/cmd/endpoint_events.go
@@ -66,6 +66,38 @@ func rawPayloadKey(platform string) string {
 	return rawPayloadKeys[platform]
 }
 
+// applyContextSize promotes a runtime's reported context size into gen_ai.context.
+//
+// Separate from usage on purpose. gen_ai.usage is additive and every report sums it; context size
+// is a level at one moment, and Qwen Code -- the first runtime to report one -- is exactly where
+// summing goes wrong: its Stop payload's input_tokens is the prompt for that turn, which already
+// contains every prior turn, so a session's total would grow with the square of its length. Read as
+// context occupancy the same number is exact and worth having.
+//
+// Both halves are required before either is written. "input_tokens" is Qwen's name for the context
+// measure and also the ecosystem's name for an additive usage count, so a reported limit beside it
+// is what says which one this payload means. Promoting a bare input_tokens here would reclassify
+// other runtimes' spend as context.
+//
+// Read from the shared alias lists rather than a per-runtime branch, the way tool call ids are, so
+// a second runtime reporting the same thing needs a spelling added and nothing else.
+func applyContextSize(fields, input map[string]interface{}) {
+	if fields == nil || input == nil {
+		return
+	}
+	limit, ok := firstToolIntAcross([]map[string]interface{}{input}, asymptoteobserve.ContextLimitKeys...)
+	if !ok || limit <= 0 {
+		return
+	}
+	used, ok := firstToolIntAcross([]map[string]interface{}{input}, asymptoteobserve.ContextUsedKeys...)
+	if !ok || used <= 0 {
+		return
+	}
+	fields["gen_ai"] = mergeNested(fields["gen_ai"], map[string]interface{}{
+		"context": map[string]interface{}{"used_tokens": used, "limit_tokens": limit},
+	})
+}
+
 func emitHookEventWithFidelity(logger *logging.Logger, action, category, severity, message, fidelity string, input map[string]interface{}, fields map[string]interface{}) {
 	if fields == nil {
 		fields = map[string]interface{}{}
@@ -75,6 +107,7 @@ func emitHookEventWithFidelity(logger *logging.Logger, action, category, severit
 		fields["raw"] = mergeNested(fields["raw"], map[string]interface{}{key: input})
 	}
 	applyToolCallID(fields, input)
+	applyContextSize(fields, input)
 	if model := getFirstStr(input, "model"); model != "" {
 		fields["model"] = model
 	}

--- a/cli/beacon-hooks/cmd/qwen_event_test.go
+++ b/cli/beacon-hooks/cmd/qwen_event_test.go
@@ -625,3 +625,29 @@ func TestQwenNotebookEditRecordsThePathWithoutClaimingADiff(t *testing.T) {
 			"asserting content Beacon never saw", diff)
 	}
 }
+
+// Why the model for Qwen occupancy has to be resolved when the log is read rather than when it is
+// written. Qwen names its model on session start and never again: the Stop payload -- the only one
+// carrying the context trio -- has no model field, so the emitted event has none either. Anything
+// keyed on the model, the token-usage utilization report included, has to recover it from the
+// session. Recording that here means a future change to this hook cannot quietly remove the reason
+// the reader does that work.
+func TestQwenStopEventCarriesNoModel(t *testing.T) {
+	logPath := setupQwenHook(t)
+
+	input := readQwenFixture(t, "stop.json")
+	if _, ok := input["model"]; ok {
+		t.Fatalf("stop fixture now has a model; the reader-side session lookup may no longer be needed: %#v", input)
+	}
+	sessionID, _ := resolveSessionIDWithTranscript(input, platformFlag)
+	logger := newHookLogger("stop", platformFlag, sessionID)
+	emitHookEvent(logger, "tool.completed", "tool", "info", "Agent response completed", input, sessionFields(sessionID, input))
+
+	event := lastEndpointEvent(t, logPath)
+	if model, ok := event["model"]; ok && fmt.Sprint(model) != "" {
+		t.Errorf("event.model = %v, want absent -- Qwen's Stop payload has no model to read", model)
+	}
+	if session, ok := event["session"].(map[string]interface{}); !ok || fmt.Sprint(session["id"]) == "" {
+		t.Errorf("event has no session id (%#v); without one the reader cannot recover the model", event["session"])
+	}
+}

--- a/cli/beacon-hooks/cmd/qwen_event_test.go
+++ b/cli/beacon-hooks/cmd/qwen_event_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -395,6 +396,54 @@ func TestQwenStopContextFieldsAreNotNormalizedIntoTokenUsage(t *testing.T) {
 		if payload[key] == nil {
 			t.Errorf("raw.qwen is missing %s, which is the only place it is preserved: %#v", key, payload)
 		}
+	}
+}
+
+// The other half of the same decision: the context measure IS normalized, into gen_ai.context
+// rather than gen_ai.usage.
+//
+// The reason they were withheld was never that the numbers are wrong -- they are exact -- but that
+// gen_ai.usage is additive and these are a level at one moment, so summing them inflates a session
+// by roughly the square of its length. A block that nothing sums is the right home, and it makes
+// Qwen's context utilization readable without making its spend wrong.
+//
+// input_tokens is the used-token count: the fixture's 110100 over a 262144 window is the 0.42 its
+// sibling context_usage reports, so context_usage is their ratio and stays in raw rather than being
+// stored a second time in different units.
+func TestQwenStopContextIsNormalizedIntoGenAIContext(t *testing.T) {
+	logPath := setupQwenHook(t)
+
+	input := readQwenFixture(t, "stop.json")
+	sessionID, _ := resolveSessionIDWithTranscript(input, platformFlag)
+	logger := newHookLogger("stop", platformFlag, sessionID)
+	emitHookEvent(logger, "tool.completed", "tool", "info", "Agent response completed", input, sessionFields(sessionID, input))
+
+	event := lastEndpointEvent(t, logPath)
+	genAI, ok := event["gen_ai"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("event has no gen_ai block: %#v", event)
+	}
+	context, ok := genAI["context"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("gen_ai has no context block: %#v", genAI)
+	}
+	raw := event["raw"].(map[string]interface{})["qwen"].(map[string]interface{})
+	for _, pair := range []struct{ normalized, source string }{
+		{"used_tokens", "input_tokens"},
+		{"limit_tokens", "context_limit"},
+	} {
+		got, want := context[pair.normalized], raw[pair.source]
+		if got == nil {
+			t.Errorf("gen_ai.context.%s missing, want the value of raw.qwen.%s (%v)", pair.normalized, pair.source, want)
+			continue
+		}
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Errorf("gen_ai.context.%s = %v, want raw.qwen.%s = %v", pair.normalized, got, pair.source, want)
+		}
+	}
+	// The additive block stays empty: this is the guarantee the sibling test above protects.
+	if usage, ok := genAI["usage"]; ok {
+		t.Fatalf("gen_ai.usage = %#v; context size must never land in the block reports sum", usage)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/schema/event.go
+++ b/cli/beacon/internal/endpoint/schema/event.go
@@ -98,6 +98,7 @@ type HealthInfo = asymptoteobserve.HealthInfo
 type ServerInfo = asymptoteobserve.ServerInfo
 type GenAIInfo = asymptoteobserve.GenAIInfo
 type GenAIAgentInfo = asymptoteobserve.GenAIAgentInfo
+type GenAIContextInfo = asymptoteobserve.GenAIContextInfo
 type GenAIConversationInfo = asymptoteobserve.GenAIConversationInfo
 type GenAIDataSourceInfo = asymptoteobserve.GenAIDataSourceInfo
 type GenAIEmbeddingsInfo = asymptoteobserve.GenAIEmbeddingsInfo

--- a/cli/beacon/internal/tokens/coverage.go
+++ b/cli/beacon/internal/tokens/coverage.go
@@ -228,6 +228,14 @@ func Coverage(events []schema.Event, installed []string) CoverageReport {
 		get(name).events++
 	}
 	for _, ue := range usageEvents {
+		if ue.contextOnly {
+			// The collector also yields events that reported only context occupancy. Those are
+			// not spend, so counting one here would mark a runtime covered on the strength of a
+			// number that never enters a total -- the precise false reassurance this report
+			// exists to prevent. Qwen Code is the live case: it reports how full its window was
+			// and never what a turn cost.
+			continue
+		}
 		name := asymptoteobserve.NormalizeHarnessName(strings.TrimSpace(ue.harness))
 		if name == "" {
 			continue

--- a/cli/beacon/internal/tokens/coverage_test.go
+++ b/cli/beacon/internal/tokens/coverage_test.go
@@ -332,3 +332,35 @@ func TestInstalledRuntimesDeduplicatesAndNeedsOnlyOneManagedRow(t *testing.T) {
 		t.Fatalf("InstalledRuntimes = %v, want [claude_code vscode]", got)
 	}
 }
+
+// The interaction between the two halves of this series. gen_ai.context events reach the shared
+// collector -- that is how the utilization report sees them -- so coverage would otherwise count
+// one as proof a runtime is reporting its spend. Qwen Code is the live case: it reports how full
+// its window was and never what a turn cost, so it must stay not_instrumented with zero usage
+// events. Counting occupancy as coverage would mark the one runtime whose spend Beacon cannot
+// read as fully covered, which is worse than saying nothing.
+func TestCoverageDoesNotCountContextOnlyEventsAsUsage(t *testing.T) {
+	events := []schema.Event{
+		usageEventFixture("2026-06-11T10:00:00Z", "qwen_code", "s1", "qwen3-coder-plus", func(e *schema.Event) {
+			e.GenAI.Usage = nil
+			e.GenAI.Context = &schema.GenAIContextInfo{
+				UsedTokens:  int64Ptr(110100),
+				LimitTokens: int64Ptr(262144),
+			}
+		}),
+	}
+	report := Coverage(events, []string{"qwen_code"})
+	line := lineFor(t, report, "qwen_code")
+	if line.Status != CoverageNotInstrumented {
+		t.Errorf("status = %q, want not_instrumented", line.Status)
+	}
+	if line.UsageEvents != 0 {
+		t.Errorf("usage events = %d, want 0 -- context occupancy is not spend", line.UsageEvents)
+	}
+	if line.Tokens != 0 {
+		t.Errorf("tokens = %d, want 0", line.Tokens)
+	}
+	if report.Covered != 0 {
+		t.Errorf("covered = %d, want 0", report.Covered)
+	}
+}

--- a/cli/beacon/internal/tokens/tokens.go
+++ b/cli/beacon/internal/tokens/tokens.go
@@ -130,6 +130,8 @@ type usageEvent struct {
 	spanID       string
 	parentSpanID string
 	usage        Usage
+	contextUsed  int64
+	contextLimit int64
 	cumulative   bool
 	metricName   string
 	rawSource    string
@@ -347,10 +349,17 @@ func userKey(user schema.UserInfo) string {
 func collectUsageEvents(events []schema.Event, sessionUsers sessionUserIndex) []*usageEvent {
 	var out []*usageEvent
 	for i, event := range events {
-		if event.GenAI == nil || event.GenAI.Usage == nil {
+		// Context-only events count too. A runtime can report how full the window was without
+		// reporting spend -- Qwen Code does exactly that -- and those events carry the whole of
+		// its context utilization. Gating on usage alone dropped them before they reached the
+		// utilization report, which is the one place they belong.
+		if event.GenAI == nil || (event.GenAI.Usage == nil && event.GenAI.Context == nil) {
 			continue
 		}
 		usage := event.GenAI.Usage
+		if usage == nil {
+			usage = &schema.GenAIUsageInfo{}
+		}
 		ue := &usageEvent{
 			order:      i,
 			action:     event.Event.Action,
@@ -410,7 +419,15 @@ func collectUsageEvents(events []schema.Event, sessionUsers sessionUserIndex) []
 		if usage.CostUSD != nil {
 			ue.usage.CostUSD = *usage.CostUSD
 		}
-		if ue.usage.TotalTokens() == 0 && ue.usage.ReasoningOutputTokens == 0 && ue.usage.CostUSD == 0 {
+		if context := event.GenAI.Context; context != nil {
+			if context.UsedTokens != nil {
+				ue.contextUsed = *context.UsedTokens
+			}
+			if context.LimitTokens != nil {
+				ue.contextLimit = *context.LimitTokens
+			}
+		}
+		if ue.usage.TotalTokens() == 0 && ue.usage.ReasoningOutputTokens == 0 && ue.usage.CostUSD == 0 && ue.contextUsed == 0 {
 			continue
 		}
 		if event.Raw != nil {
@@ -681,11 +698,20 @@ func sortedBuckets(buckets map[time.Time]*Usage) []TimeBucket {
 func buildUtilization(events []*usageEvent, nearLimitRatio float64) []ModelUtilization {
 	type sample struct{ inputTotal int64 }
 	samples := map[string]map[string]*sample{}
+	reportedWindow := map[string]int64{}
 	for _, ue := range events {
 		if ue.model == "" {
 			continue
 		}
-		inputTotal := ue.usage.InputTokens + ue.usage.CacheReadInputTokens + ue.usage.CacheCreationInputTokens
+		// A reported context size is the measurement; summing the usage fields only approximates
+		// it. Prefer the runtime's own number when it gave one, and take its window with it -- a
+		// reported limit reflects the tier actually in force, which a static model table cannot.
+		inputTotal := ue.contextUsed
+		if inputTotal <= 0 {
+			inputTotal = ue.usage.InputTokens + ue.usage.CacheReadInputTokens + ue.usage.CacheCreationInputTokens
+		} else if ue.contextLimit > 0 && ue.contextLimit > reportedWindow[ue.model] {
+			reportedWindow[ue.model] = ue.contextLimit
+		}
 		if inputTotal <= 0 {
 			continue
 		}
@@ -702,6 +728,11 @@ func buildUtilization(events []*usageEvent, nearLimitRatio float64) []ModelUtili
 	for model, calls := range samples {
 		utilization := ModelUtilization{Model: model, Calls: len(calls)}
 		window, known := ContextWindow(model)
+		// A window the runtime reported beats the static table, which is a best-effort snapshot
+		// and cannot know which tier a call actually ran under.
+		if reported := reportedWindow[model]; reported > 0 {
+			window, known = reported, true
+		}
 		if known {
 			utilization.ContextWindow = window
 		}

--- a/cli/beacon/internal/tokens/tokens.go
+++ b/cli/beacon/internal/tokens/tokens.go
@@ -130,6 +130,10 @@ type usageEvent struct {
 	spanID       string
 	parentSpanID string
 	usage        Usage
+	// contextOnly marks an event that reached the collector only because it reported context
+	// occupancy. It feeds the utilization report and nothing else: it is not spend, so it must
+	// not appear in a total, a group, a time bucket, or the count of usage-bearing events.
+	contextOnly  bool
 	contextUsed  int64
 	contextLimit int64
 	cumulative   bool
@@ -173,6 +177,12 @@ func aggregate(events []schema.Event, opts Options, sessionUsers sessionUserInde
 	byRun := map[string]*Usage{}
 	buckets := map[time.Time]*Usage{}
 	for _, ue := range usageEvents {
+		if ue.contextOnly {
+			// Context occupancy is not spend. Counting these would put zero-token rows under
+			// every grouping and report a runtime that spends nothing as usage-bearing -- which
+			// the coverage report reads as "this runtime is reporting its spend".
+			continue
+		}
 		report.Totals.add(ue.usage)
 		addGroup(byModel, ue.model, ue.usage)
 		addGroup(bySession, ue.session, ue.usage)
@@ -188,7 +198,11 @@ func aggregate(events []schema.Event, opts Options, sessionUsers sessionUserInde
 			buckets[start].add(ue.usage)
 		}
 	}
-	report.EventsWithUsage = len(usageEvents)
+	for _, ue := range usageEvents {
+		if !ue.contextOnly {
+			report.EventsWithUsage++
+		}
+	}
 	report.ByModel = sortedGroups(byModel, opts.TopLimit)
 	report.BySession = sortedGroups(bySession, opts.TopLimit)
 	report.ByUser = sortedGroups(byUser, opts.TopLimit)
@@ -427,8 +441,13 @@ func collectUsageEvents(events []schema.Event, sessionUsers sessionUserIndex) []
 				ue.contextLimit = *context.LimitTokens
 			}
 		}
-		if ue.usage.TotalTokens() == 0 && ue.usage.ReasoningOutputTokens == 0 && ue.usage.CostUSD == 0 && ue.contextUsed == 0 {
-			continue
+		if ue.usage.TotalTokens() == 0 && ue.usage.ReasoningOutputTokens == 0 && ue.usage.CostUSD == 0 {
+			if ue.contextUsed == 0 {
+				continue
+			}
+			// Kept for utilization, excluded from everything additive. A runtime that reports
+			// both context and usage is not context-only and counts normally.
+			ue.contextOnly = true
 		}
 		if event.Raw != nil {
 			if temporality, _ := event.Raw["metric_temporality"].(string); strings.EqualFold(temporality, "cumulative") {
@@ -787,7 +806,7 @@ func buildSessionDetail(events []*usageEvent, sessionID string) *SessionDetail {
 	for _, ue := range events {
 		// Match case-insensitively to stay consistent with the case-insensitive
 		// session query the token callers use to select events.
-		if !strings.EqualFold(ue.session, sessionID) {
+		if !strings.EqualFold(ue.session, sessionID) || ue.contextOnly {
 			continue
 		}
 		detail.Usage.add(ue.usage)

--- a/cli/beacon/internal/tokens/tokens.go
+++ b/cli/beacon/internal/tokens/tokens.go
@@ -179,6 +179,9 @@ func aggregate(events []schema.Event, opts Options, sessionUsers sessionUserInde
 	eventsWithUsage := 0
 	for _, ue := range usageEvents {
 		if ue.contextOnly {
+			// Context occupancy is not spend. Counting these would put zero-token rows under
+			// every grouping and report a runtime that spends nothing as usage-bearing -- which
+			// the coverage report reads as "this runtime is reporting its spend".
 			continue
 		}
 		report.Totals.add(ue.usage)
@@ -440,6 +443,11 @@ func collectUsageEvents(events []schema.Event, sessionUsers sessionUserIndex) []
 			if ue.contextUsed == 0 {
 				continue
 			}
+			// Kept for utilization, excluded from everything additive. A runtime that reports
+			// both context and usage is not context-only and counts normally.
+			//
+			// Events is zeroed as well as the event being skipped, so the struct cannot be
+			// added to a total by some later path that does not know to check the flag.
 			ue.contextOnly = true
 			ue.usage.Events = 0
 		}

--- a/cli/beacon/internal/tokens/tokens.go
+++ b/cli/beacon/internal/tokens/tokens.go
@@ -176,11 +176,9 @@ func aggregate(events []schema.Event, opts Options, sessionUsers sessionUserInde
 	byRepository := map[string]*Usage{}
 	byRun := map[string]*Usage{}
 	buckets := map[time.Time]*Usage{}
+	eventsWithUsage := 0
 	for _, ue := range usageEvents {
 		if ue.contextOnly {
-			// Context occupancy is not spend. Counting these would put zero-token rows under
-			// every grouping and report a runtime that spends nothing as usage-bearing -- which
-			// the coverage report reads as "this runtime is reporting its spend".
 			continue
 		}
 		report.Totals.add(ue.usage)
@@ -197,12 +195,9 @@ func aggregate(events []schema.Event, opts Options, sessionUsers sessionUserInde
 			}
 			buckets[start].add(ue.usage)
 		}
+		eventsWithUsage++
 	}
-	for _, ue := range usageEvents {
-		if !ue.contextOnly {
-			report.EventsWithUsage++
-		}
-	}
+	report.EventsWithUsage = eventsWithUsage
 	report.ByModel = sortedGroups(byModel, opts.TopLimit)
 	report.BySession = sortedGroups(bySession, opts.TopLimit)
 	report.ByUser = sortedGroups(byUser, opts.TopLimit)
@@ -445,9 +440,8 @@ func collectUsageEvents(events []schema.Event, sessionUsers sessionUserIndex) []
 			if ue.contextUsed == 0 {
 				continue
 			}
-			// Kept for utilization, excluded from everything additive. A runtime that reports
-			// both context and usage is not context-only and counts normally.
 			ue.contextOnly = true
+			ue.usage.Events = 0
 		}
 		if event.Raw != nil {
 			if temporality, _ := event.Raw["metric_temporality"].(string); strings.EqualFold(temporality, "cumulative") {

--- a/cli/beacon/internal/tokens/tokens.go
+++ b/cli/beacon/internal/tokens/tokens.go
@@ -358,7 +358,51 @@ func userKey(user schema.UserInfo) string {
 	}
 }
 
+// modelDeclaration is one point at which a session named its model, kept with the position it was
+// seen at so a later lookup can ask what was in force rather than what was in force last.
+type modelDeclaration struct {
+	order int
+	model string
+}
+
+// sessionModelIndex records every model a session named, in event order. Qwen Code is why it
+// exists: it declares its model on session start and never again, so its Stop payload -- the only
+// event carrying gen_ai.context -- has a session id and no model. Utilization keys its rows on the
+// model, so without this the occupancy Beacon just learned how to record is dropped before the
+// report that wanted it.
+type sessionModelIndex map[sessionContextKey][]modelDeclaration
+
+func sessionModelDeclarations(events []schema.Event) sessionModelIndex {
+	index := sessionModelIndex{}
+	for i, event := range events {
+		model := strings.TrimSpace(event.Model)
+		if model == "" || event.Session == nil || strings.TrimSpace(event.Session.ID) == "" {
+			continue
+		}
+		key := sessionKey(event)
+		if declarations := index[key]; len(declarations) > 0 && declarations[len(declarations)-1].model == model {
+			continue
+		}
+		index[key] = append(index[key], modelDeclaration{order: i, model: model})
+	}
+	return index
+}
+
+// modelAt returns the model the session had named by the given position. Scanning back to the last
+// declaration at or before the event, rather than taking the session's newest one, keeps a session
+// that switched models from having its earlier occupancy attributed to the later one.
+func (index sessionModelIndex) modelAt(key sessionContextKey, order int) string {
+	declarations := index[key]
+	for i := len(declarations) - 1; i >= 0; i-- {
+		if declarations[i].order <= order {
+			return declarations[i].model
+		}
+	}
+	return ""
+}
+
 func collectUsageEvents(events []schema.Event, sessionUsers sessionUserIndex) []*usageEvent {
+	sessionModels := sessionModelDeclarations(events)
 	var out []*usageEvent
 	for i, event := range events {
 		// Context-only events count too. A runtime can report how full the window was without
@@ -450,6 +494,14 @@ func collectUsageEvents(events []schema.Event, sessionUsers sessionUserIndex) []
 			// added to a total by some later path that does not know to check the flag.
 			ue.contextOnly = true
 			ue.usage.Events = 0
+			if ue.model == "" && event.Session != nil {
+				// Attribution only, and only here. An event reporting real spend without a model
+				// of its own stays unattributed as it always has: relabelling that would move
+				// other runtimes' spend between models on the strength of a guess. Occupancy has
+				// no such risk -- it is never summed -- and without a model it is not reportable
+				// at all.
+				ue.model = sessionModels.modelAt(sessionKey(event), i)
+			}
 		}
 		if event.Raw != nil {
 			if temporality, _ := event.Raw["metric_temporality"].(string); strings.EqualFold(temporality, "cumulative") {

--- a/cli/beacon/internal/tokens/tokens_test.go
+++ b/cli/beacon/internal/tokens/tokens_test.go
@@ -441,3 +441,73 @@ func TestAggregateTopLimitCapsGroups(t *testing.T) {
 		t.Fatalf("by_model = %#v", report.ByModel)
 	}
 }
+
+// A runtime that reports its own context size and window is measured against those, not against
+// the static model table and not against a sum of usage fields.
+//
+// Both substitutions matter. Summing input + cache read + cache creation approximates occupancy and
+// is all Beacon has for runtimes that report nothing; a reported number is the measurement itself.
+// And a reported window reflects the tier the call actually ran under, which a table keyed on a
+// model name cannot know.
+func TestUtilizationPrefersReportedContextOverInference(t *testing.T) {
+	events := []schema.Event{
+		usageEventFixture("2026-06-11T10:00:00Z", "qwen_code", "s1", "qwen3-coder-plus", func(e *schema.Event) {
+			e.GenAI.Usage = nil
+			e.GenAI.Context = &schema.GenAIContextInfo{
+				UsedTokens:  int64Ptr(110100),
+				LimitTokens: int64Ptr(262144),
+			}
+		}),
+	}
+	report := Aggregate(events, Options{})
+	if len(report.Utilization) != 1 {
+		t.Fatalf("utilization = %+v, want one row for a context-only event", report.Utilization)
+	}
+	row := report.Utilization[0]
+	if row.ContextWindow != 262144 {
+		t.Errorf("context window = %d, want the runtime's reported 262144", row.ContextWindow)
+	}
+	if row.MaxInputTokens != 110100 {
+		t.Errorf("max input = %d, want the runtime's reported 110100", row.MaxInputTokens)
+	}
+	// 110100 / 262144 is the 0.42 Qwen reports as context_usage, which is how the fixture's three
+	// fields are known to describe one measurement.
+	if row.MaxRatio < 0.419 || row.MaxRatio > 0.421 {
+		t.Errorf("max ratio = %v, want ~0.42", row.MaxRatio)
+	}
+}
+
+// Context is a level, not spend. A context-only event must not add anything to the totals a report
+// sums, or a Qwen session's cost would grow with the square of its length.
+func TestContextOnlyEventsAddNothingToTotals(t *testing.T) {
+	events := []schema.Event{
+		usageEventFixture("2026-06-11T10:00:00Z", "qwen_code", "s1", "qwen3-coder-plus", func(e *schema.Event) {
+			e.GenAI.Usage = nil
+			e.GenAI.Context = &schema.GenAIContextInfo{
+				UsedTokens:  int64Ptr(110100),
+				LimitTokens: int64Ptr(262144),
+			}
+		}),
+	}
+	report := Aggregate(events, Options{})
+	if got := report.Totals.TotalTokens(); got != 0 {
+		t.Fatalf("totals = %d tokens, want 0 -- context occupancy is not spend", got)
+	}
+	if report.Totals.CostUSD != 0 {
+		t.Fatalf("totals cost = %v, want 0", report.Totals.CostUSD)
+	}
+}
+
+// A runtime that reports no context keeps the inferred behaviour and the static window.
+func TestUtilizationStillInfersWhenNoContextIsReported(t *testing.T) {
+	events := []schema.Event{
+		usageEventFixture("2026-06-11T10:00:00Z", "claude_code", "s1", "claude-opus-5", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(1000)
+			e.GenAI.Usage.CacheRead = &schema.GenAIUsageCacheReadInfo{InputTokens: int64Ptr(500)}
+		}),
+	}
+	report := Aggregate(events, Options{})
+	if len(report.Utilization) != 1 || report.Utilization[0].MaxInputTokens != 1500 {
+		t.Fatalf("utilization = %+v, want the summed 1500", report.Utilization)
+	}
+}

--- a/cli/beacon/internal/tokens/tokens_test.go
+++ b/cli/beacon/internal/tokens/tokens_test.go
@@ -567,3 +567,80 @@ func TestUtilizationStillInfersWhenNoContextIsReported(t *testing.T) {
 		t.Fatalf("utilization = %+v, want the summed 1500", report.Utilization)
 	}
 }
+
+// The real Qwen payload, not the fixture shape the other utilization tests use. Qwen declares its
+// model on session start and never again: its Stop hook -- the only producer of gen_ai.context --
+// carries session_id, context_usage, context_limit and input_tokens, and no model at all. Since
+// buildUtilization keys rows on the model and skips events without one, occupancy was recorded on
+// the event and then dropped before reaching the report this change exists to fill. The session's
+// model is the right attribution because the events belong to one session that declared it.
+func TestUtilizationAttributesContextToTheSessionModelWhenTheEventCarriesNone(t *testing.T) {
+	events := []schema.Event{
+		{
+			Timestamp: "2026-06-11T10:00:00Z",
+			Event:     schema.EventInfo{Kind: "agent_runtime", Action: "session.start", Category: "session"},
+			Harness:   schema.HarnessInfo{Name: "qwen_code"},
+			Session:   &schema.SessionInfo{ID: "qwen-8f21c4a0"},
+			Model:     "qwen3-coder-plus",
+		},
+		{
+			Timestamp: "2026-06-11T10:01:00Z",
+			Event:     schema.EventInfo{Kind: "agent_runtime", Action: "tool.completed", Category: "tool"},
+			Harness:   schema.HarnessInfo{Name: "qwen_code"},
+			Session:   &schema.SessionInfo{ID: "qwen-8f21c4a0"},
+			GenAI: &schema.GenAIInfo{Context: &schema.GenAIContextInfo{
+				UsedTokens:  int64Ptr(110100),
+				LimitTokens: int64Ptr(262144),
+			}},
+		},
+	}
+	report := Aggregate(events, Options{})
+	if len(report.Utilization) != 1 {
+		t.Fatalf("utilization = %+v, want one row attributed to the session model", report.Utilization)
+	}
+	row := report.Utilization[0]
+	if row.Model != "qwen3-coder-plus" {
+		t.Errorf("model = %q, want the model the session declared", row.Model)
+	}
+	if row.MaxInputTokens != 110100 {
+		t.Errorf("max input tokens = %d, want the reported 110100", row.MaxInputTokens)
+	}
+	if row.ContextWindow != 262144 {
+		t.Errorf("context window = %d, want the reported 262144", row.ContextWindow)
+	}
+	// The carry-forward is for attribution only. Nothing about it makes occupancy spend.
+	if report.Totals.TotalTokens() != 0 {
+		t.Errorf("totals = %d, want 0", report.Totals.TotalTokens())
+	}
+	if report.EventsWithUsage != 0 {
+		t.Errorf("events with usage = %d, want 0", report.EventsWithUsage)
+	}
+}
+
+// The carry-forward must not reach spend. An event reporting real usage with no model of its own
+// is attributed as it always was -- summed into the totals, absent from the per-model rows -- and
+// changing that would silently move other runtimes' spend between models.
+func TestSessionModelCarryForwardDoesNotRelabelSpend(t *testing.T) {
+	events := []schema.Event{
+		{
+			Timestamp: "2026-06-11T10:00:00Z",
+			Event:     schema.EventInfo{Kind: "agent_runtime", Action: "session.start", Category: "session"},
+			Harness:   schema.HarnessInfo{Name: "claude_code"},
+			Session:   &schema.SessionInfo{ID: "s1"},
+			Model:     "claude-opus-5",
+		},
+		usageEventFixture("2026-06-11T10:01:00Z", "claude_code", "s1", "", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(100)
+			e.GenAI.Usage.OutputTokens = int64Ptr(20)
+		}),
+	}
+	report := Aggregate(events, Options{})
+	if report.Totals.TotalTokens() != 120 {
+		t.Fatalf("totals = %d, want 120", report.Totals.TotalTokens())
+	}
+	for _, group := range report.ByModel {
+		if group.Key == "claude-opus-5" {
+			t.Errorf("by-model has a claude-opus-5 row (%+v); spend with no model of its own must not be relabelled", group)
+		}
+	}
+}

--- a/cli/beacon/internal/tokens/tokens_test.go
+++ b/cli/beacon/internal/tokens/tokens_test.go
@@ -477,8 +477,14 @@ func TestUtilizationPrefersReportedContextOverInference(t *testing.T) {
 	}
 }
 
-// Context is a level, not spend. A context-only event must not add anything to the totals a report
-// sums, or a Qwen session's cost would grow with the square of its length.
+// Context is a level, not spend. A context-only event must not add anything a report sums, or a
+// Qwen session's cost would grow with the square of its length.
+//
+// "Anything" is the whole shape, not just the token and cost fields. An earlier version of this
+// test checked only those two and passed while the event was still incrementing the event counts
+// and creating zero-token rows under every grouping -- which reads as a runtime that spent nothing
+// but was nonetheless active in a spend report, and which the coverage report in beacon
+// token-usage --coverage would have read as "this runtime is reporting its spend".
 func TestContextOnlyEventsAddNothingToTotals(t *testing.T) {
 	events := []schema.Event{
 		usageEventFixture("2026-06-11T10:00:00Z", "qwen_code", "s1", "qwen3-coder-plus", func(e *schema.Event) {
@@ -489,12 +495,62 @@ func TestContextOnlyEventsAddNothingToTotals(t *testing.T) {
 			}
 		}),
 	}
-	report := Aggregate(events, Options{})
+	report := Aggregate(events, Options{BucketSize: time.Hour, SessionID: "s1"})
 	if got := report.Totals.TotalTokens(); got != 0 {
-		t.Fatalf("totals = %d tokens, want 0 -- context occupancy is not spend", got)
+		t.Errorf("totals = %d tokens, want 0 -- context occupancy is not spend", got)
 	}
 	if report.Totals.CostUSD != 0 {
-		t.Fatalf("totals cost = %v, want 0", report.Totals.CostUSD)
+		t.Errorf("totals cost = %v, want 0", report.Totals.CostUSD)
+	}
+	if report.Totals.Events != 0 {
+		t.Errorf("totals events = %d, want 0 -- the event carries no usage to have counted", report.Totals.Events)
+	}
+	if report.EventsWithUsage != 0 {
+		t.Errorf("events_with_usage = %d, want 0", report.EventsWithUsage)
+	}
+	for name, group := range map[string][]Group{
+		"by_model": report.ByModel, "by_session": report.BySession,
+		"by_harness": report.ByHarness, "by_user": report.ByUser,
+		"by_repository": report.ByRepository, "by_run": report.ByRun,
+	} {
+		if len(group) != 0 {
+			t.Errorf("%s = %+v, want no rows -- a zero-token row reads as a runtime that spent nothing but was active", name, group)
+		}
+	}
+	if len(report.Series) != 0 {
+		t.Errorf("series = %+v, want no buckets", report.Series)
+	}
+	if report.SessionDetail != nil && len(report.SessionDetail.Steps) != 0 {
+		t.Errorf("session steps = %+v, want none", report.SessionDetail.Steps)
+	}
+	// The one thing it must still do.
+	if len(report.Utilization) != 1 {
+		t.Fatalf("utilization = %+v, want the context-only event to still be measured", report.Utilization)
+	}
+}
+
+// An event reporting both spend and context is not context-only: its usage counts normally and its
+// context still feeds utilization.
+func TestEventsWithBothUsageAndContextCountAsSpend(t *testing.T) {
+	events := []schema.Event{
+		usageEventFixture("2026-06-11T10:00:00Z", "some_runtime", "s1", "some-model", func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(900)
+			e.GenAI.Usage.OutputTokens = int64Ptr(100)
+			e.GenAI.Context = &schema.GenAIContextInfo{
+				UsedTokens:  int64Ptr(50000),
+				LimitTokens: int64Ptr(200000),
+			}
+		}),
+	}
+	report := Aggregate(events, Options{})
+	if got := report.Totals.TotalTokens(); got != 1000 {
+		t.Errorf("totals = %d, want the reported 1000 spend tokens", got)
+	}
+	if report.EventsWithUsage != 1 {
+		t.Errorf("events_with_usage = %d, want 1", report.EventsWithUsage)
+	}
+	if len(report.Utilization) != 1 || report.Utilization[0].MaxInputTokens != 50000 {
+		t.Errorf("utilization = %+v, want the reported 50000 occupancy, not the 900 input", report.Utilization)
 	}
 }
 

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/converter.go
@@ -1256,6 +1256,9 @@ func GenAIFromAttrs(attrs map[string]interface{}) *GenAIInfo {
 	if usage := GenAIUsageFromAttrs(attrs); usage != nil {
 		genai.Usage = usage
 	}
+	if context := GenAIContextFromAttrs(attrs); context != nil {
+		genai.Context = context
+	}
 	if name := FirstString(attrs, "gen_ai.workflow.name"); name != "" {
 		genai.Workflow = &GenAIWorkflowInfo{Name: name}
 	}
@@ -1375,6 +1378,24 @@ func GenAIUsageFromAttrs(attrs map[string]interface{}) *GenAIUsageInfo {
 		return nil
 	}
 	return usage
+}
+
+// GenAIContextFromAttrs reads a reported context size off OTLP attributes.
+//
+// Both halves are required, which is the rule the shared alias lists set: the used-token key is
+// also the ecosystem's name for an additive usage count, and a reported limit beside it is what
+// says this payload describes how full the window was rather than what a call spent. See
+// asymptoteobserve.ContextUsedKeys.
+func GenAIContextFromAttrs(attrs map[string]interface{}) *GenAIContextInfo {
+	limit, ok := Int64Attr(attrs, asymptoteobserve.ContextLimitKeys...)
+	if !ok || limit <= 0 {
+		return nil
+	}
+	used, ok := Int64Attr(attrs, asymptoteobserve.ContextUsedKeys...)
+	if !ok || used <= 0 {
+		return nil
+	}
+	return &GenAIContextInfo{UsedTokens: &used, LimitTokens: &limit}
 }
 
 func MCPFromAttrs(attrs map[string]interface{}) *MCPInfo {

--- a/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/event.go
+++ b/collector-builder/exporter/beaconjsonexporter/internal/beaconevent/event.go
@@ -58,6 +58,7 @@ type GenAIRetrievalInfo = asymptoteobserve.GenAIRetrievalInfo
 type GenAITokenInfo = asymptoteobserve.GenAITokenInfo
 type GenAIToolInfo = asymptoteobserve.GenAIToolInfo
 type GenAIToolCallInfo = asymptoteobserve.GenAIToolCallInfo
+type GenAIContextInfo = asymptoteobserve.GenAIContextInfo
 type GenAIUsageInfo = asymptoteobserve.GenAIUsageInfo
 type GenAIUsageCacheCreationInfo = asymptoteobserve.GenAIUsageCacheCreationInfo
 type GenAIUsageCacheReadInfo = asymptoteobserve.GenAIUsageCacheReadInfo

--- a/docs/runtimes/qwen-code.mdx
+++ b/docs/runtimes/qwen-code.mdx
@@ -126,7 +126,7 @@ A project-level install reports that Qwen Code runs project hooks only in a trus
 | Subagents | Supported through `SubagentStart` and `SubagentStop` |
 | Approval decisions | Supported. Observed from `PermissionRequest`, not synthesized from pre-tool |
 | Tool call identity | Supported. Qwen's `tool_use_id` / `tool_call_id` is promoted to `gen_ai.tool.call.id` and joins pre-tool and post-tool events |
-| Token usage and cost | Not normalized. See [Known gaps](#known-gaps) |
+| Token usage and cost | Not collected. Context utilization is, through `gen_ai.context`. See [Known gaps](#known-gaps) |
 | Local JSONL and dashboard | Supported |
 | MDM deployment | Supported for the endpoint agent. Qwen hooks are installed separately in the logged-in user's context or project context |
 
@@ -170,7 +170,8 @@ Qwen carries signal with no endpoint-schema field of its own: `permission_mode` 
 ## Known gaps
 
 - **No OTLP path.** Qwen Code is a Gemini CLI fork without Gemini's OpenTelemetry export, so there is no collector endpoint to configure. Hooks are the only collection path, and `beacon endpoint install --harness qwen` says so rather than appearing to succeed.
-- **Token usage is not normalized.** Qwen's `Stop` payload carries `context_usage`, `context_limit`, and `input_tokens`, which are session-level context counters rather than per-call usage. They are preserved under `raw.qwen` but not normalized into `gen_ai.usage`, so Qwen Code activity does not appear in `beacon token-usage` reports or the dashboard token view.
+- **Token spend is not collected, and cannot be.** Qwen's `Stop` payload carries no per-call token counts. Its `input_tokens` is the prompt for that turn, which in a multi-turn session already contains every prior turn, so summing it into `gen_ai.usage` would inflate a session's total by roughly the square of its length. Qwen Code therefore contributes no rows to the spend totals in `beacon token-usage`.
+- **Context utilization is collected.** The same numbers describe how full the window was, which is a level rather than an amount, so they normalize into `gen_ai.context` instead: `input_tokens` becomes `gen_ai.context.used_tokens` and `context_limit` becomes `gen_ai.context.limit_tokens`. Qwen Code appears in the context utilization section of `beacon token-usage`, measured against the window it reported rather than a static model table. `context_usage` is the ratio of the two and stays in `raw.qwen` rather than being stored a second time in different units.
 - **A policy deny is honored in one of two phases.** The seam runs in both the `pre-tool` and `permission-request` hooks, and Asymptote returns Claude Code's deny shape, which Qwen's `PreToolUse` contract honors. Qwen's `PermissionRequest` event reads a differently shaped `hookSpecificOutput.decision` object, so a deny raised from that phase is not honored. Because the seam fails open, the cost is a deny that does not take effect on one phase, never a tool call blocked for the wrong reason.
 - **Assistant text is not collected.** `MessageDisplay` is not registered, so Asymptote records no assistant output or reasoning for Qwen Code. See [Events that are not collected](#events-that-are-not-collected).
 - **Project-level installs need a trusted folder.** Qwen gates project hooks behind trusted-folder status, so a user-level install is the one that works without further interaction. Grok Build has the same caveat.

--- a/docs/telemetry-schema/normalization.mdx
+++ b/docs/telemetry-schema/normalization.mdx
@@ -17,6 +17,21 @@ The prefix is not discarded. It is recorded as `gen_ai.provider.name`, so a prov
 
 Model ids themselves are never rewritten. Date suffixes, dots and vendor spellings are preserved as the runtime reported them, because a rule that folds `claude-sonnet-4.6` into `claude-sonnet-4-6` also turns `gpt-4.1` into `gpt-4-1`, which is not a model under any name. A split row is visible to a reader; an invented id is not.
 
+## Context size is not usage
+
+`gen_ai.usage` is additive: every report sums it to answer what a session spent. `gen_ai.context` is a level at one moment -- how full the model's window was on a call -- and summing it answers nothing.
+
+Qwen Code is the runtime that forced the split. Its `Stop` hook reports the prompt token count for a turn, which in a multi-turn session already contains every prior turn; added up, a session's total grows with roughly the square of its length. Read as context occupancy the same number is exact, so it is recorded in a block nothing sums:
+
+| Source signal | Normalized field |
+|---------------|------------------|
+| `input_tokens` alongside a reported limit, `gen_ai.context.used_tokens` | `gen_ai.context.used_tokens` |
+| `context_limit`, `gen_ai.context.limit_tokens` | `gen_ai.context.limit_tokens` |
+
+Both halves are required before either is recorded. `input_tokens` is also the ecosystem's usual name for a genuine additive usage count, so a reported limit beside it is what distinguishes a payload describing window occupancy from one reporting spend. Without that pairing the rule would reclassify other runtimes' spend as context.
+
+A reported `limit_tokens` also takes precedence over Asymptote's static context-window table when computing utilization, because it reflects the tier the call actually ran under rather than the default for a model name.
+
 ## Source mapping
 
 | Source signal | Normalized field or action |

--- a/pkg/asymptoteobserve/event.go
+++ b/pkg/asymptoteobserve/event.go
@@ -353,6 +353,28 @@ type GenAIUsageReasoningInfo struct {
 	OutputTokens *int64 `json:"output_tokens,omitempty"`
 }
 
+// GenAIContextInfo records how full the model's context was, which is a level rather than an
+// amount and therefore does not belong in GenAIUsageInfo.
+//
+// Everything in gen_ai.usage is additive: a report sums it across events to answer "what did this
+// session spend". Context size is the opposite -- it is a measurement at one moment, and summing it
+// answers nothing. Qwen Code is the case that forced the distinction: its Stop hook reports the
+// prompt token count for the turn, which in a multi-turn session already contains every prior turn,
+// so adding those up inflates a session's total by roughly the square of its length. The number is
+// exact and useful; it just is not spend.
+//
+// Keeping it in its own block means a consumer cannot reach it by accident. A rule or dashboard
+// that sums gen_ai.usage still gets only additive fields, and one that wants context utilization
+// asks for it by name.
+//
+// UsedTokens is how much of the window the request occupied. LimitTokens is the window the runtime
+// reported for that call, which is better than a local model table when present because it reflects
+// the tier actually in force. Neither has an OpenTelemetry GenAI semconv equivalent.
+type GenAIContextInfo struct {
+	UsedTokens  *int64 `json:"used_tokens,omitempty"`
+	LimitTokens *int64 `json:"limit_tokens,omitempty"`
+}
+
 // GenAIUsageInfo mirrors the OpenTelemetry GenAI semconv usage attribute
 // names. Token counts are int64 to match OTLP integer values. CostUSD has no
 // semconv equivalent; it carries runtime-reported USD cost only (for example
@@ -372,6 +394,7 @@ type GenAIWorkflowInfo struct {
 
 type GenAIInfo struct {
 	Agent              *GenAIAgentInfo        `json:"agent,omitempty"`
+	Context            *GenAIContextInfo      `json:"context,omitempty"`
 	Conversation       *GenAIConversationInfo `json:"conversation,omitempty"`
 	DataSource         *GenAIDataSourceInfo   `json:"data_source,omitempty"`
 	Embeddings         *GenAIEmbeddingsInfo   `json:"embeddings,omitempty"`

--- a/pkg/asymptoteobserve/identity.go
+++ b/pkg/asymptoteobserve/identity.go
@@ -123,3 +123,43 @@ func eventUUID(kind, name string) string {
 	hex.Encode(out, id[:])
 	return fmt.Sprintf("%s-%s-%s-%s-%s", out[0:8], out[8:12], out[12:16], out[16:20], out[20:32])
 }
+
+// ContextUsedKeys and ContextLimitKeys are the names a runtime uses for how full the model's
+// context was on a call, and for the window it was measured against.
+//
+// Promoted to gen_ai.context on every capture path from these lists, for the reason ToolCallIDKeys
+// exists: a promotion list holding only a canonical name no runtime writes drops every real value
+// into raw. A new runtime adds its spelling here rather than growing a branch in a mapper.
+//
+// Both must be present before either is promoted, which is not the usual alias-list rule and is
+// deliberate. "input_tokens" is the name Qwen Code gives the context measure, and it is also the
+// name half the ecosystem gives a genuine additive usage count -- so the key alone cannot say which
+// it is. A reported context limit alongside it is what distinguishes a payload describing how full
+// the window is from one reporting what a call spent. Without that pairing this list would quietly
+// reclassify other runtimes' spend as context.
+//
+// The distinction matters because gen_ai.usage is additive and every report sums it, while context
+// size is a level at one moment. Qwen is the case that proves it: its Stop payload's input_tokens
+// is the prompt for that turn, which already contains every prior turn, so summing inflates a
+// session by roughly the square of its length. The same number read as context occupancy is exact
+// and useful -- 110100 of a 262144 window.
+//
+// Canonical names first, so an explicitly mapped value beats a runtime-native one.
+var ContextUsedKeys = []string{
+	"gen_ai.context.used_tokens",
+	"beacon.gen_ai.context.used_tokens",
+	// Qwen Code's Stop payload. Its sibling context_usage is this value divided by the limit, so
+	// it is derivable and stays in raw rather than being stored twice in different units.
+	"input_tokens",
+}
+
+// ContextLimitKeys names the context window a runtime reported for a call. A reported window beats
+// the local model table in cli/beacon/internal/tokens, because it reflects the tier actually in
+// force rather than the default for the model name. Its presence is also what licenses reading a
+// used-token count from an ambiguous key; see ContextUsedKeys.
+var ContextLimitKeys = []string{
+	"gen_ai.context.limit_tokens",
+	"beacon.gen_ai.context.limit_tokens",
+	// Qwen Code's Stop payload.
+	"context_limit",
+}

--- a/spec/threat-rules/FIELDS.md
+++ b/spec/threat-rules/FIELDS.md
@@ -45,6 +45,8 @@ Regenerate with `beacon rules fields --markdown > spec/threat-rules/FIELDS.md`.
 | `e.gen_ai.agent.id` | string |
 | `e.gen_ai.agent.name` | string |
 | `e.gen_ai.agent.version` | string |
+| `e.gen_ai.context.limit_tokens` | int |
+| `e.gen_ai.context.used_tokens` | int |
 | `e.gen_ai.conversation.id` | string |
 | `e.gen_ai.data_source.id` | string |
 | `e.gen_ai.embeddings.dimension_count` | int |


### PR DESCRIPTION
First of wave 2. Adds `gen_ai.context` and makes Qwen Code its first producer, closing the documented Qwen gap for *utilization* — spend from Qwen remains uncollectable, and this PR explains why in the runtime docs rather than papering over it.

## The problem

Beacon has one home for token numbers, `gen_ai.usage`, and everything in it is **additive** — every report sums it to answer what a session spent. Context occupancy is not that. It is a level at one moment, and a runtime reporting it had nowhere to put it.

## Qwen, and what the repo already got right

`TestQwenStopContextFieldsAreNotNormalizedIntoTokenUsage` already records, correctly, why Qwen's `Stop` payload must not become `gen_ai.usage`: its `input_tokens` is the prompt for that turn, which in a multi-turn session already contains every prior turn, so summing it inflates a session by roughly the square of its length. **That decision stands and its test is unchanged.**

What was missing was the positive half. The same number read as *occupancy* is exact, and the fixture proves the three fields describe one measurement:

```
input_tokens   110100
context_limit  262144      110100 / 262144 = 0.42
context_usage  0.42
```

So `input_tokens` → `used_tokens`, `context_limit` → `limit_tokens`, and `context_usage` stays in `raw.qwen` rather than being stored twice in different units.

I had originally planned this as "normalize `context_usage` into the context slot" — reading the fixture showed `context_usage` is a *ratio*, not a token count, and the field the repo refused to sum is precisely the one that belongs in a non-additive slot.

## The pairing rule

**Both halves are required before either is recorded**, which is not the usual alias-list rule. `input_tokens` is Qwen's name for the context measure *and* the ecosystem's name for a genuine additive usage count — a reported limit beside it is what says which this payload means. Without the pairing, this promotion would quietly reclassify other runtimes' spend as context.

Read from shared alias lists on both capture paths (hook and OTLP), following the `ToolCallIDKeys` convention: a second runtime reporting the same thing adds a spelling, not a branch in a mapper.

## Consumers

Two, both in the utilization report:

- A **reported context size** replaces the `input + cache_read + cache_creation` sum Beacon uses to approximate occupancy when a runtime reports nothing.
- A **reported window** replaces the static model table, because it reflects the tier a call actually ran under rather than the default for a model name.

Context-only events now reach that report at all, which they did not before — the collector gated on `gen_ai.usage`, so a runtime reporting occupancy and no spend was dropped before it got there.

**Totals are untouched.** A context-only event contributes nothing to any sum; that's the property the whole separation exists to hold, and there's a test asserting it.

## Testing

All CI gates green: `cli/beacon` (`./...` and `-race ./internal/endpoint/...`), `cli/beacon-hooks`, `beaconjsonexporter`, `pkg/asymptoteobserve` (including threat-rules conformance).

`spec/threat-rules/FIELDS.md` regenerated for the two new matchable fields, per CLAUDE.md — the conformance test caught the drift before I did.

New coverage: Qwen context normalized while `gen_ai.usage` stays absent; utilization prefers reported size and window over inference; context-only events add nothing to totals; runtimes reporting no context keep the inferred behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lm8mXn8Y2pWLw6r8uEwff3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm8mXn8Y2pWLw6r8uEwff3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token aggregation and normalization semantics (new field, pairing rule, coverage/utilization behavior); mistakes could misclassify spend as context or hide Qwen utilization, but extensive tests and explicit context-only guards limit blast radius.
> 
> **Overview**
> Introduces **`gen_ai.context`** (`used_tokens` / `limit_tokens`) so context window occupancy is recorded separately from additive **`gen_ai.usage`**. Qwen Code’s Stop hook is the first producer: paired `input_tokens` + `context_limit` normalize into context (not usage), with raw fields preserved and **`context_usage`** left in `raw.qwen` as a ratio.
> 
> **Capture paths:** hooks call **`applyContextSize`** using shared **`ContextUsedKeys` / `ContextLimitKeys`** (both halves required before promotion); the OTLP exporter adds **`GenAIContextFromAttrs`** with the same pairing rule.
> 
> **Token reports:** context-only events feed **utilization** (prefer runtime-reported size and window over summed usage and the static table) but are excluded from totals, groupings, series, session spend steps, and **coverage** spend counts. **Session model carry-forward** attributes Qwen Stop context to the model declared at session start without relabeling real spend.
> 
> Docs, normalization spec, and threat-rule fields are updated; tests lock in the Qwen hook mapping and aggregation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81e456fb00ac6d5f96639dd828d09697612681f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->