### PR TITLE
CI: turn the Go module cache on, and retry module downloads

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,81 @@
+name: Set up Go
+description: >
+  actions/setup-go plus the two things this repository needs on top of it: a
+  module cache that actually restores, and a module download that survives a
+  transient proxy timeout.
+
+inputs:
+  go-version-file:
+    description: The go.mod whose toolchain line picks the Go version.
+    required: false
+    default: cli/beacon/go.mod
+  modules:
+    description: >
+      Module directories this job builds or tests, one per line. Their go.sum
+      files key the module cache, and their dependencies are downloaded up
+      front so a slow proxy fails a step that retries rather than a test step
+      that does not.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # actions/setup-go looks for go.sum in the working directory and walks up.
+    # This repository keeps five modules in subdirectories and none at the
+    # root, so the default lookup finds nothing, logs "Restore cache failed:
+    # Dependencies file is not found", and every job re-downloads every module
+    # from proxy.golang.org on every run. Naming the go.sum files explicitly is
+    # what turns the module cache on at all.
+    #
+    # The list is per-job rather than all five everywhere on purpose: it is
+    # hashed into the cache key, so a job that needs the collector's OTel tree
+    # gets an entry of its own instead of restoring -- and then never
+    # re-saving over -- the smaller entry written by a job that only builds the
+    # CLI.
+    - id: sums
+      shell: bash
+      env:
+        MODULES: ${{ inputs.modules }}
+      run: |
+        set -euo pipefail
+        {
+          echo 'paths<<SUMS_EOF'
+          while read -r dir; do
+            dir="${dir%/}"
+            [ -n "$dir" ] || continue
+            test -f "$dir/go.sum" || { echo "no go.sum in $dir" >&2; exit 1; }
+            echo "$dir/go.sum"
+          done <<< "$MODULES"
+          echo 'SUMS_EOF'
+        } >> "$GITHUB_OUTPUT"
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: ${{ inputs.go-version-file }}
+        cache-dependency-path: ${{ steps.sums.outputs.paths }}
+
+    # A cache hit makes this a no-op. On a miss it is where the download
+    # happens, and it retries: `go test` and `go build` fetch modules inline
+    # and give up on the first network error, which is how a proxy timeout
+    # reads as a failed test run rather than as a failed download.
+    - name: Download Go modules
+      shell: bash
+      env:
+        MODULES: ${{ inputs.modules }}
+      run: |
+        set -uo pipefail
+        while read -r dir; do
+          dir="${dir%/}"
+          [ -n "$dir" ] || continue
+          attempt=1
+          until (cd "$dir" && go mod download); do
+            if [ "$attempt" -ge 4 ]; then
+              echo "::error::go mod download failed in $dir after $attempt attempts"
+              exit 1
+            fi
+            delay=$((attempt * attempt * 2))
+            echo "go mod download failed in $dir; retrying in ${delay}s" >&2
+            sleep "$delay"
+            attempt=$((attempt + 1))
+          done
+        done <<< "$MODULES"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,7 @@ jobs:
           modules: |
             cli/beacon
             cli/beacon-hooks
+            collector-builder/exporter/beaconjsonexporter
       - name: Build Linux beacon binary
         working-directory: cli/beacon
         run: make build-linux-amd64
@@ -476,6 +477,7 @@ jobs:
           modules: |
             cli/beacon
             cli/beacon-hooks
+            collector-builder/exporter/beaconjsonexporter
       - name: Build collector for Linux
         run: |
           go install go.opentelemetry.io/collector/cmd/builder@v0.121.0
@@ -559,6 +561,7 @@ jobs:
           modules: |
             cli/beacon
             cli/beacon-hooks
+            collector-builder/exporter/beaconjsonexporter
 
       # Cheap, and it runs before anything is built: a syntax error in a packaging script would
       # otherwise surface inside an MSI custom action, where what the user sees is a rollback.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/setup-go
         with:
-          go-version-file: cli/beacon/go.mod
+          modules: |
+            cli/beacon
+            cli/beacon-hooks
+            collector-builder/exporter/beaconjsonexporter
+            pkg/asymptoteobserve
       - name: Check OpenCode plugin
         working-directory: plugins/opencode-beacon
         run: bun run check && bun test
@@ -219,9 +223,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/setup-go
         with:
           go-version-file: beacon-sandbox/go.mod
+          modules: |
+            beacon-sandbox
       # These tests are hermetic: no Modal account, no Anthropic key, no sandbox, and no
       # paid resources. (Go module downloads still happen, as in every other job here.)
       # They gate because they are what makes a green verification run mean
@@ -258,9 +264,11 @@ jobs:
             make_target: build-windows-amd64
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/setup-go
         with:
-          go-version-file: cli/beacon/go.mod
+          modules: |
+            cli/beacon
+            cli/beacon-hooks
       - name: Build Beacon for ${{ matrix.goos }}/${{ matrix.goarch }}
         working-directory: cli/beacon
         run: make ${{ matrix.make_target }}
@@ -305,9 +313,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/setup-go
         with:
-          go-version-file: cli/beacon/go.mod
+          modules: |
+            cli/beacon
+            cli/beacon-hooks
+            collector-builder/exporter/beaconjsonexporter
+            pkg/asymptoteobserve
       # The embedded hooks binary must match the platform under test: the CLI validates its
       # architecture at runtime, so a macOS placeholder fails hook installation on Linux.
       - name: Build platform-matched hooks binary
@@ -345,9 +357,14 @@ jobs:
         shell: pwsh
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/setup-go
         with:
-          go-version-file: cli/beacon/go.mod
+          modules: |
+            cli/beacon
+            cli/beacon-hooks
+            collector-builder/exporter/beaconjsonexporter
+            pkg/asymptoteobserve
+            beacon-sandbox
       # The embedded hooks binary must match the platform under test: the CLI validates its
       # architecture at runtime, so a placeholder fails hook installation on Windows.
       - name: Build platform-matched hooks binary
@@ -424,9 +441,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/setup-go
         with:
-          go-version-file: cli/beacon/go.mod
+          modules: |
+            cli/beacon
+            cli/beacon-hooks
       - name: Build Linux beacon binary
         working-directory: cli/beacon
         run: make build-linux-amd64
@@ -452,9 +471,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/setup-go
         with:
-          go-version-file: cli/beacon/go.mod
+          modules: |
+            cli/beacon
+            cli/beacon-hooks
       - name: Build collector for Linux
         run: |
           go install go.opentelemetry.io/collector/cmd/builder@v0.121.0
@@ -493,9 +514,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/setup-go
         with:
-          go-version-file: cli/beacon/go.mod
+          modules: |
+            cli/beacon
+            cli/beacon-hooks
       - name: Validate packaging scripts
         run: |
           test -x packaging/macos/install-endpoint.sh
@@ -531,9 +554,11 @@ jobs:
         shell: pwsh
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/setup-go
         with:
-          go-version-file: cli/beacon/go.mod
+          modules: |
+            cli/beacon
+            cli/beacon-hooks
 
       # Cheap, and it runs before anything is built: a syntax error in a packaging script would
       # otherwise surface inside an MSI custom action, where what the user sees is a rollback.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,9 +443,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go
         with:
+          # The exporter is listed because builder.yaml compiles it into the
+          # collector this job builds. Its go.sum both keys this job's module
+          # cache apart from the CLI-only jobs -- which otherwise win the same
+          # key and leave the collector tree uncached -- and prefetches the
+          # collector core with retries before the builder runs.
           modules: |
             cli/beacon
             cli/beacon-hooks
+            collector-builder/exporter/beaconjsonexporter
       - name: Build Linux beacon binary
         working-directory: cli/beacon
         run: make build-linux-amd64
@@ -473,9 +479,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go
         with:
+          # The exporter is listed because builder.yaml compiles it into the
+          # collector this job builds. Its go.sum both keys this job's module
+          # cache apart from the CLI-only jobs -- which otherwise win the same
+          # key and leave the collector tree uncached -- and prefetches the
+          # collector core with retries before the builder runs.
           modules: |
             cli/beacon
             cli/beacon-hooks
+            collector-builder/exporter/beaconjsonexporter
       - name: Build collector for Linux
         run: |
           go install go.opentelemetry.io/collector/cmd/builder@v0.121.0
@@ -556,9 +568,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go
         with:
+          # The exporter is listed because builder.yaml compiles it into the
+          # collector this job builds. Its go.sum both keys this job's module
+          # cache apart from the CLI-only jobs -- which otherwise win the same
+          # key and leave the collector tree uncached -- and prefetches the
+          # collector core with retries before the builder runs.
           modules: |
             cli/beacon
             cli/beacon-hooks
+            collector-builder/exporter/beaconjsonexporter
 
       # Cheap, and it runs before anything is built: a syntax error in a packaging script would
       # otherwise surface inside an MSI custom action, where what the user sees is a rollback.

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -29,6 +29,7 @@ jobs:
           modules: |
             cli/beacon
             cli/beacon-hooks
+            collector-builder/exporter/beaconjsonexporter
       - uses: goreleaser/goreleaser-action@v6
         with:
           # Keep formulas working until we intentionally migrate the tap to casks.

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -26,9 +26,15 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup-go
         with:
+          # The exporter is listed because builder.yaml compiles it into the
+          # collector this job builds. Its go.sum both keys this job's module
+          # cache apart from the CLI-only jobs -- which otherwise win the same
+          # key and leave the collector tree uncached -- and prefetches the
+          # collector core with retries before the builder runs.
           modules: |
             cli/beacon
             cli/beacon-hooks
+            collector-builder/exporter/beaconjsonexporter
       - uses: goreleaser/goreleaser-action@v6
         with:
           # Keep formulas working until we intentionally migrate the tap to casks.

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -24,9 +24,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/setup-go
         with:
-          go-version-file: cli/beacon/go.mod
+          modules: |
+            cli/beacon
+            cli/beacon-hooks
       - uses: goreleaser/goreleaser-action@v6
         with:
           # Keep formulas working until we intentionally migrate the tap to casks.

--- a/.github/workflows/windows-sandbox.yml
+++ b/.github/workflows/windows-sandbox.yml
@@ -48,9 +48,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/setup-go
         with:
-          go-version-file: cli/beacon/go.mod
+          modules: |
+            beacon-sandbox
+            cli/beacon
+            cli/beacon-hooks
 
       # Runs the generated-PowerShell parse test, which is skipped on a maintainer's machine
       # without pwsh. The generated scripts are assembled in Go, so a syntax error in one is


### PR DESCRIPTION
Fixes the failure in [run 34016271885](https://github.com/Asymptote-Labs/agent-beacon/actions/runs/34016271885/job/101440479231).

## What failed

A docs-only commit on `main` (#468). The macOS `go-test` job could not reach the module proxy during the collector-exporter step:

```
go.opentelemetry.io/collector/pdata@v1.27.0: Get
  "https://proxy.golang.org/go.opentelemetry.io/collector/pdata/@v/v1.27.0.zip":
  dial tcp 142.251.218.145:443: connect: operation timed out
```

Nothing in the diff was involved. What makes a single proxy timeout able to take a job down is upstream of that step, in the same log's setup section:

```
##[warning]Restore cache failed: Dependencies file is not found in
/Users/runner/work/agent-beacon/agent-beacon. Supported file pattern: go.sum
```

`actions/setup-go` looks for `go.sum` in the working directory and walks **up**. This repository keeps five modules in subdirectories and none at the root, so that lookup finds nothing. The Go module cache had therefore never restored and never saved — in any job, in any workflow — and every run re-downloaded every module from proxy.golang.org. The collector exporter pulls the OpenTelemetry collector tree, so it is the largest download and the one most likely to be caught by a slow proxy.

The second half of the problem is that `go test` and `go build` fetch modules inline and give up on the first network error. That is what turns a transient timeout into a red test step rather than a retryable download.

## The change

Both halves are fixed in one place: a composite action, `.github/actions/setup-go`, that wraps `actions/setup-go`.

- **Each job names the module directories it actually uses.** Their `go.sum` paths are passed as `cache-dependency-path`, which is what enables the cache at all.

  The list is per-job rather than all five everywhere on purpose: it is hashed into the cache key. A job that needs the collector tree gets an entry of its own, instead of restoring — and then never re-saving over — the smaller entry written by whichever CLI-only job happened to finish first.

- **A prefetch step** runs `go mod download` per module with four attempts and 2s/8s/18s backoff. On a cache hit it is a no-op; on a miss it is where the network work happens, in a step that retries.

Applied to `ci.yml` (9 jobs), `release-check.yml` (a PR gate with the same exposure), and `windows-sandbox.yml`.

`release.yml` is deliberately left alone. It has the same latent problem, but changing the signing and publishing path does not belong in a CI flake fix — happy to do it as a follow-up.

## Second commit: the collector jobs needed their own key

Cursor Bugbot caught that the first commit got the per-job key argument only half right, and the PR's own first run proved it. Four jobs build the collector — `linux-systemd-smoke`, `linux-package-smoke`, `windows-package-smoke`, `release-check` — but listed only `cli/beacon` and `cli/beacon-hooks`. `builder.yaml` compiles the local exporter into the collector (`path: ./exporter/beaconjsonexporter`), so those jobs pull an OTel tree the CLI-only jobs never touch.

Both `cross-build (linux, amd64)` and `linux-systemd-smoke` reserved the **same** key on the first run, and both lost the race:

```
Failed to save: Unable to reserve cache with key
setup-go-Linux-x64-ubuntu24-go-1.25.0-574e01a7505c..., another job may be creating this cache.
```

Five `cross-build` legs plus `linux-systemd-smoke`, `linux-package-smoke` and `release-check` all hashed to that one key. Whether the collector tree got cached at all was a coin flip, and when a CLI-only job won, the collector jobs restored the smaller cache, re-downloaded the OTel tree, and were then blocked from saving the bigger one.

Listing the exporter in those four jobs keys them apart *and* prefetches the collector core with retries. Its `go.sum` pins `pdata v1.27.0`, `component v1.27.0`, `consumer v1.27.0`, `exporter v0.121.0`, `configretry v1.27.0` and `zap v1.27.0` — every module named in the failure that opened this PR, at the versions `builder.yaml` resolves to.

`package-smoke` keeps the CLI-only list on purpose: it stubs the collector with a shell script rather than building one.

Bugbot's autofix agent pushed the same change independently while this one was being prepared; the two are merged, so both commits are in history and no module list ended up with a duplicate entry.

## Measured on this PR's own runs

Not predictions — read out of the job logs on head `79ae971`:

| Claim | Evidence |
| --- | --- |
| The cache now restores | `go-test` (macOS, the originally failing job): `Cache hit occurred on the primary key setup-go-macOS-arm64-go-1.25.0-cfd9d635...` |
| The `Restore cache failed` warning is gone | Replaced by an explicit `cache-dependency-path: cli/beacon/go.sum  cli/beacon-hooks/go.sum  collector-builder/exporter/beaconjsonexporter/go.sum` |
| Collector jobs no longer collide with CLI-only jobs | Their key is now `335813970d4f...`; `cross-build`'s is `574e01a7505c...` |
| The collector key really holds the OTel tree | `release-check`: `Cache hit occurred on the primary key setup-go-Linux-x64-ubuntu24-go-1.25.0-335813970d4f...` |

`linux-systemd-smoke` and `linux-package-smoke` still log `Failed to save` on the collector key. That is the intended shape, not a leftover bug: those three jobs deliberately share one key because they need the same modules, GitHub's reserve is atomic, so exactly one uploads per run and the others skip. The `release-check` hit above is that upload being read back.

## Known residual

Stated rather than implied: the builder generates its own module and also pulls `otlpreceiver`, the processors, `splunkhecexporter` and `healthcheckextension`, which no `go.sum` in this repository covers. Those still download inside the builder step without retries — visible in the `linux-systemd-smoke` log as `go: downloading go.opentelemetry.io/collector v0.121.0` and friends. Wrapping that step is a separate change and is not folded in here.

## Checked locally before pushing

- Both YAML files parse, and all nine `actions/setup-go@v5` call sites in `ci.yml` are replaced.
- Ran the two bash bodies verbatim against a stubbed `go`: the `go.sum` derivation produces the expected `GITHUB_OUTPUT` block, and the retry loop both recovers after two failures and fails the step with `::error::` after four.
- **`go mod download` alone is sufficient.** After it, all five modules resolve build *and* test dependencies with `GOPROXY=off`, so nothing is fetched inline during `go test` — the property that makes the prefetch meaningful rather than decorative.
- The prefetch runs before `make build-hooks-current`, so it was confirmed to work with the gitignored `cli/beacon/internal/embedded/hooks.bin` absent. It reads `go.mod`/`go.sum` without loading packages, so the missing embed target does not matter.
- After the second commit, no job's module list contains a duplicate entry, and every collector-building job lists the exporter while the two genuinely CLI-only jobs (`cross-build`, `package-smoke`) do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kn4hbgpL54SZBU6syaJgm