### PR TITLE
Token spend coverage, wave 2 (3/n): group attribution on the canonical model name

### DIFF
--- a/cli/beacon/internal/endpoint/dashboard/summary.go
+++ b/cli/beacon/internal/endpoint/dashboard/summary.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 )
 
 type Count struct {
@@ -90,8 +91,12 @@ func BuildSummary(result EventResult) Summary {
 		if event.Repository != "" {
 			summary.CountsByRepository[event.Repository]++
 		}
-		if event.Model != "" {
-			summary.CountsByModel[event.Model]++
+		// Counted under the canonical name for the reason the token rollups group on it: an event
+		// count keyed on the raw spelling splits one model across several rows, and this summary
+		// sits on the same page as a spend rollup that does not. One page disagreeing with itself
+		// about how many models ran is worse than either answer alone.
+		if model := asymptoteobserve.NormalizeModelName(event.Model); model != "" {
+			summary.CountsByModel[model]++
 		}
 		if event.MCP != nil && event.MCP.Server != "" {
 			summary.CountsByMCPServer[event.MCP.Server]++

--- a/cli/beacon/internal/endpoint/dashboard/summary_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/summary_test.go
@@ -1,0 +1,27 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+)
+
+// The same model under two spellings is one model here too. This summary renders beside a spend
+// rollup that groups canonically, so counting the raw string would have one page report two models
+// where the other reports one.
+func TestSummaryCountsOneModelUnderItsCanonicalName(t *testing.T) {
+	result := EventResult{
+		TotalMatched: 2,
+		Events: []EventRecord{
+			{Event: schema.Event{Timestamp: "2026-06-11T10:00:00Z", Model: "claude-opus-5"}},
+			{Event: schema.Event{Timestamp: "2026-06-11T10:01:00Z", Model: "anthropic/Claude-Opus-5"}},
+		},
+	}
+	summary := BuildSummary(result)
+	if got := summary.CountsByModel["claude-opus-5"]; got != 2 {
+		t.Errorf("counts_by_model[claude-opus-5] = %d, want 2; full map %v", got, summary.CountsByModel)
+	}
+	if len(summary.CountsByModel) != 1 {
+		t.Errorf("counts_by_model = %v, want a single model", summary.CountsByModel)
+	}
+}

--- a/cli/beacon/internal/tokens/tokens.go
+++ b/cli/beacon/internal/tokens/tokens.go
@@ -376,7 +376,7 @@ type sessionModelIndex map[sessionContextKey][]modelDeclaration
 func sessionModelDeclarations(events []schema.Event) sessionModelIndex {
 	index := sessionModelIndex{}
 	for i, event := range events {
-		model := strings.TrimSpace(event.Model)
+		model := asymptoteobserve.NormalizeModelName(event.Model)
 		if model == "" || event.Session == nil || strings.TrimSpace(event.Session.ID) == "" {
 			continue
 		}

--- a/cli/beacon/internal/tokens/tokens.go
+++ b/cli/beacon/internal/tokens/tokens.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/schema"
+	"github.com/asymptote-labs/agent-beacon/pkg/asymptoteobserve"
 )
 
 const defaultNearLimitRatio = 0.8
@@ -417,13 +418,25 @@ func collectUsageEvents(events []schema.Event, sessionUsers sessionUserIndex) []
 			usage = &schema.GenAIUsageInfo{}
 		}
 		ue := &usageEvent{
-			order:      i,
-			action:     event.Event.Action,
-			name:       event.Message,
-			endpoint:   event.Endpoint.Hostname,
-			harness:    event.Harness.Name,
-			user:       userKey(event.User),
-			model:      event.Model,
+			order:    i,
+			action:   event.Event.Action,
+			name:     event.Message,
+			endpoint: event.Endpoint.Hostname,
+			harness:  event.Harness.Name,
+			user:     userKey(event.User),
+			// Canonicalized on the way in, so every consumer downstream -- the by-model rollup,
+			// utilization, the coverage join, the Codex span preference that keys on model --
+			// agrees about what one model is called, from one place.
+			//
+			// Every write path already does this (see normalizeEventModel in the hook logger and
+			// SplitModelProvider in the collector exporter), so a log Beacon wrote recently is
+			// already canonical and this is a no-op on it. It is here for the logs where that does
+			// not hold: those written before that rule existed, which the runtime log retains and
+			// a --since window spans, and any JSONL Beacon reads without having written it.
+			//
+			// Grouping only. The stored event is untouched, and the raw spelling a runtime used
+			// stays in the log where an investigator can still see it.
+			model:      asymptoteobserve.NormalizeModelName(event.Model),
 			repository: event.Repository,
 			usage:      Usage{Events: 1},
 		}

--- a/cli/beacon/internal/tokens/tokens_test.go
+++ b/cli/beacon/internal/tokens/tokens_test.go
@@ -644,3 +644,66 @@ func TestSessionModelCarryForwardDoesNotRelabelSpend(t *testing.T) {
 		}
 	}
 }
+
+// Every path that writes an event now canonicalizes the model name, so a log Beacon wrote after
+// that landed cannot split. This is about the logs where that does not hold: everything written
+// before the rule existed, which the runtime log retains and a --since window spans, and any JSONL
+// Beacon reads without having written -- a customer's own file, or events forwarded in from a
+// producer with its own conventions.
+//
+// Reading is where a report can still be made whole for those, and grouping is the only place it
+// matters: three spellings of one model are three rows, each holding a third of the bill, with
+// nothing on the report saying so. A split row is not obviously wrong to a reader, which is what
+// makes it worth closing rather than tolerating.
+func TestAggregateGroupsOneModelReportedUnderSeveralSpellings(t *testing.T) {
+	mk := func(model string) schema.Event {
+		return usageEventFixture("2026-06-11T10:00:00Z", "claude_code", "s1", model, func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(10)
+		})
+	}
+	report := Aggregate([]schema.Event{
+		mk("claude-opus-5"),
+		mk("anthropic/claude-opus-5"),
+		mk("Claude-Opus-5"),
+		mk("  openrouter/anthropic/Claude-Opus-5  "),
+	}, Options{})
+
+	if len(report.ByModel) != 1 {
+		keys := make([]string, 0, len(report.ByModel))
+		for _, group := range report.ByModel {
+			keys = append(keys, group.Key)
+		}
+		t.Fatalf("by-model rows = %v, want one row for one model", keys)
+	}
+	row := report.ByModel[0]
+	if row.Key != "claude-opus-5" {
+		t.Errorf("by-model key = %q, want the canonical spelling", row.Key)
+	}
+	if row.Usage.TotalTokens() != 40 {
+		t.Errorf("by-model tokens = %d, want all 40 under the one row", row.Usage.TotalTokens())
+	}
+	if len(report.Utilization) != 1 {
+		t.Errorf("utilization rows = %d, want one -- it keys on the model too", len(report.Utilization))
+	}
+	// The totals never split, so they are the control: they were right before this change and must
+	// be unchanged by it.
+	if report.Totals.TotalTokens() != 40 {
+		t.Errorf("totals = %d, want 40", report.Totals.TotalTokens())
+	}
+}
+
+// The normalization is the shared one, so what it declines to do it declines to do here. Folding
+// the dot in "claude-sonnet-4.6" would merge it with Anthropic's "claude-sonnet-4-6", and the same
+// rule turns "gpt-4.1" into a model that exists under no name. A visible split beats an invented
+// id, so these stay two rows.
+func TestAggregateDoesNotMergeModelsThatOnlyLookAlike(t *testing.T) {
+	mk := func(model string) schema.Event {
+		return usageEventFixture("2026-06-11T10:00:00Z", "claude_code", "s1", model, func(e *schema.Event) {
+			e.GenAI.Usage.InputTokens = int64Ptr(10)
+		})
+	}
+	report := Aggregate([]schema.Event{mk("claude-sonnet-4.6"), mk("claude-sonnet-4-6")}, Options{})
+	if len(report.ByModel) != 2 {
+		t.Fatalf("by-model rows = %d, want 2 -- these are different ids and merging them needs a catalog", len(report.ByModel))
+	}
+}


### PR DESCRIPTION
Third of wave 2. Independent of #474.

## The split

One model, four spellings, four rows, each holding a quarter of the bill:

```
by-model rows = [Claude-Opus-5  anthropic/claude-opus-5  claude-opus-5  openrouter/anthropic/Claude-Opus-5]
```

Verified against `Aggregate` before the fix — that's the test output, not a hypothetical. Utilization split the same way, since it keys on the model too. The totals were always right, which is what makes this the dangerous kind of wrong: nothing on the report indicates the per-model numbers don't add up to the model's actual spend.

## This is narrower than it first looks

Worth being precise, because #466's own doc comment argues for normalizing at write time and against spreading the rule to consumers, and that argument still stands.

Every write path already canonicalizes: `normalizeEventModel` runs at the hook logger's single chokepoint (after mapper fields merge, so a new mapper can't reintroduce the split), and the collector exporter and fx mapper each call `SplitModelProvider`. **A log Beacon wrote recently is already canonical, and this change is a no-op on it.**

It's here for the logs where that doesn't hold:

- **Everything written before that rule existed.** The runtime JSONL is retained, and a `--since 30d` window spans the boundary — so reports split rows for the pre-#466 portion of the log for weeks after upgrading.
- **Any JSONL Beacon reads without having written it.** A customer's own file, or events from a producer with its own conventions. Beacon reads that log; it doesn't own everything in it.

So the claim isn't "the write path is broken." It's that the read path should be correct over any log it's pointed at, including ones written before the rule and ones written by something else.

## Applied once, at collection

`collectUsageEvents` canonicalizes on the way in, so every consumer downstream agrees about what one model is called — the by-model rollup, utilization, and `preferCodexTurnSpans`, which keys on endpoint+model and therefore dedupes slightly better as a side effect.

Grouping only. **The stored event is untouched**, and the raw spelling a runtime used stays in the log where an investigator can still see it. This normalizes how spend is *counted*, not what Beacon *recorded*.

## Why the dashboard summary is in scope

`/api/tokens` calls `AggregateScopedWithContexts`, so the dashboard's spend view is fixed for free. Its `counts_by_model` event tally is not — it counted the raw string, one field over from the same bug. Included because the two render on the same page, and one page reporting two models where the other reports one is worse than either answer alone.

## What it still refuses to do

The shared normalization only lowercases and strips the provider prefix (recorded as `gen_ai.provider.name`, not discarded). It does not fold dots, strip date suffixes, or consult an alias table — so `claude-sonnet-4.6` and `claude-sonnet-4-6` stay two rows even though they're plausibly the same model.

That's deliberate and now has a test saying so. Folding the dot merges those two, and the same rule turns `gpt-4.1` into `gpt-4-1`, a model that exists under no name. A visible split beats an invented id: a split row is something a reader can notice, an invented id isn't. Real alias mapping needs a catalog to validate against, which is pricing-work territory.

## Testing

All CI gates green: `cli/beacon` (`./...` and `-race ./internal/endpoint/...`), `cli/beacon-hooks`, `beaconjsonexporter`, `pkg/asymptoteobserve`.

Three new tests: four spellings collapse to one row holding all the spend, the totals are unchanged as a control, and lookalike ids stay separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lm8mXn8Y2pWLw6r8uEwff3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm8mXn8Y2pWLw6r8uEwff3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes per-model spend and utilization attribution on the read path; totals stay the same but model-level numbers users rely on will merge rows that were previously split.
> 
> **Overview**
> **Token rollups and the dashboard event summary now group by the shared canonical model name** (`asymptoteobserve.NormalizeModelName`) instead of the raw `event.Model` string, so multiple spellings of the same model (provider prefixes, casing, whitespace) land in one **by-model** row and one **utilization** row, with **totals unchanged**.
> 
> Normalization is applied at read time in `collectUsageEvents` and `sessionModelDeclarations` in the tokens package, and in `BuildSummary` for `counts_by_model`, so it aligns with spend rollups on the same dashboard page. **Stored events are not rewritten**; only grouping keys change. Legacy or externally sourced JSONL that was never canonicalized at write time is the main beneficiary.
> 
> **Tests** cover four spellings collapsing to one row, dashboard `counts_by_model` matching that behavior, and explicit non-merging of lookalike ids (e.g. `claude-sonnet-4.6` vs `claude-sonnet-4-6`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed26e84271990443ef0307a48685456409818f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->