### PR TITLE
Kiro support (1/7): harness identity

### DIFF
--- a/pkg/asymptoteobserve/harness.go
+++ b/pkg/asymptoteobserve/harness.go
@@ -220,6 +220,35 @@ func NormalizeHarnessName(name string) string {
 		lower == "grok_bot_desktop" || lower == "grok-bot-desktop" || lower == "cursor.grok_bot" ||
 		lower == "cursor/grok_bot" || lower == "xai_grok_bot" || lower == "xai-grok-bot":
 		return "grok_bot"
+	// Kiro is AWS's coding agent. One agent harness runs it in the Kiro IDE, the Kiro CLI
+	// (`kiro-cli`), Kiro Web, Mobile and Crew, and every local surface loads the same
+	// `.kiro/hooks/*.json` files -- so Beacon hooks all of them at once and there is one runtime
+	// to name, not two. The canonical spelling is plain `kiro` for that reason: it follows `cline`
+	// and `openhands`, not `codex_cli`, because a CLI suffix would name one of the surfaces the
+	// events come from and not the others.
+	//
+	// `kiro_code` is accepted as an input spelling but is deliberately not the canonical one.
+	// Kiro's own documentation never uses it -- the product is "Kiro", the IDE is "Kiro IDE" and
+	// the terminal client is "Kiro CLI" -- and choosing a name the vendor does not use would make
+	// harness.name harder to match against anything else a reader has seen.
+	//
+	// Equality against a closed set rather than Contains(lower, "kiro"), for the reason Pi and Oh
+	// My Pi already carry in a sharper form: "kiro" is four characters and Kiro stamps them on
+	// paths and configuration names that legitimately appear in other fields -- `.kiro/hooks`,
+	// `.kiroignore`, `KIRO_HOME`, `kiro_powers`. A substring rule would claim a harness attribute
+	// that merely mentioned one of those. There is no prefix rule for the same reason: a future
+	// runtime named "kirosaki" is not this one.
+	//
+	// Unlike Qwen Code, Muse Code and OpenHands, there is no model family to keep out of the set:
+	// Kiro runs third-party models under their own names and ships none called kiro. The closed
+	// set still holds, because that is a fact about today's model catalog rather than a property
+	// of the name, and a `kiro-*` model id appearing later would otherwise be filed as the agent.
+	case lower == "kiro" || lower == "kiro_ide" || lower == "kiro-ide" || lower == "kiro ide" ||
+		lower == "kiro_cli" || lower == "kiro-cli" || lower == "kiro cli" || lower == "kirocli" ||
+		lower == "kiro_code" || lower == "kiro-code" || lower == "kiro code" || lower == "kirocode" ||
+		lower == "kiro_agent" || lower == "kiro-agent" || lower == "kiro agent" ||
+		lower == "kiro.dev":
+		return "kiro"
 	case name != "":
 		// An unrecognized runtime keeps its own name rather than being coerced or dropped. A new
 		// harness should show up in the log as itself, not as "unknown".

--- a/pkg/asymptoteobserve/harness_test.go
+++ b/pkg/asymptoteobserve/harness_test.go
@@ -547,3 +547,72 @@ func TestGrokModelNamesAreNotTreatedAsGrokBot(t *testing.T) {
 		})
 	}
 }
+
+func TestKiroSpellingsConvergeOnKiro(t *testing.T) {
+	for _, in := range []string{
+		"kiro", "Kiro", "KIRO", " kiro ", "kiro_ide", "kiro-ide", "Kiro IDE",
+		"kiro_cli", "kiro-cli", "Kiro CLI", "kirocli", "kiro_code", "kiro-code",
+		"Kiro Code", "kirocode", "kiro_agent", "kiro-agent", "Kiro Agent", "kiro.dev",
+	} {
+		t.Run(in, func(t *testing.T) {
+			if got := NormalizeHarnessName(in); got != "kiro" {
+				t.Errorf("NormalizeHarnessName(%q) = %q, want %q", in, got, "kiro")
+			}
+		})
+	}
+}
+
+// The reason the Kiro case is an equality match rather than a Contains rule. Kiro stamps its own
+// name on paths and configuration keys that legitimately turn up in other fields -- .kiro/hooks,
+// .kiroignore, KIRO_HOME, kiro_powers -- so a substring rule would report a harness attribute that
+// merely mentioned one of them as a Kiro session. Falling through to the passthrough case is the
+// wanted behavior: the value shows up as itself, which reads as an anomaly.
+func TestNamesMerelyContainingKiroAreNotTheKiroHarness(t *testing.T) {
+	for _, name := range []string{
+		".kiro/hooks", ".kiroignore", "kiro_powers", "kiro-runtime-sandbox", "kirosaki",
+		"kiro-lm-7b", "amazonq",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := NormalizeHarnessName(name); got == "kiro" {
+				t.Errorf("NormalizeHarnessName(%q) = %q; a name merely containing \"kiro\" must "+
+					"not be reported as the Kiro harness", name, got)
+			}
+		})
+	}
+}
+
+// Kiro runs third-party models rather than a family of its own, so the risk Qwen Code, Muse Code
+// and OpenHands guard against -- a model id beginning with the same letters as the harness -- has
+// no instance here today. This pins the guard anyway: a model whose id merely starts with "kiro"
+// must not be filed as the runtime if one ever ships.
+func TestKiroModelSpellingsAreNotTheHarness(t *testing.T) {
+	for _, name := range []string{"kiro-spark-1", "kiro-coder-32b", "aws/kiro-lm-32b-v0.1"} {
+		t.Run(name, func(t *testing.T) {
+			if got := NormalizeHarnessName(name); got == "kiro" {
+				t.Errorf("NormalizeHarnessName(%q) = %q; a model id must not be reported as the "+
+					"Kiro harness", name, got)
+			}
+		})
+	}
+}
+
+// Kiro's IDE and CLI are one harness deliberately: both load the same .kiro/hooks/*.json, so one
+// Beacon install covers both and a suffix would name only one of the places the events come from.
+// Splitting them later would break every query grouping by harness.name, so the merge is pinned.
+func TestKiroIDEAndCLIResolveToOneHarness(t *testing.T) {
+	ide := NormalizeHarnessName("kiro-ide")
+	cli := NormalizeHarnessName("kiro-cli")
+	if ide != cli {
+		t.Fatalf("NormalizeHarnessName(kiro-ide) = %q and NormalizeHarnessName(kiro-cli) = %q; "+
+			"Kiro's surfaces share one hooks directory and must share one harness name", ide, cli)
+	}
+}
+
+// The normalized name is itself a spelling this function accepts, so a row read out of the runtime
+// log and fed back in resolves to the same harness rather than drifting to a second name.
+func TestKiroCanonicalNameIsStableUnderRenormalization(t *testing.T) {
+	once := NormalizeHarnessName("kiro-cli")
+	if got := NormalizeHarnessName(once); got != once {
+		t.Fatalf("NormalizeHarnessName(%q) = %q, want %q", once, got, once)
+	}
+}

--- a/pkg/asymptoteobserve/provenance_test.go
+++ b/pkg/asymptoteobserve/provenance_test.go
@@ -118,6 +118,13 @@ func TestCollectionMethodForPlatform(t *testing.T) {
 		// loads, which it does not -- and would send someone to fix Beacon for a field OpenHands
 		// never sent.
 		"openhands": CollectionMethodHook,
+		// Kiro is hook-shaped. The events, the payload shapes and the `.kiro/hooks/*.json` v1
+		// schema are all AWS's, and Beacon only adds a hook file of its own to a directory the
+		// runtime already scans -- owning that one file is a question of who wrote it, not of who
+		// defines the contract. A `plugin` here would claim Beacon ships and versions source Kiro
+		// loads and executes, which it does not: Kiro runs a command, and the command is the same
+		// beacon-hooks binary every other hook runtime runs.
+		"kiro": CollectionMethodHook,
 		// vscode is the case that justifies keying on --platform rather than on the normalized
 		// harness name: its hook and OTLP telemetry both normalize to vscode_copilot, so the
 		// harness name cannot distinguish them and only the flag can.


### PR DESCRIPTION
First of a seven-PR stack adding [Kiro](https://kiro.dev/docs/hooks/) (AWS) as a supported runtime. Each PR is one commit; each is independently green.

`harness.name` is a release contract every downstream query groups by, so the canonical name lands before the mappers — that way the hook path and anything that later reports Kiro over OTLP cannot disagree about what to call it.

**The name is plain `kiro`, not `kiro_cli` or `kiro_code`.** One agent harness runs the Kiro IDE, the Kiro CLI, Web, Mobile and Crew, and every local surface loads the same `.kiro/hooks/*.json` files — so a single Beacon install covers the IDE and the CLI at once, and a suffix would name one of the places the events come from and not the others. It follows `cline` and `openhands`, not `codex_cli`. `kiro_code` is accepted as an input spelling but is not canonical: Kiro's own documentation never uses it.

**Equality against a closed set, not `Contains(lower, "kiro")`.** "kiro" is four characters and Kiro stamps them on paths and configuration names that legitimately appear in other fields — `.kiro/hooks`, `.kiroignore`, `KIRO_HOME`, `kiro_powers` — so a substring rule would claim a harness attribute that merely mentioned one of those.

Unlike Qwen Code, Muse Code and OpenHands there is no model family to keep out of the set today, because Kiro runs third-party models under their own names. The closed set still holds, since that is a fact about today's catalog rather than a property of the name, and a test pins the guard in case a `kiro-*` model ever ships.

`CollectionMethodForPlatform` needs no change — `hook` is its default and Kiro is hook-shaped — but the mapping is pinned by a test so a later edit cannot quietly reclassify it as a plugin because Beacon happens to own the file it writes.

## Testing

`go test ./...` in `pkg/asymptoteobserve`, including new tests for spelling convergence, the substring guard, model-id rejection, IDE/CLI convergence on one name, and stability under renormalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1AqaHYCQJayWHCHwAWXKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1AqaHYCQJayWHCHwAWXKc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive naming and test contract in `pkg/asymptoteobserve` only; no runtime hook install or data-path changes in this PR.
> 
> **Overview**
> First step in Kiro support: **`NormalizeHarnessName`** now maps IDE/CLI/agent spellings (e.g. `kiro-cli`, `kiro_code`, `kiro.dev`) to the single canonical **`kiro`**, using a closed equality set so paths like `.kiro/hooks` or names like `kirosaki` are not mislabeled.
> 
> Tests cover spelling convergence, substring/model-id guards, IDE+CLI sharing one name, and stable re-normalization. **`provenance_test`** explicitly expects **`kiro`** as **`CollectionMethodHook`** so it cannot be reclassified as a plugin later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d7f5884fbe5595fcd95382804917bfffcde2d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->