### PR TITLE
Kiro support (3/7): install Kiro endpoint hooks

### DIFF
--- a/cli/beacon/internal/endpoint/hooks/kiro.go
+++ b/cli/beacon/internal/endpoint/hooks/kiro.go
@@ -1,0 +1,374 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Kiro registers hooks as standalone JSON files in a directory it scans -- `.kiro/hooks/` in a
+// project, `~/.kiro/hooks/` globally -- rather than in one file everybody shares. That makes this
+// the simplest installer of the set: Beacon writes one file of its own and never reads, rewrites
+// or deletes anything a user put beside it.
+//
+// It is worth naming why that is different from the two neighbouring shapes. OpenHands hands
+// Beacon a single hooks.json that is also where the user keeps theirs, so the installer there is a
+// careful merge. Muse Code has a settings key naming one managed file, so Beacon owning that file
+// means taking the only slot, and the installer refuses when somebody already holds it. Kiro has
+// neither problem: every file in the directory is loaded, so an extra one is additive by
+// construction and there is no slot to contend for.
+//
+// Two things about the emitted file are load-bearing and neither is obvious from the schema:
+//
+//   - No `matcher`. The field is documented as a regex, and what it matches depends on the
+//     trigger: a tool name on PreToolUse/PostToolUse, the prompt text on UserPromptSubmit, nothing
+//     at all on SessionStart and Stop. Omitting it means always-match, which is what a telemetry
+//     hook wants on every one of those. Writing the `"*"` that reads as "all tools" in Kiro's IDE
+//     tool-name field would be a different thing entirely here -- `*` is not a valid regex, so at
+//     best it matches nothing and at worst it fails to compile and takes the hook with it.
+//
+//   - No top-level key but `version` and `hooks`. Those two are the whole documented schema, and
+//     Beacon's marker goes on each hook's `name` and `description` instead, which are documented
+//     hook fields. Detection does not rely on either: the hook command is what identifies a Beacon
+//     hook, the same evidence every other runtime's detection uses, because a name is something a
+//     user can edit.
+
+const (
+	// kiroHookDirName is the directory Kiro scans, relative to the scope root.
+	kiroHookDirName = "hooks"
+
+	// kiroHookFileName is the file Beacon owns. Kebab-case and descriptive, which is what Kiro's
+	// own guidance asks for; the name has no meaning to the loader, which takes every .json in the
+	// directory.
+	kiroHookFileName = "beacon-endpoint.json"
+
+	// kiroSchemaVersion is the only value the `version` field accepts today. Written literally
+	// rather than derived, because a file whose version Kiro does not recognize is not a file with
+	// a warning -- it is hooks that never run.
+	kiroSchemaVersion = "v1"
+
+	// kiroHookName marks Beacon's hook definitions for a human reading the file. `name` is a
+	// required field, so this costs nothing; it is deliberately not what detection matches on.
+	kiroHookName = "beacon-endpoint-telemetry"
+
+	// kiroHookDescription is the `description` field, which Kiro documents as documentation only.
+	kiroHookDescription = "Beacon endpoint telemetry. Records local agent activity; makes no network calls."
+)
+
+// Kiro hook timeouts are seconds, and the runtime's own default is 60.
+//
+// Stated at the value for the reason the Qwen, Muse and OpenHands constants give: the same
+// `timeout` field means milliseconds on Qwen and seconds here, the files look alike, and getting
+// it wrong kills every hook mid-write while the install still reports success. Explicit values
+// rather than the inherited default because 60 seconds is a long time to hold an agent turn for a
+// telemetry hook that finishes in milliseconds -- these are ceilings on a hang, not budgets.
+//
+// The two long ones are long for a reason: prompt submission may run the inventory heartbeat, and
+// the closing event flushes cloud telemetry, which has a ten-second timeout of its own.
+//
+// Zero is deliberately never written. On Kiro `0` does not mean "the default", it means *no
+// timeout at all* -- a hook that hung would hang the agent turn with it, indefinitely.
+const (
+	kiroSessionStartTimeoutSeconds = 10
+	kiroPromptSubmitTimeoutSeconds = 30
+	kiroToolTimeoutSeconds         = 10
+	kiroStopTimeoutSeconds         = 45
+)
+
+// kiroEvent binds one Kiro trigger to the beacon-hooks subcommand that maps it.
+type kiroEvent struct {
+	trigger    string
+	subcommand string
+	timeout    int
+}
+
+// kiroEvents are the triggers Beacon subscribes to.
+//
+// Five of Kiro's eleven, and the six that are missing are missing on purpose:
+//
+//   - PostFileCreate, PostFileSave and PostFileDelete would duplicate PostToolUse rather than add
+//     to it. Kiro's file triggers fire only for changes the agent made, and every change the agent
+//     makes goes through a write tool -- so subscribing would record two events for one write,
+//     with no way for a reader to tell they were the same action. The duplicate would also be the
+//     poorer of the two: a file trigger offers the path through a `{{filePath}}` template, while
+//     PostToolUse carries the path, the operation, the content and the result. Double-counting a
+//     file change in a security log is worse than the coverage this leaves on the table, which is
+//     none.
+//
+//   - PreTaskExec and PostTaskExec announce a spec task starting and finishing. They are real
+//     signal with no duplicate, and they are left out because Kiro does not document what they put
+//     on stdin: without a task id or a task name the event would say that some task began, which
+//     is not something an investigator can act on. This is the one deliberate gap that a published
+//     payload would close, and it is recorded in the runtime docs as such rather than left for
+//     someone to rediscover.
+//
+//   - Manual is an operator running a hook by hand. There is nothing for Beacon to observe in it.
+//
+// SessionEnd has no entry because Kiro has no such trigger: Stop is the closing event, and it
+// fires per turn rather than per session.
+var kiroEvents = []kiroEvent{
+	{"SessionStart", "session-start", kiroSessionStartTimeoutSeconds},
+	{"UserPromptSubmit", "prompt-submit", kiroPromptSubmitTimeoutSeconds},
+	{"PreToolUse", "pre-tool", kiroToolTimeoutSeconds},
+	{"PostToolUse", "post-tool", kiroToolTimeoutSeconds},
+	{"Stop", "stop", kiroStopTimeoutSeconds},
+}
+
+type KiroOptions struct {
+	Level    Level
+	LogPath  string
+	UserMode bool
+}
+
+type KiroStatus struct {
+	Installed  bool   `json:"installed"`
+	BinaryPath string `json:"binary_path,omitempty"`
+	HooksPath  string `json:"hooks_path,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+// kiroHooksFile is the v1 hook file, typed to exactly the fields Kiro documents.
+//
+// Its own types rather than the shared settingsHook* ones, for the reason the Muse types give: a
+// field added to a shared struct for another runtime would silently change what Beacon emits here,
+// and Kiro's rejection behavior for an unknown key is not documented. Types that cannot express a
+// key Kiro has not published are what stops that.
+type kiroHooksFile struct {
+	Version string         `json:"version"`
+	Hooks   []kiroHookSpec `json:"hooks"`
+}
+
+// kiroHookSpec is one hook definition.
+//
+// `matcher`, `confirm` and `enabled: false` are all absent by construction. The first two are
+// explained on the file comment and on kiroEvents; `enabled` is written as an explicit true so the
+// file says what it does rather than relying on the default, which is the same call the Muse
+// installer makes about its schema version.
+type kiroHookSpec struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Trigger     string         `json:"trigger"`
+	Action      kiroHookAction `json:"action"`
+	Timeout     int            `json:"timeout,omitempty"`
+	Enabled     bool           `json:"enabled"`
+}
+
+// kiroHookAction is a command action. The `agent` action type -- which injects a prompt instead of
+// running a command -- is never written: it would spend model tokens and cannot observe anything.
+type kiroHookAction struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+var kiroRuntime = hookRuntime{
+	displayName: "Kiro",
+	configPath:  kiroHooksPath,
+	install:     installKiroHooks,
+	uninstall:   removeKiroHooks,
+	isInstalled: isKiroInstalledAt,
+}
+
+func InstallKiro(opts KiroOptions) (KiroStatus, error) {
+	status, err := installRuntimeHooks(kiroRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return KiroStatus{}, err
+	}
+	return kiroStatusFromRuntime(status), nil
+}
+
+func UninstallKiro(opts KiroOptions) (KiroStatus, error) {
+	status, err := uninstallRuntimeHooks(kiroRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return KiroStatus{}, err
+	}
+	return kiroStatusFromRuntime(status), nil
+}
+
+func KiroHookStatus(opts KiroOptions) KiroStatus {
+	return kiroStatusFromRuntime(runtimeHookStatus(kiroRuntime, RuntimeOptions(opts)))
+}
+
+func IsKiroInstalled(opts KiroOptions) bool {
+	return isRuntimeInstalled(kiroRuntime, RuntimeOptions(opts))
+}
+
+func kiroStatusFromRuntime(status runtimeStatus) KiroStatus {
+	return KiroStatus{
+		Installed:  status.Installed,
+		BinaryPath: status.BinaryPath,
+		HooksPath:  status.ConfigPath,
+		Message:    status.Message,
+	}
+}
+
+// installKiroHooks writes Beacon's hook file, replacing any earlier version of it wholesale.
+//
+// Wholesale rather than merged, because this file is Beacon's: nothing a user wrote lives in it,
+// and their own hooks are separate files in the same directory that this never touches. Rewriting
+// is also what lets an install drop a trigger Beacon no longer subscribes to, which a merge would
+// leave behind pointing at a subcommand that had been removed.
+func installKiroHooks(path, binaryPath, logPath, configPath string) error {
+	// Refused rather than overwritten if the file is somebody else's. The name is distinctive
+	// enough that a collision is unlikely, and "unlikely" is not a reason to delete a stranger's
+	// hooks: Kiro loads every file in the directory, so theirs is live.
+	if err := kiroHookFileIsBeacons(path); err != nil {
+		return err
+	}
+	prefix := endpointCommandPrefix("kiro", binaryPath, logPath, configPath)
+	file := kiroHooksFile{Version: kiroSchemaVersion}
+	for _, event := range kiroEvents {
+		file.Hooks = append(file.Hooks, kiroHookSpec{
+			// The trigger is in the name because Kiro documents `name` as a unique identifier and
+			// all five of these live in one file.
+			Name:        kiroHookName + "-" + strings.ToLower(event.trigger),
+			Description: kiroHookDescription,
+			Trigger:     event.trigger,
+			Action:      kiroHookAction{Type: "command", Command: prefix + " " + event.subcommand},
+			Timeout:     event.timeout,
+			Enabled:     true,
+		})
+	}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	// 0644 rather than the 0600 the settings-file installers use, for the reason the OpenHands
+	// installer gives: a project-scope file gets committed and read by everyone working in the
+	// repository, and a mode only its author can read would make the hooks stop working for the
+	// next person to check it out. The same mode is used at user scope so the two scopes do not
+	// differ in a way nobody would think to look for.
+	return os.WriteFile(path, data, 0644)
+}
+
+// kiroHookFileIsBeacons reports whether Beacon may write the file at path.
+//
+// It may when there is nothing there, when the file is empty, when it is unreadable as a v1 hook
+// file (which Kiro would be ignoring anyway), or when every hook in it is one Beacon wrote.
+// Anything else is somebody's live registration under Beacon's chosen filename, and this returns
+// an error naming it.
+func kiroHookFileIsBeacons(path string) error {
+	file, err := readKiroHooks(path)
+	if err != nil {
+		// A file Beacon cannot parse is one Kiro cannot load either, so there are no live hooks in
+		// it to protect. Overwriting is the outcome that leaves the operator with working
+		// telemetry rather than an install that refuses over a file that was already broken.
+		return nil
+	}
+	for _, hook := range file.Hooks {
+		if !isEndpointHookCommand(hook.Action.Command, "kiro") {
+			return fmt.Errorf(
+				"%s already defines a hook Beacon did not write (%q); Beacon owns that filename, "+
+					"so it will not overwrite it. Move that hook to another file in the same "+
+					"directory -- Kiro merges every hook file it finds -- and run the install again",
+				path, hook.Name)
+		}
+	}
+	return nil
+}
+
+// readKiroHooks parses a hook file, or returns an empty one when there is none.
+func readKiroHooks(path string) (kiroHooksFile, error) {
+	var file kiroHooksFile
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return file, nil
+		}
+		return kiroHooksFile{}, err
+	}
+	// An empty file is not malformed JSON to a person, and treating it as an error would make an
+	// install fail on a file somebody had created but not written.
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return file, nil
+	}
+	if err := json.Unmarshal(data, &file); err != nil {
+		return kiroHooksFile{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	return file, nil
+}
+
+// removeKiroHooks deletes Beacon's hook file.
+//
+// The whole file, because the whole file is Beacon's. A file that has since acquired a hook Beacon
+// did not write is left alone rather than deleted: an uninstall may remove what it added and
+// nothing more, and the same check that refuses to overwrite a stranger's file refuses to delete
+// one.
+func removeKiroHooks(path string) (bool, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false, nil
+	}
+	if err := kiroHookFileIsBeacons(path); err != nil {
+		return false, err
+	}
+	if err := os.Remove(path); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// isKiroInstalledAt reports whether Beacon's hooks are registered at path.
+//
+// By the hook command, not by the file existing. A file left behind from a previous version of
+// Beacon, or one truncated by a failed write, exists and registers nothing -- and reporting that
+// as installed is how an operator ends up believing a machine is monitored when it is not.
+func isKiroInstalledAt(path string) bool {
+	file, err := readKiroHooks(path)
+	if err != nil {
+		return false
+	}
+	for _, hook := range file.Hooks {
+		if isEndpointHookCommand(hook.Action.Command, "kiro") {
+			return true
+		}
+	}
+	return false
+}
+
+func kiroHooksPath(level Level) (string, error) {
+	dir, err := kiroHooksDir(level)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, kiroHookFileName), nil
+}
+
+// kiroHooksDir resolves the hooks directory for a scope.
+//
+// Both scopes are real and, unusually, neither shadows the other: Kiro documents hooks as merged
+// across scopes rather than resolved by precedence, so a user-scope install keeps working inside a
+// repository that has hooks of its own. That is the opposite of OpenHands, where the loader takes
+// the first location that exists and a project file hides the user one entirely -- and it is why
+// this installer has no advice to give about which scope to pick. User scope covers every project
+// on the machine, which is what an endpoint agent usually wants; project scope commits the hook
+// with the repository, which is what a team standardizing on Beacon usually wants; and having both
+// is not a conflict.
+//
+// KIRO_HOME takes precedence at user scope, matching how Kiro resolves it. It exists so a person
+// can keep separate Kiro profiles on one machine, and on a machine that sets it, ~/.kiro is not
+// where Kiro looks -- so an install that ignored it would write a file nothing reads.
+func kiroHooksDir(level Level) (string, error) {
+	switch level {
+	case "", LevelUser:
+		if base := strings.TrimSpace(os.Getenv("KIRO_HOME")); base != "" {
+			return filepath.Join(base, kiroHookDirName), nil
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".kiro", kiroHookDirName), nil
+	case LevelProject:
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cwd, ".kiro", kiroHookDirName), nil
+	default:
+		return "", fmt.Errorf("unknown hook level %q", level)
+	}
+}

--- a/cli/beacon/internal/endpoint/hooks/kiro_test.go
+++ b/cli/beacon/internal/endpoint/hooks/kiro_test.go
@@ -1,0 +1,556 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
+)
+
+// Kiro's hook loader is silent about a file it does not like, the same way OpenHands' and Muse's
+// are: a hook file that fails validation is skipped and the agent goes on working with no hooks
+// from it. Nothing in the runtime tells Beacon that an install stopped working, so the emitted
+// shape is pinned here rather than trusted.
+
+// kiroUserHooksPath points the user scope at a temp home and returns the path Beacon writes.
+// KIRO_HOME is cleared as well as HOME because kiroHooksDir prefers it, and a developer with it
+// set would otherwise have these tests resolve outside the temp directory.
+func kiroUserHooksPath(t *testing.T) string {
+	t.Helper()
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv("KIRO_HOME", "")
+	path, err := kiroHooksPath(LevelUser)
+	if err != nil {
+		t.Fatalf("kiroHooksPath: %v", err)
+	}
+	return path
+}
+
+func installKiroFixture(t *testing.T, path string) {
+	t.Helper()
+	if err := installKiroHooks(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installKiroHooks returned error: %v", err)
+	}
+}
+
+// readKiroFile decodes the emitted file into a loose map, so an assertion can ask about a key the
+// typed struct does not have. Several of the tests below are about keys Beacon must *not* write.
+func readKiroFile(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hook file: %v", err)
+	}
+	var document map[string]interface{}
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("decode hook file: %v", err)
+	}
+	return document
+}
+
+func kiroHookObjects(t *testing.T, path string) []map[string]interface{} {
+	t.Helper()
+	raw, ok := readKiroFile(t, path)["hooks"].([]interface{})
+	if !ok {
+		t.Fatalf("hook file has no hooks array: %#v", readKiroFile(t, path))
+	}
+	hooks := make([]map[string]interface{}, 0, len(raw))
+	for _, item := range raw {
+		hook, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("hook entry is not an object: %#v", item)
+		}
+		hooks = append(hooks, hook)
+	}
+	return hooks
+}
+
+func kiroHookCommand(t *testing.T, hook map[string]interface{}) string {
+	t.Helper()
+	action, ok := hook["action"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("hook has no action: %#v", hook)
+	}
+	command, _ := action["command"].(string)
+	return command
+}
+
+// ---------------------------------------------------------------------------
+// Fresh install
+// ---------------------------------------------------------------------------
+
+// The five triggers Beacon subscribes to, each bound to the subcommand that maps it. The trigger
+// names are the wire contract: a typo in one is not an error, it is that event silently never
+// firing.
+func TestInstallKiroBindsEveryTrigger(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	installKiroFixture(t, path)
+
+	want := map[string]string{
+		"SessionStart":     "session-start",
+		"UserPromptSubmit": "prompt-submit",
+		"PreToolUse":       "pre-tool",
+		"PostToolUse":      "post-tool",
+		"Stop":             "stop",
+	}
+	hooks := kiroHookObjects(t, path)
+	if len(hooks) != len(want) {
+		t.Fatalf("hook count = %d, want exactly %d", len(hooks), len(want))
+	}
+	seen := map[string]bool{}
+	for _, hook := range hooks {
+		trigger, _ := hook["trigger"].(string)
+		subcommand, ok := want[trigger]
+		if !ok {
+			t.Fatalf("unexpected trigger %q", trigger)
+		}
+		if seen[trigger] {
+			t.Fatalf("trigger %q registered twice", trigger)
+		}
+		seen[trigger] = true
+
+		command := kiroHookCommand(t, hook)
+		if !strings.HasSuffix(command, " "+subcommand) {
+			t.Errorf("trigger %q command = %q, want it to end in the %q subcommand", trigger, command, subcommand)
+		}
+		if !strings.Contains(command, "--platform kiro") {
+			t.Errorf("trigger %q command = %q, want --platform kiro", trigger, command)
+		}
+		// The endpoint settings ride as flags rather than as an inline VAR=value prefix, so the
+		// hook reads the right log and config wherever the runtime is running.
+		for _, flag := range []string{"--log", "--config"} {
+			if !strings.Contains(command, flag) {
+				t.Errorf("trigger %q command = %q, want the %s flag", trigger, command, flag)
+			}
+		}
+	}
+}
+
+// version is the whole reason the file loads. A value Kiro does not recognize is not a warning, it
+// is hooks that never run.
+func TestInstallKiroWritesTheV1SchemaVersion(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	installKiroFixture(t, path)
+
+	if got, _ := readKiroFile(t, path)["version"].(string); got != "v1" {
+		t.Fatalf("version = %q, want v1", got)
+	}
+}
+
+// Every hook is a command hook with an explicit timeout and an explicit enabled flag. The timeout
+// matters: Kiro's default is 60 seconds, which is a long time to hold an agent turn for a hook
+// that finishes in milliseconds.
+func TestInstallKiroWritesTypedCommandHooks(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	installKiroFixture(t, path)
+
+	timeouts := map[string]int{}
+	for _, event := range kiroEvents {
+		timeouts[event.trigger] = event.timeout
+	}
+	for _, hook := range kiroHookObjects(t, path) {
+		trigger, _ := hook["trigger"].(string)
+		action, _ := hook["action"].(map[string]interface{})
+		if got, _ := action["type"].(string); got != "command" {
+			t.Errorf("trigger %q action.type = %q, want command", trigger, got)
+		}
+		if got, _ := hook["enabled"].(bool); !got {
+			t.Errorf("trigger %q enabled = %v, want true", trigger, hook["enabled"])
+		}
+		timeout, ok := hook["timeout"].(float64)
+		if !ok {
+			t.Fatalf("trigger %q has no timeout: %#v", trigger, hook)
+		}
+		if int(timeout) != timeouts[trigger] {
+			t.Errorf("trigger %q timeout = %d, want %d", trigger, int(timeout), timeouts[trigger])
+		}
+		// Zero does not mean "the default" on Kiro, it means no timeout at all -- a hook that hung
+		// would hang the agent turn with it, indefinitely.
+		if timeout == 0 {
+			t.Errorf("trigger %q timeout = 0, which disables the timeout entirely", trigger)
+		}
+	}
+}
+
+// Names must be unique: Kiro documents `name` as the hook's identifier and all five live in one
+// file.
+func TestInstallKiroWritesUniqueHookNames(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	installKiroFixture(t, path)
+
+	seen := map[string]bool{}
+	for _, hook := range kiroHookObjects(t, path) {
+		name, _ := hook["name"].(string)
+		if name == "" {
+			t.Fatalf("hook has no name: %#v", hook)
+		}
+		if seen[name] {
+			t.Fatalf("hook name %q used twice", name)
+		}
+		seen[name] = true
+	}
+}
+
+// No matcher, on any trigger. The field is a regex whose subject depends on the trigger -- a tool
+// name here, the prompt text there, nothing at all on SessionStart and Stop -- and omitting it
+// means always-match, which is what a telemetry hook wants everywhere. The `"*"` that reads as
+// "all tools" in Kiro's IDE tool-name field is not a valid regex, so writing it here would at best
+// match nothing.
+func TestInstallKiroWritesNoMatcher(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	installKiroFixture(t, path)
+
+	for _, hook := range kiroHookObjects(t, path) {
+		if matcher, ok := hook["matcher"]; ok {
+			t.Fatalf("trigger %v carries a matcher %q; omitting it is what makes it always-match",
+				hook["trigger"], matcher)
+		}
+	}
+	// The reason, stated as a check rather than only as prose: "*" does not compile as a regex, so
+	// a future edit that "helpfully" adds it would be adding a hook that cannot fire.
+	if _, err := regexp.Compile("*"); err == nil {
+		t.Fatal("regexp.Compile(\"*\") succeeded; the reason this test gives for omitting the matcher no longer holds")
+	}
+}
+
+// Only the two documented top-level keys. Kiro's v1 schema publishes `version` and `hooks` and
+// nothing else, and its behavior for an unknown top-level key is not documented -- so the marker
+// that other runtimes get goes on each hook's name and description instead.
+func TestInstallKiroWritesOnlyDocumentedTopLevelKeys(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	installKiroFixture(t, path)
+
+	for key := range readKiroFile(t, path) {
+		if key != "version" && key != "hooks" {
+			t.Fatalf("hook file carries an undocumented top-level key %q", key)
+		}
+	}
+}
+
+// The `agent` action type injects a prompt instead of running a command: it spends model tokens
+// and cannot observe anything. Beacon never writes one, and this is the record of why rather than
+// an accident of the struct.
+func TestInstallKiroWritesNoAgentActionsOrConfirmPrompts(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	installKiroFixture(t, path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hook file: %v", err)
+	}
+	for _, forbidden := range []string{`"prompt"`, `"confirm"`, `"confirmCommand"`, `"type": "agent"`} {
+		if strings.Contains(string(data), forbidden) {
+			t.Fatalf("hook file contains %s:\n%s", forbidden, data)
+		}
+	}
+}
+
+// A project-scope hook file gets committed and read by everyone working in the repository, so a
+// mode only its author can read would make the hooks stop working for the next person to check it
+// out. The same mode is used at user scope so the two scopes do not differ in a way nobody would
+// think to look for.
+func TestInstallKiroWritesAWorldReadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not meaningful on Windows")
+	}
+	path := kiroUserHooksPath(t)
+	installKiroFixture(t, path)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat hook file: %v", err)
+	}
+	if info.Mode().Perm() != 0644 {
+		t.Fatalf("hook file mode = %v, want 0644", info.Mode().Perm())
+	}
+}
+
+// The triggers Beacon deliberately does not subscribe to must stay unsubscribed. The file triggers
+// would record a second event for a write PostToolUse already covers, in a security log where
+// double-counting a file change is worse than the coverage it buys; the task triggers have no
+// documented payload; Manual is a person running a hook by hand.
+func TestInstallKiroDoesNotSubscribeToDuplicateOrUndocumentedTriggers(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	installKiroFixture(t, path)
+
+	unwanted := map[string]bool{
+		"PostFileCreate": true, "PostFileSave": true, "PostFileDelete": true,
+		"PreTaskExec": true, "PostTaskExec": true, "Manual": true,
+	}
+	for _, hook := range kiroHookObjects(t, path) {
+		trigger, _ := hook["trigger"].(string)
+		if unwanted[trigger] {
+			t.Fatalf("subscribed to %q; see the kiroEvents comment for why it is excluded", trigger)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reinstall, uninstall, detection
+// ---------------------------------------------------------------------------
+
+// A reinstall replaces the file rather than appending to it. Kiro loads every hook in the file, so
+// an install that appended would register each trigger twice and record every event twice.
+func TestInstallKiroIsIdempotent(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	installKiroFixture(t, path)
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hook file: %v", err)
+	}
+	installKiroFixture(t, path)
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hook file: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("reinstall changed the file:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	if len(kiroHookObjects(t, path)) != len(kiroEvents) {
+		t.Fatalf("hook count after reinstall = %d, want %d", len(kiroHookObjects(t, path)), len(kiroEvents))
+	}
+}
+
+// An install rewrites the whole file, which is what lets it drop a trigger Beacon no longer
+// subscribes to. A merge would leave the stale one behind pointing at a subcommand that no longer
+// exists.
+func TestInstallKiroDropsAStaleBeaconTrigger(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	stale := `{"version":"v1","hooks":[{"name":"beacon-endpoint-telemetry-postfilesave",` +
+		`"trigger":"PostFileSave","action":{"type":"command",` +
+		`"command":"'/tmp/beacon-hooks' --platform kiro --log '/tmp/runtime.jsonl' post-tool"}}]}`
+	writeKiroFixture(t, path, stale)
+
+	installKiroFixture(t, path)
+	for _, hook := range kiroHookObjects(t, path) {
+		if trigger, _ := hook["trigger"].(string); trigger == "PostFileSave" {
+			t.Fatal("a stale Beacon trigger survived a reinstall")
+		}
+	}
+}
+
+func TestUninstallKiroRemovesTheFile(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	installKiroFixture(t, path)
+
+	removed, err := removeKiroHooks(path)
+	if err != nil {
+		t.Fatalf("removeKiroHooks: %v", err)
+	}
+	if !removed {
+		t.Fatal("removeKiroHooks reported no change")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("hook file still present: %v", err)
+	}
+	if isKiroInstalledAt(path) {
+		t.Fatal("isKiroInstalledAt = true after uninstall")
+	}
+}
+
+// Uninstalling twice is not an error, and the second call reports that it changed nothing.
+func TestUninstallKiroOnAbsentFileIsANoOp(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	removed, err := removeKiroHooks(path)
+	if err != nil {
+		t.Fatalf("removeKiroHooks: %v", err)
+	}
+	if removed {
+		t.Fatal("removeKiroHooks reported a change with no file present")
+	}
+}
+
+// Detection is by the hook command, not by the file existing. A file left behind by an earlier
+// Beacon, or truncated by a failed write, exists and registers nothing -- and reporting that as
+// installed is how an operator ends up believing a machine is monitored when it is not.
+func TestIsKiroInstalledReadsTheCommandNotTheFile(t *testing.T) {
+	path := kiroUserHooksPath(t)
+
+	writeKiroFixture(t, path, `{"version":"v1","hooks":[]}`)
+	if isKiroInstalledAt(path) {
+		t.Fatal("an empty hooks array reported as installed")
+	}
+	writeKiroFixture(t, path, `{"version":"v1","hooks":[{"name":"lint","trigger":"PostFileSave",`+
+		`"action":{"type":"command","command":"npx eslint --fix"}}]}`)
+	if isKiroInstalledAt(path) {
+		t.Fatal("somebody else's hook reported as a Beacon install")
+	}
+	// Removed rather than installed over: the install refuses a file it does not own, which is a
+	// separate property with its own test. What is under test here is detection.
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove fixture: %v", err)
+	}
+	installKiroFixture(t, path)
+	if !isKiroInstalledAt(path) {
+		t.Fatal("a Beacon install did not report as installed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Somebody else's file
+// ---------------------------------------------------------------------------
+
+// Beacon owns its filename and nothing beyond it. A file at that name holding a hook Beacon did
+// not write is somebody's live registration -- Kiro loads every file in the directory -- so the
+// install refuses rather than deleting it, and says where to move it.
+func TestInstallKiroRefusesAFileItDoesNotOwn(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	body := `{"version":"v1","hooks":[{"name":"lint-on-save","trigger":"PostFileSave",` +
+		`"action":{"type":"command","command":"npx eslint --fix"}}]}`
+	writeKiroFixture(t, path, body)
+
+	err := installKiroHooks(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json")
+	if err == nil {
+		t.Fatal("install overwrote a hook file Beacon did not write")
+	}
+	if !strings.Contains(err.Error(), "lint-on-save") {
+		t.Errorf("error does not name the hook it refused to replace: %v", err)
+	}
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read hook file: %v", readErr)
+	}
+	if string(data) != body {
+		t.Fatalf("the refused file was modified:\n%s", data)
+	}
+}
+
+// The same check guards uninstall. An uninstall may remove what it added and nothing more.
+func TestUninstallKiroLeavesAFileItDoesNotOwn(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	body := `{"version":"v1","hooks":[{"name":"lint-on-save","trigger":"PostFileSave",` +
+		`"action":{"type":"command","command":"npx eslint --fix"}}]}`
+	writeKiroFixture(t, path, body)
+
+	if _, err := removeKiroHooks(path); err == nil {
+		t.Fatal("uninstall deleted a hook file Beacon did not write")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("the refused file was removed: %v", err)
+	}
+}
+
+// A file Kiro itself could not load has no live hooks to protect, so overwriting it leaves the
+// operator with working telemetry rather than an install that refuses over something already
+// broken.
+func TestInstallKiroOverwritesAnUnparseableFile(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	writeKiroFixture(t, path, "{ this is not json")
+
+	installKiroFixture(t, path)
+	if !isKiroInstalledAt(path) {
+		t.Fatal("install did not replace an unparseable hook file")
+	}
+}
+
+// An empty file is not malformed JSON to a person, and treating it as an error would make an
+// install fail on a file somebody created but never wrote.
+func TestInstallKiroOverwritesAnEmptyFile(t *testing.T) {
+	path := kiroUserHooksPath(t)
+	writeKiroFixture(t, path, "")
+
+	installKiroFixture(t, path)
+	if !isKiroInstalledAt(path) {
+		t.Fatal("install did not fill an empty hook file")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scopes
+// ---------------------------------------------------------------------------
+
+// KIRO_HOME exists so a person can keep separate Kiro profiles on one machine, and on a machine
+// that sets it ~/.kiro is not where Kiro looks -- so an install that ignored it would write a file
+// nothing reads.
+func TestKiroUserScopeHonorsKiroHome(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	profile := t.TempDir()
+	t.Setenv("KIRO_HOME", profile)
+
+	path, err := kiroHooksPath(LevelUser)
+	if err != nil {
+		t.Fatalf("kiroHooksPath: %v", err)
+	}
+	want := filepath.Join(profile, "hooks", kiroHookFileName)
+	if path != want {
+		t.Fatalf("user scope path = %q, want %q", path, want)
+	}
+}
+
+// The default scope is the user one, matching every other runtime's installer: an empty Level is
+// what the CLI passes when the operator did not ask for a scope.
+func TestKiroEmptyLevelIsUserScope(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv("KIRO_HOME", "")
+
+	empty, err := kiroHooksPath("")
+	if err != nil {
+		t.Fatalf("kiroHooksPath(\"\"): %v", err)
+	}
+	user, err := kiroHooksPath(LevelUser)
+	if err != nil {
+		t.Fatalf("kiroHooksPath(user): %v", err)
+	}
+	if empty != user {
+		t.Fatalf("empty level = %q, user level = %q; they must agree", empty, user)
+	}
+}
+
+// Project scope is `<cwd>/.kiro/hooks/`, and it does not consult KIRO_HOME: that variable moves the
+// global directory, not the workspace one.
+func TestKiroProjectScopeIsRelativeToTheWorkingDirectory(t *testing.T) {
+	t.Setenv("KIRO_HOME", t.TempDir())
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	path, err := kiroHooksPath(LevelProject)
+	if err != nil {
+		t.Fatalf("kiroHooksPath: %v", err)
+	}
+	want := filepath.Join(cwd, ".kiro", "hooks", kiroHookFileName)
+	if path != want {
+		t.Fatalf("project scope path = %q, want %q", path, want)
+	}
+}
+
+func TestKiroUnknownLevelIsAnError(t *testing.T) {
+	if _, err := kiroHooksPath("machine"); err == nil {
+		t.Fatal("kiroHooksPath accepted an unknown level")
+	}
+}
+
+// Kiro merges hooks across scopes rather than resolving them by precedence, so a user-scope
+// install and a project-scope one are both live at once and must not collide on a path. This is
+// the opposite of OpenHands, where a project file hides the user one entirely.
+func TestKiroScopesAreDistinctPaths(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv("KIRO_HOME", "")
+
+	user, err := kiroHooksPath(LevelUser)
+	if err != nil {
+		t.Fatalf("kiroHooksPath(user): %v", err)
+	}
+	project, err := kiroHooksPath(LevelProject)
+	if err != nil {
+		t.Fatalf("kiroHooksPath(project): %v", err)
+	}
+	if user == project {
+		t.Fatalf("both scopes resolved to %q", user)
+	}
+}
+
+func writeKiroFixture(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("create hooks dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write hook fixture: %v", err)
+	}
+}


### PR DESCRIPTION
Stacked on #481. This PR's own diff is the third commit.

Kiro registers hooks as standalone JSON files in a directory it scans — `.kiro/hooks/` in a project, `~/.kiro/hooks/` globally — rather than in one file everybody shares. That makes this **the simplest installer of the set**: Beacon writes one file of its own and never reads, rewrites or deletes anything a user put beside it.

Worth naming why that is neither of the two neighbouring shapes:

- **OpenHands** hands Beacon a single `hooks.json` that is also where the user keeps theirs, so that installer is a careful merge.
- **Muse Code** has a settings key naming one managed file, so owning it means taking the only slot, and the installer refuses when somebody already holds it.
- **Kiro** has no slot to contend for: every file in the directory is loaded, so an extra one is additive by construction.

Beacon still owns only its filename. A file at `beacon-endpoint.json` holding a hook Beacon did not write is somebody's live registration, so install and uninstall both refuse it and the error says to move that hook to another file in the same directory — which works, because Kiro merges them. A file Kiro itself could not parse has no live hooks to protect and is overwritten, since refusing over something already broken would leave the operator with no telemetry and no working hook either.

### Two load-bearing details, neither obvious from the schema

**No `matcher`.** The field is a regex whose subject depends on the trigger — a tool name on `PreToolUse`, the prompt text on `UserPromptSubmit`, nothing at all on `SessionStart` and `Stop` — and omitting it means always-match, which is what a telemetry hook wants on all of them. The `"*"` that reads as "all tools" in Kiro's IDE tool-name field would be a different thing here: `*` is not a valid regex, so at best it matches nothing. A test asserts `regexp.Compile("*")` still fails, so the reason cannot silently stop holding.

**No top-level key beyond `version` and `hooks`.** Those two are the whole documented schema and Kiro's behavior for an unknown one is not published; the marker goes on each hook's documented `name` and `description` instead, and detection matches the hook command rather than either, since a name is something a user can edit.

### Five of eleven triggers

The three file triggers are left out because they would **duplicate `PostToolUse` rather than add to it** — every change the agent makes goes through a write tool, so subscribing would record two events for one write with no way to tell they were the same action, and the duplicate would be the poorer of the two (a file trigger offers a path where `PostToolUse` carries the path, the operation, the content and the result). Double-counting a file change in a security log is worse than the coverage that leaves behind, which is none.

`PreTaskExec` and `PostTaskExec` are real signal with no duplicate and are left out because Kiro does not document what they put on stdin: without a task id the event would say only that some task began. **That one is a genuine gap and is recorded as such.**

### Timeouts

Seconds here and milliseconds on Qwen, and the files look alike, so every trigger carries an explicit value rather than inheriting Kiro's 60-second default. **Zero is deliberately never written**: on Kiro it does not mean "the default", it means no timeout at all, and a hook that hung would hang the agent turn with it indefinitely.

### Scopes

Both are real and, unusually, neither shadows the other — Kiro documents hooks as merged across scopes rather than resolved by precedence, the opposite of OpenHands. So the installer has no advice to give about which to pick and writes where it is told. `KIRO_HOME` takes precedence at user scope, because on a machine that sets it `~/.kiro` is not where Kiro looks and an install that ignored it would write a file nothing reads.

## Testing

`go test ./...` and `go test -race ./internal/endpoint/...` in `cli/beacon`. New coverage for every emitted field, the absent ones (`matcher`, `confirm`, agent actions, undocumented top-level keys), idempotency, dropping a stale Beacon trigger, refusing and preserving a file Beacon does not own, overwriting an unparseable or empty one, and each scope including `KIRO_HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1AqaHYCQJayWHCHwAWXKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1AqaHYCQJayWHCHwAWXKc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to local hook file install/uninstall for telemetry; behavior is guarded by ownership checks and covered by extensive tests, with no auth or remote data path changes in this diff.
> 
> **Overview**
> Adds a **Kiro** hook installer that drops `beacon-endpoint.json` under `.kiro/hooks/` (project) or `~/.kiro/hooks/` / `KIRO_HOME/hooks` (user), wiring five triggers (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`) to `beacon-hooks` with `--platform kiro`. Unlike OpenHands/Muse installers, it does not merge shared config—only Beacon’s filename is owned; other hooks stay in sibling JSON files.
> 
> Install **replaces** the whole owned file (idempotent, drops stale Beacon triggers), uses v1 schema with **no `matcher`** (always-match) and only `version`/`hooks` at the top level, **explicit per-trigger timeouts in seconds** (never zero), command-only actions, and `0644` permissions. Install/uninstall **refuse** when `beacon-endpoint.json` contains non-Beacon hooks; broken/empty files may be overwritten. **Installed** state is detected from hook commands, not mere file presence.
> 
> Exposes `InstallKiro`, `UninstallKiro`, `KiroHookStatus`, and `IsKiroInstalled` through the shared `hookRuntime` path. Adds broad tests for emitted JSON shape, safety, scopes, and lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe1086b4a51962c806fae8b9ebd9f504da6e94b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->