### PR TITLE
Kiro support (5/7): wire Kiro into the CLI, diagnostics, dashboard and inventory

### DIFF
--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -888,7 +888,7 @@ var userScopeOnlyHookTargets = map[string]bool{
 }
 
 func allHookTargetsForLevel() []string {
-	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "openhands", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "openhands", "kiro", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 	if endpointOpts.hookLevel != "project" {
 		return all
 	}
@@ -950,6 +950,9 @@ func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[str
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
 		case "openhands":
 			status := endpointhooks.OpenHandsHookStatus(endpointhooks.OpenHandsOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
+		case "kiro":
+			status := endpointhooks.KiroHookStatus(endpointhooks.KiroOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
 		case "muse":
 			status := endpointhooks.MuseHookStatus(endpointhooks.MuseOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})

--- a/cli/beacon/cmd/endpoint_hooks.go
+++ b/cli/beacon/cmd/endpoint_hooks.go
@@ -203,6 +203,20 @@ func installEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 				"and its agent server (used by the CLI and the GUI) reads only the repository file. " +
 				"Run the install again with --level project inside a repository to cover those.")
 		}
+	case "kiro":
+		status, err := endpointhooks.InstallKiro(endpointhooks.KiroOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Kiro hooks installed: %s\n", status.HooksPath)
+		// No scope caveat, unlike OpenHands just above. Kiro merges hook files across scopes
+		// rather than resolving them by precedence, so a user-scope install keeps working inside a
+		// repository that has hooks of its own, and one install covers the IDE and the CLI at
+		// once. There is nothing here that a successful install leaves silently uncovered.
 	case "muse":
 		status, err := endpointhooks.InstallMuse(endpointhooks.MuseOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -416,6 +430,16 @@ func uninstallEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 			return err
 		}
 		fmt.Println(status.Message)
+	case "kiro":
+		status, err := endpointhooks.UninstallKiro(endpointhooks.KiroOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
 	case "muse":
 		status, err := endpointhooks.UninstallMuse(endpointhooks.MuseOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -554,6 +578,12 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
+		case "kiro":
+			statuses["kiro"] = endpointhooks.KiroHookStatus(endpointhooks.KiroOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
 		case "muse":
 			statuses["muse"] = endpointhooks.MuseHookStatus(endpointhooks.MuseOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -637,6 +667,10 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 		case "openhands":
 			status := statuses["openhands"].(endpointhooks.OpenHandsStatus)
 			fmt.Printf("OpenHands hooks: installed=%t path=%s\n", status.Installed, status.HooksPath)
+			fmt.Println(status.Message)
+		case "kiro":
+			status := statuses["kiro"].(endpointhooks.KiroStatus)
+			fmt.Printf("Kiro hooks: installed=%t path=%s\n", status.Installed, status.HooksPath)
 			fmt.Println(status.Message)
 		case "muse":
 			status := statuses["muse"].(endpointhooks.MuseStatus)

--- a/cli/beacon/cmd/endpoint_hooks_repair.go
+++ b/cli/beacon/cmd/endpoint_hooks_repair.go
@@ -148,7 +148,7 @@ func installedHookTargetsForUser(homeDir, logPath string) ([]string, error) {
 }
 
 func repairTargetOrder() []string {
-	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "openhands", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "openhands", "kiro", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 }
 
 // withUserHome runs fn as if it were executing inside another user's profile.

--- a/cli/beacon/cmd/endpoint_targets.go
+++ b/cli/beacon/cmd/endpoint_targets.go
@@ -63,6 +63,14 @@ var harnessTargets = []harnessTarget{
 	// that is All Hands' model family, and accepting it would let someone ask to install hooks for
 	// a model.
 	{name: "openhands", endpointKind: endpointTargetHook, endpointAliases: []string{"openhands", "open-hands"}, hookAliases: []string{"openhands", "open-hands"}},
+	// Kiro. One row for the IDE and the CLI together, because they are one harness reading one
+	// hooks directory -- so "kiro-ide" and "kiro-cli" are aliases of the same install rather than
+	// two targets, and asking for either gets the one that covers both. "kiro" is also the
+	// canonical harness name events are written under, so a row read out of the runtime log and
+	// passed back to --harness resolves to the runtime it names. "kiro-code" is accepted because
+	// people say it; Kiro's own documentation does not, which is why it is an alias and not the
+	// name.
+	{name: "kiro", endpointKind: endpointTargetHook, endpointAliases: []string{"kiro", "kiro-ide", "kiro-cli", "kiro-code"}, hookAliases: []string{"kiro", "kiro-ide", "kiro-cli", "kiro-code"}},
 	{name: "grok", endpointKind: endpointTargetHook, endpointAliases: []string{"grok"}, hookAliases: []string{"grok"}},
 	// "qwen-code" and "qwen_code" both normalize to "qwen-code" through normalizeHarnessKey, so the
 	// two spellings need one alias between them. "qwen-cli" is not accepted: the product is Qwen

--- a/cli/beacon/cmd/kiro_target_test.go
+++ b/cli/beacon/cmd/kiro_target_test.go
@@ -1,0 +1,227 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
+)
+
+// The install -> status -> uninstall round trip for Kiro, through the CLI entry points rather than
+// the package API.
+//
+// Wiring a runtime into `beacon endpoint hooks` means five separate switches (install, uninstall,
+// status collection, status printing, repair) plus a registry row, and every one of them fails by
+// omission rather than by error. TestEveryHookTargetIsWired proves each switch has a case; this
+// proves the cases do the thing their name claims.
+func TestEndpointHooksInstallAndUninstallKiro(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("KIRO_HOME", "")
+	cfg := endpointconfig.Config{LogPath: filepath.Join(home, "runtime.jsonl"), UserMode: true}
+
+	origLevel := endpointOpts.hookLevel
+	t.Cleanup(func() { endpointOpts.hookLevel = origLevel })
+	endpointOpts.hookLevel = "user"
+
+	hooksPath := filepath.Join(home, ".kiro", "hooks", "beacon-endpoint.json")
+	if err := installEndpointHookTarget("kiro", cfg); err != nil {
+		t.Fatalf("installEndpointHookTarget(kiro) returned error: %v", err)
+	}
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("install did not write %s: %v", hooksPath, err)
+	}
+	if !strings.Contains(string(data), "--platform kiro") {
+		t.Fatalf("the hook file does not carry the Kiro hook command:\n%s", data)
+	}
+	var document struct {
+		Version string `json:"version"`
+		Hooks   []struct {
+			Trigger string `json:"trigger"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("the hook file is not valid JSON: %v", err)
+	}
+	if document.Version != "v1" {
+		t.Fatalf("version = %q, want v1; Kiro skips a file whose version it does not know", document.Version)
+	}
+	triggers := map[string]bool{}
+	for _, hook := range document.Hooks {
+		triggers[hook.Trigger] = true
+	}
+	for _, trigger := range []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop"} {
+		if !triggers[trigger] {
+			t.Errorf("the hook file is missing the %q trigger:\n%s", trigger, data)
+		}
+	}
+
+	if !endpointhooks.IsKiroInstalled(endpointhooks.KiroOptions{
+		Level: endpointhooks.LevelUser, LogPath: cfg.LogPath, UserMode: true,
+	}) {
+		t.Fatal("IsKiroInstalled = false after installEndpointHookTarget")
+	}
+
+	if err := uninstallEndpointHookTarget("kiro", cfg); err != nil {
+		t.Fatalf("uninstallEndpointHookTarget(kiro) returned error: %v", err)
+	}
+	if _, err := os.Stat(hooksPath); !os.IsNotExist(err) {
+		t.Fatalf("uninstall left the hook file behind: %v", err)
+	}
+}
+
+// `endpoint hooks repair` walks a hard-coded list rather than the registry, so a runtime absent
+// from it is never repaired -- and repair is what fixes a hook whose binary path went stale after
+// an upgrade. It fails silently: repair reports success having skipped the runtime entirely.
+func TestKiroIsInTheRepairTargetList(t *testing.T) {
+	for _, name := range repairTargetOrder() {
+		if name == "kiro" {
+			return
+		}
+	}
+	t.Fatal("kiro is missing from the repair target list; `endpoint repair` would silently skip it")
+}
+
+// Every spelling a person plausibly types resolves to the one hook target, in both namespaces.
+// The IDE and CLI spellings matter most: they are two products to a user and one install to
+// Beacon, so both have to land on the same target rather than one of them failing to resolve.
+// Space-separated spellings ("kiro ide") are deliberately absent: normalizeHarnessKey folds case
+// and underscores but not spaces, so no runtime accepts them and Kiro is not the place to change
+// that.
+func TestKiroHarnessSpellingsResolveToTheHookTarget(t *testing.T) {
+	for _, spelling := range []string{
+		"kiro", "Kiro", " kiro ", "KIRO", "kiro-ide", "kiro_ide", "KIRO-IDE",
+		"kiro-cli", "kiro_cli", "kiro-code", "kiro_code",
+	} {
+		t.Run(spelling, func(t *testing.T) {
+			target, ok := normalizeEndpointTarget(spelling)
+			if !ok {
+				t.Fatalf("normalizeEndpointTarget(%q) = not found", spelling)
+			}
+			if target.Name != "kiro" || target.Kind != endpointTargetHook {
+				t.Fatalf("normalizeEndpointTarget(%q) = %+v, want the kiro hook target", spelling, target)
+			}
+			if got, ok := normalizeHookTarget(spelling); !ok || got != "kiro" {
+				t.Fatalf("normalizeHookTarget(%q) = %q, %t; want kiro, true", spelling, got, ok)
+			}
+		})
+	}
+}
+
+// The canonical harness name events are written under is itself an accepted spelling, so a row
+// read out of the runtime log and passed back to --harness resolves to the runtime it names.
+func TestKiroCanonicalHarnessNameIsAnAcceptedTarget(t *testing.T) {
+	target, ok := normalizeEndpointTarget("kiro")
+	if !ok || target.Name != "kiro" {
+		t.Fatalf("normalizeEndpointTarget(kiro) = %+v, %t", target, ok)
+	}
+}
+
+// Kiro stays in the --all sweep at both levels. Both scopes are real and neither shadows the other
+// -- Kiro merges hook files across scopes -- so filtering either out would drop coverage rather
+// than avoid a useless install. Install and uninstall both return on the first target error, so a
+// target wrongly filtered out is not the only thing missing: everything ordered after it in the
+// list is skipped too.
+func TestKiroIsSweptAtBothLevels(t *testing.T) {
+	origLevel := endpointOpts.hookLevel
+	t.Cleanup(func() { endpointOpts.hookLevel = origLevel })
+
+	for _, level := range []string{"user", "project"} {
+		endpointOpts.hookLevel = level
+		if !containsTarget(allHookTargetsForLevel(), "kiro") {
+			t.Fatalf("%s-level --all dropped kiro:\n%v", level, allHookTargetsForLevel())
+		}
+	}
+	if userScopeOnlyHookTargets["kiro"] {
+		t.Fatal("kiro is marked user scope only; both of its scopes are live and merged")
+	}
+}
+
+// A project-scope install writes into the repository the operator is standing in, and leaves the
+// user-scope file alone. On Kiro the two are additive rather than exclusive, so the point of this
+// is that one install does not quietly become the other.
+func TestEndpointHooksInstallKiroAtProjectLevel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("KIRO_HOME", "")
+	cfg := endpointconfig.Config{LogPath: filepath.Join(home, "runtime.jsonl"), UserMode: true}
+
+	project := t.TempDir()
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	origLevel := endpointOpts.hookLevel
+	t.Cleanup(func() { endpointOpts.hookLevel = origLevel })
+	endpointOpts.hookLevel = "project"
+
+	if err := installEndpointHookTarget("kiro", cfg); err != nil {
+		t.Fatalf("installEndpointHookTarget(kiro, project) returned error: %v", err)
+	}
+	// os.Getwd resolves symlinks on macOS, where TempDir hands back a /var path that is really
+	// /private/var, so the written path is compared through the same resolution rather than
+	// against the temp directory name.
+	resolved, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if _, err := os.ReadFile(filepath.Join(resolved, ".kiro", "hooks", "beacon-endpoint.json")); err != nil {
+		t.Fatalf("project install did not write .kiro/hooks/beacon-endpoint.json: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".kiro", "hooks", "beacon-endpoint.json")); !os.IsNotExist(err) {
+		t.Fatalf("project install also wrote the user-scope file: %v", err)
+	}
+}
+
+// Kiro loads every file in its hooks directory, so an install must be additive: a user's own hook
+// file sitting beside Beacon's has to survive both the install and the uninstall. This is the
+// property that makes Kiro's installer simpler than OpenHands', and it is worth a test rather than
+// a comment because it is the whole reason the installer never reads anything but its own file.
+func TestEndpointHooksKiroLeavesOtherHookFilesAlone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("KIRO_HOME", "")
+	cfg := endpointconfig.Config{LogPath: filepath.Join(home, "runtime.jsonl"), UserMode: true}
+
+	origLevel := endpointOpts.hookLevel
+	t.Cleanup(func() { endpointOpts.hookLevel = origLevel })
+	endpointOpts.hookLevel = "user"
+
+	theirs := filepath.Join(home, ".kiro", "hooks", "lint-on-save.json")
+	body := `{"version":"v1","hooks":[{"name":"lint-on-save","trigger":"PostFileSave",` +
+		`"action":{"type":"command","command":"npx eslint --fix"}}]}`
+	if err := os.MkdirAll(filepath.Dir(theirs), 0755); err != nil {
+		t.Fatalf("create hooks dir: %v", err)
+	}
+	if err := os.WriteFile(theirs, []byte(body), 0644); err != nil {
+		t.Fatalf("write their hook file: %v", err)
+	}
+
+	if err := installEndpointHookTarget("kiro", cfg); err != nil {
+		t.Fatalf("installEndpointHookTarget(kiro) returned error: %v", err)
+	}
+	if err := uninstallEndpointHookTarget("kiro", cfg); err != nil {
+		t.Fatalf("uninstallEndpointHookTarget(kiro) returned error: %v", err)
+	}
+
+	after, err := os.ReadFile(theirs)
+	if err != nil {
+		t.Fatalf("their hook file did not survive: %v", err)
+	}
+	if string(after) != body {
+		t.Fatalf("their hook file was modified:\n%s", after)
+	}
+}

--- a/cli/beacon/internal/endpoint/dashboard/kiro_test.go
+++ b/cli/beacon/internal/endpoint/dashboard/kiro_test.go
@@ -1,0 +1,60 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
+)
+
+// The dashboard's harness list is a hand-written sequence of calls, one per runtime, so a runtime
+// left out of it is simply absent from the page with nothing to say it should have been there.
+// That is the failure this guards: an operator looking at the dashboard to check their coverage
+// would conclude Kiro is not a supported runtime.
+func TestHookStatusesIncludesKiro(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("KIRO_HOME", "")
+
+	logPath := filepath.Join(home, "runtime.jsonl")
+	var kiro *HookStatus
+	statuses := hookStatuses(logPath, true)
+	for i := range statuses {
+		if statuses[i].Target == "kiro" {
+			kiro = &statuses[i]
+			break
+		}
+	}
+	if kiro == nil {
+		t.Fatal("hookStatuses omits kiro; the dashboard would show it as an unsupported runtime")
+	}
+	if kiro.Installed {
+		t.Fatalf("kiro reported installed with no hook file present: %+v", kiro)
+	}
+	if kiro.Path == "" {
+		t.Fatalf("kiro reported no path: %+v", kiro)
+	}
+
+	// And it flips once the hooks are actually there, so the row reflects the install rather than
+	// being a permanently empty placeholder.
+	if err := os.MkdirAll(filepath.Join(home, ".kiro", "hooks"), 0755); err != nil {
+		t.Fatalf("create .kiro/hooks: %v", err)
+	}
+	if _, err := endpointhooks.InstallKiro(endpointhooks.KiroOptions{
+		Level: endpointhooks.LevelUser, LogPath: logPath, UserMode: true,
+	}); err != nil {
+		t.Fatalf("InstallKiro: %v", err)
+	}
+	for _, status := range hookStatuses(logPath, true) {
+		if status.Target != "kiro" {
+			continue
+		}
+		if !status.Installed {
+			t.Fatalf("kiro still reported not installed after an install: %+v", status)
+		}
+		return
+	}
+	t.Fatal("kiro disappeared from hookStatuses after an install")
+}

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -374,6 +374,8 @@ func hookStatuses(logPath string, userMode bool) []HookStatus {
 	add("opencode", opencode.Installed, opencode.PluginPath, opencode.BinaryPath, opencode.Message)
 	openhands := endpointhooks.OpenHandsHookStatus(endpointhooks.OpenHandsOptions{Level: level, LogPath: logPath, UserMode: userMode})
 	add("openhands", openhands.Installed, openhands.HooksPath, openhands.BinaryPath, openhands.Message)
+	kiro := endpointhooks.KiroHookStatus(endpointhooks.KiroOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("kiro", kiro.Installed, kiro.HooksPath, kiro.BinaryPath, kiro.Message)
 	muse := endpointhooks.MuseHookStatus(endpointhooks.MuseOptions{Level: level, LogPath: logPath, UserMode: userMode})
 	add("muse", muse.Installed, muse.HooksPath, muse.BinaryPath, muse.Message)
 	qwen := endpointhooks.QwenHookStatus(endpointhooks.QwenOptions{Level: level, LogPath: logPath, UserMode: userMode})

--- a/cli/beacon/internal/endpoint/inventory/inventory.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory.go
@@ -217,6 +217,7 @@ func candidates(home, wd string) []candidate {
 	items = append(items, qwenCandidates(home, wd)...)
 	items = append(items, museCandidates(home)...)
 	items = append(items, openHandsCandidates(home, wd)...)
+	items = append(items, kiroCandidates(home, wd)...)
 	items = append(items, fxCandidates(home, wd)...)
 	seen := map[string]bool{}
 	out := make([]candidate, 0, len(items))
@@ -418,6 +419,37 @@ func openHandsCandidates(home, wd string) []candidate {
 		{runtime: "openhands", path: filepath.Join(openHandsUserDir(home), "hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		{runtime: "openhands", path: filepath.Join(wd, ".openhands", "hooks.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 	}
+}
+
+// Kiro keeps hooks as standalone files in a directory it scans, and Beacon writes one of its own
+// there -- so unlike OpenHands' hooks.json this is a file Beacon owns outright, and unlike Muse
+// Code's managed file there is no second file that has to point at it. One path per scope, and
+// finding it is the whole answer.
+//
+// Both scopes are reported, and here that is coverage rather than the shadowing problem OpenHands
+// has: Kiro merges hook files across scopes instead of taking the first it finds, so a user-scope
+// and a project-scope install are both live and an inventory showing one would understate what is
+// installed rather than overstate it.
+//
+// KIRO_HOME is read here rather than assumed away, for the same reason the installer reads it: on
+// a machine that sets it, ~/.kiro is not where Kiro looks, and an inventory scanning the wrong
+// directory reports "not installed" for a working install.
+func kiroCandidates(home, wd string) []candidate {
+	return []candidate{
+		{runtime: "kiro", path: filepath.Join(kiroUserDir(home), "hooks", "beacon-endpoint.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "kiro", path: filepath.Join(wd, ".kiro", "hooks", "beacon-endpoint.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+	}
+}
+
+// kiroUserDir resolves the global Kiro directory, mirroring the installer.
+//
+// Exported to the test as a function rather than restated there as a literal path, so the
+// expected-candidate list stays correct on a developer machine that happens to set the variable.
+func kiroUserDir(home string) string {
+	if base := strings.TrimSpace(os.Getenv("KIRO_HOME")); base != "" {
+		return base
+	}
+	return filepath.Join(home, ".kiro")
 }
 
 // openHandsUserDir resolves the user-level OpenHands state directory, mirroring the installer.
@@ -819,6 +851,13 @@ func beaconManaged(item candidate, data []byte) bool {
 	// same string in all three places.
 	case "openhands":
 		return strings.Contains(text, "--platform openhands") || strings.Contains(text, "--platform=openhands")
+	// Matched on the hook command rather than on a marker, even though Beacon owns this whole
+	// file. Kiro's v1 schema publishes exactly two top-level keys and says nothing about what it
+	// does with a third, so a marker would be a guess about a loader that fails silently -- and
+	// the command is stronger evidence anyway: it is what the installer writes, what uninstall
+	// keys on, and what survives someone renaming the hooks inside the file.
+	case "kiro":
+		return strings.Contains(text, "--platform kiro") || strings.Contains(text, "--platform=kiro")
 	}
 	if item.runtime == "claude_code" || item.runtime == "codex_cli" {
 		if strings.Contains(text, "OTEL_EXPORTER_OTLP_ENDPOINT") && localEndpointText(text) {

--- a/cli/beacon/internal/endpoint/inventory/inventory_test.go
+++ b/cli/beacon/internal/endpoint/inventory/inventory_test.go
@@ -374,6 +374,11 @@ func TestScanIncludesAllSupportedCurrentUserAndProjectConfigs(t *testing.T) {
 		// install for a machine where Beacon's hooks never run.
 		{runtime: "openhands", path: filepath.Join(openHandsUserDir(home), "hooks.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
 		{runtime: "openhands", path: filepath.Join(work, ".openhands", "hooks.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
+		// Kiro is one Beacon-owned file per scope, and both are reported because Kiro merges hook
+		// files across scopes rather than taking the first it finds -- the opposite of OpenHands
+		// above. Both can be live at once, so showing one would understate the install.
+		{runtime: "kiro", path: filepath.Join(kiroUserDir(home), "hooks", "beacon-endpoint.json"), scope: ScopeUser, format: formatJSON, kind: KindHookConfig},
+		{runtime: "kiro", path: filepath.Join(work, ".kiro", "hooks", "beacon-endpoint.json"), scope: ScopeProject, format: formatJSON, kind: KindHookConfig},
 		// fx has no Beacon-written file, so all three are its own configuration. The two MCP files
 		// are the ones that carry information nothing else here reports: fx's profile server list
 		// and the workspace servers it shares with Claude-compatible runtimes.

--- a/cli/beacon/internal/endpoint/inventory/kiro_test.go
+++ b/cli/beacon/internal/endpoint/inventory/kiro_test.go
@@ -1,0 +1,115 @@
+package inventory
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// Beacon owns its Kiro hook file outright, but detection still keys on the hook command rather
+// than on a marker: Kiro's v1 schema publishes exactly two top-level keys and says nothing about
+// what its loader does with a third, so a marker would be a guess about a loader that fails in
+// silence. Both directions matter -- missing the install reports telemetry as absent on a machine
+// that has it, and claiming another runtime's hooks attributes someone else's install to Kiro.
+func TestKiroManagedDetectionReadsTheHookCommand(t *testing.T) {
+	for name, tc := range map[string]struct {
+		hooks string
+		want  bool
+	}{
+		"flag form": {`{"version":"v1","hooks":[{"name":"beacon-endpoint-telemetry-stop","trigger":"Stop",` +
+			`"action":{"type":"command","command":"'/opt/beacon/hooks/beacon-hooks' --platform kiro --log '/tmp/runtime.jsonl' stop"}}]}`, true},
+		"equals form": {`{"version":"v1","hooks":[{"name":"b","trigger":"Stop",` +
+			`"action":{"type":"command","command":"beacon-hooks --platform=kiro stop"}}]}`, true},
+		"another runtime": {`{"version":"v1","hooks":[{"name":"b","trigger":"Stop",` +
+			`"action":{"type":"command","command":"beacon-hooks --platform claude stop"}}]}`, false},
+		// The two runtimes whose Beacon file has the same name and lives at the same depth under a
+		// dot directory. Nothing but the platform flag separates them, so this is where a
+		// substring rule would have merged two installs.
+		"grok": {`{"version":"v1","hooks":[{"name":"b","trigger":"Stop",` +
+			`"action":{"type":"command","command":"beacon-hooks --platform grok stop"}}]}`, false},
+		"the user's own": {`{"version":"v1","hooks":[{"name":"lint","trigger":"PostFileSave",` +
+			`"action":{"type":"command","command":"npx eslint --fix"}}]}`, false},
+		"no hooks at all": {`{"version":"v1","hooks":[]}`, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := beaconManaged(candidate{runtime: "kiro"}, []byte(tc.hooks))
+			if got != tc.want {
+				t.Errorf("beaconManaged(kiro) = %t, want %t for %s", got, tc.want, tc.hooks)
+			}
+		})
+	}
+}
+
+// Kiro merges hook files across scopes rather than taking the first it finds, so a user-scope and
+// a project-scope install are both live at once. Reporting both is what keeps the inventory from
+// understating an install -- the opposite of the OpenHands case, where showing one scope would
+// overstate it.
+func TestKiroCandidatesCoverBothScopes(t *testing.T) {
+	t.Setenv("KIRO_HOME", "")
+	home := t.TempDir()
+	work := t.TempDir()
+
+	items := kiroCandidates(home, work)
+	if len(items) != 2 {
+		t.Fatalf("kiroCandidates returned %d entries, want one per scope: %+v", len(items), items)
+	}
+	byScope := map[string]candidate{}
+	for _, item := range items {
+		byScope[item.scope] = item
+	}
+	user, ok := byScope[ScopeUser]
+	if !ok {
+		t.Fatalf("no user-scope candidate: %+v", items)
+	}
+	if want := filepath.Join(home, ".kiro", "hooks", "beacon-endpoint.json"); user.path != want {
+		t.Errorf("user candidate = %q, want %q", user.path, want)
+	}
+	project, ok := byScope[ScopeProject]
+	if !ok {
+		t.Fatalf("no project-scope candidate: %+v", items)
+	}
+	if want := filepath.Join(work, ".kiro", "hooks", "beacon-endpoint.json"); project.path != want {
+		t.Errorf("project candidate = %q, want %q", project.path, want)
+	}
+}
+
+// KIRO_HOME moves the global Kiro directory, and on a machine that sets it ~/.kiro is not where
+// Kiro looks. An inventory scanning the wrong directory reports "not installed" for a working
+// install, which is the direction that matters: it understates coverage silently.
+func TestKiroUserCandidateHonorsKiroHome(t *testing.T) {
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv("KIRO_HOME", profile)
+
+	items := kiroCandidates(home, t.TempDir())
+	want := filepath.Join(profile, "hooks", "beacon-endpoint.json")
+	found := false
+	for _, item := range items {
+		if item.path == want {
+			found = true
+		}
+		if item.scope == ScopeUser && item.path != want {
+			t.Errorf("user candidate = %q, want %q", item.path, want)
+		}
+	}
+	if !found {
+		t.Fatalf("no candidate under KIRO_HOME: %+v", items)
+	}
+}
+
+// The project scope does not consult KIRO_HOME: that variable moves the global directory, not the
+// workspace one.
+func TestKiroProjectCandidateIgnoresKiroHome(t *testing.T) {
+	t.Setenv("KIRO_HOME", t.TempDir())
+	work := t.TempDir()
+
+	for _, item := range kiroCandidates(t.TempDir(), work) {
+		if item.scope != ScopeProject {
+			continue
+		}
+		if want := filepath.Join(work, ".kiro", "hooks", "beacon-endpoint.json"); item.path != want {
+			t.Fatalf("project candidate = %q, want %q", item.path, want)
+		}
+		return
+	}
+	t.Fatal("no project-scope candidate")
+}


### PR DESCRIPTION
Stacked on #483. This PR's own diff is the fifth commit.

The installer from #482 is unreachable until this lands. Registering a runtime with `beacon endpoint hooks` means a registry row plus five switches — install, uninstall, status collection, status printing, repair — and **every one of them fails by omission rather than by error**: a missing repair case means `endpoint repair` reports success having skipped the runtime, and a missing dashboard row means an operator checking their coverage concludes Kiro is not supported.

### One row for the IDE and the CLI

They are one harness reading one hooks directory, so `kiro-ide` and `kiro-cli` are aliases of the same install rather than two targets, and asking for either gets the one that covers both — which is the whole reason the harness name has no surface suffix. `kiro-code` is accepted because people say it; Kiro's own documentation does not, which is why it is an alias and not the name.

### No scope caveat, and both scopes swept

Both unlike OpenHands, and for the same reason: Kiro merges hook files across scopes rather than resolving them by precedence, so a user-scope install keeps working inside a repository that has hooks of its own and there is nothing a successful install leaves silently uncovered. Filtering either scope out of the `--all` sweep would drop coverage rather than avoid a useless install.

### Inventory

Reports both scopes, and here reporting both **understates nothing** rather than avoiding an overstatement: both files can be live at once.

Detection keys on the hook command rather than on a marker even though Beacon owns the whole file, because Kiro's v1 schema publishes exactly two top-level keys and says nothing about what its loader does with a third — a marker would be a guess about a loader that fails in silence, and the command is stronger evidence anyway since it survives someone renaming the hooks inside the file. **The detection test includes Grok**, whose Beacon file has the same name at the same depth under a dot directory; nothing but the platform flag separates the two, so that is where a substring rule would have merged two installs.

## Testing

`go test ./...` and `go test -race ./internal/endpoint/...` in `cli/beacon`. New coverage for the install → status → uninstall round trip through the CLI entry points, the repair list, every harness spelling in both namespaces, the `--all` sweep at both levels, a project-scope install not touching the user file, the dashboard row flipping on install, and inventory detection at both scopes including `KIRO_HOME`.

One test covers the property that makes this installer simpler than the others: **a user's own hook file sitting beside Beacon's survives both the install and the uninstall**, because Kiro loads every file in the directory and Beacon reads none of them but its own.

Verified end to end by installing into a temp `$HOME`, firing all five triggers with real payloads, and confirming `session.started` → `prompt.submitted` → `tool.invoked` → `command.executed` → `file.modified` → `mcp.tool_invoked` → `agent.message` → `tool.completed`, all under `harness.name=kiro`, then `endpoint inventory` reporting `beacon_managed: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1AqaHYCQJayWHCHwAWXKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1AqaHYCQJayWHCHwAWXKc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive harness wiring and file-path inventory logic; no changes to auth, collector, or shared install paths beyond writing Kiro’s own hook file via existing APIs.
> 
> **Overview**
> **Registers Kiro** as a first-class hook harness so the existing `beacon endpoint hooks` installer (from the prior stack) is reachable from the CLI and surrounding surfaces.
> 
> Adds a single **`kiro` registry row** with aliases (`kiro-ide`, `kiro-cli`, `kiro-code`) and threads Kiro through **install / uninstall / status**, **`--all` sweeps** (user and project—Kiro is not filtered as user-only), **diagnostics inventory hooks**, **`repair-installed` ordering**, the **local dashboard** hook list, and **endpoint inventory** (user + project `beacon-endpoint.json` paths, `KIRO_HOME`, and `beacon_managed` detection via `--platform kiro`).
> 
> Install messaging explicitly notes **no OpenHands-style scope caveat** because Kiro merges hook files across scopes. New tests cover CLI round-trips, alias resolution, repair list membership, scope behavior, non-destructive installs beside user hook files, dashboard visibility, and inventory detection (including Grok disambiguation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981f13e8f7cb766da6b459816904629709f647fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->