### PR TITLE
Kiro support (7/7): record a Kiro file creation as a create, not a modify

### DIFF
--- a/cli/beacon-hooks/cmd/kiro.go
+++ b/cli/beacon-hooks/cmd/kiro.go
@@ -606,6 +606,9 @@ func parseKiroEdit(input map[string]interface{}, logger *logging.Logger) *evalua
 		toolName:  toolName,
 		filePath:  filePath,
 		diffStr:   diffStr,
+		// The taxonomy already answered this, and the shared diff path would otherwise write
+		// "modify" for a file that did not exist a moment ago.
+		fileOperation: kiroFileOperation(toolName, toolInput, toolResponse),
 	}
 }
 

--- a/cli/beacon-hooks/cmd/kiro_hooks_test.go
+++ b/cli/beacon-hooks/cmd/kiro_hooks_test.go
@@ -674,6 +674,12 @@ func TestKiroCreateProducesAWholeFileDiff(t *testing.T) {
 	if got := leaf(event, "event", "action"); got != "file.modified" {
 		t.Fatalf("event.action = %q, want file.modified", got)
 	}
+	// The shared diff path writes "modify" unless the runtime's parser says otherwise, which
+	// would record a file that did not exist a moment ago as an edit -- and a rule matching
+	// file.operation == "create" would never fire for Kiro.
+	if got := leaf(event, "file", "operation"); got != "create" {
+		t.Fatalf("file.operation = %q, want create", got)
+	}
 	diff := leaf(event, "file", "diff")
 	if diff == "" {
 		t.Fatal("no diff recorded for a create")
@@ -723,7 +729,11 @@ func TestKiroStrReplaceProducesAnEditDiff(t *testing.T) {
 		"tool_response": kiroResult(true, "Edited /repo/app.go"),
 	})
 
-	diff := leaf(lastEndpointEvent(t, logPath), "file", "diff")
+	event := lastEndpointEvent(t, logPath)
+	if got := leaf(event, "file", "operation"); got != "modify" {
+		t.Fatalf("file.operation = %q, want modify", got)
+	}
+	diff := leaf(event, "file", "diff")
 	if !containsLine(diff, "-return nil") || !containsLine(diff, "+return err") {
 		t.Fatalf("edit diff did not describe the replacement:\n%s", diff)
 	}
@@ -1088,4 +1098,30 @@ func runKiroPolicyDeny(t *testing.T, input map[string]interface{}) (code int, st
 		t.Fatalf("the hook returned normally; a Kiro deny must not fall through to the observing path")
 	}
 	return code, stderr, stdout
+}
+
+// The override is opt-in, so no runtime that does not set it changes shape. Claude Code's Write
+// tool creates a file and has always been recorded as "modify" on this path; that is a separate
+// question from Kiro's, and answering it here would change a recorded shape with no fixture to say
+// what it should become.
+func TestFileOperationOverrideIsOptIn(t *testing.T) {
+	setupHookConfigDirs(t)
+	platformFlag = "claude"
+	logPath := filepath.Join(t.TempDir(), "runtime.jsonl")
+	t.Setenv("BEACON_ENDPOINT_MODE", "1")
+	t.Setenv("BEACON_ENDPOINT_LOG", logPath)
+	t.Setenv("BEACON_DISABLE_GIT_METADATA", "1")
+
+	runHookWithInput(t, runPostTool, map[string]interface{}{
+		"hook_event_name": "PostToolUse",
+		"session_id":      "claude-write",
+		"cwd":             "/repo",
+		"tool_name":       "Write",
+		"tool_input":      map[string]interface{}{"file_path": "/repo/new.go", "content": "package main\n"},
+		"tool_response":   map[string]interface{}{"success": true},
+	})
+
+	if got := leaf(lastEndpointEvent(t, logPath), "file", "operation"); got != "modify" {
+		t.Fatalf("file.operation = %q, want the unchanged default modify", got)
+	}
 }

--- a/cli/beacon-hooks/cmd/post_tool.go
+++ b/cli/beacon-hooks/cmd/post_tool.go
@@ -26,11 +26,24 @@ func init() {
 
 // evaluationParams holds the platform-independent fields needed for local hook handling.
 type evaluationParams struct {
-	sessionID   string
-	toolName    string
-	filePath    string
-	diffStr     string
-	extraFields map[string]interface{}
+	sessionID string
+	toolName  string
+	filePath  string
+	diffStr   string
+	// fileOperation overrides the operation recordLocalEdit would otherwise write.
+	//
+	// That default is the literal string "modify", from diffFields, which is right for the
+	// majority of calls that reach this path and wrong for a creation: a file that did not exist
+	// before is recorded as a modification, so a rule matching file.operation == "create" never
+	// fires and a log reader cannot tell a new file from an edited one. It went unnoticed because
+	// most runtimes' create and edit tools both land here and neither told this function which it
+	// was.
+	//
+	// Empty means "leave the default alone", so no existing runtime's recorded shape changes: a
+	// runtime opts in by having its parser answer the question, which is where the answer is
+	// already known.
+	fileOperation string
+	extraFields   map[string]interface{}
 }
 
 func runPostTool(cmd *cobra.Command, args []string) {
@@ -256,6 +269,12 @@ func recordLocalEdit(params *evaluationParams, input map[string]interface{}, log
 	}
 	for key, value := range diffFields(params.filePath, params.diffStr) {
 		fields[key] = value
+	}
+	// Applied after diffFields, which is what wrote the default this replaces.
+	if params.fileOperation != "" {
+		if file, ok := fields["file"].(map[string]interface{}); ok {
+			file["operation"] = params.fileOperation
+		}
 	}
 	fields["tool"] = mergeNested(fields["tool"], map[string]interface{}{"name": params.toolName, "path": params.filePath})
 	if params.sessionID != "" {


### PR DESCRIPTION
Stacked on #485, and the last of the seven. This PR's own diff is the final commit.

A real bug the Kiro work surfaced, kept separate because it touches shared code rather than Kiro's.

The shared diff path writes `file.operation` as the literal string `"modify"`. That is right for the majority of calls that reach it and **wrong for a creation**: a file that did not exist a moment ago is recorded as an edit, so a rule matching `file.operation == "create"` never fires and a log reader cannot tell a new file from a changed one.

It went unnoticed because most runtimes' create and edit tools both land on that path and neither told the function which it was. Kiro's parser already knows — its taxonomy answers exactly this question for the observing path — so the answer is carried through rather than recomputed.

### Deliberately opt-in

`evaluationParams` grows one optional field, and **empty means "leave the default alone"**, so no runtime that does not set it changes shape. Claude Code's `Write` is the case that would: it creates a file and has always been recorded as `"modify"` here, which is a separate question from Kiro's and not one to answer with no fixture saying what it should become. A test pins that it stays as it was.

Happy to fold this into #481 instead if you'd rather the shared-path change not stand alone — it's separate because it is a fix to existing behavior rather than part of adding a runtime.

## Testing

`go test ./...` in `cli/beacon-hooks` and `cli/beacon`. A Kiro create now asserts `file.operation == "create"` and a Kiro `str_replace` asserts `"modify"`; a new test asserts Claude Code's `Write` still records the unchanged `"modify"` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1AqaHYCQJayWHCHwAWXKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1AqaHYCQJayWHCHwAWXKc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry shape change is scoped to Kiro when parsers set the override; other runtimes keep the prior default, with tests locking that in.
> 
> **Overview**
> Fixes **incorrect `file.operation` on the shared post-tool diff path**, which always defaulted to `"modify"` even when the tool created a new file. That broke policies and log readers that match on `file.operation == "create"`.
> 
> **`evaluationParams`** gains an optional **`fileOperation`** field (empty = unchanged behavior). **`recordLocalEdit`** applies it after **`diffFields`** so runtimes can override the default without changing other platforms’ telemetry.
> 
> **Kiro** opts in: **`parseKiroEdit`** sets **`fileOperation`** from **`kiroFileOperation`**, so creates (e.g. `fs_write` / multiplexed `create`) log as **`create`** while edits like **`str_replace`** stay **`modify`**.
> 
> Tests assert Kiro create/modify operations and that **Claude Code `Write`** still records **`modify`** when no override is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7800c3b950054c8414f89f5ce1650d24ac2be5e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->