### PR TITLE
feat(harness): pin goose as a canonical harness name

### DIFF
--- a/pkg/asymptoteobserve/harness.go
+++ b/pkg/asymptoteobserve/harness.go
@@ -249,6 +249,42 @@ func NormalizeHarnessName(name string) string {
 		lower == "kiro_agent" || lower == "kiro-agent" || lower == "kiro agent" ||
 		lower == "kiro.dev":
 		return "kiro"
+	// goose (Block) reaches Beacon over two paths at once, and pinning the name here is what keeps
+	// them from splitting one session in two. The hook path installs with --platform goose; the
+	// OTLP path reads goose's own resource attributes, which set service.name and
+	// service.namespace to the literal string "goose". Both land on the same value only because
+	// this case exists to say so.
+	//
+	// The canonical spelling is plain `goose` for the reason `cline`, `openhands` and `kiro` are
+	// unsuffixed: one agent core serves the CLI, the desktop app and the embedded server, all
+	// three discover the same `.agents/plugins` hooks and all three export under the same
+	// service.name -- so a CLI suffix would name one of the surfaces the events come from and not
+	// the others.
+	//
+	// Equality against a closed set rather than Contains(lower, "goose"), and here the substring
+	// rule would be worse than usual on three counts:
+	//
+	//   - GooseAI is a different company's LLM inference service. Its spellings -- gooseai,
+	//     goose-ai, goose.ai -- are a model provider, not this runtime, and they are deliberately
+	//     absent from the set. That is the Muse Spark and OpenHands LM failure in a sharper form:
+	//     those are at least the same vendor's model, while this would file a third party's
+	//     inference endpoint as Block's agent.
+	//   - "goose" is an ordinary English word, so it turns up in repository names, hostnames and
+	//     user names that a harness attribute can legitimately carry.
+	//   - goose stamps its own name across paths and configuration a reader may pass through this
+	//     function -- .goosehints, GOOSE_MODE, goose-docs -- exactly the Kiro hazard above.
+	//
+	// Everything left out falls to the passthrough case and shows up as itself, which reads as an
+	// anomaly a person can act on rather than a silent misattribution.
+	//
+	// "codename goose" is in the set because it is the project's own branding and appears in
+	// release artifacts and documentation, so it is a spelling that arrives in practice rather
+	// than one invented here.
+	case lower == "goose" || lower == "goose_cli" || lower == "goose-cli" || lower == "goose cli" ||
+		lower == "goosecli" || lower == "goose_agent" || lower == "goose-agent" || lower == "goose agent" ||
+		lower == "codename_goose" || lower == "codename-goose" || lower == "codename goose" ||
+		lower == "block_goose" || lower == "block-goose" || lower == "block goose":
+		return "goose"
 	case name != "":
 		// An unrecognized runtime keeps its own name rather than being coerced or dropped. A new
 		// harness should show up in the log as itself, not as "unknown".

--- a/pkg/asymptoteobserve/harness_test.go
+++ b/pkg/asymptoteobserve/harness_test.go
@@ -22,6 +22,7 @@ func TestHookPlatformsConvergeOnCanonicalNames(t *testing.T) {
 		"qwen":        "qwen_code",
 		"prime":       "prime_agent",
 		"muse":        "muse_code",
+		"goose":       "goose",
 	} {
 		t.Run(platform, func(t *testing.T) {
 			if got := NormalizeHarnessName(platform); got != want {
@@ -41,7 +42,7 @@ func TestCanonicalNamesAreStableUnderRenormalization(t *testing.T) {
 		"claude_code", "codex_cli", "gemini_cli", "antigravity_cli", "vscode_copilot",
 		"copilot_cli", "claude_web", "chatgpt_web", "claude_cowork", "claude_agent_sdk",
 		"openclaw_gateway", "pi_cli", "omp", "cline", "qwen_code", "prime_agent", "vercel_fx",
-		"muse_code", "grok_bot",
+		"muse_code", "grok_bot", "goose",
 	} {
 		t.Run(canonical, func(t *testing.T) {
 			if got := NormalizeHarnessName(canonical); got != canonical {
@@ -612,6 +613,67 @@ func TestKiroIDEAndCLIResolveToOneHarness(t *testing.T) {
 // log and fed back in resolves to the same harness rather than drifting to a second name.
 func TestKiroCanonicalNameIsStableUnderRenormalization(t *testing.T) {
 	once := NormalizeHarnessName("kiro-cli")
+	if got := NormalizeHarnessName(once); got != once {
+		t.Fatalf("NormalizeHarnessName(%q) = %q, want %q", once, got, once)
+	}
+}
+
+// goose (Block) is the case where the two writers demonstrably agree before normalization: the
+// hook path installs with --platform goose and goose's OTLP resource sets service.name to the
+// literal "goose". This pins that agreement rather than assuming it, because the canonical value
+// is what every other goose spelling is folded onto.
+func TestGooseSpellingsConvergeOnGoose(t *testing.T) {
+	for _, in := range []string{
+		"goose", "Goose", "GOOSE", " goose ", "goose_cli", "goose-cli", "Goose CLI", "goosecli",
+		"goose_agent", "goose-agent", "Goose Agent", "codename_goose", "codename-goose",
+		"Codename Goose", "block_goose", "block-goose", "Block Goose",
+	} {
+		t.Run(in, func(t *testing.T) {
+			if got := NormalizeHarnessName(in); got != "goose" {
+				t.Errorf("NormalizeHarnessName(%q) = %q, want %q", in, got, "goose")
+			}
+		})
+	}
+}
+
+// The sharpest reason the goose case is an equality match. GooseAI is a different company's LLM
+// inference service, so a Contains(lower, "goose") rule would report a third party's model
+// provider as Block's agent -- the Muse Spark and OpenHands LM hazard, except that those are at
+// least the same vendor's own model. These must fall through and show up as themselves.
+func TestGooseAIProviderSpellingsAreNotTheGooseHarness(t *testing.T) {
+	for _, name := range []string{
+		"gooseai", "goose-ai", "goose_ai", "goose.ai", "gooseai/gpt-neo-20b", "GooseAI",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := NormalizeHarnessName(name); got == "goose" {
+				t.Errorf("NormalizeHarnessName(%q) = %q; GooseAI is an inference provider and "+
+					"must not be reported as the goose harness", name, got)
+			}
+		})
+	}
+}
+
+// "goose" is an ordinary English word and goose stamps it across its own paths and configuration,
+// so the closed set has to exclude both. Falling through to the passthrough case is the wanted
+// behavior: the value shows up as itself, which reads as an anomaly rather than a goose session.
+func TestNamesMerelyContainingGooseAreNotTheGooseHarness(t *testing.T) {
+	for _, name := range []string{
+		".goosehints", "GOOSE_MODE", "goose-docs", "mongoose", "gooseberry", "wild-goose-chase",
+		"goose-island", "goosebumps",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := NormalizeHarnessName(name); got == "goose" {
+				t.Errorf("NormalizeHarnessName(%q) = %q; a name merely containing \"goose\" must "+
+					"not be reported as the goose harness", name, got)
+			}
+		})
+	}
+}
+
+// The normalized name is itself a spelling this function accepts, so a row read out of the runtime
+// log and fed back in resolves to the same harness rather than drifting to a second name.
+func TestGooseCanonicalNameIsStableUnderRenormalization(t *testing.T) {
+	once := NormalizeHarnessName("codename goose")
 	if got := NormalizeHarnessName(once); got != once {
 		t.Fatalf("NormalizeHarnessName(%q) = %q, want %q", once, got, once)
 	}


### PR DESCRIPTION
First of five PRs adding Goose (Block) support to Beacon. This one adds only the shared harness name; no collection path is wired up yet.

## Why

Goose reaches Beacon over two independent paths, and they must agree on one name:

- **Hooks.** Goose ships a native hook system (`crates/goose/src/hooks/`) with twelve lifecycle events, discovered from `hooks/hooks.json` inside any enabled plugin. Beacon's adapter will install with `--platform goose`.
- **OTLP.** Goose exports real OTel GenAI-semconv traces, metrics and logs over OTLP HTTP (`crates/goose/src/otel/otlp.rs`). Its resource sets `service.name` and `service.namespace` to the literal string `"goose"`.

Without a case in `NormalizeHarnessName` the two agree only by accident of the passthrough rule, and the first spelling that differs — `"Goose"`, `"codename goose"`, a resource attribute carrying a vendor prefix — splits one session in two for every query, dashboard and SIEM detection that groups by `harness.name`.

## What

- A closed-set `goose` case in `pkg/asymptoteobserve/harness.go`, placed above the passthrough.
- Canonical spelling is plain `goose`, following `cline`, `openhands` and `kiro` rather than `codex_cli`: one agent core serves the CLI, the desktop app and the embedded server, all three discover the same `.agents/plugins` hooks and all three export under the same `service.name`, so a CLI suffix would name one of the surfaces the events come from and not the others.

### Why equality and not `Contains(lower, "goose")`

Three hazards that compound, each pinned by a test:

1. **GooseAI is a different company's LLM inference service.** A substring rule would file a third party's model provider as Block's agent. This is the Muse Spark / OpenHands LM hazard except worse — those are at least the same vendor's own model. `gooseai`, `goose-ai`, `goose.ai` are deliberately out of the set.
2. **"goose" is an ordinary English word**, so it turns up in repository names, hostnames and user names a harness attribute legitimately carries.
3. **goose stamps its name across its own paths and config keys** — `.goosehints`, `GOOSE_MODE`, `goose-docs` — the same hazard the Kiro case already carries.

Everything left out falls to the passthrough case and shows up as itself, which reads as an anomaly a person can act on rather than a silent misattribution.

`codename goose` is in the set because it is the project's own branding and appears in release artifacts, so it is a spelling that arrives in practice rather than one invented here.

## Tests

- `TestGooseSpellingsConvergeOnGoose` — the accepted set, including case and whitespace variants.
- `TestGooseAIProviderSpellingsAreNotTheGooseHarness` — the inference provider must fall through.
- `TestNamesMerelyContainingGooseAreNotTheGooseHarness` — config paths, env keys and ordinary words (`mongoose`, `gooseberry`) must fall through.
- `TestGooseCanonicalNameIsStableUnderRenormalization` — a row read out of the runtime log and fed back in resolves to the same harness.
- `goose` added to the two existing shared tables (`TestHookPlatformsConvergeOnCanonicalNames`, `TestCanonicalNamesAreStableUnderRenormalization`).

Gates run green: `pkg/asymptoteobserve`, `cli/beacon`, `cli/beacon` `-race ./internal/endpoint/...`, `cli/beacon-hooks`, `collector-builder/exporter/beaconjsonexporter`.

## Series

1. **this PR** — harness identity
2. `beacon-hooks` Goose payload mapper
3. Goose hook installer + CLI wiring
4. Goose OTLP harness configuration
5. Inventory, detection and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfvajZH6CQRe2Djz42SA2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfvajZH6CQRe2Djz42SA2d)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to harness name normalization and tests in `pkg/asymptoteobserve`; no collection or auth paths change yet.
> 
> **Overview**
> Adds **Block Goose** to Beacon’s shared harness identity layer so hook installs (`--platform goose`) and OTLP `service.name`/`"goose"` always write the same canonical **`goose`** in `harness.name`, avoiding one session splitting across dashboards and SIEM queries.
> 
> `NormalizeHarnessName` gains a **closed-set equality** branch (plain `goose`, CLI/agent variants, codename/block branding)—not substring matching—so GooseAI provider strings, config paths like `.goosehints`, and unrelated words containing “goose” stay on passthrough instead of being mislabeled.
> 
> Tests pin convergence, idempotent re-normalization, hook-platform mapping, and explicit non-goose cases (GooseAI, substring false positives).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2855a8c964f70c7cfe67e8037816ca46d9d4ca0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->