### PR TITLE
feat(endpoint): install goose hooks as a discovered plugin

### DIFF
--- a/cli/beacon/cmd/endpoint_diagnostics.go
+++ b/cli/beacon/cmd/endpoint_diagnostics.go
@@ -888,7 +888,7 @@ var userScopeOnlyHookTargets = map[string]bool{
 }
 
 func allHookTargetsForLevel() []string {
-	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "openhands", "kiro", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	all := []string{"cursor", "codex", "vscode", "factory", "opencode", "openhands", "kiro", "goose", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 	if endpointOpts.hookLevel != "project" {
 		return all
 	}
@@ -950,6 +950,9 @@ func hookStatusesWithConfig(targets []string, cfg endpointconfig.Config) map[str
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
 		case "openhands":
 			status := endpointhooks.OpenHandsHookStatus(endpointhooks.OpenHandsOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
+			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
+		case "goose":
+			status := endpointhooks.GooseHookStatus(endpointhooks.GooseOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})
 			statuses[name] = hookTargetResult{Target: name, Status: targetStatus(status.Installed), Installed: status.Installed, Message: status.Message, Path: status.HooksPath, Raw: status}
 		case "kiro":
 			status := endpointhooks.KiroHookStatus(endpointhooks.KiroOptions{Level: endpointhooks.Level(endpointOpts.hookLevel), LogPath: cfg.LogPath, UserMode: cfg.UserMode})

--- a/cli/beacon/cmd/endpoint_hooks.go
+++ b/cli/beacon/cmd/endpoint_hooks.go
@@ -203,6 +203,31 @@ func installEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 				"and its agent server (used by the CLI and the GUI) reads only the repository file. " +
 				"Run the install again with --level project inside a repository to cover those.")
 		}
+	case "goose":
+		status, err := endpointhooks.InstallGoose(endpointhooks.GooseOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("goose hooks installed: %s\n", status.HooksPath)
+		// Said on every install rather than at one scope, because it is not a scope caveat: goose
+		// discovers plugins from `.agents/plugins`, the shared Open Plugins directory, and can be
+		// told to ignore one from config.yaml or from a settings.json Beacon does not write. So a
+		// file on disk is a registration, not a guarantee that goose is running it -- and that is
+		// the one thing `beacon endpoint status` cannot tell the operator either.
+		fmt.Println("goose loads this plugin unless it is disabled in ~/.config/goose/config.yaml " +
+			"or in a goose settings.json; run `goose session` once and check the runtime log to " +
+			"confirm events are arriving.")
+		if endpointhooks.Level(endpointOpts.hookLevel) == endpointhooks.LevelProject {
+			// goose keeps one plugin per name, project before user, so this replaces rather than
+			// supplements. Worth saying because it is the opposite of Kiro just below, where the
+			// scopes merge.
+			fmt.Println("A project-scope goose plugin replaces the user-scope one of the same name " +
+				"for sessions in this directory rather than running alongside it.")
+		}
 	case "kiro":
 		status, err := endpointhooks.InstallKiro(endpointhooks.KiroOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -430,6 +455,16 @@ func uninstallEndpointHookTarget(name string, cfg endpointconfig.Config) error {
 			return err
 		}
 		fmt.Println(status.Message)
+	case "goose":
+		status, err := endpointhooks.UninstallGoose(endpointhooks.GooseOptions{
+			Level:    endpointhooks.Level(endpointOpts.hookLevel),
+			LogPath:  cfg.LogPath,
+			UserMode: cfg.UserMode,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(status.Message)
 	case "kiro":
 		status, err := endpointhooks.UninstallKiro(endpointhooks.KiroOptions{
 			Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -578,6 +613,12 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 				LogPath:  cfg.LogPath,
 				UserMode: cfg.UserMode,
 			})
+		case "goose":
+			statuses["goose"] = endpointhooks.GooseHookStatus(endpointhooks.GooseOptions{
+				Level:    endpointhooks.Level(endpointOpts.hookLevel),
+				LogPath:  cfg.LogPath,
+				UserMode: cfg.UserMode,
+			})
 		case "kiro":
 			statuses["kiro"] = endpointhooks.KiroHookStatus(endpointhooks.KiroOptions{
 				Level:    endpointhooks.Level(endpointOpts.hookLevel),
@@ -667,6 +708,10 @@ func runEndpointHooksStatus(cmd *cobra.Command, args []string) error {
 		case "openhands":
 			status := statuses["openhands"].(endpointhooks.OpenHandsStatus)
 			fmt.Printf("OpenHands hooks: installed=%t path=%s\n", status.Installed, status.HooksPath)
+			fmt.Println(status.Message)
+		case "goose":
+			status := statuses["goose"].(endpointhooks.GooseStatus)
+			fmt.Printf("goose hooks: installed=%t path=%s\n", status.Installed, status.HooksPath)
 			fmt.Println(status.Message)
 		case "kiro":
 			status := statuses["kiro"].(endpointhooks.KiroStatus)

--- a/cli/beacon/cmd/endpoint_hooks_repair.go
+++ b/cli/beacon/cmd/endpoint_hooks_repair.go
@@ -148,7 +148,7 @@ func installedHookTargetsForUser(homeDir, logPath string) ([]string, error) {
 }
 
 func repairTargetOrder() []string {
-	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "openhands", "kiro", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
+	return []string{"claude", "codex", "cursor", "vscode", "factory", "opencode", "openhands", "kiro", "goose", "cline", "pi", "omp", "grok", "qwen", "muse", "hermes", "devin-cli", "devin-desktop", "antigravity"}
 }
 
 // withUserHome runs fn as if it were executing inside another user's profile.

--- a/cli/beacon/cmd/endpoint_targets.go
+++ b/cli/beacon/cmd/endpoint_targets.go
@@ -71,6 +71,16 @@ var harnessTargets = []harnessTarget{
 	// people say it; Kiro's own documentation does not, which is why it is an alias and not the
 	// name.
 	{name: "kiro", endpointKind: endpointTargetHook, endpointAliases: []string{"kiro", "kiro-ide", "kiro-cli", "kiro-code"}, hookAliases: []string{"kiro", "kiro-ide", "kiro-cli", "kiro-code"}},
+	// goose (Block). One row for the CLI and the desktop app together, because they are one agent
+	// core reading one plugins directory -- so asking for either gets the install that covers both.
+	// "goose" is also the canonical harness name events are written under, so a row read out of the
+	// runtime log and passed back to --harness resolves to the runtime it names. "gooseai" and
+	// "goose-ai" are deliberately not aliases: GooseAI is a different company's inference service,
+	// and accepting either would let someone ask to install hooks for a model provider.
+	//
+	// The OTLP target for goose is a separate row rather than a second kind on this one; it lands
+	// with the config.yaml writer that backs it.
+	{name: "goose", endpointKind: endpointTargetHook, endpointAliases: []string{"goose", "codename-goose", "block-goose"}, hookAliases: []string{"goose", "codename-goose", "block-goose"}},
 	{name: "grok", endpointKind: endpointTargetHook, endpointAliases: []string{"grok"}, hookAliases: []string{"grok"}},
 	// "qwen-code" and "qwen_code" both normalize to "qwen-code" through normalizeHarnessKey, so the
 	// two spellings need one alias between them. "qwen-cli" is not accepted: the product is Qwen

--- a/cli/beacon/cmd/goose_target_test.go
+++ b/cli/beacon/cmd/goose_target_test.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	endpointconfig "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/config"
+	endpointhooks "github.com/asymptote-labs/agent-beacon/cli/beacon/internal/endpoint/hooks"
+)
+
+// The install -> status -> uninstall round trip for goose, through the CLI entry points rather
+// than the package API.
+//
+// Wiring a runtime into `beacon endpoint hooks` means six separate places -- install, uninstall,
+// status collection, status printing, the repair list and the --all sweep -- plus a registry row,
+// and every one of them fails by omission rather than by error. TestEveryHookTargetIsWired proves
+// each switch has a case; this proves the cases do the thing their name claims.
+func TestEndpointHooksInstallAndUninstallGoose(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GOOSE_PATH_ROOT", "")
+	cfg := endpointconfig.Config{LogPath: filepath.Join(home, "runtime.jsonl"), UserMode: true}
+
+	origLevel := endpointOpts.hookLevel
+	t.Cleanup(func() { endpointOpts.hookLevel = origLevel })
+	endpointOpts.hookLevel = "user"
+
+	hooksPath := filepath.Join(home, ".agents", "plugins", "beacon-endpoint", "hooks", "hooks.json")
+	if err := installEndpointHookTarget("goose", cfg); err != nil {
+		t.Fatalf("installEndpointHookTarget(goose) returned error: %v", err)
+	}
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("install did not write %s: %v", hooksPath, err)
+	}
+	if !strings.Contains(string(data), "--platform goose") {
+		t.Fatalf("the hooks file does not carry the goose hook command:\n%s", data)
+	}
+
+	// Decoded rather than string-matched, because goose skips a hooks.json it cannot parse with a
+	// warn line the operator never sees: a file that is written but malformed looks installed and
+	// collects nothing.
+	var document struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("the hooks file is not valid JSON: %v", err)
+	}
+	for _, event := range []string{
+		"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "PostToolUseFailure",
+		"Stop", "SessionEnd",
+	} {
+		rules := document.Hooks[event]
+		if len(rules) != 1 || len(rules[0].Hooks) != 1 {
+			t.Errorf("the hooks file does not register exactly one %q action:\n%s", event, data)
+			continue
+		}
+		if rules[0].Hooks[0].Type != "command" {
+			t.Errorf("%s action type = %q, want command", event, rules[0].Hooks[0].Type)
+		}
+	}
+
+	if !endpointhooks.IsGooseInstalled(endpointhooks.GooseOptions{
+		Level: endpointhooks.LevelUser, LogPath: cfg.LogPath, UserMode: true,
+	}) {
+		t.Fatal("IsGooseInstalled = false after installEndpointHookTarget")
+	}
+
+	if err := uninstallEndpointHookTarget("goose", cfg); err != nil {
+		t.Fatalf("uninstallEndpointHookTarget(goose) returned error: %v", err)
+	}
+	if _, err := os.Stat(hooksPath); !os.IsNotExist(err) {
+		t.Fatalf("uninstall left the hooks file behind: %v", err)
+	}
+	// The plugin directory goes with it: a plugin directory with no hooks file is a plugin goose
+	// still discovers and still records in config.yaml's `plugins` map.
+	pluginRoot := filepath.Join(home, ".agents", "plugins", "beacon-endpoint")
+	if _, err := os.Stat(pluginRoot); !os.IsNotExist(err) {
+		t.Fatalf("uninstall left the plugin directory behind: %v", err)
+	}
+}
+
+// `endpoint hooks repair` walks a hard-coded list rather than the registry, so a runtime absent
+// from it is never repaired -- and repair is what fixes a hook whose binary path went stale after
+// an upgrade. It fails silently: repair reports success having skipped the runtime entirely.
+func TestGooseIsInTheRepairTargetList(t *testing.T) {
+	for _, name := range repairTargetOrder() {
+		if name == "goose" {
+			return
+		}
+	}
+	t.Fatal("goose is missing from the repair target list; `endpoint repair` would silently skip it")
+}
+
+// Every spelling a person plausibly types resolves to the one hook target, in both namespaces.
+// Space-separated spellings are deliberately absent: normalizeHarnessKey folds case and
+// underscores but not spaces, so no runtime accepts them and goose is not the place to change that.
+func TestGooseHarnessSpellingsResolveToTheHookTarget(t *testing.T) {
+	for _, spelling := range []string{
+		"goose", "Goose", " goose ", "GOOSE", "codename-goose", "codename_goose",
+		"block-goose", "block_goose",
+	} {
+		t.Run(spelling, func(t *testing.T) {
+			target, ok := normalizeEndpointTarget(spelling)
+			if !ok {
+				t.Fatalf("normalizeEndpointTarget(%q) = not found", spelling)
+			}
+			if target.Name != "goose" || target.Kind != endpointTargetHook {
+				t.Fatalf("normalizeEndpointTarget(%q) = %+v, want the goose hook target", spelling, target)
+			}
+			if got, ok := normalizeHookTarget(spelling); !ok || got != "goose" {
+				t.Fatalf("normalizeHookTarget(%q) = %q, %t; want goose, true", spelling, got, ok)
+			}
+		})
+	}
+}
+
+// GooseAI is a different company's LLM inference service, and accepting either spelling here would
+// let someone ask to install hooks for a model provider. The same exclusion NormalizeHarnessName
+// makes, made again at the point a person types a name.
+func TestGooseAIProviderSpellingsAreNotAGooseTarget(t *testing.T) {
+	for _, spelling := range []string{"gooseai", "goose-ai", "goose_ai"} {
+		t.Run(spelling, func(t *testing.T) {
+			if target, ok := normalizeEndpointTarget(spelling); ok && target.Name == "goose" {
+				t.Fatalf("normalizeEndpointTarget(%q) resolved to the goose runtime; that spelling "+
+					"names an inference provider", spelling)
+			}
+		})
+	}
+}
+
+// The canonical harness name events are written under is itself an accepted spelling, so a row
+// read out of the runtime log and passed back to --harness resolves to the runtime it names.
+func TestGooseCanonicalHarnessNameIsAnAcceptedTarget(t *testing.T) {
+	target, ok := normalizeEndpointTarget("goose")
+	if !ok || target.Name != "goose" {
+		t.Fatalf("normalizeEndpointTarget(goose) = %+v, %t", target, ok)
+	}
+}
+
+// goose stays in the --all sweep at both levels. Both scopes are real: a user install covers every
+// project on the machine, and a project install commits the plugin with the repository. Install and
+// uninstall both return on the first target error, so a target wrongly filtered out is not the only
+// thing missing -- everything ordered after it in the list is skipped too.
+func TestGooseIsSweptAtBothLevels(t *testing.T) {
+	origLevel := endpointOpts.hookLevel
+	t.Cleanup(func() { endpointOpts.hookLevel = origLevel })
+
+	for _, level := range []string{"user", "project"} {
+		endpointOpts.hookLevel = level
+		if !containsTarget(allHookTargetsForLevel(), "goose") {
+			t.Fatalf("%s-level --all dropped goose:\n%v", level, allHookTargetsForLevel())
+		}
+	}
+	if userScopeOnlyHookTargets["goose"] {
+		t.Fatal("goose is marked user scope only; its project scope is a real install location")
+	}
+}
+
+// A project-scope install writes into the repository the operator is standing in, and leaves the
+// user-scope file alone.
+//
+// On goose the two are exclusive rather than additive -- it deduplicates plugins by name with
+// project scope first -- so the point of this is that one install does not quietly become the
+// other, and that an operator who installs at both ends up with one registration rather than two
+// copies of every event.
+func TestEndpointHooksInstallGooseAtProjectLevel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GOOSE_PATH_ROOT", "")
+	cfg := endpointconfig.Config{LogPath: filepath.Join(home, "runtime.jsonl"), UserMode: true}
+
+	project := t.TempDir()
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	origLevel := endpointOpts.hookLevel
+	t.Cleanup(func() { endpointOpts.hookLevel = origLevel })
+	endpointOpts.hookLevel = "project"
+
+	if err := installEndpointHookTarget("goose", cfg); err != nil {
+		t.Fatalf("installEndpointHookTarget(goose, project) returned error: %v", err)
+	}
+	// os.Getwd resolves symlinks on macOS, where TempDir hands back a /var path that is really
+	// /private/var, so the written path is compared through the same resolution rather than against
+	// the temp directory name.
+	resolved, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	projectPath := filepath.Join(resolved, ".agents", "plugins", "beacon-endpoint", "hooks", "hooks.json")
+	if _, err := os.ReadFile(projectPath); err != nil {
+		t.Fatalf("project install did not write %s: %v", projectPath, err)
+	}
+	userPath := filepath.Join(home, ".agents", "plugins", "beacon-endpoint", "hooks", "hooks.json")
+	if _, err := os.Stat(userPath); !os.IsNotExist(err) {
+		t.Fatalf("project install also wrote the user-scope file at %s (err=%v)", userPath, err)
+	}
+}

--- a/cli/beacon/internal/endpoint/dashboard/server.go
+++ b/cli/beacon/internal/endpoint/dashboard/server.go
@@ -376,6 +376,8 @@ func hookStatuses(logPath string, userMode bool) []HookStatus {
 	add("openhands", openhands.Installed, openhands.HooksPath, openhands.BinaryPath, openhands.Message)
 	kiro := endpointhooks.KiroHookStatus(endpointhooks.KiroOptions{Level: level, LogPath: logPath, UserMode: userMode})
 	add("kiro", kiro.Installed, kiro.HooksPath, kiro.BinaryPath, kiro.Message)
+	goose := endpointhooks.GooseHookStatus(endpointhooks.GooseOptions{Level: level, LogPath: logPath, UserMode: userMode})
+	add("goose", goose.Installed, goose.HooksPath, goose.BinaryPath, goose.Message)
 	muse := endpointhooks.MuseHookStatus(endpointhooks.MuseOptions{Level: level, LogPath: logPath, UserMode: userMode})
 	add("muse", muse.Installed, muse.HooksPath, muse.BinaryPath, muse.Message)
 	qwen := endpointhooks.QwenHookStatus(endpointhooks.QwenOptions{Level: level, LogPath: logPath, UserMode: userMode})

--- a/cli/beacon/internal/endpoint/hooks/goose.go
+++ b/cli/beacon/internal/endpoint/hooks/goose.go
@@ -1,0 +1,439 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// goose discovers hooks through plugins, not through a settings file, so Beacon installs itself as
+// a plugin whose only content is a hooks file.
+//
+// The mechanism, from crates/goose/src/plugins/discovery.rs and crates/goose/src/hooks/mod.rs:
+// goose lists the immediate subdirectories of its plugins directory, treats each one as a plugin
+// named after the directory, and loads `<plugin-root>/hooks/hooks.json` from every plugin that is
+// enabled. So Beacon owns a directory rather than a file -- the Kiro shape one level up.
+//
+// Three consequences of that shape, all of which this installer is built around:
+//
+//   - The plugins directory is `.agents/plugins`, which is the Open Plugins convention rather than
+//     goose's own namespace. Another agent that implements the same specification would discover
+//     this plugin too and run its commands, and the command says `--platform goose`, so those
+//     events would be attributed to goose. Beacon has no way to tell from a payload which host
+//     invoked it -- goose sets no distinguishing variable, and the event schema carries no field
+//     for the question. This is a real limitation with no fix available on Beacon's side; it is
+//     recorded here, and in the README, rather than papered over. It costs nothing today, because
+//     goose is the only runtime Beacon supports that reads this directory.
+//   - Plugin names are deduplicated across scopes, project before user (discover_enabled_plugins
+//     sorts by scope and keeps the first of each name). So a project install of this plugin
+//     shadows the user one rather than adding to it, which is why the two write the same directory
+//     name deliberately: an operator who installs at both scopes gets one registration, not two
+//     copies of every event.
+//   - An operator can disable the plugin without touching this file, through `plugins` in
+//     config.yaml or `disabledPlugins` in settings.json. A disabled plugin still has its hooks
+//     file on disk, so "the file is there" is not the same as "the hooks run" -- see
+//     GooseHookStatus.
+//
+// What goose does with a badly-shaped file is the reason both the emitted shape and the payload
+// readers are pinned by tests: an unparseable hooks.json is skipped with a warn line, an unknown
+// event name is ignored silently, an unsupported action type is ignored silently, and an invalid
+// matcher regex drops just that rule. Nothing surfaces to the operator.
+
+// gooseHookDirName and gooseHookFileName are the path goose loads hooks from inside a plugin.
+const (
+	gooseHookDirName  = "hooks"
+	gooseHookFileName = "hooks.json"
+)
+
+// goosePluginDirName is the directory Beacon owns inside the plugins directory.
+//
+// It is also the plugin's name, because goose names a plugin after its directory. `beacon-endpoint`
+// rather than `beacon` so that the name says what it is in a listing of plugins an operator did not
+// all install themselves, and so that it does not collide with anything a person might create while
+// experimenting.
+const goosePluginDirName = "beacon-endpoint"
+
+// gooseAgentsDirName and goosePluginsDirName spell the Open Plugins layout goose discovers.
+const (
+	gooseAgentsDirName  = ".agents"
+	goosePluginsDirName = "plugins"
+)
+
+// goosePathRootEnv is goose's override for every one of its directories.
+//
+// It is honored for the same reason the Kiro installer honors KIRO_HOME: on a machine that sets it,
+// the default location is not where goose looks, so an install that ignored it would write a file
+// nothing reads. goose requires it to be absolute and ignores it otherwise, and this matches that
+// -- a relative value resolves to the default rather than to a path under the working directory.
+const goosePathRootEnv = "GOOSE_PATH_ROOT"
+
+// goose hook timeouts are seconds, and goose's own default is 30.
+//
+// Stated at every value rather than inherited, for the reason the Qwen, Muse, OpenHands and Kiro
+// constants give: the same `timeout` field means milliseconds on Qwen and seconds here, and the
+// files look alike. These are ceilings on a hang rather than budgets -- the hooks finish in
+// milliseconds.
+//
+// The two long ones are long for a reason. Prompt submission may run the inventory heartbeat, and
+// the closing events flush cloud telemetry, which has a ten-second timeout of its own. Both are
+// worth noting on this runtime specifically, because goose holds the turn for a blocking hook and
+// `Stop` is one of them: a hung stop hook is a hung turn until this timeout expires.
+const (
+	gooseSessionStartTimeoutSeconds = 10
+	goosePromptSubmitTimeoutSeconds = 30
+	gooseToolTimeoutSeconds         = 10
+	gooseStopTimeoutSeconds         = 45
+	gooseSessionEndTimeoutSeconds   = 45
+)
+
+// gooseOnFailureAllow is written on the one event where goose reads the field.
+//
+// `on_failure` is honored only for PreToolUse, and "allow" is already goose's default -- so this
+// changes nothing today and is written anyway, because the thing it guards against is goose
+// changing that default. A telemetry hook that blocked a tool call because it had itself failed
+// would be turning an observation problem into an availability problem on the operator's machine.
+// Saying so in the file means the answer does not depend on a default Beacon does not control.
+const gooseOnFailureAllow = "allow"
+
+// gooseEvent binds one goose lifecycle event to the beacon-hooks subcommand that maps it.
+type gooseEvent struct {
+	name       string
+	subcommand string
+	timeout    int
+}
+
+// gooseEvents are the seven events Beacon subscribes to, out of the twelve goose exposes.
+//
+// PostToolUse and PostToolUseFailure share the `post-tool` subcommand. They can, because their
+// payloads are identical, and they must be separate rows because goose has no single post-tool
+// event -- the mapper tells them apart by reading `event`.
+//
+// The five that are left out, and why each is left out rather than forgotten:
+//
+//   - BeforeShellExecution, AfterShellExecution, BeforeReadFile and AfterFileEdit are duplicates.
+//     goose fires each one immediately alongside PreToolUse or PostToolUse for the same call,
+//     carrying the same tool_name and the same tool_input, with only matcher_context differing --
+//     and, unlike the events they shadow, carrying no tool_call_id at all. Subscribing would record
+//     every shell command and every file edit twice, and the second copy would be the one that
+//     could not be correlated with anything.
+//   - PreToolUseResult reports what the PreToolUse hook chain decided: allow or deny, which plugin
+//     denied, and why. That is a real signal and not a duplicate, but it fires once per tool call
+//     whether or not anything was denied, so subscribing to it as-is would double the event volume
+//     to record an outcome that is "allow" almost every time. It is deliberately deferred rather
+//     than declined.
+var gooseEvents = []gooseEvent{
+	{"SessionStart", "session-start", gooseSessionStartTimeoutSeconds},
+	{"UserPromptSubmit", "prompt-submit", goosePromptSubmitTimeoutSeconds},
+	{"PreToolUse", "pre-tool", gooseToolTimeoutSeconds},
+	{"PostToolUse", "post-tool", gooseToolTimeoutSeconds},
+	{"PostToolUseFailure", "post-tool", gooseToolTimeoutSeconds},
+	{"Stop", "stop", gooseStopTimeoutSeconds},
+	{"SessionEnd", "session-end", gooseSessionEndTimeoutSeconds},
+}
+
+type GooseOptions struct {
+	Level    Level
+	LogPath  string
+	UserMode bool
+}
+
+type GooseStatus struct {
+	Installed  bool   `json:"installed"`
+	BinaryPath string `json:"binary_path,omitempty"`
+	HooksPath  string `json:"hooks_path,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+// gooseHooksFile is the document goose parses, typed to exactly the fields it reads.
+//
+// Its own types rather than the shared settingsHook* ones, for the reason the Muse and Kiro types
+// give: a field added to a shared struct for another runtime would silently change what Beacon
+// emits here. goose ignores keys it does not know rather than rejecting them, so a stray field
+// would not break the file -- it would sit in an operator's plugin directory meaning nothing,
+// which is its own kind of wrong.
+type gooseHooksFile struct {
+	Hooks map[string][]gooseHookRule `json:"hooks"`
+}
+
+// gooseHookRule is one matcher group: the rules that fire for an event.
+//
+// `matcher` is deliberately absent rather than written as a catch-all. goose tests the regex
+// against matcher_context, and matcher_context is not a tool name on every event -- on
+// UserPromptSubmit it is the *prompt text*, because HookContext::with_message sets it. A matcher
+// that looked like a harmless ".*" would therefore be a regex run over every prompt, and any
+// narrower one would silently drop prompts that did not match it. An omitted matcher always fires,
+// which is what an observing hook wants on all seven events.
+type gooseHookRule struct {
+	Hooks []gooseHookAction `json:"hooks"`
+}
+
+// gooseHookAction is a command action, holding only the fields Beacon writes.
+//
+// goose supports no other action type today and ignores the ones it does not recognize, so `type`
+// is written explicitly rather than relying on the null-means-command default: a file that says
+// what it is survives goose gaining a second action type whose absence of a `type` means something
+// else.
+type gooseHookAction struct {
+	Type      string `json:"type"`
+	Command   string `json:"command"`
+	Timeout   int    `json:"timeout,omitempty"`
+	OnFailure string `json:"on_failure,omitempty"`
+}
+
+var gooseRuntime = hookRuntime{
+	displayName: "goose",
+	configPath:  gooseHooksPath,
+	install:     installGooseHooks,
+	uninstall:   removeGooseHooks,
+	isInstalled: isGooseInstalledAt,
+}
+
+func InstallGoose(opts GooseOptions) (GooseStatus, error) {
+	status, err := installRuntimeHooks(gooseRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return GooseStatus{}, err
+	}
+	return gooseStatusFromRuntime(status), nil
+}
+
+func UninstallGoose(opts GooseOptions) (GooseStatus, error) {
+	status, err := uninstallRuntimeHooks(gooseRuntime, RuntimeOptions(opts))
+	if err != nil {
+		return GooseStatus{}, err
+	}
+	return gooseStatusFromRuntime(status), nil
+}
+
+func GooseHookStatus(opts GooseOptions) GooseStatus {
+	return gooseStatusFromRuntime(runtimeHookStatus(gooseRuntime, RuntimeOptions(opts)))
+}
+
+func IsGooseInstalled(opts GooseOptions) bool {
+	return isRuntimeInstalled(gooseRuntime, RuntimeOptions(opts))
+}
+
+func gooseStatusFromRuntime(status runtimeStatus) GooseStatus {
+	return GooseStatus{
+		Installed:  status.Installed,
+		BinaryPath: status.BinaryPath,
+		HooksPath:  status.ConfigPath,
+		Message:    status.Message,
+	}
+}
+
+// installGooseHooks writes Beacon's hooks file, replacing any earlier version of it wholesale.
+//
+// Wholesale rather than merged, because the file is Beacon's: it sits inside a plugin directory
+// Beacon created, and an operator's own hooks live in their own plugin. Rewriting is also what lets
+// an install drop an event Beacon no longer subscribes to, which a merge would leave behind
+// pointing at a subcommand that had been removed.
+func installGooseHooks(path, binaryPath, logPath, configPath string) error {
+	// Refused rather than overwritten if the file registers something Beacon did not write. The
+	// plugin directory name is distinctive, and "unlikely to collide" is not a reason to delete a
+	// stranger's hooks: whatever is in this file is live for every goose session on the machine.
+	if err := gooseHookFileIsBeacons(path); err != nil {
+		return err
+	}
+	prefix := endpointCommandPrefix(gooseHookPlatform, binaryPath, logPath, configPath)
+	file := gooseHooksFile{Hooks: map[string][]gooseHookRule{}}
+	for _, event := range gooseEvents {
+		action := gooseHookAction{
+			Type:    "command",
+			Command: prefix + " " + event.subcommand,
+			Timeout: event.timeout,
+		}
+		// Only on the event where goose reads it. Writing it everywhere would put a field in the
+		// file that goose silently ignores on six of seven events, which reads as a contract that
+		// does not exist.
+		if event.name == "PreToolUse" {
+			action.OnFailure = gooseOnFailureAllow
+		}
+		// Appended rather than assigned, so that two events sharing a subcommand -- PostToolUse and
+		// PostToolUseFailure -- stay two entries under two names rather than one overwriting the
+		// other.
+		file.Hooks[event.name] = append(file.Hooks[event.name], gooseHookRule{Hooks: []gooseHookAction{action}})
+	}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	// 0644 rather than the 0600 the settings-file installers use, for the reason the OpenHands and
+	// Kiro installers give: a project-scope plugin gets committed and read by everyone working in
+	// the repository, and a mode only its author can read would make the hooks stop working for the
+	// next person to check it out. The same mode at user scope so the two do not differ in a way
+	// nobody would think to look for.
+	return os.WriteFile(path, data, 0644)
+}
+
+// gooseHookPlatform is the `--platform` value written into every hook command, and the value the
+// hook adapter keys its goose readers on.
+const gooseHookPlatform = "goose"
+
+// gooseHookFileIsBeacons reports whether Beacon may write the file at path.
+//
+// It may when there is nothing there, when the file is empty, when it is unreadable as a hooks file
+// (which goose would be skipping anyway), or when every command in it is one Beacon wrote. Anything
+// else is somebody's live registration inside Beacon's plugin directory, and this returns an error
+// naming it.
+func gooseHookFileIsBeacons(path string) error {
+	file, err := readGooseHooks(path)
+	if err != nil {
+		// A file Beacon cannot parse is one goose cannot load either, so there are no live hooks in
+		// it to protect. Overwriting leaves the operator with working telemetry rather than an
+		// install that refuses over a file that was already broken.
+		return nil
+	}
+	for event, rules := range file.Hooks {
+		for _, rule := range rules {
+			for _, action := range rule.Hooks {
+				if strings.TrimSpace(action.Command) == "" {
+					continue
+				}
+				if !isEndpointHookCommand(action.Command, gooseHookPlatform) {
+					return fmt.Errorf(
+						"%s already defines a %s hook Beacon did not write (%q); Beacon owns that "+
+							"plugin directory, so it will not overwrite it. Move that hook into a "+
+							"plugin of its own under the same plugins directory -- goose loads every "+
+							"plugin it finds -- and run the install again",
+						path, event, action.Command)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// readGooseHooks parses a hooks file, or returns an empty one when there is none.
+func readGooseHooks(path string) (gooseHooksFile, error) {
+	var file gooseHooksFile
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return file, nil
+		}
+		return gooseHooksFile{}, err
+	}
+	// An empty file is not malformed JSON to a person, and treating it as an error would make an
+	// install fail on a file somebody had created but not written.
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return file, nil
+	}
+	if err := json.Unmarshal(data, &file); err != nil {
+		return gooseHooksFile{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	return file, nil
+}
+
+// removeGooseHooks deletes Beacon's hooks file, and the plugin directory it created with it.
+//
+// The directory too, because a plugin directory with no hooks file is a plugin goose still
+// discovers, still adds to the `plugins` map in config.yaml, and still lists -- an empty
+// registration left behind by an uninstall. Removal is bounded to the two directories Beacon made:
+// the `hooks` directory and the plugin root, each removed only if empty, so a directory an operator
+// put something else in survives.
+//
+// A file that has since acquired a hook Beacon did not write is left alone rather than deleted: an
+// uninstall may remove what it added and nothing more, and the same check that refuses to overwrite
+// a stranger's file refuses to delete one.
+func removeGooseHooks(path string) (bool, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false, nil
+	}
+	if err := gooseHookFileIsBeacons(path); err != nil {
+		return false, err
+	}
+	if err := os.Remove(path); err != nil {
+		return false, err
+	}
+	// Errors are deliberately ignored: os.Remove on a non-empty directory fails, which is exactly
+	// the case where the directory must stay. The hooks file is gone either way, which is what
+	// decides whether goose runs anything.
+	hooksDir := filepath.Dir(path)
+	_ = os.Remove(hooksDir)
+	_ = os.Remove(filepath.Dir(hooksDir))
+	return true, nil
+}
+
+// isGooseInstalledAt reports whether Beacon's hooks are registered at path.
+//
+// By the hook command, not by the file existing. A file left behind by an older Beacon, or one
+// truncated by a failed write, exists and registers nothing -- and reporting that as installed is
+// how an operator ends up believing a machine is monitored when it is not.
+//
+// What this cannot see is whether the plugin is enabled. goose lets an operator disable a plugin
+// from config.yaml's `plugins` map or from `disabledPlugins` in a settings.json at any of three
+// scopes, and a disabled plugin keeps its hooks file. Reading all four files to answer would mean
+// reimplementing goose's precedence rules against a format it does not version; reporting the
+// registration is the narrower claim and the one this function can actually make.
+func isGooseInstalledAt(path string) bool {
+	file, err := readGooseHooks(path)
+	if err != nil {
+		return false
+	}
+	for _, rules := range file.Hooks {
+		for _, rule := range rules {
+			for _, action := range rule.Hooks {
+				if isEndpointHookCommand(action.Command, gooseHookPlatform) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func gooseHooksPath(level Level) (string, error) {
+	root, err := goosePluginRoot(level)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, gooseHookDirName, gooseHookFileName), nil
+}
+
+// goosePluginRoot resolves Beacon's plugin directory for a scope.
+//
+// Both scopes are real and, unlike Kiro's, they do not add up: goose deduplicates plugins by name
+// with project scope first, so a project install of this plugin replaces the user one for sessions
+// in that repository rather than running alongside it. That is the behavior worth having -- one
+// registration means one copy of every event -- and it is why both scopes write the same directory
+// name rather than distinct ones.
+//
+// GOOSE_PATH_ROOT takes precedence at user scope, matching how goose resolves it, including the
+// requirement that it be absolute: goose ignores a relative value, so honoring one here would write
+// a file nothing reads. Project scope does not consult it, because goose's project lookup is
+// always `<project>/.agents/plugins`.
+func goosePluginRoot(level Level) (string, error) {
+	switch level {
+	case "", LevelUser:
+		base, err := gooseUserAgentsDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(base, goosePluginsDirName, goosePluginDirName), nil
+	case LevelProject:
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cwd, gooseAgentsDirName, goosePluginsDirName, goosePluginDirName), nil
+	default:
+		return "", fmt.Errorf("unknown hook level %q", level)
+	}
+}
+
+// gooseUserAgentsDir resolves the `.agents` directory goose looks in at user scope.
+func gooseUserAgentsDir() (string, error) {
+	if root := strings.TrimSpace(os.Getenv(goosePathRootEnv)); filepath.IsAbs(root) {
+		return filepath.Join(root, gooseAgentsDirName), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, gooseAgentsDirName), nil
+}

--- a/cli/beacon/internal/endpoint/hooks/goose_test.go
+++ b/cli/beacon/internal/endpoint/hooks/goose_test.go
@@ -1,0 +1,688 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/asymptote-labs/agent-beacon/cli/beacon/internal/testenv"
+)
+
+// goose's hook loader is silent about a file it does not like, the same way Kiro's, OpenHands' and
+// Muse's are, and in several distinct ways: an unparseable hooks.json is skipped with a warn line,
+// an unknown event name is ignored, an unsupported action type is ignored, and an invalid matcher
+// regex drops just that rule. Nothing reaches the operator. The emitted shape is therefore pinned
+// here rather than trusted.
+
+// gooseUserHooksPath points the user scope at a temp home and returns the path Beacon writes.
+//
+// GOOSE_PATH_ROOT is cleared as well as HOME because gooseUserAgentsDir prefers it, and a developer
+// with it set would otherwise have these tests resolve outside the temp directory.
+func gooseUserHooksPath(t *testing.T) string {
+	t.Helper()
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv(goosePathRootEnv, "")
+	path, err := gooseHooksPath(LevelUser)
+	if err != nil {
+		t.Fatalf("gooseHooksPath: %v", err)
+	}
+	return path
+}
+
+func installGooseFixture(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("create hooks dir: %v", err)
+	}
+	if err := installGooseHooks(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json"); err != nil {
+		t.Fatalf("installGooseHooks returned error: %v", err)
+	}
+}
+
+// readGooseFile decodes the emitted file into a loose map, so an assertion can ask about a key the
+// typed struct does not have. Several tests below are about keys Beacon must *not* write.
+func readGooseFile(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks file: %v", err)
+	}
+	var document map[string]interface{}
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("decode hooks file: %v", err)
+	}
+	return document
+}
+
+// gooseActions returns every action object the file registers, keyed by event name.
+func gooseActions(t *testing.T, path string) map[string][]map[string]interface{} {
+	t.Helper()
+	document := readGooseFile(t, path)
+	events, ok := document["hooks"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("hooks file has no hooks object: %#v", document)
+	}
+	out := map[string][]map[string]interface{}{}
+	for event, rawRules := range events {
+		rules, ok := rawRules.([]interface{})
+		if !ok {
+			t.Fatalf("event %q is not an array of rules: %#v", event, rawRules)
+		}
+		for _, rawRule := range rules {
+			rule, ok := rawRule.(map[string]interface{})
+			if !ok {
+				t.Fatalf("rule under %q is not an object: %#v", event, rawRule)
+			}
+			rawActions, ok := rule["hooks"].([]interface{})
+			if !ok {
+				t.Fatalf("rule under %q has no hooks array: %#v", event, rule)
+			}
+			for _, rawAction := range rawActions {
+				action, ok := rawAction.(map[string]interface{})
+				if !ok {
+					t.Fatalf("action under %q is not an object: %#v", event, rawAction)
+				}
+				out[event] = append(out[event], action)
+			}
+		}
+	}
+	return out
+}
+
+func gooseCommandFor(t *testing.T, path, event string) string {
+	t.Helper()
+	actions := gooseActions(t, path)[event]
+	if len(actions) != 1 {
+		t.Fatalf("event %q registered %d actions, want exactly 1", event, len(actions))
+	}
+	command, _ := actions[0]["command"].(string)
+	return command
+}
+
+// ---------------------------------------------------------------------------
+// Fresh install
+// ---------------------------------------------------------------------------
+
+// The seven events Beacon subscribes to, each bound to the subcommand that maps it. The event
+// names are the wire contract: goose ignores a name it does not recognize, so a typo in one is not
+// an error -- it is that event silently never firing.
+func TestInstallGooseBindsEveryEvent(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	want := map[string]string{
+		"SessionStart":       "session-start",
+		"UserPromptSubmit":   "prompt-submit",
+		"PreToolUse":         "pre-tool",
+		"PostToolUse":        "post-tool",
+		"PostToolUseFailure": "post-tool",
+		"Stop":               "stop",
+		"SessionEnd":         "session-end",
+	}
+	actions := gooseActions(t, path)
+	if len(actions) != len(want) {
+		t.Fatalf("file registers %d events, want %d: %v", len(actions), len(want), sortedKeys(actions))
+	}
+	for event, subcommand := range want {
+		command := gooseCommandFor(t, path, event)
+		if !strings.HasSuffix(command, " "+subcommand) {
+			t.Errorf("%s command = %q, want it to end in %q", event, command, subcommand)
+		}
+		if !strings.Contains(command, "--platform goose") {
+			t.Errorf("%s command = %q, want --platform goose", event, command)
+		}
+	}
+}
+
+// PostToolUse and PostToolUseFailure share the post-tool subcommand, and must still be two
+// registrations. goose has no single post-tool event; the mapper tells the two apart by reading
+// `event`, so losing either one loses half the tool results -- and a map assignment rather than an
+// append is exactly how one would overwrite the other.
+func TestInstallGooseRegistersBothPostToolEventsSeparately(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	actions := gooseActions(t, path)
+	for _, event := range []string{"PostToolUse", "PostToolUseFailure"} {
+		if len(actions[event]) != 1 {
+			t.Fatalf("%s registered %d actions, want exactly 1", event, len(actions[event]))
+		}
+	}
+}
+
+// The four duplicate events goose also offers, and PreToolUseResult.
+//
+// BeforeShellExecution, AfterShellExecution, BeforeReadFile and AfterFileEdit each fire alongside
+// PreToolUse or PostToolUse for the *same* call, with the same tool_name and tool_input and -- the
+// part that makes them worse than redundant -- no tool_call_id at all. Subscribing would record
+// every shell command and every file edit twice, with the second copy uncorrelatable.
+func TestInstallGooseDoesNotSubscribeToDuplicateEvents(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	actions := gooseActions(t, path)
+	for _, event := range []string{
+		"BeforeShellExecution", "AfterShellExecution", "BeforeReadFile", "AfterFileEdit",
+		"PreToolUseResult",
+	} {
+		if _, ok := actions[event]; ok {
+			t.Errorf("file subscribes to %s; that event duplicates one Beacon already reads, or "+
+				"fires once per call to report an outcome that is almost always \"allow\"", event)
+		}
+	}
+}
+
+// goose runs every action through `sh -c` and reads only `type`, `command`, `timeout` and
+// `on_failure`. A key it does not know is ignored rather than rejected, so a stray one would sit in
+// an operator's plugin directory meaning nothing.
+func TestInstallGooseWritesOnlyTheFieldsGooseReads(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	allowed := map[string]bool{"type": true, "command": true, "timeout": true, "on_failure": true}
+	for event, actions := range gooseActions(t, path) {
+		for _, action := range actions {
+			for key := range action {
+				if !allowed[key] {
+					t.Errorf("%s action carries key %q, which goose does not read", event, key)
+				}
+			}
+			if got, _ := action["type"].(string); got != "command" {
+				t.Errorf("%s action type = %q, want command", event, got)
+			}
+		}
+	}
+	// The document's only top-level key. goose reads `hooks` and nothing else.
+	document := readGooseFile(t, path)
+	if len(document) != 1 {
+		t.Fatalf("hooks file has %d top-level keys, want only \"hooks\": %v", len(document), sortedKeys(document))
+	}
+}
+
+// No matcher, on any event, and the reason is specific rather than tidiness: goose tests the regex
+// against matcher_context, which is *not* a tool name on every event. HookContext::with_message
+// sets it to the prompt text on UserPromptSubmit, so a matcher that looked like a harmless ".*"
+// would be a regex run over every prompt, and any narrower one would silently drop prompts that
+// did not match it. An omitted matcher always fires.
+func TestInstallGooseWritesNoMatcher(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	events, _ := readGooseFile(t, path)["hooks"].(map[string]interface{})
+	for event, rawRules := range events {
+		for _, rawRule := range rawRules.([]interface{}) {
+			rule := rawRule.(map[string]interface{})
+			if _, ok := rule["matcher"]; ok {
+				t.Errorf("%s rule carries a matcher; matcher_context is the prompt text on "+
+					"UserPromptSubmit, so any matcher there filters prompts", event)
+			}
+		}
+	}
+}
+
+// on_failure is honored only for PreToolUse, so it is written only there -- writing it everywhere
+// would put a field in the file that goose silently ignores on six of seven events.
+//
+// Its value is "allow", which is already goose's default. It is stated anyway because what it
+// guards against is goose changing that default: a telemetry hook that blocked a tool call because
+// it had itself failed would turn an observation problem into an availability problem on the
+// operator's machine.
+func TestInstallGooseWritesOnFailureAllowOnlyWhereGooseReadsIt(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	for event, actions := range gooseActions(t, path) {
+		for _, action := range actions {
+			value, present := action["on_failure"]
+			if event == "PreToolUse" {
+				if got, _ := value.(string); got != "allow" {
+					t.Errorf("PreToolUse on_failure = %v, want \"allow\" -- a telemetry hook must "+
+						"never block a tool call because it failed", value)
+				}
+				continue
+			}
+			if present {
+				t.Errorf("%s action carries on_failure=%v; goose reads that field only on "+
+					"PreToolUse", event, value)
+			}
+		}
+	}
+}
+
+// goose timeouts are seconds, and its own default is 30. Every event carries an explicit value
+// because the same `timeout` field means milliseconds on Qwen and the files look alike -- and
+// because goose holds the turn for a blocking hook, so the value on Stop is the ceiling on a hung
+// turn rather than a budget.
+func TestInstallGooseWritesSecondTimeoutsOnEveryEvent(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	want := map[string]float64{
+		"SessionStart":       gooseSessionStartTimeoutSeconds,
+		"UserPromptSubmit":   goosePromptSubmitTimeoutSeconds,
+		"PreToolUse":         gooseToolTimeoutSeconds,
+		"PostToolUse":        gooseToolTimeoutSeconds,
+		"PostToolUseFailure": gooseToolTimeoutSeconds,
+		"Stop":               gooseStopTimeoutSeconds,
+		"SessionEnd":         gooseSessionEndTimeoutSeconds,
+	}
+	for event, actions := range gooseActions(t, path) {
+		timeout, ok := actions[0]["timeout"].(float64)
+		if !ok {
+			t.Fatalf("%s action has no timeout: %#v", event, actions[0])
+		}
+		if timeout != want[event] {
+			t.Errorf("%s timeout = %v, want %v seconds", event, timeout, want[event])
+		}
+		// A millisecond value mistaken for seconds is the failure this catches: 30000 seconds is
+		// over eight hours of held turn on a blocking event.
+		if timeout > 60 {
+			t.Errorf("%s timeout = %v; goose reads this as seconds, so anything this large is a "+
+				"millisecond value in the wrong field", event, timeout)
+		}
+	}
+}
+
+// The file lives inside a plugin directory, and goose names a plugin after that directory.
+func TestGooseInstallsAsAPluginGooseDiscovers(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	if filepath.Base(path) != "hooks.json" {
+		t.Fatalf("hooks file is %q, want hooks.json", filepath.Base(path))
+	}
+	hooksDir := filepath.Dir(path)
+	if filepath.Base(hooksDir) != "hooks" {
+		t.Fatalf("hooks file is in %q, want a \"hooks\" directory", filepath.Base(hooksDir))
+	}
+	pluginRoot := filepath.Dir(hooksDir)
+	if filepath.Base(pluginRoot) != goosePluginDirName {
+		t.Fatalf("plugin directory is %q, want %q", filepath.Base(pluginRoot), goosePluginDirName)
+	}
+	// `.agents/plugins` is the Open Plugins layout goose discovers, not a Beacon invention.
+	if got := filepath.Base(filepath.Dir(pluginRoot)); got != "plugins" {
+		t.Fatalf("plugin root sits in %q, want \"plugins\"", got)
+	}
+	if got := filepath.Base(filepath.Dir(filepath.Dir(pluginRoot))); got != ".agents" {
+		t.Fatalf("plugins directory sits in %q, want \".agents\"", got)
+	}
+}
+
+// A project-scope plugin gets committed and read by everyone working in the repository, so a mode
+// only its author can read would make the hooks stop working for the next person to check it out.
+// The same mode at user scope, so the two do not differ in a way nobody would think to look for.
+func TestInstallGooseWritesAWorldReadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not meaningful on Windows")
+	}
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat hooks file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0644 {
+		t.Fatalf("hooks file mode = %o, want 644", perm)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reinstall, uninstall, detection
+// ---------------------------------------------------------------------------
+
+func TestInstallGooseIsIdempotent(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks file: %v", err)
+	}
+	installGooseFixture(t, path)
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks file: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("reinstall changed the file:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// An install replaces the file wholesale, which is what lets it drop an event Beacon no longer
+// subscribes to. A merge would leave the stale entry behind pointing at a subcommand that had been
+// removed -- a hook that runs on every turn and fails.
+func TestInstallGooseDropsAStaleBeaconEvent(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	stale := gooseHooksFile{Hooks: map[string][]gooseHookRule{
+		"Stop": {{Hooks: []gooseHookAction{{
+			Type:    "command",
+			Command: "/tmp/beacon-hooks --platform goose --log /tmp/runtime.jsonl retired-subcommand",
+		}}}},
+	}}
+	data, err := json.MarshalIndent(stale, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal stale file: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+
+	installGooseFixture(t, path)
+	if command := gooseCommandFor(t, path, "Stop"); strings.Contains(command, "retired-subcommand") {
+		t.Fatalf("Stop command = %q, want the stale Beacon entry replaced", command)
+	}
+}
+
+// The uninstall takes the plugin directory with the file, because a plugin directory with no hooks
+// file is a plugin goose still discovers, still records in config.yaml's `plugins` map and still
+// lists: an empty registration left behind by an uninstall.
+func TestUninstallGooseRemovesTheFileAndThePluginDirectory(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	removed, err := removeGooseHooks(path)
+	if err != nil {
+		t.Fatalf("removeGooseHooks returned error: %v", err)
+	}
+	if !removed {
+		t.Fatal("removeGooseHooks reported nothing removed")
+	}
+	pluginRoot := filepath.Dir(filepath.Dir(path))
+	if _, err := os.Stat(pluginRoot); !os.IsNotExist(err) {
+		t.Fatalf("plugin directory %s survived the uninstall (err=%v)", pluginRoot, err)
+	}
+	// The plugins directory itself is not Beacon's and must survive.
+	if _, err := os.Stat(filepath.Dir(pluginRoot)); err != nil {
+		t.Fatalf("plugins directory did not survive the uninstall: %v", err)
+	}
+}
+
+// Removal is bounded to directories Beacon created and left empty. Anything an operator put in
+// them survives, because an uninstall may remove what it added and nothing more.
+func TestUninstallGooseLeavesAPluginDirectoryWithOtherContent(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	installGooseFixture(t, path)
+
+	pluginRoot := filepath.Dir(filepath.Dir(path))
+	readme := filepath.Join(pluginRoot, "README.md")
+	if err := os.WriteFile(readme, []byte("notes\n"), 0644); err != nil {
+		t.Fatalf("write sibling file: %v", err)
+	}
+
+	if _, err := removeGooseHooks(path); err != nil {
+		t.Fatalf("removeGooseHooks returned error: %v", err)
+	}
+	if _, err := os.Stat(readme); err != nil {
+		t.Fatalf("a file Beacon did not write was removed with the plugin directory: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("hooks file survived the uninstall (err=%v); that is what decides whether goose "+
+			"runs anything", err)
+	}
+}
+
+func TestUninstallGooseOnAbsentFileIsANoOp(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	removed, err := removeGooseHooks(path)
+	if err != nil {
+		t.Fatalf("removeGooseHooks returned error: %v", err)
+	}
+	if removed {
+		t.Fatal("removeGooseHooks reported a removal with no file present")
+	}
+}
+
+// Detection reads the hook command, not the file. A file left behind by an older Beacon, or one
+// truncated by a failed write, exists and registers nothing -- and reporting that as installed is
+// how an operator ends up believing a machine is monitored when it is not.
+func TestIsGooseInstalledReadsTheCommandNotTheFile(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	if isGooseInstalledAt(path) {
+		t.Fatal("reported installed with no file present")
+	}
+
+	foreign := gooseHooksFile{Hooks: map[string][]gooseHookRule{
+		"SessionStart": {{Hooks: []gooseHookAction{{Type: "command", Command: "/usr/local/bin/audit.sh"}}}},
+	}}
+	data, err := json.MarshalIndent(foreign, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal foreign file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("create hooks dir: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write foreign file: %v", err)
+	}
+	if isGooseInstalledAt(path) {
+		t.Fatal("reported installed for a file registering somebody else's hook")
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove foreign file: %v", err)
+	}
+	installGooseFixture(t, path)
+	if !isGooseInstalledAt(path) {
+		t.Fatal("reported not installed after a successful install")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Files Beacon does not own
+// ---------------------------------------------------------------------------
+
+// The plugin directory name is distinctive, and "unlikely to collide" is not a reason to delete a
+// stranger's hooks: whatever is in this file is live for every goose session on the machine.
+func TestInstallGooseRefusesAFileItDoesNotOwn(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	foreign := gooseHooksFile{Hooks: map[string][]gooseHookRule{
+		"PreToolUse": {{Hooks: []gooseHookAction{{Type: "command", Command: "${PLUGIN_ROOT}/scripts/policy.sh"}}}},
+	}}
+	data, err := json.MarshalIndent(foreign, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal foreign file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("create hooks dir: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write foreign file: %v", err)
+	}
+
+	err = installGooseHooks(path, "/tmp/beacon-hooks", "/tmp/runtime.jsonl", "/tmp/config.json")
+	if err == nil {
+		t.Fatal("install overwrote a file Beacon did not write")
+	}
+	if !strings.Contains(err.Error(), "policy.sh") {
+		t.Fatalf("error does not name the hook it refused over: %v", err)
+	}
+	after, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read file after refused install: %v", readErr)
+	}
+	if string(after) != string(data) {
+		t.Fatalf("file changed despite the refusal:\n%s", after)
+	}
+}
+
+func TestUninstallGooseLeavesAFileItDoesNotOwn(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	foreign := []byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"/usr/local/bin/notify.sh"}]}]}}`)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("create hooks dir: %v", err)
+	}
+	if err := os.WriteFile(path, foreign, 0644); err != nil {
+		t.Fatalf("write foreign file: %v", err)
+	}
+
+	if _, err := removeGooseHooks(path); err == nil {
+		t.Fatal("uninstall removed a file Beacon did not write")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file after refused uninstall: %v", err)
+	}
+	if string(after) != string(foreign) {
+		t.Fatalf("file changed despite the refusal:\n%s", after)
+	}
+}
+
+// A file goose cannot parse is one it is already skipping, so there are no live hooks in it to
+// protect. Overwriting leaves the operator with working telemetry rather than an install that
+// refuses over a file that was already broken.
+func TestInstallGooseOverwritesAnUnparseableOrEmptyFile(t *testing.T) {
+	for name, contents := range map[string]string{
+		"unparseable": "{not json",
+		"empty":       "",
+		"whitespace":  "   \n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := gooseUserHooksPath(t)
+			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				t.Fatalf("create hooks dir: %v", err)
+			}
+			if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+			installGooseFixture(t, path)
+			if !isGooseInstalledAt(path) {
+				t.Fatal("install did not replace the file")
+			}
+		})
+	}
+}
+
+// An action with no command is ignored by goose rather than rejected, so it is not somebody's live
+// hook and must not make the install refuse.
+func TestInstallGooseIgnoresACommandlessActionWhenCheckingOwnership(t *testing.T) {
+	path := gooseUserHooksPath(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("create hooks dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command"}]}]}}`), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	installGooseFixture(t, path)
+	if !isGooseInstalledAt(path) {
+		t.Fatal("install did not replace a file whose only action goose would ignore")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+// GOOSE_PATH_ROOT relocates every goose directory, so on a machine that sets it the default
+// location is not where goose looks and an install that ignored it would write a file nothing
+// reads.
+func TestGooseUserScopeHonorsGoosePathRoot(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	root := t.TempDir()
+	t.Setenv(goosePathRootEnv, root)
+
+	path, err := gooseHooksPath(LevelUser)
+	if err != nil {
+		t.Fatalf("gooseHooksPath: %v", err)
+	}
+	want := filepath.Join(root, ".agents", "plugins", goosePluginDirName, "hooks", "hooks.json")
+	if path != want {
+		t.Fatalf("gooseHooksPath = %q, want %q", path, want)
+	}
+}
+
+// goose requires GOOSE_PATH_ROOT to be absolute and ignores it otherwise, so honoring a relative
+// value here would write a file nothing reads -- under the working directory, of all places.
+func TestGooseUserScopeIgnoresARelativePathRoot(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	t.Setenv(goosePathRootEnv, "relative/goose")
+
+	path, err := gooseHooksPath(LevelUser)
+	if err != nil {
+		t.Fatalf("gooseHooksPath: %v", err)
+	}
+	want := filepath.Join(home, ".agents", "plugins", goosePluginDirName, "hooks", "hooks.json")
+	if path != want {
+		t.Fatalf("gooseHooksPath = %q, want the home default %q", path, want)
+	}
+}
+
+func TestGooseEmptyLevelIsUserScope(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv(goosePathRootEnv, "")
+
+	empty, err := gooseHooksPath("")
+	if err != nil {
+		t.Fatalf("gooseHooksPath(\"\"): %v", err)
+	}
+	user, err := gooseHooksPath(LevelUser)
+	if err != nil {
+		t.Fatalf("gooseHooksPath(LevelUser): %v", err)
+	}
+	if empty != user {
+		t.Fatalf("empty level = %q, user level = %q; they must be the same scope", empty, user)
+	}
+}
+
+// Project scope is always `<cwd>/.agents/plugins`, and deliberately does not consult
+// GOOSE_PATH_ROOT: goose's project lookup joins the project root directly.
+func TestGooseProjectScopeIgnoresThePathRoot(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Setenv(goosePathRootEnv, t.TempDir())
+
+	path, err := gooseHooksPath(LevelProject)
+	if err != nil {
+		t.Fatalf("gooseHooksPath: %v", err)
+	}
+	want := filepath.Join(cwd, ".agents", "plugins", goosePluginDirName, "hooks", "hooks.json")
+	if path != want {
+		t.Fatalf("gooseHooksPath = %q, want %q", path, want)
+	}
+}
+
+// Both scopes write the same plugin directory name deliberately. goose deduplicates plugins by
+// name with project scope first, so matching names means one registration -- and one copy of every
+// event -- for an operator who installed at both.
+func TestGooseScopesShareOnePluginName(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv(goosePathRootEnv, "")
+
+	user, err := gooseHooksPath(LevelUser)
+	if err != nil {
+		t.Fatalf("gooseHooksPath(user): %v", err)
+	}
+	project, err := gooseHooksPath(LevelProject)
+	if err != nil {
+		t.Fatalf("gooseHooksPath(project): %v", err)
+	}
+	pluginName := func(path string) string { return filepath.Base(filepath.Dir(filepath.Dir(path))) }
+	if pluginName(user) != pluginName(project) {
+		t.Fatalf("user plugin is %q and project plugin is %q; goose keys deduplication on the "+
+			"name, so differing names would run both and double every event",
+			pluginName(user), pluginName(project))
+	}
+}
+
+func TestGooseUnknownLevelIsAnError(t *testing.T) {
+	if _, err := gooseHooksPath("cluster"); err == nil {
+		t.Fatal("gooseHooksPath accepted an unknown level")
+	}
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
Third of five PRs adding Goose (Block) support, and the one that makes the integration actually collect. **Stacked on [#495](https://github.com/Asymptote-Labs/agent-beacon/pull/495)** — it binds the events that PR maps, so it targets that branch and should merge after it.

`beacon endpoint hooks install --harness goose` now works.

## Shape: Beacon owns a directory, not a file

Goose finds hooks through **plugins**: it lists the immediate subdirectories of its plugins directory, treats each as a plugin named after the directory, and loads `<plugin-root>/hooks/hooks.json` from every enabled one. So Beacon installs a plugin whose only content is a hooks file — the Kiro shape, one level up:

```
~/.agents/plugins/beacon-endpoint/hooks/hooks.json
```

Three consequences the installer is built around:

**1. `.agents/plugins` is the Open Plugins convention, not Goose's namespace.** Another agent implementing the same spec would discover this plugin and run its commands, and the command says `--platform goose`, so those events would be attributed to Goose. Beacon cannot tell from a payload which host invoked it — Goose sets no distinguishing variable and the event schema has no field for the question. **This is a real limitation with no fix on Beacon's side**; it is recorded in the installer rather than papered over. It costs nothing today, because Goose is the only supported runtime that reads this directory.

**2. Plugin names are deduplicated across scopes, project before user.** A project install *replaces* the user one rather than adding to it. Both scopes write the same directory name deliberately: an operator who installs at both gets one registration, not two copies of every event. The install prints this, because it is the opposite of Kiro, where the scopes merge.

**3. A disabled plugin keeps its hooks file.** An operator can disable it from `config.yaml`'s `plugins` map or from `disabledPlugins` in a `settings.json` at any of three scopes. So "the file is there" is not "the hooks run", and `isGooseInstalledAt` reports the *registration* rather than pretending to know the rest — answering properly would mean reimplementing Goose's precedence across four files it does not version. The install says so rather than leaving it to be discovered from an empty log.

## Events

Seven of Goose's twelve, each bound to the subcommand that maps it:

`SessionStart`→session-start · `UserPromptSubmit`→prompt-submit · `PreToolUse`→pre-tool · `PostToolUse`→post-tool · `PostToolUseFailure`→post-tool · `Stop`→stop · `SessionEnd`→session-end

`PostToolUse` and `PostToolUseFailure` share a subcommand and are **two registrations** — Goose has no single post-tool event, and the mapper tells them apart by reading `event`.

**Five left out, for stated reasons:**

- `BeforeShellExecution`, `AfterShellExecution`, `BeforeReadFile`, `AfterFileEdit` — each fires alongside `PreToolUse`/`PostToolUse` for the **same call** with the same `tool_name` and `tool_input`, and carries **no `tool_call_id` at all**. Subscribing would record every shell command and file edit twice, with the second copy uncorrelatable.
- `PreToolUseResult` — a real signal (what the hook chain decided, who denied, why), but it fires once per call to report an outcome that is almost always "allow". Deferred rather than declined.

## Three load-bearing details of the emitted file

- **No matcher.** Goose tests the regex against `matcher_context`, and that is the **prompt text** on `UserPromptSubmit` (`HookContext::with_message` sets it). A matcher that looked like a harmless `".*"` would be a regex run over every prompt; a narrower one would silently drop prompts.
- **`on_failure: allow`, on `PreToolUse` only** — the one event Goose reads it on. The value is already Goose's default; it is stated because what it guards against is that default *changing*. A telemetry hook that blocked a tool call because it had itself failed would turn an observation problem into an availability problem on the operator's machine.
- **Timeouts in seconds, explicit on every event.** The same `timeout` field means milliseconds on Qwen and the files look alike; a test rejects any value over 60 for that reason. Goose holds the turn for a blocking hook, so the value on `Stop` is a ceiling on a hung turn.

## CLI wiring

Six places, each of which fails by omission rather than by error: install, uninstall, status collection, status printing, `repairTargetOrder()`, `allHookTargetsForLevel()` — plus the registry row and the diagnostics/dashboard status readers. `TestEveryHookTargetIsWired` now covers `goose`.

`gooseai` / `goose-ai` are deliberately **not** aliases: GooseAI is a different company's inference service, and accepting either would let someone ask to install hooks for a model provider. Pinned by a test.

## Verification

**27 installer tests + 7 CLI target tests**, and every installer branch was mutation-checked:

```
CAUGHT: post-tool events collapsed onto one map key
CAUGHT: on_failure written on every event
CAUGHT: duplicate events subscribed
CAUGHT: timeouts written as milliseconds
CAUGHT: ownership check dropped
CAUGHT: plugin directory left behind on uninstall
CAUGHT: uninstall removes a non-empty plugin directory
CAUGHT: relative GOOSE_PATH_ROOT honored
```

**Verified end to end by hand**, not just by tests: installed into a scratch home, then drove each of the seven events through `sh -c` with a real `HookContext` payload exactly as Goose runs them, and read the runtime log.

| event driven | recorded | notes |
|---|---|---|
| SessionStart | `session.started` | |
| UserPromptSubmit | `prompt.submitted` | prompt text retained |
| PreToolUse (`shell`) | `tool.invoked` id=call-1 | reply `{"decision":"allow"}` |
| PostToolUse (`shell`) | `command.executed` id=call-1 | correlates with the pre event |
| PostToolUse (`edit`) | `file.modified` | fragment diff `-timeout := 5` / `+timeout := 30` |
| PostToolUseFailure (`edit`) | `tool.failed` | **no diff** — the edit never landed |
| PostToolUse (`github__create_issue`) | `mcp.tool_invoked` | server=github tool=create_issue |
| Stop | `tool.completed` | reply `{"decision":"allow"}` |
| SessionEnd | `session.ended` | no working_directory — Goose sent none |

All nine carry `harness.name=goose`, `harness.collection_method=hook`, `event.fidelity=observed`. Uninstall removes the file and the plugin directory and leaves the shared `plugins/` directory alone.

Gates green: `pkg/asymptoteobserve`, `cli/beacon-hooks`, `cli/beacon`, `cli/beacon -race ./internal/endpoint/...`, `collector-builder/exporter/beaconjsonexporter`.

## Series

1. [#494](https://github.com/Asymptote-Labs/agent-beacon/pull/494) — harness identity
2. [#495](https://github.com/Asymptote-Labs/agent-beacon/pull/495) — hook payload mapper
3. **this PR** — hook installer + CLI wiring
4. Goose OTLP harness configuration (token usage, cost, model — what hooks cannot see)
5. Inventory, detection and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfvajZH6CQRe2Djz42SA2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfvajZH6CQRe2Djz42SA2d)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI and local filesystem hook installation with tests; no changes to auth, collector, or shared runtime paths beyond new goose-specific files.
> 
> **Overview**
> Adds **goose (Block)** as a hook target so `beacon endpoint hooks install --harness goose` installs Beacon as an Open Plugins plugin at `.agents/plugins/beacon-endpoint/hooks/hooks.json`, wiring seven goose lifecycle events to `beacon-hooks` with `--platform goose`.
> 
> The new installer handles user and project scope (honoring absolute `GOOSE_PATH_ROOT` at user scope), refuses to overwrite non-Beacon hooks in that plugin dir, removes the plugin directory on uninstall, and documents operator caveats on install (plugin can be disabled in goose config; project scope **replaces** user scope for the same plugin name).
> 
> **goose** is registered in the harness target table (`goose`, `codename-goose`, `block-goose`; **not** GooseAI spellings), and threaded through install/uninstall/status, `--all` sweeps, repair order, inventory hook status, and the endpoint dashboard hook list. Extensive unit and CLI wiring tests cover emitted `hooks.json` shape, paths, and round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a366988aca8c903084ca2798ded303eaf35854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->