### PR TITLE
feat(endpoint): configure goose's OTLP export to the local collector

### DIFF
--- a/cli/beacon/cmd/endpoint_targets.go
+++ b/cli/beacon/cmd/endpoint_targets.go
@@ -71,16 +71,27 @@ var harnessTargets = []harnessTarget{
 	// people say it; Kiro's own documentation does not, which is why it is an alias and not the
 	// name.
 	{name: "kiro", endpointKind: endpointTargetHook, endpointAliases: []string{"kiro", "kiro-ide", "kiro-cli", "kiro-code"}, hookAliases: []string{"kiro", "kiro-ide", "kiro-cli", "kiro-code"}},
-	// goose (Block). One row for the CLI and the desktop app together, because they are one agent
-	// core reading one plugins directory -- so asking for either gets the install that covers both.
-	// "goose" is also the canonical harness name events are written under, so a row read out of the
-	// runtime log and passed back to --harness resolves to the runtime it names. "gooseai" and
-	// "goose-ai" are deliberately not aliases: GooseAI is a different company's inference service,
-	// and accepting either would let someone ask to install hooks for a model provider.
+	// goose (Block). One name for the CLI and the desktop app together, because they are one agent
+	// core reading one plugins directory and exporting under one service.name -- so asking for
+	// either gets the install that covers both. "goose" is also the canonical harness name events
+	// are written under, so a row read out of the runtime log and passed back to --harness resolves
+	// to the runtime it names.
 	//
-	// The OTLP target for goose is a separate row rather than a second kind on this one; it lands
-	// with the config.yaml writer that backs it.
-	{name: "goose", endpointKind: endpointTargetHook, endpointAliases: []string{"goose", "codename-goose", "block-goose"}, hookAliases: []string{"goose", "codename-goose", "block-goose"}},
+	// Two rows, and it is the only runtime with both kinds under one name. They split the two
+	// commands cleanly: `endpoint install --harness goose` configures the OTLP export, because only
+	// the first row carries endpoint aliases, and `endpoint hooks install --harness goose` installs
+	// the hooks, because only the second carries hook aliases. The two lookups are built from
+	// different alias lists, so neither row can shadow the other.
+	//
+	// Both paths are wanted on a goose endpoint and neither subsumes the other: hooks see prompts,
+	// tool calls, commands and file edits; OTLP carries the token usage, reported cost, model,
+	// provider and reasoning that goose puts on no hook at all.
+	//
+	// "gooseai" and "goose-ai" are deliberately not aliases on either row: GooseAI is a different
+	// company's inference service, and accepting either would let someone ask to install telemetry
+	// for a model provider.
+	{name: "goose", endpointKind: endpointTargetOTLP, endpointAliases: []string{"goose", "codename-goose", "block-goose"}},
+	{name: "goose", endpointKind: endpointTargetHook, hookAliases: []string{"goose", "codename-goose", "block-goose"}},
 	{name: "grok", endpointKind: endpointTargetHook, endpointAliases: []string{"grok"}, hookAliases: []string{"grok"}},
 	// "qwen-code" and "qwen_code" both normalize to "qwen-code" through normalizeHarnessKey, so the
 	// two spellings need one alias between them. "qwen-cli" is not accepted: the product is Qwen

--- a/cli/beacon/cmd/endpoint_user_config.go
+++ b/cli/beacon/cmd/endpoint_user_config.go
@@ -116,7 +116,7 @@ func resolveUserConfigTargets(values []string) (userConfigTargets, error) {
 		}
 		if endpointOK && endpointTarget.Kind == endpointTargetOTLP {
 			switch endpointTarget.Name {
-			case "claude", "codex", "gemini":
+			case "claude", "codex", "gemini", "goose":
 				if !seenNative[endpointTarget.Name] {
 					targets.native = append(targets.native, endpointTarget.Name)
 					seenNative[endpointTarget.Name] = true
@@ -133,6 +133,11 @@ func resolveUserConfigTargets(values []string) (userConfigTargets, error) {
 
 func repairNativeRuntimeConfigForUser(info consoleUserInfo, cfg endpointconfig.Config, targets []string) ([]string, []string, error) {
 	grpcEndpoint := fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.GRPCPort)
+	// goose is the one native-config harness that cannot use the gRPC address: its
+	// opentelemetry-otlp build enables only the HTTP transport. Pointing it at 4317 fails silently
+	// -- the exporter builds and the telemetry never arrives -- so the two endpoints are kept as
+	// separate values rather than one being derived at the call site.
+	httpEndpoint := fmt.Sprintf("http://127.0.0.1:%d", cfg.Collector.HTTPPort)
 	seen := map[string]bool{}
 	var configured []string
 	var paths []string
@@ -190,6 +195,23 @@ func repairNativeRuntimeConfigForUser(info consoleUserInfo, cfg endpointconfig.C
 				configured = append(configured, "gemini")
 				paths = append(paths, path)
 				seen["gemini"] = true
+			case "goose":
+				if seen["goose"] {
+					continue
+				}
+				path, err := harness.ConfigureGoose(harness.ConfigureOptions{Endpoint: httpEndpoint, UserMode: true})
+				if err != nil {
+					return struct{}{}, err
+				}
+				if err := collapseUserConfigBackups(path); err != nil {
+					return struct{}{}, err
+				}
+				if err := chownUserConfigArtifacts(info, path); err != nil {
+					return struct{}{}, err
+				}
+				configured = append(configured, "goose")
+				paths = append(paths, path)
+				seen["goose"] = true
 			}
 		}
 		return struct{}{}, nil

--- a/cli/beacon/cmd/goose_target_test.go
+++ b/cli/beacon/cmd/goose_target_test.go
@@ -101,10 +101,19 @@ func TestGooseIsInTheRepairTargetList(t *testing.T) {
 	t.Fatal("goose is missing from the repair target list; `endpoint repair` would silently skip it")
 }
 
-// Every spelling a person plausibly types resolves to the one hook target, in both namespaces.
+// Every spelling a person plausibly types resolves to goose in both namespaces, and the two
+// namespaces resolve to different kinds on purpose.
+//
+// goose is the only runtime with both, under one name: `endpoint install --harness goose`
+// configures the OTLP export and `endpoint hooks install --harness goose` installs the hooks. Both
+// are wanted on a goose endpoint and neither subsumes the other -- hooks see prompts, tool calls,
+// commands and file edits; OTLP carries the token usage, cost, model and reasoning goose puts on no
+// hook at all -- so a spelling that resolved in only one namespace would silently offer half the
+// integration.
+//
 // Space-separated spellings are deliberately absent: normalizeHarnessKey folds case and
 // underscores but not spaces, so no runtime accepts them and goose is not the place to change that.
-func TestGooseHarnessSpellingsResolveToTheHookTarget(t *testing.T) {
+func TestGooseHarnessSpellingsResolveInBothNamespaces(t *testing.T) {
 	for _, spelling := range []string{
 		"goose", "Goose", " goose ", "GOOSE", "codename-goose", "codename_goose",
 		"block-goose", "block_goose",
@@ -114,9 +123,12 @@ func TestGooseHarnessSpellingsResolveToTheHookTarget(t *testing.T) {
 			if !ok {
 				t.Fatalf("normalizeEndpointTarget(%q) = not found", spelling)
 			}
-			if target.Name != "goose" || target.Kind != endpointTargetHook {
-				t.Fatalf("normalizeEndpointTarget(%q) = %+v, want the goose hook target", spelling, target)
+			// The endpoint namespace is the OTLP row: `endpoint install` configures config.yaml.
+			if target.Name != "goose" || target.Kind != endpointTargetOTLP {
+				t.Fatalf("normalizeEndpointTarget(%q) = %+v, want the goose OTLP target", spelling, target)
 			}
+			// The hook namespace is the hook row, built from a separate alias list so neither row
+			// can shadow the other.
 			if got, ok := normalizeHookTarget(spelling); !ok || got != "goose" {
 				t.Fatalf("normalizeHookTarget(%q) = %q, %t; want goose, true", spelling, got, ok)
 			}
@@ -144,6 +156,9 @@ func TestGooseCanonicalHarnessNameIsAnAcceptedTarget(t *testing.T) {
 	target, ok := normalizeEndpointTarget("goose")
 	if !ok || target.Name != "goose" {
 		t.Fatalf("normalizeEndpointTarget(goose) = %+v, %t", target, ok)
+	}
+	if hookTarget, ok := normalizeHookTarget("goose"); !ok || hookTarget != "goose" {
+		t.Fatalf("normalizeHookTarget(goose) = %q, %t", hookTarget, ok)
 	}
 }
 

--- a/cli/beacon/internal/endpoint/harness/goose.go
+++ b/cli/beacon/internal/endpoint/harness/goose.go
@@ -1,0 +1,317 @@
+package harness
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// goose's OpenTelemetry export, pointed at the local collector.
+//
+// This is the second of goose's two collection paths and it is not a duplicate of the first. The
+// hook path sees prompts, tool calls, commands and file edits; goose populates no tool output on a
+// hook at all and sends no usage event, so token counts, reported cost, the provider and model, and
+// the assistant's own reasoning reach Beacon only here. A goose endpoint wants both installed.
+//
+// What goose exports, from crates/goose/src/otel/otlp.rs and the spans in goose-agent: traces,
+// metrics and logs, with a resource carrying service.name=goose, and OTel GenAI semconv spans --
+// `chat` with gen_ai.provider.name, gen_ai.request.model, gen_ai.response.model,
+// gen_ai.response.finish_reasons and the full gen_ai.usage.* set including cache reads and writes;
+// `execute_tool` with gen_ai.tool.name and gen_ai.tool.call.id. Those are the names Beacon's
+// collector exporter already reads, which is why this file only has to get the endpoint right.
+//
+// Two things about that endpoint are easy to get wrong and are the whole substance of this file.
+
+// gooseOTLPProtocolNote records the constraint that separates goose from every other OTLP harness
+// Beacon configures.
+//
+// goose's opentelemetry-otlp build enables only the HTTP transport (`http-proto`), not
+// `grpc-tonic`. Claude Code, Codex and Gemini are all pointed at the collector's gRPC port; goose
+// must be pointed at the HTTP one, and pointing it at 4317 would not fail loudly -- the exporter
+// builds either way and the failure surfaces as telemetry that never arrives.
+//
+// Worse, goose *checks* for the mismatch in the one direction it can see: if the environment sets
+// OTEL_EXPORTER_OTLP_PROTOCOL to a gRPC variant, goose disables the signal entirely and prints one
+// warning to stderr, because exporting would panic its background threads. So an operator who set
+// that variable for another tool has silently turned goose's export off, and nothing in the config
+// file says so. gooseStatus reads the environment for exactly that reason.
+const gooseOTLPProtocolNote = "goose exports OTLP over HTTP only; point it at the collector's HTTP port"
+
+// goose config keys. These are read by promote_config_to_env, which copies them into the
+// environment before the exporters are built -- and only when the corresponding variable is not
+// already set, so an environment variable wins over the file.
+const (
+	gooseOTLPEndpointKey = "otel_exporter_otlp_endpoint"
+	gooseOTLPTimeoutKey  = "otel_exporter_otlp_timeout"
+)
+
+// gooseOTLPTimeoutMillis is the export timeout written alongside the endpoint.
+//
+// Milliseconds, which is what OTEL_EXPORTER_OTLP_TIMEOUT means and what goose promotes it as. Ten
+// seconds: the collector is on loopback, so an export that has not completed by then is not slow,
+// it is not running -- and goose's exporters run on their own threads, so a longer value costs a
+// hung background thread rather than a hung turn.
+const gooseOTLPTimeoutMillis = 10000
+
+// goosePathRootEnv is goose's override for every one of its directories, honored here for the same
+// reason the hook installer honors it: on a machine that sets it, ~/.config/goose is not where
+// goose looks, so writing there would configure a file nothing reads. goose requires it to be
+// absolute and ignores it otherwise.
+const goosePathRootEnv = "GOOSE_PATH_ROOT"
+
+func DiscoverGoose() Harness {
+	h := Harness{Name: "goose", DisplayName: "goose", Capability: "otel_config"}
+	detectExecutable(&h, "goose")
+	path, err := gooseConfigPath()
+	if err != nil {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = err.Error()
+		return h
+	}
+	h.ConfigPath = path
+	if !h.Detected && fileExists(path) {
+		h.Detected = true
+	}
+	if fileExists(path) {
+		status, msg := gooseStatus(path)
+		h.TelemetryStatus = status
+		h.Message = msg
+	} else {
+		h.TelemetryStatus = TelemetryMissing
+		h.Message = "goose config file was not found"
+	}
+	return h
+}
+
+// ConfigureGoose points goose's OTLP exporters at the local collector.
+//
+// opts.Endpoint must be the collector's HTTP endpoint; see gooseOTLPProtocolNote. The caller picks
+// it, because the caller is what knows the configured port -- and the two callers that configure
+// the gRPC-speaking harnesses pass a different value, which is precisely the mistake this comment
+// exists to prevent.
+func ConfigureGoose(opts ConfigureOptions) (string, error) {
+	path, err := gooseConfigPath()
+	if err != nil {
+		return "", err
+	}
+
+	// The document is edited as a yaml.Node rather than round-tripped through a map, and that is
+	// not fussiness: config.yaml is a file the operator writes by hand. It holds their provider,
+	// their model, their extensions and their permissions, and a map round-trip would reorder every
+	// key alphabetically and delete every comment in it. Beacon is changing two keys and must leave
+	// the rest of the file looking like the file they wrote.
+	var document yaml.Node
+	existing, readErr := os.ReadFile(path)
+	switch {
+	case readErr == nil:
+		if len(strings.TrimSpace(string(existing))) > 0 {
+			if err := yaml.Unmarshal(existing, &document); err != nil {
+				return "", fmt.Errorf("goose config YAML is invalid: %w", err)
+			}
+		}
+		if err := backup(path, existing); err != nil {
+			return "", err
+		}
+	case os.IsNotExist(readErr):
+	default:
+		return "", readErr
+	}
+
+	mapping, err := gooseRootMapping(&document)
+	if err != nil {
+		return "", err
+	}
+	setYAMLMappingValue(mapping, gooseOTLPEndpointKey, opts.Endpoint)
+	setYAMLMappingValue(mapping, gooseOTLPTimeoutKey, fmt.Sprint(gooseOTLPTimeoutMillis))
+
+	data, err := marshalYAMLDocument(&document)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return "", err
+	}
+	// 0600, matching the other harness config writers. config.yaml sits beside secrets.yaml in a
+	// directory goose keeps per user, and nothing else needs to read it.
+	return path, os.WriteFile(path, data, 0600)
+}
+
+// gooseRootMapping returns the document's top-level mapping, creating one for an empty document.
+//
+// An empty file is the common case on a machine where goose has been installed but never
+// configured, and it decodes to a zero Node rather than to a mapping -- so without this the first
+// key would be set on nothing.
+func gooseRootMapping(document *yaml.Node) (*yaml.Node, error) {
+	if document.Kind == 0 {
+		document.Kind = yaml.DocumentNode
+		document.Content = []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}
+		return document.Content[0], nil
+	}
+	if document.Kind != yaml.DocumentNode || len(document.Content) == 0 {
+		return nil, fmt.Errorf("goose config YAML is not a document")
+	}
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("goose config YAML top level is not a mapping")
+	}
+	return root, nil
+}
+
+// marshalYAMLDocument renders an edited document at two-space indentation.
+//
+// yaml.Marshal defaults to four, which would silently re-indent every nested block in the
+// operator's file -- their extensions map, their permissions -- on an edit that touched two
+// top-level keys. Two spaces is what goose's own writer emits and what the documented examples use.
+//
+// What cannot be preserved, and is stated here rather than discovered from a diff: yaml.v3 does not
+// retain blank lines between top-level keys, so a config written with paragraph breaks comes back
+// without them. Comments, key order, values and nesting all survive; the blank lines do not. That
+// is the reason ConfigureGoose backs the file up before writing.
+func marshalYAMLDocument(document *yaml.Node) ([]byte, error) {
+	var out bytes.Buffer
+	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(document); err != nil {
+		return nil, err
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+// setYAMLMappingValue sets a key in a mapping node, replacing the value in place when the key is
+// already present so that its position and any comment attached to it survive.
+func setYAMLMappingValue(mapping *yaml.Node, key, value string) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value != key {
+			continue
+		}
+		// Style is cleared along with the value: a key that was previously written as a quoted
+		// string or a block scalar would otherwise keep that style and render the new value in it.
+		mapping.Content[i+1].Kind = yaml.ScalarNode
+		mapping.Content[i+1].Tag = ""
+		mapping.Content[i+1].Style = 0
+		mapping.Content[i+1].Value = value
+		mapping.Content[i+1].Content = nil
+		return
+	}
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Value: value})
+}
+
+// gooseStatus reports whether goose is configured to export to a local collector.
+//
+// It reads the environment as well as the file, which none of the other harness status functions
+// do, and there are two distinct reasons -- both cases where the file says telemetry is on and
+// goose is exporting nothing:
+//
+//   - promote_config_to_env copies the file's endpoint into the environment only when the variable
+//     is not already set, so OTEL_EXPORTER_OTLP_ENDPOINT in goose's launch environment silently
+//     overrides the file. An operator who pointed another tool at a remote collector has
+//     redirected goose too.
+//   - OTEL_SDK_DISABLED and a gRPC OTEL_EXPORTER_OTLP_PROTOCOL each turn export off entirely,
+//     the second because goose is built without the gRPC transport and disables the signal rather
+//     than panicking its exporter threads.
+//
+// Reporting "enabled" from the file alone would be wrong in all three cases, and wrong in the
+// direction that matters: it would tell an operator a runtime is covered when it is silent.
+func gooseStatus(path string) (TelemetryStatus, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return TelemetryMissing, err.Error()
+	}
+	var root map[string]interface{}
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return TelemetryMisconfigured, "goose config YAML is invalid"
+	}
+	endpoint := strings.TrimSpace(fmt.Sprint(root[gooseOTLPEndpointKey]))
+	if endpoint == "" || endpoint == "<nil>" {
+		return TelemetryDisabled, "goose OTLP endpoint is not configured"
+	}
+	if override := strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")); override != "" && override != endpoint {
+		return TelemetryMisconfigured, fmt.Sprintf(
+			"OTEL_EXPORTER_OTLP_ENDPOINT=%s in the environment overrides the configured %s; goose "+
+				"promotes the config file only when the variable is unset", override, endpoint)
+	}
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("OTEL_SDK_DISABLED")), "true") {
+		return TelemetryMisconfigured, "OTEL_SDK_DISABLED=true in the environment turns goose telemetry off"
+	}
+	if protocol := gooseConfiguredProtocol(); protocol != "" && !gooseProtocolIsHTTP(protocol) {
+		return TelemetryMisconfigured, fmt.Sprintf(
+			"OTEL_EXPORTER_OTLP_PROTOCOL=%s selects gRPC, which this goose build does not include; "+
+				"goose disables OTLP export rather than exporting. %s", protocol, gooseOTLPProtocolNote)
+	}
+	if !strings.Contains(endpoint, "127.0.0.1") && !strings.Contains(endpoint, "localhost") {
+		return TelemetryMisconfigured, fmt.Sprintf("goose OTLP endpoint %s is not local", endpoint)
+	}
+	return TelemetryEnabled, "goose exports OTLP to the local collector"
+}
+
+// gooseConfiguredProtocol reads the OTLP protocol the environment selects, preferring the
+// signal-specific variable over the shared one, as the OTel specification requires and as goose's
+// signal_protocol_is_http does.
+//
+// Traces is the signal asked about because it is the one that carries goose's GenAI spans; a build
+// that exported metrics and not traces would still be reported here as configured, which is the
+// honest answer for a check about whether the endpoint is pointed at the right place.
+func gooseConfiguredProtocol() string {
+	if value := strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")); value != "" {
+		return value
+	}
+	return strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))
+}
+
+// gooseProtocolIsHTTP mirrors goose's own signal_protocol_is_http: the spec default when unset is
+// http/protobuf, and anything that is not one of the two HTTP spellings is a gRPC variant goose
+// will refuse to use.
+func gooseProtocolIsHTTP(protocol string) bool {
+	switch strings.ToLower(strings.TrimSpace(protocol)) {
+	case "", "http/protobuf", "http/json":
+		return true
+	default:
+		return false
+	}
+}
+
+// gooseConfigPath resolves goose's config.yaml, mirroring how goose resolves it.
+//
+// GOOSE_PATH_ROOT relocates it wholesale, and goose ignores a relative value -- so honoring one
+// would write a file nothing reads, under the working directory of all places.
+//
+// Otherwise goose calls etcetera's choose_app_strategy, which is the Windows strategy on Windows
+// and XDG everywhere else -- macOS included. That last part is the one worth stating, because it is
+// the opposite of what a reader would assume and getting it wrong fails silently: on macOS goose
+// reads ~/.config/goose/config.yaml, not ~/Library/Application Support. (goose's own paths.rs
+// mentions the Application Support directory, but as a legacy location kept for compatibility, and
+// choose_native_strategy -- the variant that would resolve there -- is not the one it calls.)
+//
+// On Windows the same call gives %APPDATA%\Block\goose\config, from the author and app name
+// goose passes: "Block" is deliberate there and is not the product's name, which is why it cannot
+// be derived from anything else in this file.
+func gooseConfigPath() (string, error) {
+	if root := strings.TrimSpace(os.Getenv(goosePathRootEnv)); filepath.IsAbs(root) {
+		return filepath.Join(root, "config", "config.yaml"), nil
+	}
+	if runtime.GOOS == "windows" {
+		appData, err := os.UserConfigDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(appData, "Block", "goose", "config", "config.yaml"), nil
+	}
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); filepath.IsAbs(xdg) {
+		return filepath.Join(xdg, "goose", "config.yaml"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "goose", "config.yaml"), nil
+}

--- a/cli/beacon/internal/endpoint/harness/goose_test.go
+++ b/cli/beacon/internal/endpoint/harness/goose_test.go
@@ -1,0 +1,523 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// goose's config.yaml is a file the operator writes by hand -- their provider, their model, their
+// extensions, their permissions -- and Beacon changes two keys in it. Most of what is pinned here
+// is therefore about what Beacon must *not* disturb, plus the one value that is easy to get wrong
+// and fails silently: the endpoint must be the collector's HTTP address, because goose's build
+// carries no gRPC transport.
+
+func gooseConfigFixture(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv(goosePathRootEnv, "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	// Cleared so a developer with any of these exported does not have the status assertions below
+	// resolve against their own environment.
+	for _, key := range []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_SDK_DISABLED",
+		"OTEL_EXPORTER_OTLP_PROTOCOL", "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+	} {
+		t.Setenv(key, "")
+	}
+	path, err := gooseConfigPath()
+	if err != nil {
+		t.Fatalf("gooseConfigPath: %v", err)
+	}
+	return path
+}
+
+func writeGooseConfig(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func readGooseConfig(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var root map[string]interface{}
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	return root
+}
+
+// ---------------------------------------------------------------------------
+// Configure
+// ---------------------------------------------------------------------------
+
+func TestConfigureGooseWritesTheEndpointAndTimeout(t *testing.T) {
+	path := gooseConfigFixture(t)
+
+	written, err := ConfigureGoose(ConfigureOptions{Endpoint: "http://127.0.0.1:4318", UserMode: true})
+	if err != nil {
+		t.Fatalf("ConfigureGoose returned error: %v", err)
+	}
+	if written != path {
+		t.Fatalf("ConfigureGoose wrote %q, want %q", written, path)
+	}
+	root := readGooseConfig(t, path)
+	if got := root[gooseOTLPEndpointKey]; got != "http://127.0.0.1:4318" {
+		t.Fatalf("%s = %v, want the local HTTP endpoint", gooseOTLPEndpointKey, got)
+	}
+	// Milliseconds, which is what OTEL_EXPORTER_OTLP_TIMEOUT means and what goose promotes it as.
+	if got := root[gooseOTLPTimeoutKey]; got != gooseOTLPTimeoutMillis {
+		t.Fatalf("%s = %v, want %d", gooseOTLPTimeoutKey, got, gooseOTLPTimeoutMillis)
+	}
+}
+
+// The whole substance of this harness. goose's opentelemetry-otlp build enables only the HTTP
+// transport, so the gRPC port every other OTLP harness is given would fail silently here -- the
+// exporter builds, and the telemetry never arrives. The two callers that configure goose pass the
+// HTTP endpoint; this pins that a gRPC-looking one is not what ends up reported as working.
+func TestGooseStatusRejectsANonLocalEndpoint(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, "otel_exporter_otlp_endpoint: https://otel.example.com:4318\n")
+
+	status, msg := gooseStatus(path)
+	if status != TelemetryMisconfigured {
+		t.Fatalf("status = %q, want misconfigured for a remote endpoint (%s)", status, msg)
+	}
+}
+
+// config.yaml holds an operator's provider, model, extensions and permissions. A map round-trip
+// would reorder every key alphabetically and delete every comment; Beacon changes two keys and
+// must leave the rest of the file looking like the file they wrote.
+func TestConfigureGoosePreservesCommentsAndKeyOrder(t *testing.T) {
+	path := gooseConfigFixture(t)
+	original := `# goose configuration -- hand written, do not reformat
+GOOSE_MODE: smart_approve
+
+# the provider we settled on after the bake-off
+active_provider: anthropic
+GOOSE_TEMPERATURE: 0.2
+
+extensions:
+  developer:
+    enabled: true # the built-in one
+`
+	writeGooseConfig(t, path, original)
+
+	if _, err := ConfigureGoose(ConfigureOptions{Endpoint: "http://127.0.0.1:4318", UserMode: true}); err != nil {
+		t.Fatalf("ConfigureGoose returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	rewritten := string(data)
+
+	for _, comment := range []string{
+		"# goose configuration -- hand written, do not reformat",
+		"# the provider we settled on after the bake-off",
+		"# the built-in one",
+	} {
+		if !strings.Contains(rewritten, comment) {
+			t.Errorf("comment %q did not survive the rewrite:\n%s", comment, rewritten)
+		}
+	}
+	// Key order, which a map round-trip would sort: GOOSE_MODE must still come before
+	// active_provider, and both before the keys Beacon appended.
+	order := []string{"GOOSE_MODE", "active_provider", "GOOSE_TEMPERATURE", "extensions", gooseOTLPEndpointKey}
+	previous := -1
+	for _, key := range order {
+		index := strings.Index(rewritten, key+":")
+		if index < 0 {
+			t.Fatalf("key %q is missing from the rewritten file:\n%s", key, rewritten)
+		}
+		if index < previous {
+			t.Fatalf("key %q moved ahead of an earlier key; the file was reordered:\n%s", key, rewritten)
+		}
+		previous = index
+	}
+	// Nesting is re-emitted at two spaces, not yaml.Marshal's default four: an edit that touched
+	// two top-level keys must not silently re-indent the operator's extensions block.
+	if !strings.Contains(rewritten, "\n  developer:") {
+		t.Errorf("nested keys were re-indented away from two spaces:\n%s", rewritten)
+	}
+	// The operator's own values are unchanged, not merely present.
+	root := readGooseConfig(t, path)
+	if root["GOOSE_MODE"] != "smart_approve" || root["active_provider"] != "anthropic" {
+		t.Fatalf("Beacon changed a value it does not own: %#v", root)
+	}
+	if extensions, ok := root["extensions"].(map[string]interface{}); !ok || extensions["developer"] == nil {
+		t.Fatalf("the extensions block did not survive: %#v", root["extensions"])
+	}
+}
+
+// A reconfigure replaces the existing value in place rather than appending a second key, which
+// would leave a duplicate that YAML resolves to the last one and a reader resolves to whichever
+// they see first.
+func TestConfigureGooseReplacesAnExistingEndpointInPlace(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, `otel_exporter_otlp_endpoint: "http://127.0.0.1:9999"
+GOOSE_MODE: chat
+`)
+
+	if _, err := ConfigureGoose(ConfigureOptions{Endpoint: "http://127.0.0.1:4318", UserMode: true}); err != nil {
+		t.Fatalf("ConfigureGoose returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if count := strings.Count(string(data), gooseOTLPEndpointKey+":"); count != 1 {
+		t.Fatalf("%s appears %d times, want once:\n%s", gooseOTLPEndpointKey, count, data)
+	}
+	if got := readGooseConfig(t, path)[gooseOTLPEndpointKey]; got != "http://127.0.0.1:4318" {
+		t.Fatalf("%s = %v, want the new endpoint", gooseOTLPEndpointKey, got)
+	}
+	// The replacement clears the old scalar's style, so a value that had been quoted does not keep
+	// rendering the new one in quotes -- and, more importantly, a block scalar does not.
+	if strings.Contains(string(data), `"http://127.0.0.1:4318"`) {
+		t.Fatalf("the replaced value kept the old quoting style:\n%s", data)
+	}
+}
+
+// An empty file is the common case on a machine where goose is installed but never configured. It
+// decodes to a zero Node rather than to a mapping, so without the document-creation branch the
+// first key would be set on nothing.
+func TestConfigureGooseCreatesAMissingOrEmptyConfig(t *testing.T) {
+	for name, setup := range map[string]func(t *testing.T, path string){
+		"missing":    func(t *testing.T, path string) {},
+		"empty":      func(t *testing.T, path string) { writeGooseConfig(t, path, "") },
+		"whitespace": func(t *testing.T, path string) { writeGooseConfig(t, path, "  \n\n") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := gooseConfigFixture(t)
+			setup(t, path)
+			if _, err := ConfigureGoose(ConfigureOptions{Endpoint: "http://127.0.0.1:4318"}); err != nil {
+				t.Fatalf("ConfigureGoose returned error: %v", err)
+			}
+			if got := readGooseConfig(t, path)[gooseOTLPEndpointKey]; got != "http://127.0.0.1:4318" {
+				t.Fatalf("%s = %v after configuring a %s file", gooseOTLPEndpointKey, got, name)
+			}
+		})
+	}
+}
+
+// Invalid YAML is refused rather than overwritten. This is the opposite call from the hook
+// installer, and deliberately: there Beacon owns the file, here the operator does, and a parse
+// failure is far more likely to mean a config Beacon cannot read than one goose cannot.
+func TestConfigureGooseRefusesInvalidYAML(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, "GOOSE_MODE: [unclosed\n")
+
+	if _, err := ConfigureGoose(ConfigureOptions{Endpoint: "http://127.0.0.1:4318"}); err == nil {
+		t.Fatal("ConfigureGoose overwrote a config it could not parse")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(data), "[unclosed") {
+		t.Fatalf("the unparseable config was modified:\n%s", data)
+	}
+}
+
+// Every configure backs the file up first, matching the other harness writers. The operator's
+// config is the thing being edited, so the copy is what makes the edit reversible.
+func TestConfigureGooseBacksUpTheExistingConfig(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, "GOOSE_MODE: chat\n")
+
+	if _, err := ConfigureGoose(ConfigureOptions{Endpoint: "http://127.0.0.1:4318"}); err != nil {
+		t.Fatalf("ConfigureGoose returned error: %v", err)
+	}
+	matches, err := filepath.Glob(path + ".beacon.*.bak")
+	if err != nil {
+		t.Fatalf("glob backups: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("found %d backups, want 1", len(matches))
+	}
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(data) != "GOOSE_MODE: chat\n" {
+		t.Fatalf("backup does not hold the original config:\n%s", data)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Status: the three ways the file says yes and goose exports nothing
+// ---------------------------------------------------------------------------
+
+func TestGooseStatusReportsEnabledForALocalEndpoint(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, "otel_exporter_otlp_endpoint: http://127.0.0.1:4318\n")
+
+	if status, msg := gooseStatus(path); status != TelemetryEnabled {
+		t.Fatalf("status = %q (%s), want enabled", status, msg)
+	}
+}
+
+func TestGooseStatusReportsDisabledWithNoEndpoint(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, "GOOSE_MODE: chat\n")
+
+	if status, _ := gooseStatus(path); status != TelemetryDisabled {
+		t.Fatalf("status = %q, want disabled when no endpoint is configured", status)
+	}
+}
+
+// promote_config_to_env copies the file's endpoint into the environment only when the variable is
+// not already set, so OTEL_EXPORTER_OTLP_ENDPOINT in goose's launch environment silently overrides
+// the file. An operator who pointed another tool at a remote collector has redirected goose too,
+// and the config file still says local.
+func TestGooseStatusDetectsAnEnvironmentEndpointOverride(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, "otel_exporter_otlp_endpoint: http://127.0.0.1:4318\n")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel.vendor.example")
+
+	status, msg := gooseStatus(path)
+	if status != TelemetryMisconfigured {
+		t.Fatalf("status = %q, want misconfigured when the environment overrides the file", status)
+	}
+	if !strings.Contains(msg, "otel.vendor.example") {
+		t.Fatalf("message does not name the overriding endpoint: %s", msg)
+	}
+}
+
+// An environment variable that agrees with the file is not an override.
+func TestGooseStatusAcceptsAMatchingEnvironmentEndpoint(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, "otel_exporter_otlp_endpoint: http://127.0.0.1:4318\n")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
+
+	if status, msg := gooseStatus(path); status != TelemetryEnabled {
+		t.Fatalf("status = %q (%s), want enabled", status, msg)
+	}
+}
+
+func TestGooseStatusDetectsOtelSDKDisabled(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, "otel_exporter_otlp_endpoint: http://127.0.0.1:4318\n")
+	t.Setenv("OTEL_SDK_DISABLED", "TRUE")
+
+	status, msg := gooseStatus(path)
+	if status != TelemetryMisconfigured {
+		t.Fatalf("status = %q, want misconfigured when the SDK is disabled", status)
+	}
+	if !strings.Contains(msg, "OTEL_SDK_DISABLED") {
+		t.Fatalf("message does not name the variable: %s", msg)
+	}
+}
+
+// The sharpest of the three. goose is built without the gRPC transport, so a gRPC protocol
+// selection makes it disable OTLP export rather than export -- it would panic its exporter threads
+// otherwise. One stderr warning is the only signal, and the config file still says local.
+func TestGooseStatusDetectsAGRPCProtocolSelection(t *testing.T) {
+	for name, env := range map[string]struct{ key, value string }{
+		"shared":          {"OTEL_EXPORTER_OTLP_PROTOCOL", "grpc"},
+		"signal-specific": {"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := gooseConfigFixture(t)
+			writeGooseConfig(t, path, "otel_exporter_otlp_endpoint: http://127.0.0.1:4318\n")
+			t.Setenv(env.key, env.value)
+
+			status, msg := gooseStatus(path)
+			if status != TelemetryMisconfigured {
+				t.Fatalf("status = %q, want misconfigured when gRPC is selected", status)
+			}
+			if !strings.Contains(msg, "HTTP") {
+				t.Fatalf("message does not say what to use instead: %s", msg)
+			}
+		})
+	}
+}
+
+// The HTTP spellings, and the unset default, must not be reported as a problem. The spec default
+// when the variable is unset is http/protobuf, which is what goose's own signal_protocol_is_http
+// treats as acceptable.
+func TestGooseStatusAcceptsTheHTTPProtocols(t *testing.T) {
+	for _, protocol := range []string{"", "http/protobuf", "http/json", "HTTP/PROTOBUF"} {
+		t.Run(protocol, func(t *testing.T) {
+			path := gooseConfigFixture(t)
+			writeGooseConfig(t, path, "otel_exporter_otlp_endpoint: http://127.0.0.1:4318\n")
+			t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", protocol)
+
+			if status, msg := gooseStatus(path); status != TelemetryEnabled {
+				t.Fatalf("status = %q (%s), want enabled for protocol %q", status, msg, protocol)
+			}
+		})
+	}
+}
+
+// The signal-specific variable wins over the shared one, as the OTel specification requires and as
+// goose's own resolution does. Without that ordering, an operator who set the shared variable to
+// gRPC for another tool and the traces one back to HTTP for goose would be reported as broken.
+func TestGooseProtocolPrefersTheSignalSpecificVariable(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, "otel_exporter_otlp_endpoint: http://127.0.0.1:4318\n")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "http/protobuf")
+
+	if status, msg := gooseStatus(path); status != TelemetryEnabled {
+		t.Fatalf("status = %q (%s), want enabled; the traces protocol overrides the shared one",
+			status, msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+// goose calls etcetera's choose_app_strategy, which is XDG everywhere except Windows -- macOS
+// included. That is the opposite of what a reader would assume, and getting it wrong fails
+// silently by writing a file goose never reads.
+func TestGooseConfigPathFollowsTheXDGLayout(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv(goosePathRootEnv, "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	path, err := gooseConfigPath()
+	if err != nil {
+		t.Fatalf("gooseConfigPath: %v", err)
+	}
+	if runtime := filepath.Base(filepath.Dir(path)); runtime != "goose" {
+		t.Fatalf("config sits in %q, want a goose directory", runtime)
+	}
+	if filepath.Base(path) != "config.yaml" {
+		t.Fatalf("config file is %q, want config.yaml", filepath.Base(path))
+	}
+}
+
+func TestGooseConfigPathHonorsXDGConfigHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv(goosePathRootEnv, "")
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	path, err := gooseConfigPath()
+	if err != nil {
+		t.Fatalf("gooseConfigPath: %v", err)
+	}
+	if want := filepath.Join(xdg, "goose", "config.yaml"); path != want {
+		t.Fatalf("gooseConfigPath = %q, want %q", path, want)
+	}
+}
+
+// GOOSE_PATH_ROOT relocates every goose directory and outranks XDG_CONFIG_HOME, matching goose's
+// own resolution -- and a relative value is ignored, because goose ignores it.
+func TestGooseConfigPathHonorsAnAbsolutePathRootAndIgnoresARelativeOne(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	root := t.TempDir()
+	t.Setenv(goosePathRootEnv, root)
+	path, err := gooseConfigPath()
+	if err != nil {
+		t.Fatalf("gooseConfigPath: %v", err)
+	}
+	if want := filepath.Join(root, "config", "config.yaml"); path != want {
+		t.Fatalf("gooseConfigPath = %q, want %q", path, want)
+	}
+
+	t.Setenv(goosePathRootEnv, "relative/goose")
+	path, err = gooseConfigPath()
+	if err != nil {
+		t.Fatalf("gooseConfigPath: %v", err)
+	}
+	if strings.Contains(path, "relative") {
+		t.Fatalf("gooseConfigPath = %q; goose ignores a relative GOOSE_PATH_ROOT and so must this", path)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+// The canonical harness name, so the row this produces lines up with the events in the runtime log
+// rather than introducing a second spelling for the same runtime.
+func TestDiscoverGooseUsesTheCanonicalHarnessName(t *testing.T) {
+	gooseConfigFixture(t)
+	h := DiscoverGoose()
+	if h.Name != "goose" {
+		t.Fatalf("harness name = %q, want goose", h.Name)
+	}
+	if h.Capability != "otel_config" {
+		t.Fatalf("capability = %q, want otel_config", h.Capability)
+	}
+	if h.TelemetryStatus != TelemetryMissing {
+		t.Fatalf("status = %q, want missing with no config file present", h.TelemetryStatus)
+	}
+}
+
+func TestDiscoverGooseReportsAConfiguredEndpoint(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, "otel_exporter_otlp_endpoint: http://127.0.0.1:4318\n")
+
+	h := DiscoverGoose()
+	if h.TelemetryStatus != TelemetryEnabled {
+		t.Fatalf("status = %q (%s), want enabled", h.TelemetryStatus, h.Message)
+	}
+	if h.ConfigPath != path {
+		t.Fatalf("config path = %q, want %q", h.ConfigPath, path)
+	}
+	// A config file goose wrote is itself evidence goose is on the machine, which matters on a host
+	// where the binary is not on Beacon's PATH -- a desktop-app install, or a shell Beacon did not
+	// inherit.
+	if !h.Detected {
+		t.Fatal("a goose config file exists but the harness was not reported as detected")
+	}
+}
+
+func TestDiscoverGooseIsInDiscoverAll(t *testing.T) {
+	gooseConfigFixture(t)
+	for _, h := range DiscoverAll() {
+		if h.Name == "goose" {
+			return
+		}
+	}
+	t.Fatal("goose is missing from DiscoverAll; `beacon endpoint status` would never list it")
+}
+
+// ValidateConfigured is given the collector's gRPC address, and goose is the one harness that must
+// never be measured against it. Its own status message is the more specific answer, and the shared
+// wrapper would overwrite it with "endpoint could not be fully validated" for a goose install that
+// is correctly pointed at the HTTP port.
+func TestValidateConfiguredKeepsGoosesOwnMessage(t *testing.T) {
+	path := gooseConfigFixture(t)
+	writeGooseConfig(t, path, "otel_exporter_otlp_endpoint: http://127.0.0.1:4318\n")
+
+	for _, result := range ValidateConfigured("http://127.0.0.1:4317") {
+		if result.Harness != "goose" {
+			continue
+		}
+		if result.Status != TelemetryEnabled {
+			t.Fatalf("goose status = %q (%s), want enabled", result.Status, result.Message)
+		}
+		if strings.Contains(result.Message, "could not be fully validated") {
+			t.Fatalf("goose was measured against the gRPC endpoint: %s", result.Message)
+		}
+		return
+	}
+	t.Fatal("goose is missing from ValidateConfigured")
+}

--- a/cli/beacon/internal/endpoint/harness/goose_test.go
+++ b/cli/beacon/internal/endpoint/harness/goose_test.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -20,6 +21,10 @@ func gooseConfigFixture(t *testing.T) string {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	// APPDATA is redirected as well, because on Windows goose's config resolves through it rather
+	// than through HOME. Without this the tests below write goose a real config file in the
+	// developer's own profile -- and the next test to run discovers it.
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 	t.Setenv(goosePathRootEnv, "")
 	t.Setenv("XDG_CONFIG_HOME", "")
 	// Cleared so a developer with any of these exported does not have the status assertions below
@@ -387,6 +392,9 @@ func TestGooseProtocolPrefersTheSignalSpecificVariable(t *testing.T) {
 // included. That is the opposite of what a reader would assume, and getting it wrong fails
 // silently by writing a file goose never reads.
 func TestGooseConfigPathFollowsTheXDGLayout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("goose takes the Windows strategy there; TestGooseConfigPathUsesTheWindowsStrategy covers it")
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
@@ -397,8 +405,8 @@ func TestGooseConfigPathFollowsTheXDGLayout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("gooseConfigPath: %v", err)
 	}
-	if runtime := filepath.Base(filepath.Dir(path)); runtime != "goose" {
-		t.Fatalf("config sits in %q, want a goose directory", runtime)
+	if dir := filepath.Base(filepath.Dir(path)); dir != "goose" {
+		t.Fatalf("config sits in %q, want a goose directory", dir)
 	}
 	if filepath.Base(path) != "config.yaml" {
 		t.Fatalf("config file is %q, want config.yaml", filepath.Base(path))
@@ -406,6 +414,9 @@ func TestGooseConfigPathFollowsTheXDGLayout(t *testing.T) {
 }
 
 func TestGooseConfigPathHonorsXDGConfigHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("goose ignores XDG_CONFIG_HOME there; TestGooseConfigPathUsesTheWindowsStrategy asserts that")
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
@@ -422,12 +433,35 @@ func TestGooseConfigPathHonorsXDGConfigHome(t *testing.T) {
 	}
 }
 
+// Windows is the one platform where etcetera's choose_app_strategy is not XDG, so goose's config
+// lands under %APPDATA%\Block\goose\config -- with the extra "config" segment, and with
+// XDG_CONFIG_HOME ignored no matter what it says. Neither half is derivable from the layout above,
+// which is why this asserts the whole path rather than a directory name.
+func TestGooseConfigPathUsesTheWindowsStrategy(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("the Windows strategy only applies on Windows")
+	}
+	appData := t.TempDir()
+	t.Setenv("APPDATA", appData)
+	t.Setenv(goosePathRootEnv, "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	path, err := gooseConfigPath()
+	if err != nil {
+		t.Fatalf("gooseConfigPath: %v", err)
+	}
+	if want := filepath.Join(appData, "Block", "goose", "config", "config.yaml"); path != want {
+		t.Fatalf("gooseConfigPath = %q, want %q", path, want)
+	}
+}
+
 // GOOSE_PATH_ROOT relocates every goose directory and outranks XDG_CONFIG_HOME, matching goose's
 // own resolution -- and a relative value is ignored, because goose ignores it.
 func TestGooseConfigPathHonorsAnAbsolutePathRootAndIgnoresARelativeOne(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 	t.Setenv("XDG_CONFIG_HOME", "")
 
 	root := t.TempDir()

--- a/cli/beacon/internal/endpoint/harness/harness.go
+++ b/cli/beacon/internal/endpoint/harness/harness.go
@@ -53,6 +53,7 @@ func DiscoverAll() []Harness {
 		DiscoverClaude(),
 		DiscoverCodex(),
 		DiscoverGemini(),
+		DiscoverGoose(),
 		DiscoverAntigravity(),
 		DiscoverCopilotCLI(),
 		DiscoverOpenCode(),
@@ -411,6 +412,7 @@ func ValidateConfigured(endpoint string) []ValidationResult {
 	claude := DiscoverClaude()
 	codex := DiscoverCodex()
 	gemini := DiscoverGemini()
+	goose := DiscoverGoose()
 	copilot := discoverCopilotCLI(endpoint)
 	factory := DiscoverFactory()
 	vscode := discoverVSCode(endpoint)
@@ -429,6 +431,17 @@ func ValidateConfigured(endpoint string) []ValidationResult {
 			Harness: gemini.Name,
 			Status:  gemini.TelemetryStatus,
 			Message: validateEndpointMessage(gemini.TelemetryStatus, gemini.Message, endpoint),
+		},
+		{
+			Harness: goose.Name,
+			Status:  goose.TelemetryStatus,
+			// The shared endpoint message is deliberately not applied to goose. It asserts that a
+			// harness reporting "enabled" is pointed at the endpoint passed in, and that endpoint is
+			// the collector's gRPC address -- which is the one address goose must never be pointed
+			// at, since its build carries no gRPC transport. gooseStatus has already checked the
+			// configured value against the local collector and against the environment overrides
+			// that silently turn its export off, so its own message is the more specific answer.
+			Message: goose.Message,
 		},
 		{
 			Harness: copilot.Name,

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle.go
@@ -829,6 +829,15 @@ func configureHarnesses(cfg endpointconfig.Config) ([]string, error) {
 				return paths, err
 			}
 			paths = append(paths, path)
+		// goose takes the HTTP endpoint, not the gRPC one every harness above is given. Its
+		// opentelemetry-otlp build enables only the HTTP transport, and pointing it at 4317 fails
+		// silently: the exporter builds, and the telemetry never arrives.
+		case "goose":
+			path, err := harness.ConfigureGoose(harness.ConfigureOptions{Endpoint: httpEndpoint, UserMode: cfg.UserMode})
+			if err != nil {
+				return paths, err
+			}
+			paths = append(paths, path)
 		case "vscode", "vs_code", "vscode_copilot":
 			path, err := harness.ConfigureVSCode(harness.VSCodeConfigOptions{Endpoint: httpEndpoint})
 			if err != nil {

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -966,3 +966,43 @@ func TestConfigureHarnessesRejectsQwenAsHookManaged(t *testing.T) {
 		}
 	}
 }
+
+// goose is the one harness here that must be given the collector's HTTP endpoint rather than its
+// gRPC one, and the mistake fails silently: its opentelemetry-otlp build enables only the HTTP
+// transport, so an exporter pointed at 4317 builds successfully and then exports nothing. Nothing
+// in goose's config file or in `beacon endpoint status` would say so, which is why the port is
+// asserted here rather than left to the call site reading correctly.
+func TestConfigureHarnessesGivesGooseTheHTTPEndpoint(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GOOSE_PATH_ROOT", "")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	cfg := endpointconfig.Config{
+		Harnesses: []string{"goose"},
+		Collector: endpointconfig.Collector{
+			GRPCPort: 54317,
+			HTTPPort: 54318,
+		},
+	}
+
+	paths, err := configureHarnesses(cfg)
+	if err != nil {
+		t.Fatalf("configureHarnesses returned error: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("configureHarnesses wrote %d paths, want 1: %v", len(paths), paths)
+	}
+	data, err := os.ReadFile(paths[0])
+	if err != nil {
+		t.Fatalf("read goose config: %v", err)
+	}
+	written := string(data)
+	if !strings.Contains(written, "54318") {
+		t.Fatalf("goose was not pointed at the collector's HTTP port:\n%s", written)
+	}
+	if strings.Contains(written, "54317") {
+		t.Fatalf("goose was pointed at the collector's gRPC port, which its build cannot use:\n%s", written)
+	}
+}

--- a/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
+++ b/cli/beacon/internal/endpoint/lifecycle/lifecycle_test.go
@@ -976,6 +976,9 @@ func TestConfigureHarnessesGivesGooseTheHTTPEndpoint(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	// On Windows goose's config resolves through APPDATA rather than HOME, so it is redirected too
+	// -- otherwise this writes a real config file into the developer's own profile.
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 	t.Setenv("GOOSE_PATH_ROOT", "")
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 

--- a/cli/beacon/internal/tokens/coverage.go
+++ b/cli/beacon/internal/tokens/coverage.go
@@ -77,6 +77,19 @@ var usageExpectation = map[string]struct {
 	"vercel_fx":         {ExpectReported, "session store carries cumulative usage and cost"},
 	"asymptote_observe": {ExpectReported, "SDK spans carry semconv usage"},
 
+	// goose is a stronger claim than the generic-OTLP entries below it and a weaker one than the
+	// reported entries above. Its `chat` span carries the full gen_ai.usage.* set, cache reads and
+	// writes included, under the exact semconv names -- that is read out of the runtime, not hoped
+	// for. What is conditional is whether it arrives: usage reaches Beacon only over OTLP, and a
+	// goose endpoint with hooks installed and `beacon endpoint install --harness goose` never run
+	// is correctly silent. Reporting that as a fault would be crying wolf at an operator who
+	// installed exactly half of what goose offers, which is the case this table exists to keep
+	// clean.
+	//
+	// It also carries no cost: goose reports tokens and not a price, so gen_ai.usage.cost_usd stays
+	// empty here by the runtime's choice rather than by Beacon declining to derive one.
+	"goose": {ExpectGenericOTLP, "usage arrives on OTLP chat spans; install `--harness goose` to enable the export"},
+
 	"gemini_cli":       {ExpectGenericOTLP, "only if it emits OTel GenAI semconv usage"},
 	"copilot_cli":      {ExpectGenericOTLP, "only if it emits OTel GenAI semconv usage"},
 	"vscode_copilot":   {ExpectGenericOTLP, "only if it emits OTel GenAI semconv usage"},


### PR DESCRIPTION
Fourth of five PRs adding Goose (Block) support. **Stacked on [#496](https://github.com/Asymptote-Labs/agent-beacon/pull/496)** — it changes the target row that PR adds, so it targets that branch.

`beacon endpoint install --harness goose` now works.

## Why this is not a duplicate of the hook path

Hooks see prompts, tool calls, commands and file edits. Goose populates **no tool output on a hook at all** and sends no usage event — so token counts, reported cost, the provider and model, and the assistant's own reasoning reach Beacon **only here**. A Goose endpoint wants both installed, which is why Goose becomes the one runtime with a row in both target namespaces:

- `beacon endpoint install --harness goose` → configures the OTLP export
- `beacon endpoint hooks install --harness goose` → installs the hooks

The two lookups are built from separate alias lists, so neither row shadows the other.

## Almost none of the mapping work is new

Goose already emits OTel GenAI semconv spans, and they are names Beacon's collector exporter reads today:

- `chat` — `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.request.temperature`, `gen_ai.response.model`, `gen_ai.response.finish_reasons`, `gen_ai.response.id`, and the full `gen_ai.usage.*` set **including cache reads and writes**
- `execute_tool` — `gen_ai.tool.name`, `gen_ai.tool.call.id`

So what this PR has to get right is the **endpoint**. There are two ways to get it wrong, and both fail silently.

### 1. Goose is HTTP-only

Goose's `opentelemetry-otlp` build enables only the HTTP transport, not `grpc-tonic`. Claude Code, Codex and Gemini are all pointed at the collector's **gRPC** port; Goose must be pointed at the **HTTP** one. Port 4317 would not fail loudly — the exporter builds and the telemetry never arrives.

Both call sites pass `httpEndpoint`, and `TestConfigureHarnessesGivesGooseTheHTTPEndpoint` asserts the **written port** rather than trusting the call site to read correctly. That test exists because the first round of mutation checks found this exact mutation *uncaught*:

```
NOT CAUGHT: goose given the gRPC endpoint in lifecycle    ← before
CAUGHT    : goose given the gRPC endpoint in lifecycle    ← after
```

### 2. The file is not the whole answer

Three environment conditions each leave the config file saying "local" while Goose exports nothing, so `gooseStatus` reads the environment too:

| condition | what Goose does |
|---|---|
| `OTEL_EXPORTER_OTLP_ENDPOINT` set | `promote_config_to_env` copies the file's endpoint **only when the variable is unset** — so another tool's remote collector silently redirects Goose |
| `OTEL_SDK_DISABLED=true` | disables every signal |
| `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` | Goose **disables the signal** rather than panicking its exporter threads; one stderr warning is the only signal |

Reporting "enabled" from the file alone would tell an operator a runtime is covered when it is silent. The signal-specific `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` correctly outranks the shared variable, matching the OTel spec and Goose's own resolution.

## Editing someone else's config file

`config.yaml` is written by hand — provider, model, extensions, permissions. A map round-trip would sort every key and delete every comment in order to change two, so the document is edited as a `yaml.Node`.

Verified by hand, not just asserted:

```yaml
# my goose setup -- please do not reformat      ← comment survives
active_provider: anthropic                       ← order and value survive
extensions:
  developer:
    enabled: true # the built-in one             ← inline comment + 2-space indent survive
otel_exporter_otlp_endpoint: http://127.0.0.1:4318   ← appended
otel_exporter_otlp_timeout: 10000
```

Stated plainly rather than left to be discovered from a diff: **blank lines between top-level keys are not preserved** — yaml.v3 cannot retain them. Comments, key order, values, nesting and two-space indentation all do survive. That is why the write backs the file up first. Invalid YAML is **refused** rather than overwritten — the opposite call from the hook installer, deliberately, because there Beacon owns the file and here the operator does.

## Path resolution

Goose calls etcetera's `choose_app_strategy`, which is **XDG everywhere except Windows** — macOS included. So on macOS its config is `~/.config/goose/config.yaml`, **not** `~/Library/Application Support`. That is the opposite of what a reader assumes, and getting it wrong writes a file Goose never reads. (Goose's own `paths.rs` mentions Application Support, but as a legacy location; `choose_native_strategy` — the variant that resolves there — is not the one it calls.) Windows gets `%APPDATA%\Block\goose\config`, and `GOOSE_PATH_ROOT` outranks both, ignored when relative exactly as Goose ignores it.

## Token-usage coverage

Goose is added as `generic_otlp`, not `reported`, and that is deliberate: the semconv usage names are read out of the runtime, but whether they *arrive* depends on whether this export was installed. An endpoint with hooks only is correctly silent, and calling that a fault would cry wolf at an operator who installed half of what Goose offers. Goose also reports no cost, so `gen_ai.usage.cost_usd` stays empty by the runtime's choice rather than by Beacon declining to derive one.

## Tests

31 cases in `harness/goose_test.go` + 1 in `lifecycle_test.go`. Mutation-checked:

```
CAUGHT: goose given the gRPC endpoint in lifecycle
CAUGHT: yaml.Node replaced by a real map round-trip
CAUGHT: environment endpoint override ignored
CAUGHT: gRPC protocol check dropped
CAUGHT: signal-specific protocol not preferred
```

One test from PR #496 is updated rather than added to: `TestGooseHarnessSpellingsResolveToTheHookTarget` asserted the endpoint namespace resolved to the hook kind, which this PR intentionally changes. It is now `TestGooseHarnessSpellingsResolveInBothNamespaces` and asserts the split.

`ValidateConfigured` keeps Goose's own status message rather than the shared wrapper, which would measure it against the gRPC endpoint — the one address Goose must never be pointed at.

Gates green: `pkg/asymptoteobserve`, `cli/beacon-hooks`, `cli/beacon`, `cli/beacon -race ./internal/endpoint/...`, `collector-builder/exporter/beaconjsonexporter`.

## Series

1. [#494](https://github.com/Asymptote-Labs/agent-beacon/pull/494) — harness identity
2. [#495](https://github.com/Asymptote-Labs/agent-beacon/pull/495) — hook payload mapper
3. [#496](https://github.com/Asymptote-Labs/agent-beacon/pull/496) — hook installer + CLI wiring
4. **this PR** — OTLP harness configuration
5. Inventory, detection and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfvajZH6CQRe2Djz42SA2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfvajZH6CQRe2Djz42SA2d)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CLI writes operator-owned Goose config and telemetry routing; mis-pointing OTLP fails silently, though tests and status checks target HTTP-only and env override cases.
> 
> **Overview**
> **`beacon endpoint install --harness goose`** now wires Block Goose’s OTLP export to the local collector, complementing the existing hook path rather than replacing it.
> 
> Goose becomes the only runtime with **two target rows under one name**: endpoint aliases resolve to **OTLP** (`endpoint install` writes `config.yaml`), while hook aliases still resolve to **hooks** (`endpoint hooks install`). User-config repair and lifecycle install both call new **`ConfigureGoose`**, which must use the collector’s **HTTP** port (Goose’s OTLP build is HTTP-only; gRPC would fail silently).
> 
> The new harness module discovers Goose, resolves config paths (XDG / Windows / `GOOSE_PATH_ROOT`), edits **`config.yaml` via `yaml.Node`** so comments and key order survive, backs up before write, and reports status including env overrides (`OTEL_EXPORTER_OTLP_*`, `OTEL_SDK_DISABLED`, gRPC protocol). **`ValidateConfigured`** keeps Goose’s own message instead of comparing it to the gRPC endpoint. Token coverage marks **`goose`** as **`generic_otlp`** (usage only when OTLP install ran).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6489d172919f7d092113e514d3323ce8cafa2f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->