### PR TITLE
docs: add the v1.3.10 changelog entry

### DIFF
--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -11,6 +11,31 @@ Stay up to date with the latest changes to the Agent Beacon CLI.
 
 ## September 2026
 
+### v1.3.10 · September 12, 2026
+
+- **goose (Block) hook telemetry** · The hooks binary reads goose's plugin hook
+  payloads (`--platform goose`), covering session start and end, prompts, tool
+  lifecycle, command lines, and file creates and edits with diffs. goose spells
+  three envelope fields its own way (`event`, `working_dir`, `message`) and
+  reports a failed tool call as its own `PostToolUseFailure` event with a payload
+  otherwise identical to `PostToolUse`, so the event name is what decides whether
+  a write is recorded as landed. MCP tools are identified by goose's
+  `<extension>__<tool>` prefix not naming a built-in extension, since goose sends
+  no tool output and no `mcp_*` argument to give it away. goose classifies a
+  blocking hook's stdout, so `PreToolUse` and `Stop` answer with an explicit
+  `{"decision":"allow"}` — the `{}` other runtimes read as no opinion is a failed
+  hook here — and a policy-seam deny is returned as `{"decision":"block"}`,
+  goose's own spelling for it. Approval decisions and token usage are not on any
+  goose hook and are not synthesized. See [goose](/runtimes/goose).
+- **`goose` is a canonical harness name** · `codename-goose`, `block-goose`, and
+  the CLI and agent spellings all normalize to `goose`, so the hook path and
+  goose's own OpenTelemetry export land on one harness instead of splitting a
+  session in two. GooseAI spellings (`gooseai`, `goose-ai`, `goose.ai`) are
+  deliberately left unmapped and pass through as themselves — that is a different
+  company's inference service, not this runtime.
+- **Security** · Bumps `google.golang.org/grpc` to 1.83.2 in the collector
+  exporter and sandbox modules.
+
 ### v1.3.9 · September 9, 2026
 
 - **Cloud agents can send telemetry to Asymptote Managed** · Claude Code cloud sandboxes had two upload targets, a GCS or S3 bucket you own. `BEACON_CLOUD_UPLOAD=asymptote` with `BEACON_CLOUD_INGEST_URL` and a `BEACON_CLOUD_DEVICE_KEY` minted for the environment now posts the sandbox log to managed ingest, the same endpoint the laptop forwarder uses, so cloud-agent sessions appear in the dashboard beside endpoint sessions. New lines are sent on every Stop, in batches under the ingest limits; a revoked key is reported, never retried past the offset. See [Claude Code Cloud Agents](/runtimes/claude-code-cloud-agents).


### PR DESCRIPTION
The CLI changelog stopped at v1.3.9, so the latest release was undocumented on
the docs site. This adds the v1.3.10 entry at the top of `docs/changelog/cli.mdx`.

The entry is written from the commit range `v1.3.9..v1.3.10` and the published
release, and covers the three things that shipped:

- **goose (Block) hook telemetry** — the payload mapping in `beacon-hooks`
  (`--platform goose`): goose's own `event`/`working_dir`/`message` spellings,
  `PostToolUseFailure` as the only thing separating a write that landed from one
  that did not, MCP detection by the `<extension>__<tool>` prefix, the explicit
  `{"decision":"allow"}` on goose's blocking hooks, and `{"decision":"block"}`
  for a policy-seam deny. Notes that approvals and token usage are absent from
  goose's hooks and are not synthesized.
- **`goose` as a canonical harness name** — `codename-goose` and `block-goose`
  normalize to it; GooseAI spellings deliberately do not.
- **Security** — `google.golang.org/grpc` 1.83.2.

One deliberate omission: the entry does not mention
`beacon endpoint hooks install --harness goose` or
`beacon endpoint install --harness goose`. `docs/runtimes/goose.mdx` and
CLAUDE.md both document those commands, but there is no goose code under
`cli/beacon/` on main — no `internal/endpoint/hooks/goose.go`, no
`internal/endpoint/harness/goose.go`, and no open PR carrying them. Only the
hooks binary and the harness-name normalization landed in v1.3.10, so the
changelog describes the adapter rather than an install path a user cannot run
yet. Worth reconciling separately, either by landing the installer or by
softening the runtime page until it lands.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm1e3YSovqpC1Sw19UmXGi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm1e3YSovqpC1Sw19UmXGi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to the CLI changelog; no runtime or install behavior changes in this PR.
> 
> **Overview**
> Documents **CLI v1.3.10** (September 12, 2026) at the top of the Agent Beacon CLI changelog so the site matches the shipped release after v1.3.9.
> 
> The new entry describes **goose (Block) hook telemetry** via `beacon-hooks` with `--platform goose`: goose-specific envelope fields, `PostToolUseFailure` vs landed writes, MCP detection by `<extension>__<tool>`, blocking-hook responses (`allow` / `block`), and that approvals and token usage are not synthesized. It also notes **`goose` as the canonical harness name** (with GooseAI spellings left unmapped) and a **security** bump of `google.golang.org/grpc` to 1.83.2 in collector exporter and sandbox modules, with a link to the goose runtime page.
> 
> **Docs-only**; no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a978ffcb42ae8101423480fc26405c1b3e50f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->